### PR TITLE
Parser: cleanup whitespace in grammar

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -137,7 +137,7 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 %token OBLOCKSEP        /* LexFilter #light inserts when transforming CtxtSeqBlock(NotFirstInSeqBlock, _, AddBlockEnd) to CtxtSeqBlock(FirstInSeqBlock, _, AddBlockEnd) on exact alignment */
 
 /*    REVIEW: merge OEND, ODECLEND, OBLOCKEND and ORIGHT_BLOCK_END into one token */
-%token OEND             /* LexFilter #light inserts when closing CtxtFun, CtxtMatchClauses, CtxtWithAsLet _        */
+%token OEND             /* LexFilter #light inserts when closing CtxtFun, CtxtMatchClauses, CtxtWithAsLet _ */
 %token ODECLEND         /* LexFilter #light inserts when closing CtxtDo and CtxtLetDecl(block) */
 %token ORIGHT_BLOCK_END /* LexFilter #light inserts when closing CtxtSeqBlock(_, _, AddOneSidedBlockEnd) */
 %token OBLOCKEND OBLOCKEND_COMING_SOON OBLOCKEND_IS_HERE       /* LexFilter #light inserts when closing CtxtSeqBlock(_, _, AddBlockEnd) */
@@ -490,7 +490,7 @@ hashDirectiveArg:
       { let s, kind = $1
         ParsedHashDirectiveArgument.String(s, kind, lhs parseState) }
   | sourceIdentifier
-      { let c,v = $1
+      { let c, v = $1
         ParsedHashDirectiveArgument.SourceIdentifier(c, v, lhs parseState) }
 
 
@@ -509,9 +509,8 @@ signatureFile:
   /* This will result in NO intellisense for the file! Ideally we wouldn't need this rule */
   /* Note: the compiler assumes there is at least one "fragment", so an empty one is used (see 4488) */
   | error EOF
-     { let emptySigFileFrag = ParsedSigFileFragment.AnonModule([], rhs parseState 1) in
+     { let emptySigFileFrag = ParsedSigFileFragment.AnonModule([], rhs parseState 1)
        ParsedSigFile([], [emptySigFileFrag]) }
-
 
 
 /* The start of a module declaration */
@@ -527,7 +526,7 @@ moduleIntro:
 namespaceIntro:
   | NAMESPACE opt_rec path
       { let mNamespace = rhs parseState 1
-        mNamespace, $2, $3.LongIdent, grabXmlDoc(parseState, [], 1)  }
+        mNamespace, $2, $3.LongIdent, grabXmlDoc(parseState, [], 1) }
 
 
 /* The contents of a signature file */
@@ -561,7 +560,8 @@ fileNamespaceSpecList:
 
 fileNamespaceSpec:
   | namespaceIntro deprecated_opt_equals fileModuleSpec
-     { let mNamespace, isRec, path, xml = $1 in ($3 (Some mNamespace, isRec, path, xml)) }
+     { let mNamespace, isRec, path, xml = $1
+       $3 (Some mNamespace, isRec, path, xml) }
 
 
 /* The single module declaration that can make up a signature file */
@@ -577,7 +577,7 @@ fileModuleSpec:
         if not (isNil path) then errorR(Error(FSComp.SR.parsNamespaceOrModuleNotBoth(), m2))
         let lid = path@path2
         let trivia: SynModuleOrNamespaceSigTrivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }
-        ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(lid, (isRec || isRec2), SynModuleOrNamespaceKind.NamedModule, $4, xmlDoc, $1 @ attribs2, vis, m, trivia)))  }
+        ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(lid, (isRec || isRec2), SynModuleOrNamespaceKind.NamedModule, $4, xmlDoc, $1 @ attribs2, vis, m, trivia))) }
 
   | moduleSpfnsPossiblyEmptyBlock
     { let m = (rhs parseState 1)
@@ -592,7 +592,7 @@ fileModuleSpec:
                 match mNamespaceOpt with
                 | None -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None }
                 | Some mNamespace -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }
-            ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia))  }
+            ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia)) }
 
 
 moduleSpfnsPossiblyEmptyBlock:
@@ -636,7 +636,7 @@ moduleSpfns:
 
 moduleSpfn:
   | hashDirective
-      { SynModuleSigDecl.HashDirective($1, rhs2 parseState 1 1)  }
+      { SynModuleSigDecl.HashDirective($1, rhs2 parseState 1 1) }
 
   | valSpfn
       { $1 }
@@ -750,7 +750,7 @@ moduleSpecBlock:
       { $3 }
 
   /* non-#light-syntax, with sig/end or begin/end */
-  |             sigOrBegin moduleSpfnsPossiblyEmpty END
+  | sigOrBegin moduleSpfnsPossiblyEmpty END
       { $2 }
 
 
@@ -785,7 +785,7 @@ tyconSpfn:
         fun leadingKeyword -> $3 leadingKeyword mLhs $1 (Some mEquals) }
   | typeNameInfo opt_classSpfn
       { let mWithKwd, members = $2
-        let (SynComponentInfo(range=range)) = $1
+        let (SynComponentInfo(range = range)) = $1
         let m =
             match members with
             | [] ->
@@ -804,7 +804,7 @@ tyconSpfnRhsBlock:
   /* This rule allows members to be given for record and union types in the #light syntax */
   /* without the use of 'with' ... 'end'. For example: */
   /*     type R = */
-  /*         { a : int } */
+  /*         { a: int } */
   /*         member r.A = a */
   /* It also takes into account that any existing 'with' */
   /* block still needs to be considered and may occur indented or undented from the core type */
@@ -832,13 +832,13 @@ tyconSpfnRhs:
            SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.Simple($1, $1.Range), augmentation, mWhole, trivia)) }
 
   | tyconClassSpfn
-     {  let needsCheck, (kind, decls) = $1
-        let objectModelRange =
-            match decls with
-            | [] -> lhs parseState
-            | decls ->
-                let start = mkSynRange parseState.ResultStartPosition parseState.ResultStartPosition
-                (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
+     { let needsCheck, (kind, decls) = $1
+       let objectModelRange =
+           match decls with
+           | [] -> lhs parseState
+           | decls ->
+               let start = mkSynRange parseState.ResultStartPosition parseState.ResultStartPosition
+               (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
 
        (fun leadingKeyword nameRange nameInfo mEquals augmentation ->
            if needsCheck && isNil decls then
@@ -913,7 +913,7 @@ classSpfnMembers:
   | classSpfnMembersAtLeastOne
      { $1 }
 
-  |  /* EMPTY */
+  | /* EMPTY */
      { [] }
 
 
@@ -934,7 +934,7 @@ classMemberSpfn:
            let m = rhs parseState 3
            match getSetRangeOpt with
            | None -> unionRanges m ty.Range
-           | Some gs -> unionRanges m (gs : GetSetKeywords).Range
+           | Some gs -> unionRanges m (gs: GetSetKeywords).Range
            |> fun m -> (m, $1) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
            |> unionRangeWithXmlDoc doc
            |> fun m ->
@@ -961,7 +961,7 @@ classMemberSpfn:
      { let mWhole = rhs2 parseState 1 4
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let mVal = rhs parseState 3
-       let (SynField(xmlDoc = xmlDoc)) as field = $4 $1 false mWhole (Some (SynLeadingKeyword.Val mVal))
+       let (SynField(xmlDoc = xmlDoc)) as field = $4 $1 false mWhole (Some(SynLeadingKeyword.Val mVal))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
        SynMemberSig.ValField(field, mWhole) }
 
@@ -970,7 +970,7 @@ classMemberSpfn:
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let mStatic = rhs parseState 3
        let mVal = rhs parseState 4
-       let (SynField(xmlDoc = xmlDoc)) as field = $5 $1 true mWhole (Some (SynLeadingKeyword.StaticVal(mStatic, mVal)))
+       let (SynField(xmlDoc = xmlDoc)) as field = $5 $1 true mWhole (Some(SynLeadingKeyword.StaticVal(mStatic, mVal)))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
        SynMemberSig.ValField(field, mWhole) }
 
@@ -1003,9 +1003,9 @@ classMemberSpfnGetSet:
       Some mWith, $2 }
 
   | OWITH classMemberSpfnGetSetElements error
-    {  let mWith = rhs parseState 1
-       reportParseErrorAt mWith (FSComp.SR.parsUnmatchedWith())
-       Some mWith, $2 }
+    { let mWith = rhs parseState 1
+      reportParseErrorAt mWith (FSComp.SR.parsUnmatchedWith())
+      Some mWith, $2 }
 
 
 /* The "get, set" on a property member in a signature */
@@ -1013,9 +1013,9 @@ classMemberSpfnGetSetElements:
   | nameop
     { (let (SynIdent(id:Ident, _)) = $1
        if id.idText = "get" then
-           SynMemberKind.PropertyGet, Some (GetSetKeywords.Get id.idRange)
+           SynMemberKind.PropertyGet, Some(GetSetKeywords.Get id.idRange)
        else if id.idText = "set" then
-           SynMemberKind.PropertySet, Some (GetSetKeywords.Set id.idRange)
+           SynMemberKind.PropertySet, Some(GetSetKeywords.Set id.idRange)
        else
            raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
 
@@ -1027,9 +1027,9 @@ classMemberSpfnGetSetElements:
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
 
       if id.idText = "get" then
-          SynMemberKind.PropertyGetSet, Some (GetSetKeywords.GetSet(id.idRange, id2.idRange))
+          SynMemberKind.PropertyGetSet, Some(GetSetKeywords.GetSet(id.idRange, id2.idRange))
       else
-          SynMemberKind.PropertyGetSet, Some (GetSetKeywords.GetSet(id2.idRange, id.idRange)) }
+          SynMemberKind.PropertyGetSet, Some(GetSetKeywords.GetSet(id2.idRange, id.idRange)) }
 
 memberSpecFlags:
   | memberFlags { $1 }
@@ -1068,7 +1068,7 @@ implementationFile:
   /* This will result in NO intellisense for the file! Ideally we wouldn't need this rule */
   /* Note: the compiler assumes there is at least one "fragment", so an empty one is used (see 4488) */
   | error EOF
-     { let emptyImplFileFrag = ParsedImplFileFragment.AnonModule([], rhs parseState 1) in
+     { let emptyImplFileFrag = ParsedImplFileFragment.AnonModule([], rhs parseState 1)
        ParsedImplFile ([], [emptyImplFileFrag]) }
 
 
@@ -1106,7 +1106,8 @@ fileNamespaceImplList:
 /* A single namespace definition in an implementation file */
 fileNamespaceImpl:
   | namespaceIntro deprecated_opt_equals fileModuleImpl
-     { let mNamespace, isRec, path, xml = $1 in ($3 (Some mNamespace, isRec, path, xml)) }
+     { let mNamespace, isRec, path, xml = $1
+       $3 (Some mNamespace, isRec, path, xml) }
 
 
 /* A single module definition in an implementation file */
@@ -1151,7 +1152,7 @@ moduleDefnsOrExprPossiblyEmptyOrBlock:
        $2 }
 
   | OBLOCKBEGIN error oblockend
-     { []  }
+     { [] }
 
   | moduleDefnsOrExprPossiblyEmpty
      { $1 }
@@ -1218,7 +1219,7 @@ moduleDefns:
 /* A single definition in a namespace, module or F# Interactive file*/
 moduleDefnOrDirective:
   | moduleDefn
-      { $1  }
+      { $1 }
 
   | hashDirective
       { [ SynModuleDecl.HashDirective($1, rhs2 parseState 1 1) ] }
@@ -1233,14 +1234,14 @@ moduleDefn:
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         parseState.ResetSynArgNameGenerator()
         let (BindingSetPreAttrs(_, _, _, _, mWhole)) = $3
-        mkDefnBindings (mWhole, $3, $1, $2, mWhole)  }
+        mkDefnBindings (mWhole, $3, $1, $2, mWhole) }
 
   /* 'let' or 'do' definitions in #light */
   | opt_attributes opt_access hardwhiteLetBindings %prec decl_let
       { let hwlb, m, _ = $3
         if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         parseState.ResetSynArgNameGenerator()
-        mkDefnBindings (m, hwlb, $1, $2, m)  }
+        mkDefnBindings (m, hwlb, $1, $2, m) }
 
   /* 'do' definitions in non-#light*/
   | opt_attributes opt_access doBinding %prec decl_let
@@ -1333,13 +1334,13 @@ namedModuleAbbrevBlock:
      { $2 }
 
   | path
-     { $1  }
+     { $1 }
 
 
 /* The right-hand-side of a module definition */
 namedModuleDefnBlock:
   | OBLOCKBEGIN wrappedNamedModuleDefn oblockend
-     { Choice2Of2 $2  }
+     { Choice2Of2 $2 }
 
   | OBLOCKBEGIN wrappedNamedModuleDefn recover
      { // The lex filter ensures we can only get a mismatch in OBLOCKBEGIN/OBLOCKEND tokens if there was some other kind of error, hence we don't need to report this error
@@ -1413,7 +1414,7 @@ opt_attributes:
   | attributes
       { $1 }
 
-  |            %prec prec_opt_attributes_none
+  | %prec prec_opt_attributes_none
       { [] }
 
 /* A list of sets of custom attributes */
@@ -1457,21 +1458,21 @@ attribute:
   | path opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType
      { let arg = match $3 with None -> mkSynUnit $1.Range | Some e -> e
        let m = unionRanges $1.Range arg.Range
-       ({ TypeName=$1; ArgExpr=arg; Target=None; AppliesToGetterAndSetter=false; Range=m } : SynAttribute) }
+       ({ TypeName = $1; ArgExpr = arg; Target = None; AppliesToGetterAndSetter = false; Range = m }: SynAttribute) }
 
   /* A custom attribute with an attribute target */
   | attributeTarget path opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType
      { let arg = match $4 with None -> mkSynUnit $2.Range | Some e -> e
-       let startRange = match $1 with Some (ident:Ident) -> ident.idRange | None -> $2.Range
+       let startRange = match $1 with Some(ident:Ident) -> ident.idRange | None -> $2.Range
        let m = unionRanges startRange arg.Range
-       ({ TypeName=$2; ArgExpr=arg; Target=$1; AppliesToGetterAndSetter=false; Range=m } : SynAttribute) }
+       ({ TypeName = $2; ArgExpr = arg; Target = $1; AppliesToGetterAndSetter = false; Range = m }: SynAttribute) }
 
   /* A custom attribute with an attribute target */
   | attributeTarget OBLOCKBEGIN path oblockend opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType
      { let arg = match $6 with None -> mkSynUnit $3.Range | Some e -> e
        let startRange = match $1 with Some ident -> ident.idRange | None -> $3.Range
        let m = unionRanges startRange arg.Range
-       ({ TypeName=$3; ArgExpr=arg; Target=$1; AppliesToGetterAndSetter=false; Range=m } : SynAttribute) }
+       ({ TypeName = $3; ArgExpr = arg; Target = $1; AppliesToGetterAndSetter = false; Range = m }: SynAttribute) }
 
 
 /* The target of a custom attribute */
@@ -1551,9 +1552,9 @@ tyconDefn:
             raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition(typeNameId.ToString()))
 
        let nameRange = rhs parseState 1
-       let (tcDefRepr:SynTypeDefnRepr), mWith ,members = $3 nameRange
+       let (tcDefRepr: SynTypeDefnRepr), mWith, members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
-       let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
+       let mWhole = (declRange, members) ||> unionRangeWithListBy (fun (mem: SynMemberDefn) -> mem.Range)
 
        fun leadingKeyword ->
            let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = $2; WithKeyword = mWith }
@@ -1581,7 +1582,7 @@ tyconDefn:
          | _ -> reportParseErrorAt (rhs2 parseState 1 5) (FSComp.SR.parsOnlyClassCanTakeValueArguments()); tcDefRepr
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members)
-                    ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
+                    ||> unionRangeWithListBy (fun (mem: SynMemberDefn) -> mem.Range)
                     |> unionRangeWithXmlDoc xmlDoc
        fun leadingKeyword ->
            let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = Some mEquals; WithKeyword = mWith }
@@ -1593,7 +1594,7 @@ tyconDefnRhsBlock:
   /* This rule allows members to be given for record and union types in the #light syntax */
   /* without the use of 'with' ... 'end'. For example: */
   /*     type R = */
-  /*         { a : int } */
+  /*         { a: int } */
   /*         member r.A = a */
   /* It also takes into account that any existing 'with' */
   /* block still needs to be considered and may occur indented or undented from the core type */
@@ -1661,16 +1662,16 @@ tyconClassDefn:
        needsCheck, (SynTypeDefnKind.Unspecified, decls), mopt }
 
   | classOrInterfaceOrStruct classDefnBlock END
-     { false, ($1, $2), Some (rhs2 parseState 1 3) }
+     { false, ($1, $2), Some(rhs2 parseState 1 3) }
 
   | classOrInterfaceOrStruct classDefnBlock recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedClassInterfaceOrStruct())
-       let m = (rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range)
+       let m = (rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d: SynMemberDefn) -> d.Range)
        false, ($1, $2), Some(m) }
 
   | classOrInterfaceOrStruct error END
      { // silent recovery
-       false, ($1, []), Some (rhs2 parseState 1 3) }
+       false, ($1, []), Some(rhs2 parseState 1 3) }
 
 
 /* The right-hand-side of a object type definition where the class/interface/struct kind has not been specified */
@@ -1679,14 +1680,14 @@ classDefnBlockKindUnspecified:
      { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileTypeDefinition())
        let mopt =
            match $2 with
-           | _ :: _ -> Some((rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range))
+           | _ :: _ -> Some((rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d: SynMemberDefn) -> d.Range))
            | _ -> None
        false, $2, mopt }
 
   | OBLOCKBEGIN classDefnMembers oblockend
      { let mopt =
            match $2 with
-           | _ :: _ -> Some((rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range))
+           | _ :: _ -> Some((rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d: SynMemberDefn) -> d.Range))
            | _ -> None
        true, $2, mopt }
 
@@ -1731,16 +1732,16 @@ classDefnMembersAtLeastOne:
 classDefnMemberGetSet:
   | WITH classDefnMemberGetSetElements
      { let mWithKwd = rhs parseState 1
-       mWithKwd, $2  }
+       mWithKwd, $2 }
 
   | OWITH classDefnMemberGetSetElements OEND
      { let mWithKwd = rhs parseState 1
-       mWithKwd, $2  }
+       mWithKwd, $2 }
 
   | OWITH classDefnMemberGetSetElements error
      { let mWithKwd = rhs parseState 1
        reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedWith())
-       mWithKwd, $2  }
+       mWithKwd, $2 }
 
 /* The "get, set" part of a member definition */
 classDefnMemberGetSetElements:
@@ -1754,7 +1755,7 @@ classDefnMemberGetSetElements:
 classDefnMemberGetSetElement:
   | opt_inline opt_attributes bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedSequentialExprBlock
      { let mEquals = rhs parseState 5
-       let mRhs = ($6 : SynExpr).Range
+       let mRhs = ($6: SynExpr).Range
        ($1, $2, $3, $4, Some mEquals, $6, mRhs) }
 
 
@@ -1830,7 +1831,7 @@ classDefnMember:
 
   | opt_attributes opt_access STATIC classDefnBindings
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-       [mkClassMemberLocalBindings(true, Some (rhs parseState 3), $1, $2, $4)] }
+       [mkClassMemberLocalBindings(true, Some(rhs parseState 3), $1, $2, $4)] }
 
   | opt_attributes opt_access memberFlags memberCore opt_ODECLEND
      { let rangeStart = rhs parseState 1
@@ -1840,13 +1841,13 @@ classDefnMember:
        $4 $2 flags $1 rangeStart }
 
   | opt_attributes opt_access interfaceMember appType opt_interfaceImplDefn
-     {  if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesAreNotPermittedOnInterfaceImplementations(), rhs parseState 1))
-        if Option.isSome $2 then errorR(Error(FSComp.SR.parsInterfacesHaveSameVisibilityAsEnclosingType(), rhs parseState 3))
-        let mWithKwd, members, mWhole =
-            match $5 with
-            | None -> None, None, rhs2 parseState 1 4
-            | Some (mWithKwd, members, m) -> Some mWithKwd, Some members, unionRanges (rhs2 parseState 1 4) m
-        [ SynMemberDefn.Interface($4, mWithKwd, members, mWhole) ] }
+     { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesAreNotPermittedOnInterfaceImplementations(), rhs parseState 1))
+       if Option.isSome $2 then errorR(Error(FSComp.SR.parsInterfacesHaveSameVisibilityAsEnclosingType(), rhs parseState 3))
+       let mWithKwd, members, mWhole =
+           match $5 with
+           | None -> None, None, rhs2 parseState 1 4
+           | Some(mWithKwd, members, m) -> Some mWithKwd, Some members, unionRanges (rhs2 parseState 1 4) m
+       [ SynMemberDefn.Interface($4, mWithKwd, members, mWhole) ] }
 
   | opt_attributes opt_access abstractMemberFlags opt_inline nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet opt_ODECLEND
      { let ty, arity = $8
@@ -1867,20 +1868,20 @@ classDefnMember:
        [ SynMemberDefn.AbstractSlot(valSpfn, mkFlags (getSetAdjuster arity), mWhole, trivia) ] }
 
   | opt_attributes opt_access inheritsDefn
-     {  if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalOnInherit(), rhs parseState 1))
-        if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityIllegalOnInherit(), rhs parseState 1))
-        [ $3 ] }
+     { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalOnInherit(), rhs parseState 1))
+       if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityIllegalOnInherit(), rhs parseState 1))
+       [ $3 ] }
 
   | opt_attributes opt_access valDefnDecl opt_ODECLEND
-     {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let rangeStart = rhs parseState 1
-        $3 rangeStart $1 None }
+     { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
+       let rangeStart = rhs parseState 1
+       $3 rangeStart $1 None }
 
   | opt_attributes opt_access STATIC valDefnDecl opt_ODECLEND
-     {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let mStatic = rhs parseState 3
-        let rangeStart = rhs parseState 1
-        $4 rangeStart $1 (Some mStatic)  }
+     { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
+       let mStatic = rhs parseState 3
+       let rangeStart = rhs parseState 1
+       $4 rangeStart $1 (Some mStatic) }
 
   | opt_attributes opt_access memberFlags autoPropsDefnDecl opt_ODECLEND
      { let rangeStart = rhs parseState 1
@@ -1890,42 +1891,42 @@ classDefnMember:
        $4 $1 flags rangeStart }
 
   | opt_attributes opt_access NEW atomicPattern optAsSpec EQUALS typedSequentialExprBlock opt_ODECLEND
-     {  let mWholeBindLhs = rhs2 parseState 1 (if Option.isSome $5 then 5 else 4)
-        let mNew = rhs parseState 3
-        let xmlDoc = grabXmlDoc(parseState, $1, 1)
-        let m = unionRanges mWholeBindLhs $7.Range |> unionRangeWithXmlDoc xmlDoc
-        let mEquals = rhs parseState 6
-        let expr = $7
-        let valSynData = SynValData (Some CtorMemberFlags, SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), Option.map snd $5)
-        let vis = $2
-        let declPat = SynPat.LongIdent(SynLongIdent([mkSynId (rhs parseState 3) "new"], [], [None]), None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
-        // Check that 'SynPatForConstructorDecl' matches this correctly
-        assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
-        let synBindingTrivia: SynBindingTrivia = { LeadingKeyword = SynLeadingKeyword.New mNew; InlineKeyword = None; EqualsRange = Some mEquals }
-        [ SynMemberDefn.Member(SynBinding (None, SynBindingKind.Normal, false, false, $1, xmlDoc, valSynData, declPat, None, expr, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, synBindingTrivia), m) ] }
+     { let mWholeBindLhs = rhs2 parseState 1 (if Option.isSome $5 then 5 else 4)
+       let mNew = rhs parseState 3
+       let xmlDoc = grabXmlDoc(parseState, $1, 1)
+       let m = unionRanges mWholeBindLhs $7.Range |> unionRangeWithXmlDoc xmlDoc
+       let mEquals = rhs parseState 6
+       let expr = $7
+       let valSynData = SynValData (Some CtorMemberFlags, SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), Option.map snd $5)
+       let vis = $2
+       let declPat = SynPat.LongIdent(SynLongIdent([mkSynId (rhs parseState 3) "new"], [], [None]), None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+       // Check that 'SynPatForConstructorDecl' matches this correctly
+       assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
+       let synBindingTrivia: SynBindingTrivia = { LeadingKeyword = SynLeadingKeyword.New mNew; InlineKeyword = None; EqualsRange = Some mEquals }
+       [ SynMemberDefn.Member(SynBinding (None, SynBindingKind.Normal, false, false, $1, xmlDoc, valSynData, declPat, None, expr, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, synBindingTrivia), m) ] }
 
   | opt_attributes opt_access STATIC typeKeyword tyconDefn
-     {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
-        [ SynMemberDefn.NestedType($5 leadingKeyword, None, rhs2 parseState 1 5) ] }
+     { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
+       let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
+       [ SynMemberDefn.NestedType($5 leadingKeyword, None, rhs2 parseState 1 5) ] }
 
 
 /* A 'val' definition in an object type definition */
 valDefnDecl:
   | VAL opt_mutable opt_access ident COLON typ
-     {  let mVal = rhs parseState 1
-        let mRhs = rhs2 parseState 4 6
-        let mValDecl = rhs2 parseState 1 6
-        (fun rangeStart attribs mStaticOpt ->
-            let isStatic = Option.isSome mStaticOpt
-            let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
-            let mValDecl = unionRanges rangeStart mValDecl |> unionRangeWithXmlDoc xmlDoc
-            let leadingKeyword =
-                match mStaticOpt with
-                | None -> SynLeadingKeyword.Val mVal
-                | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
-            let fld = SynField(attribs, isStatic, Some $4, $6, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
-            [ SynMemberDefn.ValField(fld, mValDecl) ]) }
+     { let mVal = rhs parseState 1
+       let mRhs = rhs2 parseState 4 6
+       let mValDecl = rhs2 parseState 1 6
+       (fun rangeStart attribs mStaticOpt ->
+           let isStatic = Option.isSome mStaticOpt
+           let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
+           let mValDecl = unionRanges rangeStart mValDecl |> unionRangeWithXmlDoc xmlDoc
+           let leadingKeyword =
+               match mStaticOpt with
+               | None -> SynLeadingKeyword.Val mVal
+               | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
+           let fld = SynField(attribs, isStatic, Some $4, $6, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
+           [ SynMemberDefn.ValField(fld, mValDecl) ]) }
 
 
 /* An auto-property definition in an object type definition */
@@ -1965,7 +1966,7 @@ atomicPatternLongIdent:
   | GLOBAL DOT pathOp
      { let globalIdent = ident(MangledGlobalName, rhs parseState 1)
        let mDot = rhs parseState 2
-       None, prependIdentInLongIdentWithTrivia (SynIdent(globalIdent, (Some (IdentTrivia.OriginalNotation "global")))) mDot $3 }
+       None, prependIdentInLongIdentWithTrivia (SynIdent(globalIdent, (Some(IdentTrivia.OriginalNotation "global")))) mDot $3 }
 
   | pathOp
      { (None, $1) }
@@ -2008,12 +2009,12 @@ opt_interfaceImplDefn:
   | WITH objectImplementationBlock declEnd
      { let mWithKwd = rhs parseState 1
        let members = $2
-       let m = (rhs parseState 1, members) ||> unionRangeWithListBy (fun (mem:SynMemberDefn) -> mem.Range)
-       Some (mWithKwd, members, m) }
+       let m = (rhs parseState 1, members) ||> unionRangeWithListBy (fun (mem: SynMemberDefn) -> mem.Range)
+       Some(mWithKwd, members, m) }
 
   | WITH
      { let mWithKwd = rhs parseState 1
-       Some (mWithKwd, [], mWithKwd) }
+       Some(mWithKwd, [], mWithKwd) }
 
   | /* EMPTY */
      { None }
@@ -2130,7 +2131,7 @@ tyconDefnOrSpfnSimpleRepr:
   /* type MyAlias = SomeTypeProvider<@"foo">    is a common error, special-case it */
   | opt_attributes opt_access path LQUOTE STRING recover
      { errorR(Error(FSComp.SR.parsUnexpectedQuotationOperatorInTypeAliasDidYouMeanVerbatimString(), rhs parseState 4))
-       SynTypeDefnSimpleRepr.TypeAbbrev(ParserDetail.ErrorRecovery, SynType.LongIdent($3), unionRanges (rhs parseState 1) $3.Range)  }
+       SynTypeDefnSimpleRepr.TypeAbbrev(ParserDetail.ErrorRecovery, SynType.LongIdent($3), unionRanges (rhs parseState 1) $3.Range) }
 
   /* A type abbreviation */
   | opt_attributes opt_access typ
@@ -2169,7 +2170,7 @@ tyconDefnOrSpfnSimpleRepr:
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsInlineAssemblyCannotHaveVisibilityDeclarations(), rhs parseState 2))
        let s, _ = $5
        let ilType = ParseAssemblyCodeType s parseState.LexBuffer.ReportLibraryOnlyFeatures parseState.LexBuffer.LanguageVersion (rhs parseState 5)
-       SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(box ilType, mLhs)  }
+       SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(box ilType, mLhs) }
 
 
 /* The core of a record type definition */
@@ -2601,7 +2602,7 @@ exconIntro:
       { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF unionCaseRepr
-      { SynUnionCase([], SynIdent($1,None), SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF recover
       { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
@@ -2611,7 +2612,7 @@ exconRepr:
      { None }
 
   | EQUALS path
-     { Some ($2.LongIdent) }
+     { Some($2.LongIdent) }
 
 /*-------------------------------------------------------------------------*/
 /* F# Definitions, Types, Patterns and Expressions */
@@ -2649,7 +2650,7 @@ defnBindings:
 
   | cPrototype
       { let bindRange = lhs parseState
-        BindingSetPreAttrs(bindRange, false, false, $1, bindRange)  }
+        BindingSetPreAttrs(bindRange, false, false, $1, bindRange) }
 
 
 /* A 'do ...' statement in the non-#light syntax */
@@ -2722,7 +2723,8 @@ classDefnBindings:
      { $1 }
 
   | hardwhiteLetBindings
-     { let b, m, _ = $1 in b }
+     { let b, m, _ = $1
+       b }
 
   | hardwhiteDoBinding
      { fst $1 }
@@ -2730,13 +2732,13 @@ classDefnBindings:
 
 /* The terminator for a 'let ....' binding in the #light syntax */
 hardwhiteDefnBindingsTerminator:
-  |  ODECLEND
+  | ODECLEND
      { let mToken = rhs parseState 1
        // In LexFilter.fs the IN token could have been transformed to an ODECLEND one.
        let mIn = if (mToken.EndColumn - mToken.StartColumn) = 2 then Some mToken else None
        (fun _ m -> ()), mIn }
 
-  |  recover
+  | recover
      { (fun kwd m ->
          let msg =
              match kwd with
@@ -2771,7 +2773,7 @@ cPrototype:
             let binding =
                 mkSynBinding
                     (xmlDoc, bindingPat)
-                    (vis, false, false, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, Some (None, rty), rhsExpr, mRhs, [], attrs, None, trivia)
+                    (vis, false, false, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, Some(None, rty), rhsExpr, mRhs, [], attrs, None, trivia)
             [], [binding]) }
 
 /* A list of arguments in an 'extern' DllImport function definition */
@@ -2797,10 +2799,12 @@ externMoreArgs:
 /* A single argument in an 'extern' DllImport function definition */
 externArg:
   | opt_attributes cType
-     { let m = lhs parseState in SynPat.Typed(SynPat.Wild m, $2, m) |> addAttribs $1 }
+     { let m = lhs parseState
+       SynPat.Typed(SynPat.Wild m, $2, m) |> addAttribs $1 }
 
   | opt_attributes cType ident
-     { let m = lhs parseState in SynPat.Typed(SynPat.Named(SynIdent($3, None), false, None, m), $2, m) |> addAttribs $1 }
+     { let m = lhs parseState
+       SynPat.Typed(SynPat.Named(SynIdent($3, None), false, None, m), $2, m) |> addAttribs $1 }
 
 /* An type in an 'extern' DllImport function definition */
 cType:
@@ -2814,15 +2818,15 @@ cType:
 
   | cType STAR
      { let m = lhs parseState
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [ Some (IdentTrivia.OriginalNotation "*") ])), None, [$1], [], None, true, m) }
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [ Some(IdentTrivia.OriginalNotation "*") ])), None, [$1], [], None, true, m) }
 
   | cType AMP
      { let m = lhs parseState
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [ Some (IdentTrivia.OriginalNotation "&") ])), None, [$1], [], None, true, m) }
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [ Some(IdentTrivia.OriginalNotation "&") ])), None, [$1], [], None, true, m) }
 
   | VOID STAR
      { let m = lhs parseState
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [ Some (IdentTrivia.OriginalNotation "void*") ])), None, [], [], None, true, m) }
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [ Some(IdentTrivia.OriginalNotation "void*") ])), None, [], [], None, true, m) }
 
 
 /* A return type in an 'extern' DllImport function definition */
@@ -2832,20 +2836,20 @@ cRetType:
 
   | opt_attributes VOID
      { let m = rhs parseState 2
-       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [ Some (IdentTrivia.OriginalNotation "void") ])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) }
+       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [ Some(IdentTrivia.OriginalNotation "void") ])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) }
 
 
 localBindings:
   | attr_localBinding moreLocalBindings
       { let (moreBindings, moreBindingRanges) = List.unzip $2
-        let moreLocalBindingsLastRange = if moreBindingRanges.IsEmpty then None else Some (List.last moreBindingRanges)
+        let moreLocalBindingsLastRange = if moreBindingRanges.IsEmpty then None else Some(List.last moreBindingRanges)
         match $1 with
-        | Some (localBindingRange, attrLocalBindingBuilder) ->
+        | Some(localBindingRange, attrLocalBindingBuilder) ->
            let lastRange =
                match moreLocalBindingsLastRange with
                | None -> localBindingRange
                | Some m -> m
-           Some lastRange, (fun xmlDoc attrs vis leadingKeyword -> attrLocalBindingBuilder xmlDoc attrs vis leadingKeyword true ::  moreBindings)
+           Some lastRange, (fun xmlDoc attrs vis leadingKeyword -> attrLocalBindingBuilder xmlDoc attrs vis leadingKeyword true :: moreBindings)
         | None ->
            moreLocalBindingsLastRange, (fun _xmlDoc _attrs _vis _leadingKeyword -> moreBindings) }
 
@@ -2854,7 +2858,7 @@ moreLocalBindings:
   | AND attr_localBinding moreLocalBindings
       { let leadingKeyword = SynLeadingKeyword.And(rhs parseState 1)
         (match $2 with
-         | Some (localBindingRange, attrLocalBindingBuilder) ->
+         | Some(localBindingRange, attrLocalBindingBuilder) ->
             let xmlDoc = grabXmlDoc(parseState, [], 1)
             let xmlDoc = if xmlDoc.IsEmpty then grabXmlDoc(parseState, [], 2) else xmlDoc
             (attrLocalBindingBuilder xmlDoc [] None leadingKeyword false, localBindingRange) :: $3
@@ -2879,7 +2883,7 @@ attr_localBinding:
 /* A single binding in an expression or definition */
 localBinding:
   | opt_inline opt_mutable bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedExprWithStaticOptimizationsBlock
-      { let (expr:SynExpr), opts = $6
+      { let (expr: SynExpr), opts = $6
         let mEquals = rhs parseState 5
         let mRhs = expr.Range
         let optReturnType = $4
@@ -2903,7 +2907,7 @@ localBinding:
           (fun xmlDoc attrs vis leadingKeyword ->
             let mEquals = rhs parseState 5
             let zeroWidthAtEnd = mEquals.EndRange
-            let rhsExpr = arbExpr("localBinding1", zeroWidthAtEnd)
+            let rhsExpr = arbExpr ("localBinding1", zeroWidthAtEnd)
             let spBind = if IsDebugPointBinding bindingPat rhsExpr then DebugPointAtBinding.Yes mWhole else DebugPointAtBinding.NoneAtLet
             let trivia: SynBindingTrivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = Some mEquals }
             mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
@@ -2919,7 +2923,7 @@ localBinding:
           (fun xmlDoc attrs vis (leadingKeyword: SynLeadingKeyword) ->
             let spBind = DebugPointAtBinding.Yes(unionRanges leadingKeyword.Range mRhs)
             let trivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = None }
-            let rhsExpr = arbExpr("localBinding2", mRhs)
+            let rhsExpr = arbExpr ("localBinding2", mRhs)
             mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
         mWhole, localBindingBuilder }
 
@@ -3021,7 +3025,7 @@ rawConstant:
       SynConst.String(s, synStringKind, lhs parseState) }
 
   | sourceIdentifier
-    { let c,v = $1
+    { let c, v = $1
       SynConst.SourceIdentifier(c, v, lhs parseState) }
 
   | BYTEARRAY
@@ -3200,7 +3204,8 @@ namePatPairs:
      { [$1], lhs parseState }
 
    | namePatPair seps namePatPairs
-     { let (rs, _) = $3 in ($1 :: rs), lhs parseState }
+     { let (rs, _) = $3
+       ($1 :: rs), lhs parseState }
 
 namePatPair:
    | ident EQUALS parenPattern
@@ -3295,7 +3300,8 @@ atomicPattern:
       { SynPat.DeprecatedCharRange($1, $3, rhs2 parseState 1 3) }
 
   | LBRACE recordPatternElementsAux rbrace
-      { let rs, m = $2 in SynPat.Record(rs, rhs2 parseState 1 3) }
+      { let rs, m = $2
+        SynPat.Record(rs, rhs2 parseState 1 3) }
 
   | LBRACK listPatternElements RBRACK
       { SynPat.ArrayOrList(false, $2, lhs parseState) }
@@ -3379,22 +3385,22 @@ parenPatternBody:
 /* "(pat)"!  Here are some examples: */
 /*    a, b                  parses as (a, b) */
 /*    (a, b)           also parses as (a, b) */
-/*    (a, b : t)            parses as (a, (b:t)) */
+/*    (a, b: t)            parses as (a, (b: t)) */
 /*    a, b as t             parses as ((a, b) as t) */
 /*    (a, b as t)      also parses as ((a, b) as t) */
 /*    a, b | c, d            parses as ((a, b) | (c, d)) */
 /*    (a, b | c, d)     also parses as ((a, b) | (c, d)) */
-/*    (a : t, b)            parses as ((a:t), b) */
-/*    (a : t1, b : t2)      parses as ((a:t), (b:t2)) */
-/*    (a, b as nm : t)      parses as (((a, b) as nm) : t) */
-/*    (a, b :: c : t)       parses as (((a, b) :: c) : t) */
+/*    (a: t, b)            parses as ((a: t), b) */
+/*    (a: t1, b: t2)      parses as ((a: t), (b: t2)) */
+/*    (a, b as nm: t)      parses as (((a, b) as nm): t) */
+/*    (a, b :: c: t)       parses as (((a, b) :: c): t) */
 /* */
 /* Probably the most unexpected thing here is that 'as nm' binds the */
 /* whole pattern to the left, whereas ': t' binds only the pattern */
 /* immediately preceding in the tuple. */
 /* */
-/* Also, it is unexpected that '(a, b : t)' in a pattern (a, (b : 't)) binds differently to */
-/* '(a, b : t)' in an expression ((a, b) : 't). It's not that easy to solve that without */
+/* Also, it is unexpected that '(a, b: t)' in a pattern (a, (b: 't)) binds differently to */
+/* '(a, b: t)' in an expression ((a, b): 't). It's not that easy to solve that without */
 /* duplicating the entire expression grammar, or making a fairly severe breaking change */
 /* to the language. */
 parenPattern:
@@ -3476,7 +3482,9 @@ recordPatternElementsAux: /* Fix 1190 */
       { [$1], lhs parseState }
 
   | recordPatternElement seps recordPatternElementsAux
-      { let r = $1 in let (rs, dropMark) = $3 in (r :: rs), lhs parseState }
+      { let r = $1
+        let (rs, dropMark) = $3
+        (r :: rs), lhs parseState }
 
 recordPatternElement:
   | path EQUALS parenPattern
@@ -3559,11 +3567,11 @@ sequentialExpr:
 
   | hardwhiteLetBindings %prec prec_args_error
      { let hwlb, m, mIn = $1
-       let mLetKwd, isUse = match hwlb with (BindingSetPreAttrs(m, _, isUse, _, _))  -> m, isUse
+       let mLetKwd, isUse = match hwlb with (BindingSetPreAttrs(m, _, isUse, _, _)) -> m, isUse
        let usedKeyword = if isUse then "use" else "let"
        reportParseErrorAt mLetKwd (FSComp.SR.parsExpectedExpressionAfterLet(usedKeyword, usedKeyword))
        let fauxRange = m.EndRange // zero width range at end of m
-       mkLocalBindings (m, hwlb, mIn, arbExpr("seqExpr", fauxRange)) }
+       mkLocalBindings (m, hwlb, mIn, arbExpr ("seqExpr", fauxRange)) }
 
 /* Use this as the last terminal when performing error recovery */
 /* The contract for using this is that (a) if EOF occurs then the */
@@ -3602,7 +3610,7 @@ declExpr:
 
   | defnBindings IN error %prec expr_let
      { let mIn = rhs parseState 2 |> Some
-       mkLocalBindings (rhs2 parseState 1 2, $1, mIn, arbExpr("declExpr1", (rhs parseState 3))) }
+       mkLocalBindings (rhs2 parseState 1 2, $1, mIn, arbExpr ("declExpr1", (rhs parseState 3))) }
 /*
     FSComp.SR.parsNoMatchingInForLet() -- leave this in for now - it's an unused error string
 */
@@ -3613,8 +3621,8 @@ declExpr:
 
   | hardwhiteLetBindings error %prec expr_let
      { let hwlb, m, mIn = $1
-       reportParseErrorAt (match hwlb with (BindingSetPreAttrs(m, _, _, _, _))  -> m) (FSComp.SR.parsErrorInReturnForLetIncorrectIndentation())
-       mkLocalBindings (m, hwlb, mIn, arbExpr("declExpr2", (rhs parseState 2))) }
+       reportParseErrorAt (match hwlb with (BindingSetPreAttrs(m, _, _, _, _)) -> m) (FSComp.SR.parsErrorInReturnForLetIncorrectIndentation())
+       mkLocalBindings (m, hwlb, mIn, arbExpr ("declExpr2", (rhs parseState 2))) }
 
   | hardwhiteLetBindings OBLOCKSEP typedSequentialExprBlock %prec expr_let
      { let hwlb, m, mIn = $1
@@ -3622,8 +3630,8 @@ declExpr:
 
   | hardwhiteLetBindings OBLOCKSEP error %prec expr_let
      { let hwlb, m, mIn = $1
-       //reportParseErrorAt (match hwlb with (BindingSetPreAttrs(m, _, _, _, _))  -> m) (FSComp.SR.parsErrorInReturnForLetIncorrectIndentation())
-       mkLocalBindings (unionRanges m (rhs parseState 3), hwlb, mIn, arbExpr("declExpr3", (rhs parseState 3))) }
+       //reportParseErrorAt (match hwlb with (BindingSetPreAttrs(m, _, _, _, _)) -> m) (FSComp.SR.parsErrorInReturnForLetIncorrectIndentation())
+       mkLocalBindings (unionRanges m (rhs parseState 3), hwlb, mIn, arbExpr ("declExpr3", (rhs parseState 3))) }
 
   | hardwhiteDoBinding %prec expr_let
      { let e = snd $1
@@ -3722,7 +3730,7 @@ declExpr:
         let mEnd = m.EndRange
         let spIfToThen = DebugPointAtBinding.Yes mEnd
         let trivia = { IfKeyword = m; IsElif = false; ThenKeyword = m; ElseKeyword = None; IfToThenRange = m }
-        exprFromParseError (SynExpr.IfThenElse(arbExpr("ifGuard1", mEnd), arbExpr("thenBody1", mEnd), None, spIfToThen, true, m, trivia)) }
+        exprFromParseError (SynExpr.IfThenElse(arbExpr ("ifGuard1", mEnd), arbExpr ("thenBody1", mEnd), None, spIfToThen, true, m, trivia)) }
 
   | LAZY declExpr %prec expr_lazy
       { SynExpr.Lazy($2, unionRanges (rhs parseState 1) $2.Range) }
@@ -3761,7 +3769,7 @@ declExpr:
         let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileBodyArb = unionRanges (rhs parseState 4) (rhs parseState 5)
         let mWhileAll = unionRanges (rhs parseState 1) (rhs parseState 5)
-        SynExpr.While(spWhile, $2, arbExpr("whileBody1", mWhileBodyArb), mWhileAll) }
+        SynExpr.While(spWhile, $2, arbExpr ("whileBody1", mWhileBodyArb), mWhileAll) }
 
   | WHILE declExpr recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsWhileDoExpected())
@@ -3769,11 +3777,11 @@ declExpr:
         let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileBodyArb = rhs parseState 3
         let mWhileAll = unionRanges (rhs parseState 1) (rhs parseState 3)
-        exprFromParseError (SynExpr.While(spWhile, $2, arbExpr("whileBody2", mWhileBodyArb), mWhileAll))  }
+        exprFromParseError (SynExpr.While(spWhile, $2, arbExpr ("whileBody2", mWhileBodyArb), mWhileAll)) }
 
   | WHILE recover
       { if not $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileWhile())
-        arbExpr("whileLoop1", rhs parseState 1)  }
+        arbExpr ("whileLoop1", rhs parseState 1) }
 
   | WHILE error doneDeclEnd
       { //silent recovery
@@ -3781,7 +3789,7 @@ declExpr:
         let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileBodyArb = rhs parseState 3
         let mWhileAll = unionRanges (rhs parseState 1) (rhs parseState 3)
-        exprFromParseError (SynExpr.While(spWhile, arbExpr("whileGuard1", mWhileHeader), arbExpr("whileBody3", mWhileBodyArb), mWhileAll))  }
+        exprFromParseError (SynExpr.While(spWhile, arbExpr ("whileGuard1", mWhileHeader), arbExpr ("whileBody3", mWhileBodyArb), mWhileAll)) }
 
   | FOR forLoopBinder doToken typedSequentialExprBlock doneDeclEnd
       { let mFor = rhs parseState 1
@@ -3805,7 +3813,7 @@ declExpr:
         let (a, b, _, spIn) = $2
         let mForLoopBodyArb = rhs parseState 5
         let mForLoopAll = rhs2 parseState 1 5
-        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody2a", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr ("forLoopBody2a", mForLoopBodyArb), mForLoopAll) }
 
   | FOR forLoopBinder doToken ends_coming_soon_or_recover
       { if not $4 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsExpectedExpressionAfterToken())
@@ -3814,7 +3822,7 @@ declExpr:
         let (a, b, _, spIn) = $2
         let mForLoopBodyArb = rhs parseState 3
         let mForLoopAll = rhs2 parseState 1 3
-        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody2", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr ("forLoopBody2", mForLoopBodyArb), mForLoopAll) }
 
   | FOR forLoopBinder ends_coming_soon_or_recover
       { let (a, b, ok, spIn) = $2
@@ -3823,7 +3831,7 @@ declExpr:
         let spFor = DebugPointAtFor.Yes mFor
         let mForLoopBodyArb = rhs parseState 3
         let mForLoopAll = rhs2 parseState 1 3
-        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody1", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr ("forLoopBody1", mForLoopBodyArb), mForLoopAll) }
 
   | FOR forLoopBinder opt_OBLOCKSEP arrowThenExprR %prec expr_let
      { let spFor = DebugPointAtFor.Yes(rhs parseState 1)
@@ -3853,7 +3861,7 @@ declExpr:
         let (a, b, c, d, e, spTo) = $2
         let mForLoopBodyArb = rhs parseState 5
         let mForLoopAll = rhs2 parseState 1 5
-        SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr ("declExpr11", mForLoopBodyArb), mForLoopAll) }
 
   | FOR forLoopRange doToken recover
       { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
@@ -3862,7 +3870,7 @@ declExpr:
         let (a, b, c, d, e, spTo) = $2
         let mForLoopBodyArb = rhs parseState 3
         let mForLoopAll = rhs2 parseState 1 3
-        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll)) }
+        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr ("declExpr11", mForLoopBodyArb), mForLoopAll)) }
 
   | FOR forLoopRange recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
@@ -3871,7 +3879,7 @@ declExpr:
         let (a, b, c, d, e, spTo) = $2
         let mForLoopBodyArb = (rhs parseState 2).EndRange
         let mForLoopAll = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll)) }
+        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr ("declExpr11", mForLoopBodyArb), mForLoopAll)) }
 
   | FOR error doToken typedSequentialExprBlock doneDeclEnd
       { // silent recovery
@@ -3879,11 +3887,11 @@ declExpr:
         let spToFake = DebugPointAtInOrTo.Yes mFor
         let mForLoopAll = unionRanges (rhs parseState 1) $4.Range
         let spFor = DebugPointAtFor.Yes mFor
-        SynExpr.For(spFor, spToFake, mkSynId mFor "_loopVar", None, arbExpr("startLoopRange1", mFor), true, arbExpr("endLoopRange1", rhs parseState 3), $4, mForLoopAll) }
+        SynExpr.For(spFor, spToFake, mkSynId mFor "_loopVar", None, arbExpr ("startLoopRange1", mFor), true, arbExpr ("endLoopRange1", rhs parseState 3), $4, mForLoopAll) }
 
   | FOR ends_coming_soon_or_recover
       { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsIdentifierExpected())
-        arbExpr("declExpr12", (rhs parseState 1)) }
+        arbExpr ("declExpr12", (rhs parseState 1)) }
 
   | FOR parenPattern error doneDeclEnd
       { reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsInOrEqualExpected())
@@ -3892,7 +3900,7 @@ declExpr:
         let spInFake = DebugPointAtInOrTo.Yes mFor
         let mForLoopBodyArb = rhs parseState 4
         let mForLoopAll = rhs2 parseState 1 4
-        SynExpr.ForEach(spFor, spInFake, SeqExprOnly false, true, $2, arbExpr("forLoopCollection", mFor), arbExpr("forLoopBody3", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spInFake, SeqExprOnly false, true, $2, arbExpr ("forLoopCollection", mFor), arbExpr ("forLoopBody3", mForLoopBodyArb), mForLoopAll) }
 
   | FOR parenPattern recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
@@ -3902,7 +3910,7 @@ declExpr:
         let spIn = DebugPointAtInOrTo.Yes mIn
         let mForLoopBodyArb = (rhs parseState 2).EndRange
         let mForLoopAll = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, $2, arbExpr("forLoopCollection", mFor), arbExpr("forLoopBody3", mForLoopBodyArb), mForLoopAll)) }
+        exprFromParseError (SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, $2, arbExpr ("forLoopCollection", mFor), arbExpr ("forLoopBody3", mForLoopBodyArb), mForLoopAll)) }
 
   | YIELD declExpr
      { SynExpr.YieldOrReturn(($1, not $1), $2, unionRanges (rhs parseState 1) $2.Range) }
@@ -3912,11 +3920,11 @@ declExpr:
 
   | YIELD recover
      { let mYieldAll = rhs parseState 1
-       SynExpr.YieldOrReturn(($1, not $1), arbExpr("yield", mYieldAll), mYieldAll) }
+       SynExpr.YieldOrReturn(($1, not $1), arbExpr ("yield", mYieldAll), mYieldAll) }
 
   | YIELD_BANG recover
      { let mYieldAll = rhs parseState 1
-       SynExpr.YieldOrReturnFrom(($1, not $1), arbExpr("yield!", mYieldAll), mYieldAll) }
+       SynExpr.YieldOrReturnFrom(($1, not $1), arbExpr ("yield!", mYieldAll), mYieldAll) }
 
   | BINDER headBindingPattern EQUALS typedSequentialExprBlock IN opt_OBLOCKSEP moreBinders typedSequentialExprBlock %prec expr_let
      { let spBind = DebugPointAtBinding.Yes(rhs2 parseState 1 5)
@@ -4036,7 +4044,7 @@ declExpr:
 
   | declExpr LESS recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("<"))
-       exprFromParseError (mkSynInfix (rhs parseState 2) $1 "<" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError (mkSynInfix (rhs parseState 2) $1 "<" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr GREATER declExpr
      { mkSynInfix (rhs parseState 2) $1 ">" $3 }
@@ -4069,85 +4077,85 @@ declExpr:
 
   | declExpr JOIN_IN OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("in"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "@in" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "@in" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr BAR_BAR OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("||"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "||" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "||" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_BAR_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr OR OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("or"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "or" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "or" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr AMP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("&"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "&" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "&" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr AMP_AMP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("&&"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "&&" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "&&" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_AMP_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr EQUALS OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("="))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "=" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "=" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_COMPARE_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr DOLLAR OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("$"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "$" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "$" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr LESS OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("<"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "<" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "<" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr GREATER OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression(">"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 ">" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 ">" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_AT_HAT_OP OBLOCKEND_COMING_SOON  %prec infix_at_hat_op_binary
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr PERCENT_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr COLON_COLON OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("::"))
        let identExpr = mkSynOperator (rhs parseState 2) "::"
-       let tupExpr = SynExpr.Tuple(false, [$1;(arbExpr("declExprInfix", (rhs parseState 3).StartRange))], [rhs parseState 2], unionRanges $1.Range (rhs parseState 3).StartRange)
+       let tupExpr = SynExpr.Tuple(false, [$1;(arbExpr ("declExprInfix", (rhs parseState 3).StartRange))], [rhs parseState 2], unionRanges $1.Range (rhs parseState 3).StartRange)
        SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range (rhs parseState 3).StartRange) }
 
   | declExpr PLUS_MINUS_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr MINUS OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("-"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "-" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "-" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr STAR OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("*"))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "*" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 "*" (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_STAR_DIV_MOD_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_STAR_STAR_OP OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
-       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
+       exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr ("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr DOT_DOT declExpr
       { let wholem = rhs2 parseState 1 3
@@ -4283,7 +4291,7 @@ ifExprCases:
         let mElse, elseExpr = $2
         (fun exprGuard mIf isElif ->
             let mIfToThen = unionRanges mIf mThen
-            let lastBranch : SynExpr = match elseExpr with None -> exprThen | Some e -> e
+            let lastBranch: SynExpr = match elseExpr with None -> exprThen | Some e -> e
             let mIfToEndOfLastBranch = unionRanges mIf lastBranch.Range
             let spIfToThen = DebugPointAtBinding.Yes(mIfToThen)
             let trivia = { IfKeyword = mIf; IsElif = isElif; ThenKeyword = mThen; ElseKeyword = mElse; IfToThenRange = mIfToThen }
@@ -4315,7 +4323,7 @@ ifExprElifs:
   | OELSE OBLOCKBEGIN typedSequentialExpr recover
       { let mElse = rhs parseState 1
         if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElse())
-        Some mElse, Some (exprFromParseError $3) }
+        Some mElse, Some(exprFromParseError $3) }
 
   | ELIF declExpr ifExprCases
       { let mElif = rhs parseState 1
@@ -4324,13 +4332,13 @@ ifExprElifs:
         if length > 4 then
             let mElse = mkRange mElif.FileName (mkPos mElif.StartLine mElif.StartColumn) (mkPos mElif.StartLine (mElif.StartColumn + 4))
             let mIf = mkRange mElif.FileName (mkPos mElif.StartLine (mElif.EndColumn - 2)) (mkPos mElif.StartLine mElif.EndColumn)
-            Some mElse, (Some ($3 $2 mIf false))
+            Some mElse, (Some($3 $2 mIf false))
         else
-            None, Some ($3 $2 mElif true) }
+            None, Some($3 $2 mElif true) }
 
   | ELIF declExpr recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElif())
-        None, Some (exprFromParseError $2) }
+        None, Some(exprFromParseError $2) }
 
 tupleExpr:
   | tupleExpr COMMA declExpr
@@ -4397,10 +4405,10 @@ minusExpr:
       { SynExpr.New(false, $2, $4, unionRanges (rhs parseState 1) $4.Range) }
 
   | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP error
-      { SynExpr.New(false, $2, arbExpr("minusExpr", (rhs parseState 4)), unionRanges (rhs parseState 1) ($2).Range) }
+      { SynExpr.New(false, $2, arbExpr ("minusExpr", (rhs parseState 4)), unionRanges (rhs parseState 1) ($2).Range) }
 
   | NEW error
-      { arbExpr("minusExpr2", (rhs parseState 1)) }
+      { arbExpr ("minusExpr2", (rhs parseState 1)) }
 
   | UPCAST minusExpr
       { SynExpr.InferredUpcast($2, unionRanges (rhs parseState 1) $2.Range) }
@@ -4413,7 +4421,7 @@ minusExpr:
 
 appExpr:
   | appExpr argExpr %prec expr_app
-      { SynExpr.App(ExprAtomicFlag.NonAtomic, false, $1, $2, unionRanges $1.Range $2.Range)  }
+      { SynExpr.App(ExprAtomicFlag.NonAtomic, false, $1, $2, unionRanges $1.Range $2.Range) }
 
   | atomicExpr
       { let arg, _ = $1
@@ -4483,7 +4491,7 @@ atomicExpr:
   | GLOBAL
       { let m = rhs parseState 1
         let ident = ident(MangledGlobalName, m)
-        SynExpr.LongIdent(false, SynLongIdent([ident], [], [Some (IdentTrivia.OriginalNotation "global")]), None, m), false }
+        SynExpr.LongIdent(false, SynLongIdent([ident], [], [Some(IdentTrivia.OriginalNotation "global")]), None, m), false }
 
   | identExpr
       { $1, false }
@@ -4570,12 +4578,12 @@ atomicExprQualification:
 
   | LBRACK error RBRACK
       { let mArg = rhs2 parseState 1 3
-        (fun e mLhs mDot -> mkSynDotBrackGet mLhs mDot e (arbExpr("indexerExpr1", mArg))) }
+        (fun e mLhs mDot -> mkSynDotBrackGet mLhs mDot e (arbExpr ("indexerExpr1", mArg))) }
 
   | LBRACK recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket())
         let mArg = (rhs parseState 1).EndRange
-        (fun e mLhs mDot -> exprFromParseError (mkSynDotBrackGet mLhs mDot e (arbExpr("indexerExpr2", mArg)))) }
+        (fun e mLhs mDot -> exprFromParseError (mkSynDotBrackGet mLhs mDot e (arbExpr ("indexerExpr2", mArg)))) }
 
 /* the start of atomicExprAfterType must not overlap with the valid postfix tokens of the type syntax, e.g. new List<T>(...) */
 atomicExprAfterType:
@@ -4621,7 +4629,7 @@ beginEndExpr:
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBegin()); exprFromParseError $2 }
 
   | BEGIN error END
-      { (* silent recovery *) arbExpr("beginEndExpr", (lhs parseState))  }
+      { (* silent recovery *) arbExpr ("beginEndExpr", (lhs parseState)) }
 
   | BEGIN END
       { mkSynUnit (lhs parseState) }
@@ -4634,25 +4642,25 @@ quoteExpr:
   | LQUOTE typedSequentialExpr recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))
         let mExpr = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, mExpr))  }
+        exprFromParseError (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, mExpr)) }
 
   | LQUOTE error RQUOTE
-      { (* silent recovery *) SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }
+      { (* silent recovery *) SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr ("quoteExpr", (rhs parseState 2)), false, lhs parseState) }
 
   | LQUOTE recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))
-        exprFromParseError (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }
+        exprFromParseError (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr ("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1)) }
 
 arrayExpr:
   | LBRACK_BAR arrayExprElements BAR_RBRACK
-      {  $2 (lhs parseState) }
+      { $2 (lhs parseState) }
 
   | LBRACK_BAR arrayExprElements recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())
         exprFromParseError ($2 (rhs2 parseState 1 2)) }
 
   | LBRACK_BAR error BAR_RBRACK
-      {  (* silent recovery *) SynExpr.ArrayOrList(true, [ ], lhs parseState) }
+      { (* silent recovery *) SynExpr.ArrayOrList(true, [ ], lhs parseState) }
 
   | LBRACK_BAR recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())
@@ -4674,38 +4682,38 @@ parenExpr:
 
   | LPAREN error rparen
       { // silent recovery
-        SynExpr.Paren(arbExpr("parenExpr1", (rhs parseState 1).EndRange), (rhs parseState 1), Some(rhs parseState 3), (rhs2 parseState 1 3)) }
+        SynExpr.Paren(arbExpr ("parenExpr1", (rhs parseState 1).EndRange), (rhs parseState 1), Some(rhs parseState 3), (rhs2 parseState 1 3)) }
 
   | LPAREN TYPE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
         let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
-        arbExpr("parenExpr2tcs", mLhs) }
+        arbExpr ("parenExpr2tcs", mLhs) }
 
   | LPAREN MODULE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
         let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
-        arbExpr("parenExpr2mcs", mLhs) }
+        arbExpr ("parenExpr2mcs", mLhs) }
 
   | LPAREN RBRACE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
         let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
-        arbExpr("parenExpr2rbcs", mLhs) }
+        arbExpr ("parenExpr2rbcs", mLhs) }
 
   | LPAREN OBLOCKEND_COMING_SOON
       { let lparenRange = (rhs parseState 1)
         reportParseErrorAt lparenRange (FSComp.SR.parsUnmatchedParen())
-        SynExpr.Paren(arbExpr("parenExpr2obecs", lparenRange.EndRange), lparenRange, None, lparenRange) }
+        SynExpr.Paren(arbExpr ("parenExpr2obecs", lparenRange.EndRange), lparenRange, None, lparenRange) }
 
   | LPAREN recover %prec prec_atomexpr_lparen_error
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
-        arbExpr("parenExpr2", (lhs parseState))  }
+        arbExpr ("parenExpr2", (lhs parseState)) }
 
         // This is really what we should be doing, but it fails because param info expects the range of the expression
         // to extend all the way over the "recover", to the end of the file if necessary
         //
         // let mLeftParen = rhs parseState 1
         //let mLhs = if $2 then unionRangeWithPos mLeftParen (rhs parseState 2).Start else mLeftParen
-        //arbExpr("parenExpr2", mLhs)  }
+        //arbExpr ("parenExpr2", mLhs) }
 
 parenExprBody:
   | typars COLON LPAREN classMemberSpfn rparen typedSequentialExpr
@@ -4736,7 +4744,8 @@ typarAlts:
 
 braceExpr:
   | LBRACE braceExprBody rbrace
-     {  let m, r = $2 in r (rhs2 parseState 1 3) }
+     { let m, r = $2
+       r (rhs2 parseState 1 3) }
 
   | LBRACE braceExprBody recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())
@@ -4746,7 +4755,7 @@ braceExpr:
 
   | LBRACE error rbrace
      { // silent recovery
-       arbExpr("braceExpr", rhs2 parseState 1 3)  }
+       arbExpr ("braceExpr", rhs2 parseState 1 3) }
 
   | LBRACE recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())
@@ -4754,12 +4763,12 @@ braceExpr:
        SynExpr.Record(None, None, [], rhs parseState 1) }
 
   | LBRACE rbrace
-     {  let m = rhs2 parseState 1 2
-        SynExpr.Record(None, None, [], m) }
+     { let m = rhs2 parseState 1 2
+       SynExpr.Record(None, None, [], m) }
 
 braceExprBody:
   | recdExpr
-     {  (lhs parseState), (fun m -> let a, b, c = $1 in SynExpr.Record(a, b, c, m)) }
+     { (lhs parseState), (fun m -> let a, b, c = $1 in SynExpr.Record(a, b, c, m)) }
 
   | objExpr
      { $1 }
@@ -4797,11 +4806,11 @@ forLoopBinder:
 
   | parenPattern IN ends_coming_soon_or_recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedExpressionAfterToken())
-       ($1, arbExpr("forLoopBinder", (rhs parseState 2)), false, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
+       ($1, arbExpr ("forLoopBinder", (rhs parseState 2)), false, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
 
   | parenPattern ends_coming_soon_or_recover
      { if not $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInOrEqualExpected())
-       ($1, arbExpr("forLoopBinder2", (rhs parseState 1).EndRange), false, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
+       ($1, arbExpr ("forLoopBinder2", (rhs parseState 1).EndRange), false, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
 
 forLoopRange:
   | parenPattern EQUALS declExpr forLoopDirection declExpr
@@ -4841,7 +4850,7 @@ opt_inlineAssemblyTypeArg:
       { [] }
 
   | typeKeyword LPAREN typ rparen
-      {  [$3] }
+      { [$3] }
 
 optInlineAssemblyReturnTypes:
   | /* EMPTY */
@@ -4851,7 +4860,7 @@ optInlineAssemblyReturnTypes:
      { [$2] }
 
   | COLON LPAREN rparen
-     {  [] }
+     { [] }
 
 recdExpr:
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType recdExprBindings opt_seps_recd
@@ -4861,10 +4870,11 @@ recdExpr:
        let l = rebindRanges (dummyField, None, None) l $6
        let (SynExprRecordField(_, _, _, inheritsSep)) = List.head l
        let bindings = List.tail l
-       (Some ($2, arg, rhs2 parseState 2 4, inheritsSep, rhs parseState 1), None, bindings) }
+       (Some($2, arg, rhs2 parseState 2 4, inheritsSep, rhs parseState 1), None, bindings) }
 
   | recdExprCore
-    { let a, b = $1 in (None, a, b) }
+    { let a, b = $1
+      None, a, b }
 
 recdExprCore:
   | appExpr EQUALS declExprBlock recdExprBindings opt_seps_recd
@@ -4907,17 +4917,17 @@ recdExprCore:
 
 /* handles case like {x with}  */
   | appExpr WITH recdBinding recdExprBindings opt_seps_recd
-     {  let l = List.rev $4
-        let l = rebindRanges $3 l $5
-        (Some ($1, (rhs parseState 2, None)), l) }
+     { let l = List.rev $4
+       let l = rebindRanges $3 l $5
+       (Some($1, (rhs parseState 2, None)), l) }
 
   | appExpr OWITH opt_seps_recd OEND
-     { (Some ($1, (rhs parseState 2, None)), []) }
+     { (Some($1, (rhs parseState 2, None)), []) }
 
   | appExpr OWITH recdBinding recdExprBindings opt_seps_recd OEND
-     {  let l = List.rev $4
-        let l = rebindRanges $3 l $5
-        (Some ($1, (rhs parseState 2, None)), l) }
+     { let l = List.rev $4
+       let l = rebindRanges $3 l $5
+       (Some($1, (rhs parseState 2, None)), l) }
 
 opt_seps_recd:
   | seps_recd
@@ -4931,7 +4941,8 @@ seps_recd:
      { (rhs parseState 1), None }
 
   | SEMICOLON
-     { let m = (rhs parseState 1) in (m, Some m.End) }
+     { let m = (rhs parseState 1)
+       m, Some m.End }
 
   | SEMICOLON OBLOCKSEP
      { (rhs2 parseState 1 2), Some (rhs parseState 1).End }
@@ -5013,10 +5024,10 @@ objExprBaseCall:
      { $2, None }
 
 
-
 opt_objExprBindings:
   | objExprBindings
-     { let mWithKwd, bindings, members = $1 in Some mWithKwd, bindings, members }
+     { let mWithKwd, bindings, members = $1
+       Some mWithKwd, bindings, members }
 
   | /* EMPTY */
      { None, [], [] }
@@ -5073,9 +5084,9 @@ braceBarExprCore:
      { let orig, flds = $2
        let flds =
            flds |> List.choose (function
-             | SynExprRecordField((synLongIdent, _), mEquals, Some e, _) when orig.IsSome -> Some (synLongIdent, mEquals, e) // copy-and-update, long identifier signifies nesting
-             | SynExprRecordField((SynLongIdent([ _id ], _, _) as synLongIdent, _), mEquals, Some e, _) -> Some (synLongIdent, mEquals, e) // record construction, long identifier not valid
-             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> Some (synLongIdent, mEquals, arbExpr("anonField", synLongIdent.Range))
+             | SynExprRecordField((synLongIdent, _), mEquals, Some e, _) when orig.IsSome -> Some(synLongIdent, mEquals, e) // copy-and-update, long identifier signifies nesting
+             | SynExprRecordField((SynLongIdent([ _id ], _, _) as synLongIdent, _), mEquals, Some e, _) -> Some(synLongIdent, mEquals, e) // record construction, long identifier not valid
+             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> Some(synLongIdent, mEquals, arbExpr ("anonField", synLongIdent.Range))
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
        let mLeftBrace = rhs parseState 1
        let mRightBrace = rhs parseState 3
@@ -5089,7 +5100,7 @@ braceBarExprCore:
        let flds =
            flds |> List.map (function
              | SynExprRecordField((synLongIdent, _), mEquals, Some e, _) -> (synLongIdent, mEquals, e)
-             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> (synLongIdent, mEquals, arbExpr("anonField", synLongIdent.Range)))
+             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> (synLongIdent, mEquals, arbExpr ("anonField", synLongIdent.Range)))
        let mLeftBrace = rhs parseState 1
        let mExpr = rhs parseState 2
        (fun (mStruct: range option) ->
@@ -5102,7 +5113,7 @@ braceBarExprCore:
        let mRightBrace = rhs parseState 3
        (fun (mStruct: range option) ->
            let m = match mStruct with | None -> unionRanges mLeftBrace mRightBrace | Some mStruct -> unionRanges mStruct mRightBrace
-           arbExpr("braceBarExpr", m)) }
+           arbExpr ("braceBarExpr", m)) }
 
   | LBRACE_BAR recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())
@@ -5121,13 +5132,13 @@ braceBarExprCore:
 anonLambdaExpr:
   | FUN atomicPatterns RARROW typedSequentialExprBlock
      { let mAll = unionRanges (rhs parseState 1) $4.Range
-       let mArrow = Some (rhs parseState 3)
+       let mArrow = Some(rhs parseState 3)
        mkSynFunMatchLambdas parseState.SynArgNameGenerator false mAll $2 mArrow $4 }
 
   | FUN atomicPatterns RARROW error
      { let mAll = rhs2 parseState 1 3
-       let mArrow = Some (rhs parseState 3)
-       mkSynFunMatchLambdas parseState.SynArgNameGenerator false mAll $2 mArrow (arbExpr("anonLambdaExpr1", (rhs parseState 4))) }
+       let mArrow = Some(rhs parseState 3)
+       mkSynFunMatchLambdas parseState.SynArgNameGenerator false mAll $2 mArrow (arbExpr ("anonLambdaExpr1", (rhs parseState 4))) }
 
   | OFUN atomicPatterns RARROW typedSequentialExprBlockR OEND
       { let mArrow = rhs parseState 3
@@ -5145,21 +5156,21 @@ anonLambdaExpr:
   | OFUN atomicPatterns RARROW ORIGHT_BLOCK_END OEND
      { let mLambda = rhs2 parseState 1 3
        reportParseErrorAt mLambda (FSComp.SR.parsMissingFunctionBody())
-       let mArrow = Some (rhs parseState 3)
-       mkSynFunMatchLambdas parseState.SynArgNameGenerator false mLambda $2 mArrow (arbExpr("anonLambdaExpr2", mLambda.EndRange)) }
+       let mArrow = Some(rhs parseState 3)
+       mkSynFunMatchLambdas parseState.SynArgNameGenerator false mLambda $2 mArrow (arbExpr ("anonLambdaExpr2", mLambda.EndRange)) }
 
   | OFUN atomicPatterns RARROW recover
      { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFunBody())
        let mLambda = rhs2 parseState 1 3
-       let mArrow = Some (rhs parseState 3)
-       exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false mLambda $2 mArrow (arbExpr("anonLambdaExpr3", mLambda.EndRange))) }
+       let mArrow = Some(rhs parseState 3)
+       exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false mLambda $2 mArrow (arbExpr ("anonLambdaExpr3", mLambda.EndRange))) }
 
   | OFUN atomicPatterns error OEND
      { let mLambda = rhs2 parseState 1 2
-       exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false mLambda $2 None (arbExpr("anonLambdaExpr4", mLambda.EndRange))) }
+       exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false mLambda $2 None (arbExpr ("anonLambdaExpr4", mLambda.EndRange))) }
 
   | OFUN error OEND
-     { exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false (rhs parseState 1) [] None (arbExpr("anonLambdaExpr5", (rhs parseState 2)))) }
+     { exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false (rhs parseState 1) [] None (arbExpr ("anonLambdaExpr5", (rhs parseState 2)))) }
 
 anonMatchingExpr:
   | FUNCTION withPatternClauses %prec expr_function
@@ -5199,12 +5210,12 @@ opt_topReturnTypeWithTypeConstraints:
       { let mColon = rhs parseState 1
         let ty, arity = $2
         let arity = (match arity with SynValInfo([], rmdata)-> rmdata | _ -> SynInfo.unnamedRetVal)
-        Some (Some mColon, SynReturnInfo((ty, arity), rhs parseState 2)) }
+        Some(Some mColon, SynReturnInfo((ty, arity), rhs parseState 2)) }
 
   | COLON recover
       { let mColon = rhs parseState 1
         let ty, arity = SynType.FromParseError(mColon.EndRange), SynInfo.unnamedRetVal
-        Some (Some mColon, SynReturnInfo((ty, arity), mColon.EndRange)) }
+        Some(Some mColon, SynReturnInfo((ty, arity), mColon.EndRange)) }
 
 topType:
   | topTupleType RARROW topType
@@ -5220,7 +5231,8 @@ topType:
        SynType.Fun(dty, rty, lhs parseState, { ArrowRange = mArrow }), SynValInfo([dmdata], SynInfo.unnamedRetVal) }
 
   | topTupleType
-     { let ty, rmdata = $1 in ty, (SynValInfo([], (match rmdata with [md] -> md | _ -> SynInfo.unnamedRetVal))) }
+     { let ty, rmdata = $1
+       ty, (SynValInfo([], (match rmdata with [md] -> md | _ -> SynInfo.unnamedRetVal))) }
 
 topTupleType:
   | topAppType STAR topTupleTypeElements
@@ -5245,7 +5257,8 @@ topTupleType:
         mkSynTypeTuple path, List.choose snd $2 }
 
   | topAppType
-     { let ty, mdata = $1 in ty, [mdata] }
+     { let ty, mdata = $1
+       ty, [mdata] }
 
 topTupleTypeElements:
   | topAppType STAR topTupleTypeElements
@@ -5455,17 +5468,17 @@ appTypeConPower:
   | appTypeCon INFIX_AT_HAT_OP atomicRationalConstant
     { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedInfixOperator())
       if $2 = "^-" then SynType.MeasurePower($1, SynRationalConst.Negate($3), lhs parseState)
-      else SynType.MeasurePower($1, $3, lhs parseState)  }
+      else SynType.MeasurePower($1, $3, lhs parseState) }
 
   | appTypeCon
     { $1 }
 
 appType:
   | appType arrayTypeSuffix
-      {  SynType.Array($2, $1, lhs parseState) }
+      { SynType.Array($2, $1, lhs parseState) }
 
   | appType HIGH_PRECEDENCE_BRACK_APP arrayTypeSuffix /* only HPA for "name[]" allowed here */
-      {  SynType.Array($3, $1, lhs parseState) }
+      { SynType.Array($3, $1, lhs parseState) }
 
   | appType appTypeConPower
       /* note: use "rhs parseState 1" to deal with parens in "(int) list" */
@@ -5483,12 +5496,12 @@ appType:
       { $1 }
 
   | typar COLON_GREATER typ
-      {  let tp, typ = $1, $3
-         let m = lhs parseState
-         SynType.WithGlobalConstraints(SynType.Var(tp, rhs parseState 1), [SynTypeConstraint.WhereTyparSubtypeOfType(tp, typ, m)], m)  }
+      { let tp, typ = $1, $3
+        let m = lhs parseState
+        SynType.WithGlobalConstraints(SynType.Var(tp, rhs parseState 1), [SynTypeConstraint.WhereTyparSubtypeOfType(tp, typ, m)], m) }
 
   | UNDERSCORE COLON_GREATER typ %prec COLON_GREATER
-      {  SynType.HashConstraint($3, lhs parseState) }
+      { SynType.HashConstraint($3, lhs parseState) }
 
 arrayTypeSuffix:
   | LBRACK RBRACK
@@ -5589,7 +5602,8 @@ arrayTypeSuffix:
 
 appTypePrefixArguments:
   | typeArgActual COMMA typeArgActual typeArgListElements
-      { let typeArgs, commas = $4 in $1 :: $3 :: List.rev typeArgs, (rhs parseState 2) :: (List.rev commas) }
+      { let typeArgs, commas = $4
+        $1 :: $3 :: List.rev typeArgs, (rhs parseState 2) :: (List.rev commas) }
 
 typeArgListElements:
   | typeArgListElements COMMA typeArgActual
@@ -5636,7 +5650,7 @@ atomTypeOrAnonRecdType:
      { let flds, isStruct = $1
        let flds2 =
            flds |> List.choose (function
-             | (SynField([], false, Some id, ty, false, _xmldoc, None, _m, _trivia)) -> Some (id, ty)
+             | (SynField([], false, Some id, ty, false, _xmldoc, None, _m, _trivia)) -> Some(id, ty)
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
        SynType.AnonRecd(isStruct, flds2, rhs parseState 1) }
 
@@ -5692,8 +5706,8 @@ atomType:
        SynType.StaticConstant(SynConst.String(null, SynStringKind.Regular, m), m) }
 
   | CONST atomicExpr
-     {  let e, _ = $2
-        SynType.StaticConstantExpr(e, lhs parseState) }
+     { let e, _ = $2
+       SynType.StaticConstantExpr(e, lhs parseState) }
 
   | FALSE
       { SynType.StaticConstant(SynConst.Bool false, lhs parseState) }
@@ -5705,7 +5719,8 @@ atomType:
      { (* silent recovery *) SynType.Anon(lhs parseState) }
 
   | appTypeCon typeArgsNoHpaDeprecated %prec prec_atomtyp_path
-     { let mLessThan, mGreaterThan, args, commas, mWhole = $2 in SynType.App($1, Some(mLessThan), args, commas, mGreaterThan, false, unionRanges $1.Range mWhole) }
+     { let mLessThan, mGreaterThan, args, commas, mWhole = $2
+       SynType.App($1, Some(mLessThan), args, commas, mGreaterThan, false, unionRanges $1.Range mWhole) }
 
   | atomType DOT path %prec prec_atomtyp_get_path
      { SynType.LongIdentApp($1, $3, None, [], [], None, unionRanges (rhs parseState 1) $3.Range) }
@@ -5793,7 +5808,7 @@ typeArgActualOrDummyIfEmpty:
        $1 }
 
 dummyTypeArg:
-  |  /* EMPTY */
+  | /* EMPTY */
      { let m = rhs parseState 1
        let dummyStatVal = SynType.StaticConstant(SynConst.Int32(0), m)
        let dummyName = SynType.LongIdent(SynLongIdent([ident("", m)], [], [None]))
@@ -5856,13 +5871,13 @@ measureTypeExpr:
 
 typar:
   | QUOTE ident
-     {  let id = mkSynId (lhs parseState) ($2).idText
-        SynTypar(id, TyparStaticReq.None, false) }
+     { let id = mkSynId (lhs parseState) ($2).idText
+       SynTypar(id, TyparStaticReq.None, false) }
 
   | INFIX_AT_HAT_OP ident
-    {  if $1 <> "^" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.tcUnexpectedSymbolInTypeExpression($1))
-       let id = mkSynId (lhs parseState) ($2).idText
-       SynTypar(id, TyparStaticReq.HeadType, false) }
+    { if $1 <> "^" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.tcUnexpectedSymbolInTypeExpression($1))
+      let id = mkSynId (lhs parseState) ($2).idText
+      SynTypar(id, TyparStaticReq.HeadType, false) }
 
 ident:
   | IDENT
@@ -5871,17 +5886,19 @@ ident:
 /* A A.B.C path used to an identifier */
 path:
   | GLOBAL
-      { SynLongIdent([ident(MangledGlobalName, rhs parseState 1)], [], [Some (IdentTrivia.OriginalNotation "global")]) }
+      { SynLongIdent([ident(MangledGlobalName, rhs parseState 1)], [], [Some(IdentTrivia.OriginalNotation "global")]) }
 
   | ident
      { SynLongIdent([$1], [], [None]) }
 
   | path DOT ident
-     { let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) }
+     { let (SynLongIdent(lid, dotms, trivia)) = $1
+       SynLongIdent(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) }
 
   | path DOT ends_coming_soon_or_recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
-       let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid, dotms @ [rhs parseState 2], trivia)  }
+       let (SynLongIdent(lid, dotms, trivia)) = $1
+       SynLongIdent(lid, dotms @ [rhs parseState 2], trivia) }
 
 
 /* An operator name, with surrounding parentheses */
@@ -5892,10 +5909,10 @@ opName:
        ident(CompileOpName $2, rhs parseState 2), IdentTrivia.OriginalNotationWithParen(lpr, $2, rpr) }
 
   | LPAREN error rparen
-     {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName())
-        let lpr = rhs parseState 1
-        let rpr = rhs parseState 3
-        ident(CompileOpName "****", rhs parseState 2), IdentTrivia.HasParenthesis(lpr, rpr) }
+     { reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName())
+       let lpr = rhs parseState 1
+       let rpr = rhs parseState 3
+       ident(CompileOpName "****", rhs parseState 2), IdentTrivia.HasParenthesis(lpr, rpr) }
 
   | LPAREN_STAR_RPAREN
      { let m = rhs parseState 1
@@ -6084,7 +6101,7 @@ declEnd:
   | ODECLEND
       { }
   | OEND
-      {   }
+      { }
   | END
       { }
 
@@ -6105,10 +6122,12 @@ opt_ODECLEND:
 
 deprecated_opt_equals:
   | EQUALS { deprecatedWithError (FSComp.SR.parsNoEqualShouldFollowNamespace()) (lhs parseState); () }
-  | /* EMPTY */ {  }
+  | /* EMPTY */ { }
 
 opt_equals:
-  | EQUALS { let mEquals = rhs parseState 1 in (Some mEquals) }
+  | EQUALS
+      { let mEquals = rhs parseState 1
+        Some mEquals }
   | /* EMPTY */ { None }
 
 opt_OBLOCKSEP:
@@ -6128,7 +6147,7 @@ opt_bar:
   | /* EMPTY */ { }
 
 opt_inline:
-  | INLINE { Some (rhs parseState 1) }
+  | INLINE { Some(rhs parseState 1) }
   | /* EMPTY */ { None }
 
 opt_mutable:
@@ -6170,7 +6189,9 @@ colonOrEquals:
           mlCompatWarning (FSComp.SR.parsSyntaxModuleSigEndDeprecated()) (lhs parseState)
       None
     }
-  | EQUALS { let mEquals = rhs parseState 1 in Some mEquals }
+  | EQUALS
+      { let mEquals = rhs parseState 1
+        Some mEquals }
 
 /* A literal string or a string from a keyword like __SOURCE_FILE__ */
 string:
@@ -6196,8 +6217,7 @@ interpolatedStringParts:
         { SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
 
   | INTERP_STRING_PART interpolatedStringParts
-     {
-       let rbrace = parseState.InputEndPosition 1
+     { let rbrace = parseState.InputEndPosition 1
        let lbrace = parseState.InputStartPosition 2
        reportParseErrorAt (mkSynRange rbrace lbrace) (FSComp.SR.parsEmptyFillInInterpolatedString())
        SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: $2 }
@@ -6215,8 +6235,7 @@ interpolatedString:
       [ SynInterpolatedStringPart.String(s, rhs parseState 1) ], synStringKind }
 
   | INTERP_STRING_BEGIN_PART interpolatedStringParts
-    {
-      let s, synStringKind, _ = $1
+    { let s, synStringKind, _ = $1
       let rbrace = parseState.InputEndPosition 1
       let lbrace = parseState.InputStartPosition 2
       reportParseErrorAt (mkSynRange rbrace lbrace) (FSComp.SR.parsEmptyFillInInterpolatedString())

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -27,38 +27,38 @@ open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
 open FSharp.Compiler.Xml
 
-// This function is called by the generated parser code. Returning initiates error recovery 
+// This function is called by the generated parser code. Returning initiates error recovery
 // It must be called precisely "parse_error_rich"
-let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) -> 
+let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
     errorR(SyntaxError(box ctxt, ctxt.ParseState.LexBuffer.LexemeRange)))
 
-%} 
+%}
 
 // Producing these changes the lex state, e.g. string --> token, or nesting level of braces in interpolated strings
 %token <byte[] * SynByteStringKind * ParseHelpers.LexerContinuation> BYTEARRAY
-%token <string * SynStringKind * ParseHelpers.LexerContinuation> STRING 
+%token <string * SynStringKind * ParseHelpers.LexerContinuation> STRING
 %token <string * SynStringKind * ParseHelpers.LexerContinuation> INTERP_STRING_BEGIN_END
-%token <string * SynStringKind * ParseHelpers.LexerContinuation> INTERP_STRING_BEGIN_PART 
-%token <string * ParseHelpers.LexerContinuation> INTERP_STRING_PART 
-%token <string * ParseHelpers.LexerContinuation> INTERP_STRING_END 
+%token <string * SynStringKind * ParseHelpers.LexerContinuation> INTERP_STRING_BEGIN_PART
+%token <string * ParseHelpers.LexerContinuation> INTERP_STRING_PART
+%token <string * ParseHelpers.LexerContinuation> INTERP_STRING_END
 %token <ParseHelpers.LexerContinuation> LBRACE RBRACE
 
 %token <string * string> KEYWORD_STRING // Like __SOURCE_DIRECTORY__
-%token <string> IDENT 
-%token <string> HASH_IDENT 
-%token <string> INFIX_STAR_STAR_OP 
-%token <string> INFIX_COMPARE_OP 
-%token <string> INFIX_AT_HAT_OP 
-%token <string> INFIX_BAR_OP 
+%token <string> IDENT
+%token <string> HASH_IDENT
+%token <string> INFIX_STAR_STAR_OP
+%token <string> INFIX_COMPARE_OP
+%token <string> INFIX_AT_HAT_OP
+%token <string> INFIX_BAR_OP
 %token <string> PREFIX_OP
-%token <string> INFIX_STAR_DIV_MOD_OP 
-%token <string> INFIX_AMP_OP 
-%token <string> PLUS_MINUS_OP 
-%token <string> ADJACENT_PREFIX_OP 
+%token <string> INFIX_STAR_DIV_MOD_OP
+%token <string> INFIX_AMP_OP
+%token <string> PLUS_MINUS_OP
+%token <string> ADJACENT_PREFIX_OP
 %token <string> FUNKY_OPERATOR_NAME
 
-/* bool indicates if INT8 was 'bad' max_int+1, e.g. '128'  */
-%token <sbyte * bool> INT8 
+/* bool indicates if INT8 was 'bad' max_int+1, e.g. '128' */
+%token <sbyte * bool> INT8
 %token <int16 * bool> INT16
 %token <int32 * bool> INT32 INT32_DOT_DOT
 %token <int64 * bool> INT64
@@ -72,24 +72,24 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 %token <single> IEEE32
 %token <double> IEEE64
 %token <char> CHAR
-%token <System.Decimal> DECIMAL 
+%token <System.Decimal> DECIMAL
 %token <(string * string)> BIGNUM
 %token <bool> LET YIELD YIELD_BANG AND_BANG
 %token <bool> LESS GREATER /* here the bool indicates if the tokens are part of a type application or type parameter declaration, e.g. C<int>, detected by the lex filter */
-%token <string> PERCENT_OP BINDER 
-%token <string * bool> LQUOTE RQUOTE  RQUOTE_DOT 
+%token <string> PERCENT_OP BINDER
+%token <string * bool> LQUOTE RQUOTE RQUOTE_DOT
 %token BAR_BAR UPCAST DOWNCAST NULL RESERVED MODULE NAMESPACE DELEGATE CONSTRAINT BASE
 %token AND AS ASSERT OASSERT ASR BEGIN DO DONE DOWNTO ELSE ELIF END DOT_DOT DOT_DOT_HAT
-%token EXCEPTION FALSE FOR FUN FUNCTION IF IN JOIN_IN FINALLY DO_BANG 
-%token LAZY OLAZY  MATCH MATCH_BANG  MUTABLE NEW OF 
+%token EXCEPTION FALSE FOR FUN FUNCTION IF IN JOIN_IN FINALLY DO_BANG
+%token LAZY OLAZY MATCH MATCH_BANG MUTABLE NEW OF
 %token OPEN OR REC THEN TO TRUE TRY TYPE VAL INLINE INTERFACE INSTANCE CONST
 %token WHEN WHILE WITH HASH AMP AMP_AMP QUOTE LPAREN RPAREN RPAREN_COMING_SOON RPAREN_IS_HERE STAR COMMA RARROW GREATER_BAR_RBRACK LPAREN_STAR_RPAREN
-%token QMARK QMARK_QMARK DOT COLON COLON_COLON COLON_GREATER  COLON_QMARK_GREATER COLON_QMARK COLON_EQUALS SEMICOLON 
-%token SEMICOLON_SEMICOLON LARROW EQUALS  LBRACK  LBRACK_BAR  LBRACE_BAR  LBRACK_LESS 
+%token QMARK QMARK_QMARK DOT COLON COLON_COLON COLON_GREATER COLON_QMARK_GREATER COLON_QMARK COLON_EQUALS SEMICOLON
+%token SEMICOLON_SEMICOLON LARROW EQUALS LBRACK LBRACK_BAR LBRACE_BAR LBRACK_LESS
 %token BAR_RBRACK BAR_RBRACE UNDERSCORE
 %token BAR RBRACK RBRACE_COMING_SOON RBRACE_IS_HERE MINUS DOLLAR
-%token GREATER_RBRACK STRUCT SIG 
-%token STATIC MEMBER CLASS ABSTRACT OVERRIDE DEFAULT CONSTRUCTOR INHERIT 
+%token GREATER_RBRACK STRUCT SIG
+%token STATIC MEMBER CLASS ABSTRACT OVERRIDE DEFAULT CONSTRUCTOR INHERIT
 %token EXTERN VOID PUBLIC PRIVATE INTERNAL GLOBAL
 
 /* for parser 'escape hatch' out of expression context without consuming the 'recover' token */
@@ -108,8 +108,8 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 %token ODO_BANG         /* LexFilter #light converts 'DO_BANG' tokens to 'ODO_BANG' */
 %token OTHEN            /* LexFilter #light converts 'THEN' tokens to 'OTHEN' */
 %token OELSE            /* LexFilter #light converts 'ELSE' tokens to 'OELSE' except if immeditely followed by 'if', when they become 'ELIF' */
-%token OWITH            /* LexFilter #light converts SOME (but not all) 'WITH' tokens to 'OWITH' */ 
-%token OFUNCTION        /* LexFilter #light converts 'FUNCTION' tokens to 'OFUNCTION' */ 
+%token OWITH            /* LexFilter #light converts SOME (but not all) 'WITH' tokens to 'OWITH' */
+%token OFUNCTION        /* LexFilter #light converts 'FUNCTION' tokens to 'OFUNCTION' */
 %token OFUN             /* LexFilter #light converts 'FUN' tokens to 'OFUN' */
 
 
@@ -118,21 +118,21 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 %token OBLOCKBEGIN      /* LexFilter #light inserts for:
                                   - just after first '=' or ':' when in 'CtxtModuleHead', i.e. after 'module' and sequence of dot/identifier/access tokens
                                   - just after first '=' when in 'CtxtMemberHead'
-                                  - just after first '=' when in 'CtxtType' 
+                                  - just after first '=' when in 'CtxtType'
                                   - just after 'do' in any context (when opening CtxtDo)
-                                  - just after 'finally' in any context 
+                                  - just after 'finally' in any context
                                   - just after 'with' (when opening CtxtWithAsAugment)
                                   - just after 'else' (when opening CtxtElse)
                                   - just after 'then' (when opening CtxtThen)
                                   - just after 'interface' (when pushing CtxtParen(INTERFACE), i.e. next token is DEFAULT | OVERRIDE | INTERFACE | NEW | TYPE | STATIC | END | MEMBER | ABSTRACT  | INHERIT | LBRACK_LESS)
                                   - just after 'class' (when pushing CtxtParen(CLASS)
-                                  - just after 'class' 
+                                  - just after 'class'
                            But not when opening these CtxtSeqBlocks:
-                                  - just after first non-dot/identifier token past 'namespace' 
-                                  - just after first '=' when in 'CtxtLetDecl' or 'CtxtWithAsLet' 
+                                  - just after first non-dot/identifier token past 'namespace'
+                                  - just after first '=' when in 'CtxtLetDecl' or 'CtxtWithAsLet'
                                   - just after 'lazy' in any context
-                                  - just after '->' in any context                                  
-                                  - when opening CtxtNamespaceHead, CtxtModuleHead 
+                                  - just after '->' in any context
+                                  - when opening CtxtNamespaceHead, CtxtModuleHead
                         */
 %token OBLOCKSEP        /* LexFilter #light inserts when transforming CtxtSeqBlock(NotFirstInSeqBlock, _, AddBlockEnd) to CtxtSeqBlock(FirstInSeqBlock, _, AddBlockEnd) on exact alignment */
 
@@ -149,7 +149,7 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 /* These are artificial */
 %token <string> LEX_FAILURE
 %token <ParseHelpers.LexerContinuation> COMMENT WHITESPACE HASH_LINE HASH_LIGHT INACTIVECODE LINE_COMMENT STRING_TEXT EOF
-%token <range * string * ParseHelpers.LexerContinuation> HASH_IF HASH_ELSE HASH_ENDIF 
+%token <range * string * ParseHelpers.LexerContinuation> HASH_IF HASH_ELSE HASH_ENDIF
 
 %start signatureFile implementationFile interaction typedSequentialExprEOF typEOF
 %type <SynExpr> typedSequentialExprEOF
@@ -179,14 +179,14 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 %type <SynModuleDecl list> moduleDefnsOrExprPossiblyEmptyOrBlock
 %type <SynLongIdent> path
 %type <SynLongIdent> pathOp
-/*     LESS    GREATER        parsedOk   typeArgs           m for each   mWhole  */
+/* LESS GREATER parsedOk typeArgs m for each mWhole */
 %type <range * range option * bool     * SynType list * range list * range> typeArgsActual
-/*     LESS    GREATER        typeArgs           m for each   mWhole  */
+/* LESS GREATER typeArgs m for each mWhole */
 %type <range * range option * SynType list * range list * range> typeArgsNoHpaDeprecated
 %type <SynTypar> typar
 
-/* About precedence rules: 
- * 
+/* About precedence rules:
+ *
  * Tokens and dummy-terminals are given precedence below (lowest first).
  * A rule has precedence of the first token or the dummy terminal given after %prec.
  * The precedence resolve shift/reduce conflicts:
@@ -234,8 +234,8 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 
 /* start with lowest */
 
-%nonassoc prec_args_error             /* less than RPAREN */
-%nonassoc prec_atomexpr_lparen_error  /* less than RPAREN */
+%nonassoc prec_args_error            /* less than RPAREN */
+%nonassoc prec_atomexpr_lparen_error /* less than RPAREN */
 
 %right AS
 
@@ -248,15 +248,15 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 /* prec_pat_pat_action = "pattern when expr -> expr"
  * Lower than match extensions - i.e. BAR.
  */
-%nonassoc prec_pat_pat_action          /* lower than BAR */
+%nonassoc prec_pat_pat_action /* lower than BAR */
 
 /* "a then b" as an object constructor is very low precedence */
 /* Lower than "if a then b" */
 %left prec_then_before
-%nonassoc prec_then_if 
-%left  BAR
+%nonassoc prec_then_if
+%left BAR
 
-%right SEMICOLON  prec_semiexpr_sep OBLOCKSEP
+%right SEMICOLON prec_semiexpr_sep OBLOCKSEP
 %right prec_defn_sep
 
 /* prec_atompat_pathop = precedence of at atomic pattern, e.g "Constructor".
@@ -266,12 +266,12 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
  *  - null
  *  - LBRACK = [
  *  - TRUE, FALSE
- 
+
  */
 %nonassoc prec_atompat_pathop
 %nonassoc INT8 UINT8 INT16 UINT16 INT32 UINT32 INT64 UINT64 NATIVEINT UNATIVEINT IEEE32 IEEE64 CHAR KEYWORD_STRING STRING BYTEARRAY BIGNUM DECIMAL
 %nonassoc INTERP_STRING_BEGIN INTERP_STRING_PART INTERP_STRING_END
-%nonassoc LPAREN LBRACE LBRACK_BAR 
+%nonassoc LPAREN LBRACE LBRACK_BAR
 %nonassoc TRUE FALSE UNDERSCORE NULL
 
 
@@ -280,15 +280,15 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
  * prec_tuptyptail_prefix lower than "T * T * T * T" extensions.
  * Lower than possible extensions:
  *  - STAR, IDENT, RARROW
- *  - LBRACK = [ - for "base[]" types              
+ *  - LBRACK = [ - for "base[]" types
  * Shifts not reduces.
  */
 %nonassoc prec_typ_prefix             /* lower than STAR, IDENT, RARROW etc */
 %nonassoc prec_tuptyp_prefix          /* ditto */
 %nonassoc prec_tuptyptail_prefix      /* ditto */
 %nonassoc prec_toptuptyptail_prefix      /* ditto */
-        
-%right    RARROW
+
+%right RARROW
 %nonassoc IDENT LBRACK
 
 /* prec_opt_attributes_none = precedence of no attributes
@@ -296,7 +296,7 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
  * Committing to an opt_attribute (reduce) forces the decision that a following LET is a moduleDefn.
  * At the top-level, it could turn out to be an expr, so prefer to shift and find out...
  */
-%nonassoc prec_opt_attributes_none    /* lower than LET, NEW */
+%nonassoc prec_opt_attributes_none  /* lower than LET, NEW */
 
 /* LET, NEW higher than SEMICOLON so shift
  *   "seqExpr = seqExpr; . let x = y in z"
@@ -304,7 +304,7 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
  */
 %nonassoc LET NEW
 
-       
+
 /* Redundant dummies: expr_let, expr_function, expr_fun, expr_match */
 /* Resolves conflict: expr_try, expr_if */
 %nonassoc expr_let
@@ -312,27 +312,27 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 %nonassoc expr_function expr_fun expr_match expr_try expr_do
 %nonassoc decl_match decl_do
 %nonassoc expr_if                     /* lower than ELSE to disambiguate "if _ then if _ then _ else _" */
-%nonassoc ELSE   
+%nonassoc ELSE
 
 /* prec_atomtyp_path = precedence of atomType "path"
  * Lower than possible extension "path<T1, T2>" to allow "path . <" shift.
  * Extensions: LESS
  */
-%nonassoc prec_atomtyp_path           /* lower than LESS */
-%nonassoc prec_atomtyp_get_path       /* lower than LESS */
+%nonassoc prec_atomtyp_path     /* lower than LESS */
+%nonassoc prec_atomtyp_get_path /* lower than LESS */
 
 /* prec_no_more_attr_bindings = precedence of "moreLocalBindings = ."
  * Lower precedence than AND so further bindings are shifted.
  */
-%nonassoc prec_no_more_attr_bindings  /* lower than AND */
+%nonassoc prec_no_more_attr_bindings /* lower than AND */
 %nonassoc OPEN
 
 /* prec_interfaces_prefix - lower than extensions, i.e. INTERFACE */
 %nonassoc prec_interfaces_prefix      /* lower than INTERFACE */
 %nonassoc INTERFACE
 
-%right LARROW 
-%right COLON_EQUALS 
+%right LARROW
+%right COLON_EQUALS
 %nonassoc pat_tuple expr_tuple
 %left COMMA
 %nonassoc open_range_expr
@@ -343,19 +343,19 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 %left OR BAR_BAR JOIN_IN
 %left AND
 %left AND_BANG
-%left  AMP AMP_AMP 
+%left AMP AMP_AMP
 %nonassoc pat_conj
 %nonassoc expr_not
-%left COLON_GREATER  COLON_QMARK_GREATER
-%left INFIX_COMPARE_OP DOLLAR LESS GREATER EQUALS  INFIX_BAR_OP INFIX_AMP_OP 
+%left COLON_GREATER COLON_QMARK_GREATER
+%left INFIX_COMPARE_OP DOLLAR LESS GREATER EQUALS INFIX_BAR_OP INFIX_AMP_OP
 %right INFIX_AT_HAT_OP
 %right COLON_COLON
-%nonassoc pat_isinst 
+%nonassoc pat_isinst
 %left COLON_QMARK
 %left PLUS_MINUS_OP MINUS expr_prefix_plus_minus ADJACENT_PREFIX_OP
-%left  INFIX_STAR_DIV_MOD_OP STAR PERCENT_OP
+%left INFIX_STAR_DIV_MOD_OP STAR PERCENT_OP
 %right INFIX_STAR_STAR_OP
-%left  QMARK_QMARK
+%left QMARK_QMARK
 %left head_expr_adjacent_minus
 %left expr_app expr_assert expr_lazy LAZY ASSERT
 %left arg_expr_adjacent_minus
@@ -383,19 +383,19 @@ let parse_error_rich = Some (fun (ctxt: ParseErrorContext<_>) ->
 /* An interaction in F# Interactive */
 interaction:
   | interactiveItemsTerminator
-     { ParsedScriptInteraction.Definitions ($1, lhs parseState) }
+     { ParsedScriptInteraction.Definitions($1, lhs parseState) }
 
-  | SEMICOLON 
+  | SEMICOLON
      { warning(Error(FSComp.SR.parsUnexpectedSemicolon(), rhs parseState 1))
-       ParsedScriptInteraction.Definitions ([], lhs parseState) }
+       ParsedScriptInteraction.Definitions([], lhs parseState) }
 
   | OBLOCKSEP
-     { ParsedScriptInteraction.Definitions ([], lhs parseState) }
+     { ParsedScriptInteraction.Definitions([], lhs parseState) }
 
 
-interactiveTerminator: 
+interactiveTerminator:
   | SEMICOLON_SEMICOLON {}
-  | EOF     { checkEndOfFileError $1 }
+  | EOF { checkEndOfFileError $1 }
 
 
 /* An group of items considered to be one interaction, plus a terminator */
@@ -404,29 +404,29 @@ interactiveTerminator:
 /* text. More or less identical to 'moduleDefns' but where SEMICOLON_SEMICOLON is */
 /* not part of the grammar of topSeps and HASH interactions are not part of */
 /* the swalloed blob, since things like #use must be processed separately. */
-/* REVIEW: limiting the input chunks until the next # directive can lead to */ 
+/* REVIEW: limiting the input chunks until the next # directive can lead to */
 /* discrepencies between whole-file type checking in FSI and FSC. */
 
 interactiveItemsTerminator:
-  | interactiveTerminator  
+  | interactiveTerminator
      { [] }
 
-  | interactiveDefns interactiveTerminator 
+  | interactiveDefns interactiveTerminator
      { $1 }
 
-  | interactiveExpr  interactiveTerminator 
+  | interactiveExpr interactiveTerminator
      { $1 }
 
-  | interactiveHash  interactiveTerminator 
+  | interactiveHash interactiveTerminator
      { $1 }
 
-  | interactiveDefns interactiveSeparators interactiveItemsTerminator 
+  | interactiveDefns interactiveSeparators interactiveItemsTerminator
      { $1 @ $3 }
 
-  | interactiveExpr  interactiveSeparators interactiveItemsTerminator 
+  | interactiveExpr interactiveSeparators interactiveItemsTerminator
      { $1 @ $3 }
 
-  | interactiveHash  interactiveSeparators interactiveItemsTerminator 
+  | interactiveHash interactiveSeparators interactiveItemsTerminator
      { $1 @ $3 }
 
 
@@ -445,24 +445,24 @@ interactiveExpr:
       { match $2 with
         | Some vis -> errorR(Error(FSComp.SR.parsUnexpectedVisibilityDeclaration(vis.ToString()), rhs parseState 3))
         | _ -> ()
-        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes ($1, rangeOfNonNilAttrs $1) ] else []
+        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes($1, rangeOfNonNilAttrs $1) ] else []
         attrDecls @ [ mkSynExprDecl $3 ] }
 
 /* A #directive interaction in F# Interactive */
-interactiveHash:      
-  | hashDirective 
+interactiveHash:
+  | hashDirective
       { [SynModuleDecl.HashDirective($1, rhs parseState 1)] }
 
 /* One or more separators between interactions in F# Interactive */
-interactiveSeparators: 
-  | interactiveSeparator { } 
+interactiveSeparators:
+  | interactiveSeparator { }
 
   | interactiveSeparator interactiveSeparators { }
 
 /* One separator between interactions in F# Interactive */
-interactiveSeparator: 
-  | SEMICOLON { } 
-  | OBLOCKSEP { }  
+interactiveSeparator:
+  | SEMICOLON { }
+  | OBLOCKSEP { }
 
 /*--------------------------------------------------------------------------*/
 /* #directives - used by both F# Interactive directives and #nowarn etc.    */
@@ -470,52 +470,52 @@ interactiveSeparator:
 
 /* A #directive in a module, namespace or an interaction */
 hashDirective:
-  | HASH IDENT hashDirectiveArgs                            
+  | HASH IDENT hashDirectiveArgs
      { let m = match $3 with [] -> rhs2  parseState 1 2 | _ -> rhs2  parseState 1 3
-       ParsedHashDirective ($2, $3, m) }
+       ParsedHashDirective($2, $3, m) }
 
 
 /* The arguments to a #directive */
-hashDirectiveArgs: 
+hashDirectiveArgs:
   | /* EMPTY */
-     { [] } 
+     { [] }
 
-  | hashDirectiveArgs hashDirectiveArg 
+  | hashDirectiveArgs hashDirectiveArg
      { $1 @ [$2] }
 
 
 /* One argument to a #directive */
 hashDirectiveArg:
-  | string 
+  | string
       { let s, kind = $1
-        ParsedHashDirectiveArgument.String (s, kind, lhs parseState) }
-  | sourceIdentifier 
+        ParsedHashDirectiveArgument.String(s, kind, lhs parseState) }
+  | sourceIdentifier
       { let c,v = $1
-        ParsedHashDirectiveArgument.SourceIdentifier (c, v, lhs parseState) }
+        ParsedHashDirectiveArgument.SourceIdentifier(c, v, lhs parseState) }
 
 
 /*--------------------------------------------------------------------------*/
 /* F# Language Proper - signature files */
 
 /* The contents of a signature file */
-signatureFile: 
-  | fileNamespaceSpecs EOF 
+signatureFile:
+  | fileNamespaceSpecs EOF
      { checkEndOfFileError $2; $1 }
 
-  | fileNamespaceSpecs error EOF 
+  | fileNamespaceSpecs error EOF
      { $1 }
 
   /* If this rule fires it is kind of catastrophic: error recovery yields no results! */
   /* This will result in NO intellisense for the file! Ideally we wouldn't need this rule */
   /* Note: the compiler assumes there is at least one "fragment", so an empty one is used (see 4488) */
-  | error EOF 
-     { let emptySigFileFrag = ParsedSigFileFragment.AnonModule([], rhs parseState 1) in 
-       ParsedSigFile ([], [emptySigFileFrag]) }     
+  | error EOF
+     { let emptySigFileFrag = ParsedSigFileFragment.AnonModule([], rhs parseState 1) in
+       ParsedSigFile([], [emptySigFileFrag]) }
 
 
 
 /* The start of a module declaration */
-moduleIntro: 
+moduleIntro:
   | moduleKeyword opt_attributes opt_access opt_rec path
       { if not (isNil $2) then
             parseState.LexBuffer.CheckLanguageFeatureAndRecover LanguageFeature.AttributesToRightOfModuleKeyword (rhs parseState 4)
@@ -524,49 +524,49 @@ moduleIntro:
 
 
 /* The start of a namespace declaration */
-namespaceIntro: 
-  | NAMESPACE opt_rec path 
+namespaceIntro:
+  | NAMESPACE opt_rec path
       { let mNamespace = rhs parseState 1
         mNamespace, $2, $3.LongIdent, grabXmlDoc(parseState, [], 1)  }
 
 
 /* The contents of a signature file */
-fileNamespaceSpecs: 
-  | fileModuleSpec  
-      { ParsedSigFile ([], [ ($1 (None, false, [], PreXmlDoc.Empty)) ]) }
+fileNamespaceSpecs:
+  | fileModuleSpec
+      { ParsedSigFile([], [ ($1 (None, false, [], PreXmlDoc.Empty)) ]) }
 
-  | fileModuleSpec  fileNamespaceSpecList 
-      { // If there are namespaces, the first fileModuleImpl may only contain # directives 
-        let decls = 
-            match ($1 (None, false, [], PreXmlDoc.Empty)) with 
-            | ParsedSigFileFragment.AnonModule(decls, m) -> decls  
-            | ParsedSigFileFragment.NamespaceFragment(decls = decls) -> decls 
+  | fileModuleSpec fileNamespaceSpecList
+      { // If there are namespaces, the first fileModuleImpl may only contain # directives
+        let decls =
+            match ($1 (None, false, [], PreXmlDoc.Empty)) with
+            | ParsedSigFileFragment.AnonModule(decls, m) -> decls
+            | ParsedSigFileFragment.NamespaceFragment(decls = decls) -> decls
             | ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(range = m)) ->
                 raiseParseErrorAt m (FSComp.SR.parsOnlyHashDirectivesAllowed())
-        let decls = 
-            decls |> List.collect (function 
-                | (SynModuleSigDecl.HashDirective (hd, _)) -> [hd]
-                | d ->  
+        let decls =
+            decls |> List.collect (function
+                | (SynModuleSigDecl.HashDirective(hd, _)) -> [hd]
+                | d ->
                      reportParseErrorAt d.Range (FSComp.SR.parsOnlyHashDirectivesAllowed())
                      [])
-        ParsedSigFile (decls, $2) } 
+        ParsedSigFile(decls, $2) }
 
 
-fileNamespaceSpecList: 
-  | fileNamespaceSpec fileNamespaceSpecList 
+fileNamespaceSpecList:
+  | fileNamespaceSpec fileNamespaceSpecList
      { $1 :: $2 }
 
-  | fileNamespaceSpec 
+  | fileNamespaceSpec
      { [$1] }
 
-fileNamespaceSpec: 
-  | namespaceIntro deprecated_opt_equals fileModuleSpec 
+fileNamespaceSpec:
+  | namespaceIntro deprecated_opt_equals fileModuleSpec
      { let mNamespace, isRec, path, xml = $1 in ($3 (Some mNamespace, isRec, path, xml)) }
 
 
 /* The single module declaration that can make up a signature file */
-fileModuleSpec: 
-  | opt_attributes opt_access moduleIntro moduleSpfnsPossiblyEmptyBlock 
+fileModuleSpec:
+  | opt_attributes opt_access moduleIntro moduleSpfnsPossiblyEmptyBlock
     { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
       let m2 = rhs parseState 3
       let mDeclsAndAttrs = (List.map (fun (a: SynAttributeList) -> a.Range) $1) @ (List.map (fun (d: SynModuleSigDecl) -> d.Range) $4)
@@ -579,40 +579,40 @@ fileModuleSpec:
         let trivia: SynModuleOrNamespaceSigTrivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }
         ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(lid, (isRec || isRec2), SynModuleOrNamespaceKind.NamedModule, $4, xmlDoc, $1 @ attribs2, vis, m, trivia)))  }
 
-  | moduleSpfnsPossiblyEmptyBlock 
-    { let m = (rhs parseState 1) 
-      (fun (mNamespaceOpt, isRec, path, xml) -> 
+  | moduleSpfnsPossiblyEmptyBlock
+    { let m = (rhs parseState 1)
+      (fun (mNamespaceOpt, isRec, path, xml) ->
         match path with
-        | [] -> ParsedSigFileFragment.AnonModule($1, m)  
+        | [] -> ParsedSigFileFragment.AnonModule($1, m)
         | _ ->
             let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
             let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
             xml.MarkAsInvalid()
-            let trivia: SynModuleOrNamespaceSigTrivia = 
+            let trivia: SynModuleOrNamespaceSigTrivia =
                 match mNamespaceOpt with
                 | None -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None }
                 | Some mNamespace -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }
-            ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia))  } 
+            ParsedSigFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia))  }
 
 
-moduleSpfnsPossiblyEmptyBlock: 
+moduleSpfnsPossiblyEmptyBlock:
   | moduleSpfnsPossiblyEmpty
       { $1 }
 
-  | OBLOCKBEGIN moduleSpfnsPossiblyEmpty oblockend  opt_OBLOCKSEP
+  | OBLOCKBEGIN moduleSpfnsPossiblyEmpty oblockend opt_OBLOCKSEP
       { $2 }
 
-  | OBLOCKBEGIN moduleSpfnsPossiblyEmpty recover 
+  | OBLOCKBEGIN moduleSpfnsPossiblyEmpty recover
        { // The lex filter ensures we can only get a mismatch in OBLOCKBEGIN/OBLOCKEND tokens if there was some other kind of error, hence we don't need to report this error
-         // reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnClosedBlockInHashLight())   
-         $2 
+         // reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnClosedBlockInHashLight())
+         $2
        }
 
-  | OBLOCKBEGIN error oblockend                
+  | OBLOCKBEGIN error oblockend
        { [] }
-      
 
-moduleSpfnsPossiblyEmpty: 
+
+moduleSpfnsPossiblyEmpty:
   | moduleSpfns
       { $1 }
 
@@ -621,27 +621,27 @@ moduleSpfnsPossiblyEmpty:
 
   | /* EMPTY */
       { [] }
-      
 
-moduleSpfns: 
-  | moduleSpfn  opt_topSeparators moduleSpfns 
-     { $1 :: $3 } 
 
-  | error topSeparators moduleSpfns 
+moduleSpfns:
+  | moduleSpfn opt_topSeparators moduleSpfns
+     { $1 :: $3 }
+
+  | error topSeparators moduleSpfns
      { (* silent recovery *) $3 }
 
-  | moduleSpfn  opt_topSeparators 
-     { [$1] } 
+  | moduleSpfn opt_topSeparators
+     { [$1] }
 
 
-moduleSpfn: 
-  | hashDirective 
-      { SynModuleSigDecl.HashDirective ($1, rhs2 parseState 1 1)  } 
+moduleSpfn:
+  | hashDirective
+      { SynModuleSigDecl.HashDirective($1, rhs2 parseState 1 1)  }
 
-  | valSpfn 
+  | valSpfn
       { $1 }
 
-  | opt_attributes opt_access moduleIntro colonOrEquals namedModuleAbbrevBlock 
+  | opt_attributes opt_access moduleIntro colonOrEquals namedModuleAbbrevBlock
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let mModule, isRec, path, vis, attribs2 = $3
         if isRec then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsInvalidUseOfRec())
@@ -653,7 +653,7 @@ moduleSpfn:
         | _ ->
             let lid: SynLongIdent = $5
             let m = unionRanges mModule lid.Range
-            SynModuleSigDecl.ModuleAbbrev(List.head path, lid.LongIdent, m) } 
+            SynModuleSigDecl.ModuleAbbrev(List.head path, lid.LongIdent, m) }
 
   | opt_attributes opt_access moduleIntro colonOrEquals moduleSpecBlock
       { let mModule, isRec, path, vis, attribs2 = $3
@@ -681,7 +681,7 @@ moduleSpfn:
 
   | opt_attributes opt_access typeKeyword tyconSpfn tyconSpfnList
       { if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
-        let leadingKeyword = SynTypeDefnLeadingKeyword.Type (rhs parseState 3)
+        let leadingKeyword = SynTypeDefnLeadingKeyword.Type(rhs parseState 3)
         let (SynTypeDefnSig (SynComponentInfo (cas, a, cs, b, _xmlDoc, d, d2, d3), typeRepr, members, range, trivia)) = $4 leadingKeyword
         _xmlDoc.MarkAsInvalid()
         let attrs = $1 @ cas
@@ -692,7 +692,7 @@ moduleSpfn:
             |> unionRangeWithXmlDoc xmlDoc
         let tc = (SynTypeDefnSig(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), typeRepr, members, mDefn, trivia))
         let m = (mDefn, $5) ||> unionRangeWithListBy (fun (a: SynTypeDefnSig) -> a.Range) |> unionRanges (rhs parseState 3)
-        SynModuleSigDecl.Types (tc :: $5, m) }
+        SynModuleSigDecl.Types(tc :: $5, m) }
 
   | opt_attributes opt_access exconSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
@@ -706,13 +706,13 @@ moduleSpfn:
   | openDecl
       { SynModuleSigDecl.Open($1, (rhs parseState 1)) }
 
-valSpfn: 
+valSpfn:
   | opt_attributes opt_access VAL opt_attributes opt_inline opt_mutable opt_access nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), (mEquals, konst: SynExpr option) = ($1), ($4), (Option.isSome $5), ($6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
         if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
-        let m = 
-            rhs2 parseState 1 11 
+        let m =
+            rhs2 parseState 1 11
             |> unionRangeWithXmlDoc doc
             |> fun m ->
                 match konst with
@@ -720,41 +720,41 @@ valSpfn:
                 | Some e -> unionRanges m e.Range
         let mVal = rhs parseState 3
         let trivia: SynValSigTrivia = { LeadingKeyword = SynLeadingKeyword.Val mVal; InlineKeyword = $5; WithKeyword = None; EqualsRange = mEquals }
-        let valSpfn = SynValSig((attr1@attr2), id, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, m, trivia) 
+        let valSpfn = SynValSig((attr1@attr2), id, explicitValTyparDecls, ty, arity, isInline, isMutable, doc, vis2, konst, m, trivia)
         SynModuleSigDecl.Val(valSpfn, m)
       }
 
 /* The optional literal value on a literal specification in a signature */
-optLiteralValueSpfn: 
+optLiteralValueSpfn:
   | /* EMPTY */
       { None, None }
 
-  | EQUALS declExpr 
+  | EQUALS declExpr
       { let mEquals = rhs parseState 1
         Some(mEquals), Some($2) }
 
   | EQUALS OBLOCKBEGIN declExpr oblockend opt_ODECLEND
       { let mEquals = rhs parseState 1
         Some(mEquals), Some($3) }
-  
+
 
 /* A block of definitions in a module in a signature file */
-moduleSpecBlock: 
+moduleSpecBlock:
 
   /* #light-syntax, with no sig/end or begin/end */
-  | OBLOCKBEGIN moduleSpfns oblockend 
+  | OBLOCKBEGIN moduleSpfns oblockend
       { $2 }
 
   /* #light-syntax, with sig/end or begin/end */
-  | OBLOCKBEGIN sigOrBegin moduleSpfnsPossiblyEmpty END oblockend 
+  | OBLOCKBEGIN sigOrBegin moduleSpfnsPossiblyEmpty END oblockend
       { $3 }
 
   /* non-#light-syntax, with sig/end or begin/end */
-  |             sigOrBegin moduleSpfnsPossiblyEmpty END 
+  |             sigOrBegin moduleSpfnsPossiblyEmpty END
       { $2 }
 
 
-tyconSpfnList:  
+tyconSpfnList:
   | AND tyconSpfn tyconSpfnList
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconSpfn =
@@ -778,12 +778,12 @@ tyconSpfnList:
 
 
 /* A type definition in a signature */
-tyconSpfn: 
-  | typeNameInfo  EQUALS tyconSpfnRhsBlock 
-      { let mLhs = rhs parseState 1 
+tyconSpfn:
+  | typeNameInfo EQUALS tyconSpfnRhsBlock
+      { let mLhs = rhs parseState 1
         let mEquals = rhs parseState 2
         fun leadingKeyword -> $3 leadingKeyword mLhs $1 (Some mEquals) }
-  | typeNameInfo  opt_classSpfn       
+  | typeNameInfo opt_classSpfn
       { let mWithKwd, members = $2
         let (SynComponentInfo(range=range)) = $1
         let m =
@@ -796,11 +796,11 @@ tyconSpfn:
                 (range, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
         fun leadingKeyword ->
             let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = None; WithKeyword = mWithKwd }
-            SynTypeDefnSig($1, SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.None m, m), members, m, trivia) }
+            SynTypeDefnSig($1, SynTypeDefnSigRepr.Simple(SynTypeDefnSimpleRepr.None m, m), members, m, trivia) }
 
 
 /* The right-hand-side of a type definition in a signature */
-tyconSpfnRhsBlock: 
+tyconSpfnRhsBlock:
   /* This rule allows members to be given for record and union types in the #light syntax */
   /* without the use of 'with' ... 'end'. For example: */
   /*     type R = */
@@ -809,29 +809,29 @@ tyconSpfnRhsBlock:
   /* It also takes into account that any existing 'with' */
   /* block still needs to be considered and may occur indented or undented from the core type */
   /* representation. */
-  | OBLOCKBEGIN  tyconSpfnRhs opt_OBLOCKSEP classSpfnMembers opt_classSpfn oblockend opt_classSpfn  
-     { let m = lhs parseState 
-       (fun leadingKeyword mLhs nameInfo mEquals -> 
+  | OBLOCKBEGIN tyconSpfnRhs opt_OBLOCKSEP classSpfnMembers opt_classSpfn oblockend opt_classSpfn
+     { let m = lhs parseState
+       (fun leadingKeyword mLhs nameInfo mEquals ->
            let members = $4 @ (snd $5)
            $2 leadingKeyword mLhs nameInfo mEquals (checkForMultipleAugmentations m members (snd $7))) }
 
   | tyconSpfnRhs opt_classSpfn
-     { let m = lhs parseState 
+     { let m = lhs parseState
        (fun leadingKeyword mLhs nameInfo mEquals ->
-           let _, members = $2 
+           let _, members = $2
            $1 leadingKeyword mLhs nameInfo mEquals members) }
 
 
 /* The right-hand-side of a type definition in a signature */
-tyconSpfnRhs: 
-  | tyconDefnOrSpfnSimpleRepr 
-     { (fun leadingKeyword mLhs nameInfo mEquals augmentation -> 
+tyconSpfnRhs:
+  | tyconDefnOrSpfnSimpleRepr
+     { (fun leadingKeyword mLhs nameInfo mEquals augmentation ->
            let declRange = unionRanges mLhs $1.Range
            let mWhole = (declRange, augmentation) ||> unionRangeWithListBy (fun (mem: SynMemberSig) -> mem.Range)
            let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = mEquals }
-           SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.Simple ($1, $1.Range), augmentation, mWhole, trivia)) }
+           SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.Simple($1, $1.Range), augmentation, mWhole, trivia)) }
 
-  | tyconClassSpfn 
+  | tyconClassSpfn
      {  let needsCheck, (kind, decls) = $1
         let objectModelRange =
             match decls with
@@ -840,87 +840,87 @@ tyconSpfnRhs:
                 let start = mkSynRange parseState.ResultStartPosition parseState.ResultStartPosition
                 (start, decls) ||> unionRangeWithListBy (fun (s: SynMemberSig) -> s.Range)
 
-       (fun leadingKeyword nameRange nameInfo mEquals augmentation -> 
+       (fun leadingKeyword nameRange nameInfo mEquals augmentation ->
            if needsCheck && isNil decls then
               reportParseErrorAt nameRange (FSComp.SR.parsEmptyTypeDefinition())
-           
+
            let declRange = unionRanges nameRange objectModelRange
            let mWhole = (declRange, augmentation) ||> unionRangeWithListBy (fun (mem: SynMemberSig) -> mem.Range)
            let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = mEquals }
-           SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.ObjectModel (kind, decls, objectModelRange), augmentation, mWhole, trivia)) }
+           SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.ObjectModel(kind, decls, objectModelRange), augmentation, mWhole, trivia)) }
 
   | DELEGATE OF topType
-     { let m = lhs parseState 
+     { let m = lhs parseState
        let ty, arity = $3
        let flags = AbstractMemberFlags true SynMemberKind.Member
        let valSig = SynValSig([], (SynIdent(mkSynId m "Invoke", None)), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, m, SynValSigTrivia.Zero)
-       let invoke = SynMemberSig.Member(valSig, flags, m, SynMemberSigMemberTrivia.Zero) 
-       (fun leadingKeyword nameRange nameInfo mEquals augmentation -> 
+       let invoke = SynMemberSig.Member(valSig, flags, m, SynMemberSigMemberTrivia.Zero)
+       (fun leadingKeyword nameRange nameInfo mEquals augmentation ->
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
            let mWhole = unionRanges nameRange m
            let trivia: SynTypeDefnSigTrivia = { LeadingKeyword = leadingKeyword; WithKeyword = None; EqualsRange = mEquals }
-           SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.ObjectModel (SynTypeDefnKind.Delegate (ty, arity), [invoke], m), [], mWhole, trivia)) }
+           SynTypeDefnSig(nameInfo, SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Delegate(ty, arity), [invoke], m), [], mWhole, trivia)) }
 
 
 /* The right-hand-side of an object type definition in a signature */
-tyconClassSpfn: 
+tyconClassSpfn:
   | classSpfnBlockKindUnspecified
-     { let needsCheck, decls = $1 
+     { let needsCheck, decls = $1
        needsCheck, (SynTypeDefnKind.Unspecified, decls) }
 
   | classOrInterfaceOrStruct classSpfnBlock END
      { false, ($1, $2) }
 
-  | classOrInterfaceOrStruct classSpfnBlock recover 
+  | classOrInterfaceOrStruct classSpfnBlock recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedClassInterfaceOrStruct())
        false, ($1, $2) }
 
   | classOrInterfaceOrStruct error END
-     { // silent recovery 
+     { // silent recovery
        false, ($1, []) }
 
 
 /* The right-hand-side of an object type definition in a signature with no explicit kind */
 classSpfnBlockKindUnspecified:
-  | OBLOCKBEGIN  classSpfnMembers oblockend 
+  | OBLOCKBEGIN classSpfnMembers oblockend
      { true, $2 }
 
-  | OBLOCKBEGIN  classSpfnMembers recover
+  | OBLOCKBEGIN classSpfnMembers recover
      { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileTypeSignature())
        false, $2 }
 
   /* NOTE: these rules enable the non-#light syntax to omit the kind of a type. */
-  | BEGIN  classSpfnBlock END 
+  | BEGIN classSpfnBlock END
      { false, $2 }
 
-  | BEGIN  classSpfnBlock recover
+  | BEGIN classSpfnBlock recover
      { false, $2 }
 
 
 /* The right-hand-side of an object type definition in a signature */
 classSpfnBlock:
-  | OBLOCKBEGIN  classSpfnMembers oblockend 
+  | OBLOCKBEGIN classSpfnMembers oblockend
       { $2 }
 
-  | OBLOCKBEGIN  classSpfnMembers recover 
+  | OBLOCKBEGIN classSpfnMembers recover
       { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileTypeSignature())
         $2 }
-  | classSpfnMembers 
+  | classSpfnMembers
       { $1 }
 
 /* The members of an object type definition in a signature, possibly empty */
-classSpfnMembers:  
-  | classSpfnMembersAtLeastOne 
-     { $1 } 
+classSpfnMembers:
+  | classSpfnMembersAtLeastOne
+     { $1 }
 
   |  /* EMPTY */
      { [] }
 
 
 /* The members of an object type definition in a signature */
-classSpfnMembersAtLeastOne:  
-  | classMemberSpfn opt_seps classSpfnMembers 
-     { $1 :: $3 } 
+classSpfnMembersAtLeastOne:
+  | classMemberSpfn opt_seps classSpfnMembers
+     { $1 :: $3 }
 
 
 /* A object member in a signature */
@@ -928,20 +928,20 @@ classMemberSpfn:
   | opt_attributes opt_access memberSpecFlags opt_inline opt_access nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet optLiteralValueSpfn
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        let isInline, doc, vis2, id, explicitValTyparDecls, (ty, arity), (mEquals, optLiteralValue) = (Option.isSome $4), grabXmlDoc(parseState, $1, 1), $5, $6, $7, $9, $11
-       let mWith, (getSet, getSetRangeOpt) = $10 
+       let mWith, (getSet, getSetRangeOpt) = $10
        let getSetAdjuster arity = match arity, getSet with SynValInfo([], _), SynMemberKind.Member -> SynMemberKind.PropertyGet | _ -> getSet
-       let mWhole = 
-           let m = rhs parseState 3 
-           match getSetRangeOpt with 
+       let mWhole =
+           let m = rhs parseState 3
+           match getSetRangeOpt with
            | None -> unionRanges m ty.Range
            | Some gs -> unionRanges m (gs : GetSetKeywords).Range
            |> fun m -> (m, $1) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
            |> unionRangeWithXmlDoc doc
-           |> fun m -> 
+           |> fun m ->
                match optLiteralValue with
                | None -> m
                | Some e -> unionRanges m e.Range
-       
+
        let flags, leadingKeyword = $3
        let flags = flags (getSetAdjuster arity)
        let trivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $4; WithKeyword = mWith; EqualsRange = mEquals }
@@ -949,23 +949,23 @@ classMemberSpfn:
        let trivia: SynMemberSigMemberTrivia = { GetSetKeywords = getSetRangeOpt }
        SynMemberSig.Member(valSpfn, flags, mWhole, trivia) }
 
-  | opt_attributes opt_access interfaceMember appType  
+  | opt_attributes opt_access interfaceMember appType
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-       SynMemberSig.Interface ($4, unionRanges (rhs parseState 3) ($4).Range) }
+       SynMemberSig.Interface($4, unionRanges (rhs parseState 3) ($4).Range) }
 
-  | opt_attributes opt_access INHERIT appType 
+  | opt_attributes opt_access INHERIT appType
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-       SynMemberSig.Inherit ($4, unionRanges (rhs parseState 3) ($4).Range) }
+       SynMemberSig.Inherit($4, unionRanges (rhs parseState 3) ($4).Range) }
 
-  | opt_attributes opt_access VAL fieldDecl 
+  | opt_attributes opt_access VAL fieldDecl
      { let mWhole = rhs2 parseState 1 4
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let mVal = rhs parseState 3
        let (SynField(xmlDoc = xmlDoc)) as field = $4 $1 false mWhole (Some (SynLeadingKeyword.Val mVal))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
-       SynMemberSig.ValField (field, mWhole) }
+       SynMemberSig.ValField(field, mWhole) }
 
-  | opt_attributes opt_access STATIC VAL fieldDecl 
+  | opt_attributes opt_access STATIC VAL fieldDecl
      { let mWhole = rhs2 parseState 1 5
        if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let mStatic = rhs parseState 3
@@ -974,12 +974,12 @@ classMemberSpfn:
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
        SynMemberSig.ValField(field, mWhole) }
 
-  | opt_attributes  opt_access STATIC typeKeyword tyconSpfn 
+  | opt_attributes opt_access STATIC typeKeyword tyconSpfn
      { let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        SynMemberSig.NestedType($5 leadingKeyword, rhs2 parseState 1 5) }
 
-  | opt_attributes opt_access NEW COLON topTypeWithTypeConstraints  
+  | opt_attributes opt_access NEW COLON topTypeWithTypeConstraints
      { let vis, doc, (ty, valSynInfo) = $2, grabXmlDoc(parseState, $1, 1), $5
        let mNew = rhs parseState 3
        let m = unionRanges (rhs parseState 1) ty.Range |> unionRangeWithXmlDoc doc
@@ -991,10 +991,10 @@ classMemberSpfn:
 
 /* The optional "with get, set" on a member in a signature */
 classMemberSpfnGetSet:
-  | /* EMPTY */ 
+  | /* EMPTY */
     { None, (SynMemberKind.Member, None) }
 
-  | WITH classMemberSpfnGetSetElements 
+  | WITH classMemberSpfnGetSetElements
     { let mWith = rhs parseState 1
       Some mWith, $2 }
 
@@ -1010,46 +1010,46 @@ classMemberSpfnGetSet:
 
 /* The "get, set" on a property member in a signature */
 classMemberSpfnGetSetElements:
-  | nameop 
-    { (let (SynIdent(id:Ident, _)) = $1 
-       if id.idText = "get" then 
+  | nameop
+    { (let (SynIdent(id:Ident, _)) = $1
+       if id.idText = "get" then
            SynMemberKind.PropertyGet, Some (GetSetKeywords.Get id.idRange)
-       else if id.idText = "set" then 
+       else if id.idText = "set" then
            SynMemberKind.PropertySet, Some (GetSetKeywords.Set id.idRange)
-       else 
+       else
            raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
 
   | nameop COMMA nameop
-    { let (SynIdent(id, _)) = $1 
+    { let (SynIdent(id, _)) = $1
       let (SynIdent(id2, _)) = $3
       if not ((id.idText = "get" && id2.idText = "set") ||
-              (id.idText = "set" && id2.idText = "get")) then 
+              (id.idText = "set" && id2.idText = "get")) then
          raiseParseErrorAt (rhs2 parseState 1 3) (FSComp.SR.parsGetOrSetRequired())
-      
+
       if id.idText = "get" then
           SynMemberKind.PropertyGetSet, Some (GetSetKeywords.GetSet(id.idRange, id2.idRange))
       else
           SynMemberKind.PropertyGetSet, Some (GetSetKeywords.GetSet(id2.idRange, id.idRange)) }
 
-memberSpecFlags: 
-  | memberFlags { $1 }  
+memberSpecFlags:
+  | memberFlags { $1 }
   | abstractMemberFlags { $1 }
 
 
 /* Part of an exception definition in a signature file */
-exconSpfn: 
-  | exconCore opt_classSpfn 
+exconSpfn:
+  | exconCore opt_classSpfn
      { let mWithKwd, members = $2
        SynExceptionSig($1, mWithKwd, members, lhs parseState) }
-  
+
 
 /* The optional augmentation on a type definition in a signature */
-opt_classSpfn: 
-  | WITH classSpfnBlock declEnd 
+opt_classSpfn:
+  | WITH classSpfnBlock declEnd
      { let mWithKwd = rhs parseState 1
-       (Some mWithKwd), $2 } 
+       (Some mWithKwd), $2 }
 
-  | /* EMPTY */                   
+  | /* EMPTY */
      { None, [] }
 
 
@@ -1057,60 +1057,60 @@ opt_classSpfn:
 /* F# Language Proper - implementation files */
 
 /* The contents of an implementation file */
-implementationFile: 
-  | fileNamespaceImpls EOF 
+implementationFile:
+  | fileNamespaceImpls EOF
      { checkEndOfFileError $2; $1 }
 
-  | fileNamespaceImpls error EOF 
+  | fileNamespaceImpls error EOF
      { $1 }
 
   /* If this rule fires it is kind of catastrophic: error recovery yields no results! */
   /* This will result in NO intellisense for the file! Ideally we wouldn't need this rule */
   /* Note: the compiler assumes there is at least one "fragment", so an empty one is used (see 4488) */
-  | error EOF 
-     { let emptyImplFileFrag = ParsedImplFileFragment.AnonModule([], rhs parseState 1) in 
+  | error EOF
+     { let emptyImplFileFrag = ParsedImplFileFragment.AnonModule([], rhs parseState 1) in
        ParsedImplFile ([], [emptyImplFileFrag]) }
 
 
 /* The sequence of namespace definitions or a single module definition that makes up an implementation file */
-fileNamespaceImpls: 
-  | fileModuleImpl   
+fileNamespaceImpls:
+  | fileModuleImpl
       { ParsedImplFile ([], [ ($1 (None, false, [], PreXmlDoc.Empty)) ]) }
 
-  | fileModuleImpl fileNamespaceImplList 
-      { // If there are namespaces, the first fileModuleImpl may only contain # directives 
-        let decls = 
-            match ($1 (None, false, [], PreXmlDoc.Empty)) with 
-            | ParsedImplFileFragment.AnonModule(decls, m) -> decls  
-            | ParsedImplFileFragment.NamespaceFragment(decls = decls) -> decls 
+  | fileModuleImpl fileNamespaceImplList
+      { // If there are namespaces, the first fileModuleImpl may only contain # directives
+        let decls =
+            match ($1 (None, false, [], PreXmlDoc.Empty)) with
+            | ParsedImplFileFragment.AnonModule(decls, m) -> decls
+            | ParsedImplFileFragment.NamespaceFragment(decls = decls) -> decls
             | ParsedImplFileFragment.NamedModule(SynModuleOrNamespace(range = m)) ->
                 raiseParseErrorAt m (FSComp.SR.parsOnlyHashDirectivesAllowed())
-        let decls = 
-            decls |> List.collect (function 
-                | (SynModuleDecl.HashDirective (hd, _)) -> [hd]
-                | d ->  
+        let decls =
+            decls |> List.collect (function
+                | (SynModuleDecl.HashDirective(hd, _)) -> [hd]
+                | d ->
                      reportParseErrorAt d.Range (FSComp.SR.parsOnlyHashDirectivesAllowed())
                      [])
-        ParsedImplFile (decls, $2) } 
+        ParsedImplFile (decls, $2) }
 
 
 /* The sequence of namespace definitions that can make up an implementation file */
-fileNamespaceImplList: 
-  | fileNamespaceImpl fileNamespaceImplList 
+fileNamespaceImplList:
+  | fileNamespaceImpl fileNamespaceImplList
      { $1 :: $2 }
 
-  | fileNamespaceImpl 
+  | fileNamespaceImpl
      { [$1] }
 
 
 /* A single namespace definition in an implementation file */
-fileNamespaceImpl: 
-  | namespaceIntro deprecated_opt_equals fileModuleImpl 
+fileNamespaceImpl:
+  | namespaceIntro deprecated_opt_equals fileModuleImpl
      { let mNamespace, isRec, path, xml = $1 in ($3 (Some mNamespace, isRec, path, xml)) }
 
 
 /* A single module definition in an implementation file */
-fileModuleImpl: 
+fileModuleImpl:
   | opt_attributes opt_access moduleIntro moduleDefnsOrExprPossiblyEmptyOrBlock
     { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
       let m2 = rhs parseState 3
@@ -1124,20 +1124,20 @@ fileModuleImpl:
         let trivia: SynModuleOrNamespaceTrivia = { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Module mModule }
         ParsedImplFileFragment.NamedModule(SynModuleOrNamespace(lid, (isRec || isRec2), SynModuleOrNamespaceKind.NamedModule, $4, xmlDoc, $1@attribs2, vis, m, trivia))) }
 
-  | moduleDefnsOrExprPossiblyEmptyOrBlock 
-    { let m = (rhs parseState 1) 
-      (fun (mNamespaceOpt, isRec, path, xml) -> 
-        match path with 
-        | [] -> ParsedImplFileFragment.AnonModule($1, m)  
+  | moduleDefnsOrExprPossiblyEmptyOrBlock
+    { let m = (rhs parseState 1)
+      (fun (mNamespaceOpt, isRec, path, xml) ->
+        match path with
+        | [] -> ParsedImplFileFragment.AnonModule($1, m)
         | _ ->
             let lastDeclRange = List.tryLast $1 |> Option.map (fun decl -> decl.Range) |> Option.defaultValue (rhs parseState 1)
             let m = mkRange lastDeclRange.FileName (lhs parseState).Start lastDeclRange.End
             xml.MarkAsInvalid()
-            let trivia: SynModuleOrNamespaceTrivia = 
+            let trivia: SynModuleOrNamespaceTrivia =
                 match mNamespaceOpt with
                  | None -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.None }
                  | Some mNamespace -> { LeadingKeyword = SynModuleOrNamespaceLeadingKeyword.Namespace mNamespace }
-            ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia)) } 
+            ParsedImplFileFragment.NamespaceFragment(path, isRec, SynModuleOrNamespaceKind.DeclaredNamespace, $1, PreXmlDoc.Empty, [], m, trivia)) }
 
 
 /* A collection/block of definitions or expressions making up a module or namespace, possibly empty */
@@ -1145,12 +1145,12 @@ moduleDefnsOrExprPossiblyEmptyOrBlock:
   | OBLOCKBEGIN moduleDefnsOrExprPossiblyEmpty oblockend opt_OBLOCKSEP
      { $2 }
 
-  | OBLOCKBEGIN moduleDefnsOrExprPossiblyEmpty recover 
+  | OBLOCKBEGIN moduleDefnsOrExprPossiblyEmpty recover
      { // The lex filter ensures we can only get a mismatch in OBLOCKBEGIN/OBLOCKEND tokens if there was some other kind of error, hence we don't need to report this error
-       // reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnClosedBlockInHashLight())   
+       // reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnClosedBlockInHashLight())
        $2 }
 
-  | OBLOCKBEGIN error oblockend                
+  | OBLOCKBEGIN error oblockend
      { []  }
 
   | moduleDefnsOrExprPossiblyEmpty
@@ -1169,41 +1169,41 @@ moduleDefnsOrExprPossiblyEmpty:
 /* A collection of definitions or expressions making up a module or namespace */
 /* A naked expression is only allowed at the start of a module/file, or straight after a topSeparators */
 moduleDefnsOrExpr:
-  | opt_attributes opt_access declExpr topSeparators moduleDefnsOrExpr 
+  | opt_attributes opt_access declExpr topSeparators moduleDefnsOrExpr
       { match $2 with
         | Some vis -> errorR(Error(FSComp.SR.parsUnexpectedVisibilityDeclaration(vis.ToString()), rhs parseState 3))
         | _ -> ()
-        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes ($1, rangeOfNonNilAttrs $1) ] else [] 
+        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes($1, rangeOfNonNilAttrs $1) ] else []
         attrDecls @ mkSynExprDecl $3 :: $5 }
 
   | opt_attributes opt_access declExpr topSeparators
       { match $2 with
         | Some vis -> errorR(Error(FSComp.SR.parsUnexpectedVisibilityDeclaration(vis.ToString()), rhs parseState 3))
         | _ -> ()
-        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes ($1, rangeOfNonNilAttrs $1) ] else [] 
+        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes($1, rangeOfNonNilAttrs $1) ] else []
         attrDecls @ [ mkSynExprDecl $3 ] }
 
   | opt_attributes opt_access declExpr
       { match $2 with
         | Some vis -> errorR(Error(FSComp.SR.parsUnexpectedVisibilityDeclaration(vis.ToString()), rhs parseState 3))
         | _ -> ()
-        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes ($1, rangeOfNonNilAttrs $1) ] else [] 
+        let attrDecls = if not (isNil $1) then [ SynModuleDecl.Attributes($1, rangeOfNonNilAttrs $1) ] else []
         attrDecls @ [ mkSynExprDecl $3 ] }
 
-  | moduleDefns 
-      { $1 } 
+  | moduleDefns
+      { $1 }
 
   | opt_attributes error
-     { if not (isNil $1) then [ SynModuleDecl.Attributes ($1, rangeOfNonNilAttrs $1) ] else [] }
+     { if not (isNil $1) then [ SynModuleDecl.Attributes($1, rangeOfNonNilAttrs $1) ] else [] }
 
 
 /* A sequence of definitions in a namespace or module */
 moduleDefns:
-  | moduleDefnOrDirective moduleDefns 
-      { $1 @ $2 } 
+  | moduleDefnOrDirective moduleDefns
+      { $1 @ $2 }
 
-  | moduleDefnOrDirective topSeparators moduleDefnsOrExpr 
-      { $1 @ $3 } 
+  | moduleDefnOrDirective topSeparators moduleDefnsOrExpr
+      { $1 @ $3 }
 
   | moduleDefnOrDirective
       { $1 }
@@ -1211,17 +1211,17 @@ moduleDefns:
   | moduleDefnOrDirective topSeparators
       { $1 }
 
-  | error topSeparators moduleDefnsOrExpr 
-      { $3 } 
+  | error topSeparators moduleDefnsOrExpr
+      { $3 }
 
 
 /* A single definition in a namespace, module or F# Interactive file*/
 moduleDefnOrDirective:
-  | moduleDefn 
-      { $1  } 
+  | moduleDefn
+      { $1  }
 
-  | hashDirective 
-      { [ SynModuleDecl.HashDirective ($1, rhs2 parseState 1 1) ] } 
+  | hashDirective
+      { [ SynModuleDecl.HashDirective($1, rhs2 parseState 1 1) ] }
 
 
 /* A single definition in a namespace, module or interaction. */
@@ -1229,25 +1229,25 @@ moduleDefnOrDirective:
 moduleDefn:
 
   /* 'let' definitions in non-#light*/
-  | opt_attributes opt_access defnBindings                   %prec decl_let 
+  | opt_attributes opt_access defnBindings %prec decl_let
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         parseState.ResetSynArgNameGenerator()
-        let (BindingSetPreAttrs(_, _, _, _, mWhole)) = $3 
+        let (BindingSetPreAttrs(_, _, _, _, mWhole)) = $3
         mkDefnBindings (mWhole, $3, $1, $2, mWhole)  }
 
   /* 'let' or 'do' definitions in #light */
-  | opt_attributes opt_access hardwhiteLetBindings          %prec decl_let 
+  | opt_attributes opt_access hardwhiteLetBindings %prec decl_let
       { let hwlb, m, _ = $3
         if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         parseState.ResetSynArgNameGenerator()
         mkDefnBindings (m, hwlb, $1, $2, m)  }
 
   /* 'do' definitions in non-#light*/
-  | opt_attributes opt_access doBinding %prec decl_let 
+  | opt_attributes opt_access doBinding %prec decl_let
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let mWhole = rhs parseState 3 
+        let mWhole = rhs parseState 3
         mkDefnBindings (mWhole, $3, $1, $2, mWhole) }
-  
+
   /* 'type' definitions */
   | opt_attributes opt_access typeKeyword tyconDefn tyconDefnList
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
@@ -1259,7 +1259,7 @@ moduleDefn:
         let mDefn = (h, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) |> unionRangeWithXmlDoc xmlDoc
         let tc = SynTypeDefn(SynComponentInfo(attrs, a, cs, b, xmlDoc, d, d2, d3), e, f, g, mDefn, trivia)
         let types = tc :: $5
-        [ SynModuleDecl.Types(types, (rhs parseState 3, types) ||> unionRangeWithListBy (fun t -> t.Range) ) ] }
+        [ SynModuleDecl.Types(types, (rhs parseState 3, types) ||> unionRangeWithListBy (fun t -> t.Range)) ] }
 
   /* 'exception' definitions */
   | opt_attributes opt_access exconDefn
@@ -1277,7 +1277,7 @@ moduleDefn:
         let attribs, (mModule, isRec, path, vis, attribs2) = $1, $3
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
         match $5 with
-        | Choice1Of2 eqn -> 
+        | Choice1Of2 eqn ->
             if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
             if isRec then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsInvalidUseOfRec())
             if not (isSingleton path) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsModuleAbbreviationMustBeSimpleName())
@@ -1286,8 +1286,8 @@ moduleDefn:
             match vis with
             | Some vis -> raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsIgnoreAttributesOnModuleAbbreviationAlwaysPrivate(vis.ToString()))
             | None -> ()
-            [ SynModuleDecl.ModuleAbbrev(List.head path, eqn, (rhs parseState 3, eqn) ||> unionRangeWithListBy (fun id -> id.idRange) ) ]
-        | Choice2Of2 (def, mEndOpt) -> 
+            [ SynModuleDecl.ModuleAbbrev(List.head path, eqn, (rhs parseState 3, eqn) ||> unionRangeWithListBy (fun id -> id.idRange)) ]
+        | Choice2Of2 (def, mEndOpt) ->
             if not (isSingleton path) then raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsModuleAbbreviationMustBeSimpleName())
             let info = SynComponentInfo(attribs @ attribs2, None, [], path, xmlDoc, false, vis, rhs parseState 3)
             let mEquals = rhs parseState 4
@@ -1325,84 +1325,84 @@ openDecl:
   | OPEN typeKeyword appType
       { SynOpenDeclTarget.Type($3, (rhs parseState 3)) }
 
-/* The right-hand-side of a module abbreviation definition */ 
+/* The right-hand-side of a module abbreviation definition */
 /* This occurs on the right of a module abbreviation (#light encloses the r.h.s. with OBLOCKBEGIN/OBLOCKEND) */
 /* We don't use it in signature files */
 namedModuleAbbrevBlock:
-  | OBLOCKBEGIN path oblockend 
+  | OBLOCKBEGIN path oblockend
      { $2 }
 
-  | path 
+  | path
      { $1  }
-       
 
-/* The right-hand-side of a module definition */ 
+
+/* The right-hand-side of a module definition */
 namedModuleDefnBlock:
-  | OBLOCKBEGIN wrappedNamedModuleDefn oblockend 
+  | OBLOCKBEGIN wrappedNamedModuleDefn oblockend
      { Choice2Of2 $2  }
 
   | OBLOCKBEGIN wrappedNamedModuleDefn recover
      { // The lex filter ensures we can only get a mismatch in OBLOCKBEGIN/OBLOCKEND tokens if there was some other kind of error, hence we don't need to report this error
        Choice2Of2 $2 }
 
-  | OBLOCKBEGIN moduleDefnsOrExpr oblockend 
-       { // There is an ambiguity here 
+  | OBLOCKBEGIN moduleDefnsOrExpr oblockend
+       { // There is an ambiguity here
          // In particular, consider the following two:
          //
-         // module M2 = 
+         // module M2 =
          //    System.DateTime.Now
-         // module M2 = 
+         // module M2 =
          //    Microsoft.FSharp.Core.List
          // The second is a module abbreviation, the first a module containing a single expression.
-         // The resolution is in favour of the module abbreviation, i.e. anything of the form 
+         // The resolution is in favour of the module abbreviation, i.e. anything of the form
          //    module M2 = ID.ID.ID.ID
          // will be taken as a module abbreviation, regardles of the identifiers themselves.
          //
-         // This is similar to the ambiguitty between 
+         // This is similar to the ambiguitty between
          //    type X = int
-         // and 
+         // and
          //    type X = OneValue
          // However in that case we do use type name lookup to make the resolution.
 
-         match $2 with 
-         | [ SynModuleDecl.Expr (LongOrSingleIdent(false, SynLongIdent(path, _, _), None, _), _) ] -> 
+         match $2 with
+         | [ SynModuleDecl.Expr(LongOrSingleIdent(false, SynLongIdent(path, _, _), None, _), _) ] ->
              Choice1Of2  path
          | _ ->
-             Choice2Of2 ($2, None) 
+             Choice2Of2 ($2, None)
        }
 
-  | OBLOCKBEGIN moduleDefnsOrExpr recover 
+  | OBLOCKBEGIN moduleDefnsOrExpr recover
      { // The lex filter ensures we can only get a mismatch in OBLOCKBEGIN/OBLOCKEND tokens if there was some other kind of error, hence we don't need to report this error
-       // reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnClosedBlockInHashLight())   
+       // reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnClosedBlockInHashLight())
        Choice2Of2 ($2, None) }
 
-  | OBLOCKBEGIN error oblockend                
+  | OBLOCKBEGIN error oblockend
      { let mEnd = rhs parseState 3
        Choice2Of2 ([], Some mEnd) }
 
-  | wrappedNamedModuleDefn 
+  | wrappedNamedModuleDefn
      { Choice2Of2 $1 }
 
-  | path 
+  | path
      { Choice1Of2 $1.LongIdent }
 
 
-/* A module definition that includes a 'begin'...'end' (rarely used in F# with #light syntax) */ 
+/* A module definition that includes a 'begin'...'end' (rarely used in F# with #light syntax) */
 wrappedNamedModuleDefn:
-  | structOrBegin moduleDefnsOrExprPossiblyEmpty END 
+  | structOrBegin moduleDefnsOrExprPossiblyEmpty END
      { let mEnd = rhs parseState 3
        $2, Some mEnd }
 
-  | structOrBegin moduleDefnsOrExprPossiblyEmpty recover 
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBeginOrStruct())  
+  | structOrBegin moduleDefnsOrExprPossiblyEmpty recover
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBeginOrStruct())
        $2, None }
 
-  | structOrBegin error END                      
+  | structOrBegin error END
      { let mEnd = rhs parseState 3
        [], Some mEnd }
 
 
-tyconDefnAugmentation: 
+tyconDefnAugmentation:
   | WITH classDefnBlock declEnd
      { let mWithKwd = rhs parseState 1
        mWithKwd, $2 }
@@ -1410,15 +1410,15 @@ tyconDefnAugmentation:
 
 /* An optional list of custom attributes */
 opt_attributes:
-  | attributes                                
+  | attributes
       { $1 }
 
-  |            %prec prec_opt_attributes_none 
+  |            %prec prec_opt_attributes_none
       { [] }
 
 /* A list of sets of custom attributes */
-attributes: 
-  | attributeList                     
+attributes:
+  | attributeList
      { $1 }
 
   | attributeList attributes
@@ -1443,58 +1443,58 @@ attributeList:
 
 
 /* One set of custom attributes, not including [< ... >] */
-attributeListElements: 
-  | attribute                     
+attributeListElements:
+  | attribute
      { [$1] }
 
-  | attributeListElements seps attribute 
+  | attributeListElements seps attribute
      { $1 @ [$3] }
 
 
 /* One custom attribute */
 attribute:
   /* A custom attribute */
-  | path opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType 
+  | path opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType
      { let arg = match $3 with None -> mkSynUnit $1.Range | Some e -> e
-       let m = unionRanges  $1.Range arg.Range
+       let m = unionRanges $1.Range arg.Range
        ({ TypeName=$1; ArgExpr=arg; Target=None; AppliesToGetterAndSetter=false; Range=m } : SynAttribute) }
 
   /* A custom attribute with an attribute target */
-  | attributeTarget path opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType 
+  | attributeTarget path opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType
      { let arg = match $4 with None -> mkSynUnit $2.Range | Some e -> e
        let startRange = match $1 with Some (ident:Ident) -> ident.idRange | None -> $2.Range
        let m = unionRanges startRange arg.Range
        ({ TypeName=$2; ArgExpr=arg; Target=$1; AppliesToGetterAndSetter=false; Range=m } : SynAttribute) }
 
   /* A custom attribute with an attribute target */
-  | attributeTarget OBLOCKBEGIN path oblockend opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType 
-     { let arg = match $6 with None -> mkSynUnit $3.Range | Some e -> e 
+  | attributeTarget OBLOCKBEGIN path oblockend opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType
+     { let arg = match $6 with None -> mkSynUnit $3.Range | Some e -> e
        let startRange = match $1 with Some ident -> ident.idRange | None -> $3.Range
        let m = unionRanges startRange arg.Range
        ({ TypeName=$3; ArgExpr=arg; Target=$1; AppliesToGetterAndSetter=false; Range=m } : SynAttribute) }
 
 
 /* The target of a custom attribute */
-attributeTarget: 
-  | moduleKeyword COLON 
-      { Some(ident("module", (rhs parseState 1))) } 
+attributeTarget:
+  | moduleKeyword COLON
+      { Some(ident("module", (rhs parseState 1))) }
 
-  | typeKeyword COLON 
-      { Some(ident("type", (rhs parseState 1))) } 
+  | typeKeyword COLON
+      { Some(ident("type", (rhs parseState 1))) }
 
-  | ident COLON { Some($1) } 
+  | ident COLON { Some($1) }
 
   /* return */
-  | YIELD COLON 
+  | YIELD COLON
       { if $1 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSyntaxError())
-        Some(ident("return", (rhs parseState 1))) } 
+        Some(ident("return", (rhs parseState 1))) }
 
 /* Flags on a member */
-memberFlags: 
-  | STATIC MEMBER 
+memberFlags:
+  | STATIC MEMBER
       { let mStatic = rhs parseState 1
         let mMember = rhs parseState 2
-        StaticMemberFlags, (SynLeadingKeyword.StaticMember(mStatic, mMember)) }  
+        StaticMemberFlags, (SynLeadingKeyword.StaticMember(mStatic, mMember)) }
   | MEMBER
       { let mMember = rhs parseState 1
         NonVirtualMemberFlags, (SynLeadingKeyword.Member mMember) }
@@ -1506,15 +1506,15 @@ memberFlags:
         OverrideMemberFlags, (SynLeadingKeyword.Default mDefault) }
 
 /* The name of a type in a signature or implementation, possibly with type parameters and constraints */
-typeNameInfo: 
+typeNameInfo:
   | opt_attributes tyconNameAndTyparDecls opt_typeConstraints
      { let typars, lid, fixity, vis = $2
        let xmlDoc = grabXmlDoc(parseState, $1, 1)
        SynComponentInfo ($1, typars, $3, lid, xmlDoc, fixity, vis, rangeOfLid lid) }
 
 /* Part of a set of type definitions */
-tyconDefnList:  
-  | AND tyconDefn tyconDefnList 
+tyconDefnList:
+  | AND tyconDefn tyconDefnList
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let tyconDefn =
            let leadingKeyword = SynTypeDefnLeadingKeyword.And(rhs parseState 1)
@@ -1531,25 +1531,25 @@ tyconDefnList:
                let componentInfo = SynComponentInfo (a, typars, c, lid, xmlDoc, fixity, vis, mLongId)
                SynTypeDefn(componentInfo, typeRepr, members, implicitConstructor, range, trivia)
        tyconDefn :: $3 }
-  |                             
+  |
      { [] }
 
 /* A type definition */
-tyconDefn: 
-  | typeNameInfo 
+tyconDefn:
+  | typeNameInfo
      { fun leadingKeyword ->
            let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = None; WithKeyword = None }
            SynTypeDefn($1, SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.None($1.Range), $1.Range), [], None, $1.Range, trivia) }
 
-  | typeNameInfo opt_equals tyconDefnRhsBlock 
+  | typeNameInfo opt_equals tyconDefnRhsBlock
      { match $2 with
        | Some _ -> ()
        | None ->
-            let (SynComponentInfo(_, _, _, lid, _, _, _, _)) = $1 
+            let (SynComponentInfo(_, _, _, lid, _, _, _, _)) = $1
             // While the spec doesn't allow long idents here, the parser doesn't enforce this, so take one ident
             let typeNameId = List.last lid
             raiseParseErrorAt (rhs parseState 2) (FSComp.SR.parsEqualsMissingInTypeDefinition(typeNameId.ToString()))
-       
+
        let nameRange = rhs parseState 1
        let (tcDefRepr:SynTypeDefnRepr), mWith ,members = $3 nameRange
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
@@ -1566,7 +1566,7 @@ tyconDefn:
            let trivia: SynTypeDefnTrivia = { LeadingKeyword = leadingKeyword; EqualsRange = None; WithKeyword = None }
            SynTypeDefn($1, SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Augmentation mWithKwd, [], m), classDefns, None, m, trivia) }
 
-  | typeNameInfo opt_attributes opt_access opt_HIGH_PRECEDENCE_APP  simplePatterns optAsSpec EQUALS tyconDefnRhsBlock
+  | typeNameInfo opt_attributes opt_access opt_HIGH_PRECEDENCE_APP simplePatterns optAsSpec EQUALS tyconDefnRhsBlock
      { let vis, spats, az = $3, $5, $6
        let nameRange = rhs parseState 1
        let (tcDefRepr, mWith, members) = $8 nameRange
@@ -1574,10 +1574,10 @@ tyconDefn:
        let mEquals = rhs parseState 7
        // Gets the XML doc comments prior to the implicit constructor
        let xmlDoc = grabXmlDoc(parseState, $2, 2)
-       let memberCtorPattern = SynMemberDefn.ImplicitCtor (vis, $2, spats, Option.map snd az, xmlDoc, rangeOfLid lid, { AsKeyword = Option.map fst az })
-       let tcDefRepr = 
+       let memberCtorPattern = SynMemberDefn.ImplicitCtor(vis, $2, spats, Option.map snd az, xmlDoc, rangeOfLid lid, { AsKeyword = Option.map fst az })
+       let tcDefRepr =
          match tcDefRepr with
-         | SynTypeDefnRepr.ObjectModel (k, cspec, m) -> SynTypeDefnRepr.ObjectModel (k, memberCtorPattern :: cspec, m)
+         | SynTypeDefnRepr.ObjectModel (k, cspec, m) -> SynTypeDefnRepr.ObjectModel(k, memberCtorPattern :: cspec, m)
          | _ -> reportParseErrorAt (rhs2 parseState 1 5) (FSComp.SR.parsOnlyClassCanTakeValueArguments()); tcDefRepr
        let declRange = unionRanges (rhs parseState 1) tcDefRepr.Range
        let mWhole = (declRange, members)
@@ -1589,7 +1589,7 @@ tyconDefn:
 
 
 /* The right-hand-side of a type definition */
-tyconDefnRhsBlock: 
+tyconDefnRhsBlock:
   /* This rule allows members to be given for record and union types in the #light syntax */
   /* without the use of 'with' ... 'end'. For example: */
   /*     type R = */
@@ -1598,7 +1598,7 @@ tyconDefnRhsBlock:
   /* It also takes into account that any existing 'with' */
   /* block still needs to be considered and may occur indented or undented from the core type */
   /* representation. */
-  | OBLOCKBEGIN  tyconDefnRhs opt_OBLOCKSEP classDefnMembers opt_classDefn oblockend opt_classDefn  
+  | OBLOCKBEGIN tyconDefnRhs opt_OBLOCKSEP classDefnMembers opt_classDefn oblockend opt_classDefn
      { let mWith, optClassDefn = $5
        let mWith2, optClassDefn2 = $7
        let m = unionRanges (rhs parseState 1) (match optClassDefn2 with [] -> (match optClassDefn with [] -> (rhs parseState 4) | _ -> (rhs parseState 5)) | _ -> (rhs parseState 7))
@@ -1607,7 +1607,7 @@ tyconDefnRhsBlock:
            let mWith = Option.orElse mWith2 mWith
            tcDefRepr, mWith, members) }
 
-  | OBLOCKBEGIN  tyconDefnRhs opt_OBLOCKSEP classDefnMembers opt_classDefn recover
+  | OBLOCKBEGIN tyconDefnRhs opt_OBLOCKSEP classDefnMembers opt_classDefn recover
      { if not $6 then reportParseErrorAt (rhs parseState 6) (FSComp.SR.parsUnexpectedEndOfFileTypeDefinition())
        let mWith, optClassDefn = $5
        let m = unionRanges (rhs parseState 1) (match optClassDefn with [] -> (rhs parseState 4) | _ -> (rhs parseState 5))
@@ -1624,111 +1624,111 @@ tyconDefnRhsBlock:
 
 
 /* The right-hand-side of a type definition */
-tyconDefnRhs: 
+tyconDefnRhs:
 
   /* A simple type definition */
-  | tyconDefnOrSpfnSimpleRepr 
+  | tyconDefnOrSpfnSimpleRepr
      { let m = $1.Range
-       (fun nameRange augmentation -> SynTypeDefnRepr.Simple ($1, m), augmentation) }
+       (fun nameRange augmentation -> SynTypeDefnRepr.Simple($1, m), augmentation) }
 
   /* An object type definition */
-  | tyconClassDefn 
-     { let needsCheck, (kind, decls), mopt = $1 
-       let m = match mopt with 
+  | tyconClassDefn
+     { let needsCheck, (kind, decls), mopt = $1
+       let m = match mopt with
                | None -> (lhs parseState).StartRange // create a zero-width range
                | Some m -> m
-       (fun nameRange augmentation -> 
-           if needsCheck && isNil decls then 
+       (fun nameRange augmentation ->
+           if needsCheck && isNil decls then
                reportParseErrorAt nameRange (FSComp.SR.parsEmptyTypeDefinition())
-           SynTypeDefnRepr.ObjectModel (kind, decls, m), augmentation) }
+           SynTypeDefnRepr.ObjectModel(kind, decls, m), augmentation) }
 
   /* A delegate type definition */
   | DELEGATE OF topType
-     { let m = lhs parseState 
+     { let m = lhs parseState
        let ty, arity = $3
-       (fun nameRange augmentation -> 
-           let valSig = SynValSig([], (SynIdent(mkSynId m "Invoke", None)), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, m, SynValSigTrivia.Zero) 
+       (fun nameRange augmentation ->
+           let valSig = SynValSig([], (SynIdent(mkSynId m "Invoke", None)), inferredTyparDecls, ty, arity, false, false, PreXmlDoc.Empty, None, None, m, SynValSigTrivia.Zero)
            let flags = AbstractMemberFlags true SynMemberKind.Member
-           let invoke = SynMemberDefn.AbstractSlot(valSig, flags, m, SynMemberDefnAbstractSlotTrivia.Zero) 
+           let invoke = SynMemberDefn.AbstractSlot(valSig, flags, m, SynMemberDefnAbstractSlotTrivia.Zero)
            if not (isNil augmentation) then raiseParseErrorAt m (FSComp.SR.parsAugmentationsIllegalOnDelegateType())
-           SynTypeDefnRepr.ObjectModel (SynTypeDefnKind.Delegate (ty, arity), [invoke], m), []) }
+           SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Delegate(ty, arity), [invoke], m), []) }
 
 
 /* The right-hand-side of a object type definition */
-tyconClassDefn: 
+tyconClassDefn:
   | classDefnBlockKindUnspecified
-     { let needsCheck, decls, mopt = $1 
+     { let needsCheck, decls, mopt = $1
        needsCheck, (SynTypeDefnKind.Unspecified, decls), mopt }
 
-  | classOrInterfaceOrStruct classDefnBlock END 
+  | classOrInterfaceOrStruct classDefnBlock END
      { false, ($1, $2), Some (rhs2 parseState 1 3) }
 
-  | classOrInterfaceOrStruct classDefnBlock recover 
+  | classOrInterfaceOrStruct classDefnBlock recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedClassInterfaceOrStruct())
        let m = (rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range)
        false, ($1, $2), Some(m) }
 
   | classOrInterfaceOrStruct error END
-     { // silent recovery 
+     { // silent recovery
        false, ($1, []), Some (rhs2 parseState 1 3) }
 
 
 /* The right-hand-side of a object type definition where the class/interface/struct kind has not been specified */
 classDefnBlockKindUnspecified:
-  | OBLOCKBEGIN  classDefnMembers recover
+  | OBLOCKBEGIN classDefnMembers recover
      { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileTypeDefinition())
        let mopt =
            match $2 with
-           | _ :: _ -> Some( (rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range) )
+           | _ :: _ -> Some((rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range))
            | _ -> None
        false, $2, mopt }
 
-  | OBLOCKBEGIN  classDefnMembers oblockend 
+  | OBLOCKBEGIN classDefnMembers oblockend
      { let mopt =
            match $2 with
-           | _ :: _ -> Some( (rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range) )
+           | _ :: _ -> Some((rhs parseState 1, $2) ||> unionRangeWithListBy (fun (d:SynMemberDefn) -> d.Range))
            | _ -> None
        true, $2, mopt }
 
 
 /* The contents of an object type definition or type augmentation */
 classDefnBlock:
-  | OBLOCKBEGIN  classDefnMembers recover 
+  | OBLOCKBEGIN classDefnMembers recover
       { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileTypeDefinition())
         $2 }
 
-  | OBLOCKBEGIN  classDefnMembers oblockend 
+  | OBLOCKBEGIN classDefnMembers oblockend
       { $2 }
 
-  | classDefnMembers 
+  | classDefnMembers
       { $1 }
 
 
 /* The members of an object type definition or type augmentation, possibly empty */
-classDefnMembers:  
+classDefnMembers:
   | classDefnMembersAtLeastOne
      { $1 }
 
   /* REVIEW: Error recovery rules that are followed by potentially empty productions are suspicious! */
-  | error classDefnMembers 
+  | error classDefnMembers
      { $2 }
 
   | /* EMPTY */
      { [] }
-  
+
 
 /* The members of an object type definition or type augmentation */
 classDefnMembersAtLeastOne:
   | classDefnMember opt_seps classDefnMembers
      { match $1, $3 with
-       | [ SynMemberDefn.Interface (members=Some []; range=m) ], nextMember :: _ ->
+       | [ SynMemberDefn.Interface(members=Some []; range=m) ], nextMember :: _ ->
            warning(IndentationProblem(FSComp.SR.lexfltTokenIsOffsideOfContextStartedEarlier(warningStringOfPos m.Start), nextMember.Range))
        | _ -> ()
        $1 @ $3 }
 
 
 /* The "with get, set" part of a member definition */
-classDefnMemberGetSet: 
+classDefnMemberGetSet:
   | WITH classDefnMemberGetSetElements
      { let mWithKwd = rhs parseState 1
        mWithKwd, $2  }
@@ -1743,57 +1743,57 @@ classDefnMemberGetSet:
        mWithKwd, $2  }
 
 /* The "get, set" part of a member definition */
-classDefnMemberGetSetElements: 
-  | classDefnMemberGetSetElement 
-     { [$1], None  }
+classDefnMemberGetSetElements:
+  | classDefnMemberGetSetElement
+     { [$1], None }
 
   | classDefnMemberGetSetElement AND classDefnMemberGetSetElement
      { let mAnd = rhs parseState 2
        [$1;$3], Some mAnd }
 
-classDefnMemberGetSetElement: 
-  | opt_inline opt_attributes bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedSequentialExprBlock 
+classDefnMemberGetSetElement:
+  | opt_inline opt_attributes bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedSequentialExprBlock
      { let mEquals = rhs parseState 5
-       let mRhs = ($6 : SynExpr).Range 
+       let mRhs = ($6 : SynExpr).Range
        ($1, $2, $3, $4, Some mEquals, $6, mRhs) }
 
 
 /* The core of a member definition */
-memberCore:  
+memberCore:
   /* Methods and simple getter properties */
-  | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedSequentialExprBlock  
-     { let mRhs = $5.Range 
+  | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedSequentialExprBlock
+     { let mRhs = $5.Range
        let optReturnType = $3
        let mEquals = rhs parseState 4
-       let bindingPat, mBindLhs = $2 
+       let bindingPat, mBindLhs = $2
        (fun vis flagsBuilderAndLeadingKeyword attrs rangeStart ->
             let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, rangeStart)
-            let memFlagsBuilder, leadingKeyword = flagsBuilderAndLeadingKeyword 
+            let memFlagsBuilder, leadingKeyword = flagsBuilderAndLeadingKeyword
             let memberFlags = memFlagsBuilder SynMemberKind.Member
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let trivia: SynBindingTrivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = Some mEquals }
             let binding = mkSynBinding (xmlDoc, bindingPat) (vis, (Option.isSome $1), false, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, optReturnType, $5, mRhs, [], attrs, Some memberFlags, trivia)
             let memberRange = unionRanges rangeStart mRhs |> unionRangeWithXmlDoc xmlDoc
-            [ SynMemberDefn.Member (binding, memberRange) ]) }
+            [ SynMemberDefn.Member(binding, memberRange) ]) }
 
   /* Properties with explicit get/set, also indexer properties */
-  | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints classDefnMemberGetSet  
+  | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints classDefnMemberGetSet
      { let mWith, (classDefnMemberGetSetElements, mAnd) = $4
-       let mWhole = (rhs parseState 2, classDefnMemberGetSetElements) ||> unionRangeWithListBy (fun (_, _, _, _, _, _, m2) -> m2) 
-       let propertyNameBindingPat, _ = $2 
+       let mWhole = (rhs parseState 2, classDefnMemberGetSetElements) ||> unionRangeWithListBy (fun (_, _, _, _, _, _, m2) -> m2)
+       let propertyNameBindingPat, _ = $2
        let optPropertyType = $3
 
        mkSynMemberDefnGetSet
-           parseState 
-           $1 
-           mWith 
-           classDefnMemberGetSetElements 
-           mAnd 
-           mWhole 
-           propertyNameBindingPat 
+           parseState
+           $1
+           mWith
+           classDefnMemberGetSetElements
+           mAnd
+           mWhole
+           propertyNameBindingPat
            optPropertyType }
 
-abstractMemberFlags: 
+abstractMemberFlags:
   | ABSTRACT
       { let mAbstract = rhs parseState 1
         AbstractMemberFlags true, SynLeadingKeyword.Abstract mAbstract }
@@ -1827,35 +1827,35 @@ classDefnMember:
   | opt_attributes opt_access classDefnBindings
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        [mkClassMemberLocalBindings(false, None, $1, $2, $3)] }
-       
-  | opt_attributes opt_access STATIC classDefnBindings  
+
+  | opt_attributes opt_access STATIC classDefnBindings
      { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        [mkClassMemberLocalBindings(true, Some (rhs parseState 3), $1, $2, $4)] }
-              
+
   | opt_attributes opt_access memberFlags memberCore opt_ODECLEND
      { let rangeStart = rhs parseState 1
        if Option.isSome $2 then
            errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let flags = $3
        $4 $2 flags $1 rangeStart }
-       
-  | opt_attributes opt_access interfaceMember appType opt_interfaceImplDefn  
+
+  | opt_attributes opt_access interfaceMember appType opt_interfaceImplDefn
      {  if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesAreNotPermittedOnInterfaceImplementations(), rhs parseState 1))
         if Option.isSome $2 then errorR(Error(FSComp.SR.parsInterfacesHaveSameVisibilityAsEnclosingType(), rhs parseState 3))
         let mWithKwd, members, mWhole =
             match $5 with
             | None -> None, None, rhs2 parseState 1 4
             | Some (mWithKwd, members, m) -> Some mWithKwd, Some members, unionRanges (rhs2 parseState 1 4) m
-        [ SynMemberDefn.Interface ($4, mWithKwd, members, mWhole) ] }
-        
-  | opt_attributes opt_access abstractMemberFlags opt_inline nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet  opt_ODECLEND
+        [ SynMemberDefn.Interface($4, mWithKwd, members, mWhole) ] }
+
+  | opt_attributes opt_access abstractMemberFlags opt_inline nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints classMemberSpfnGetSet opt_ODECLEND
      { let ty, arity = $8
        let isInline, doc, id, explicitValTyparDecls = (Option.isSome $4), grabXmlDoc(parseState, $1, 1), $5, $6
        let mWith, (getSet, getSetRangeOpt) = $9
        let getSetAdjuster arity = match arity, getSet with SynValInfo([], _), SynMemberKind.Member -> SynMemberKind.PropertyGet | _ -> getSet
-       let mWhole = 
+       let mWhole =
            let m = rhs parseState 1
-           match getSetRangeOpt with 
+           match getSetRangeOpt with
            | None -> unionRanges m ty.Range
            | Some gs -> unionRanges m gs.Range
            |> unionRangeWithXmlDoc doc
@@ -1863,9 +1863,9 @@ classDefnMember:
        let mkFlags, leadingKeyword = $3
        let trivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $4; WithKeyword = mWith; EqualsRange = None }
        let valSpfn = SynValSig($1, id, explicitValTyparDecls, ty, arity, isInline, false, doc, None, None, mWhole, trivia)
-       let trivia: SynMemberDefnAbstractSlotTrivia = { GetSetKeywords = getSetRangeOpt } 
+       let trivia: SynMemberDefnAbstractSlotTrivia = { GetSetKeywords = getSetRangeOpt }
        [ SynMemberDefn.AbstractSlot(valSpfn, mkFlags (getSetAdjuster arity), mWhole, trivia) ] }
-       
+
   | opt_attributes opt_access inheritsDefn
      {  if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalOnInherit(), rhs parseState 1))
         if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityIllegalOnInherit(), rhs parseState 1))
@@ -1875,7 +1875,7 @@ classDefnMember:
      {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let rangeStart = rhs parseState 1
         $3 rangeStart $1 None }
-        
+
   | opt_attributes opt_access STATIC valDefnDecl opt_ODECLEND
      {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let mStatic = rhs parseState 3
@@ -1883,13 +1883,13 @@ classDefnMember:
         $4 rangeStart $1 (Some mStatic)  }
 
   | opt_attributes opt_access memberFlags autoPropsDefnDecl opt_ODECLEND
-     { let rangeStart = rhs parseState 1 
+     { let rangeStart = rhs parseState 1
        if Option.isSome $2 then
            errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
        let flags = $3
        $4 $1 flags rangeStart }
 
-  | opt_attributes opt_access NEW  atomicPattern optAsSpec EQUALS typedSequentialExprBlock opt_ODECLEND
+  | opt_attributes opt_access NEW atomicPattern optAsSpec EQUALS typedSequentialExprBlock opt_ODECLEND
      {  let mWholeBindLhs = rhs2 parseState 1 (if Option.isSome $5 then 5 else 4)
         let mNew = rhs parseState 3
         let xmlDoc = grabXmlDoc(parseState, $1, 1)
@@ -1897,14 +1897,14 @@ classDefnMember:
         let mEquals = rhs parseState 6
         let expr = $7
         let valSynData = SynValData (Some CtorMemberFlags, SynValInfo([SynInfo.InferSynArgInfoFromPat $4], SynInfo.unnamedRetVal), Option.map snd $5)
-        let vis = $2 
-        let declPat = SynPat.LongIdent (SynLongIdent([mkSynId (rhs parseState 3) "new"], [], [None]), None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
+        let vis = $2
+        let declPat = SynPat.LongIdent(SynLongIdent([mkSynId (rhs parseState 3) "new"], [], [None]), None, Some noInferredTypars, SynArgPats.Pats [$4], vis, rhs parseState 3)
         // Check that 'SynPatForConstructorDecl' matches this correctly
         assert (match declPat with SynPatForConstructorDecl _ -> true | _ -> false)
         let synBindingTrivia: SynBindingTrivia = { LeadingKeyword = SynLeadingKeyword.New mNew; InlineKeyword = None; EqualsRange = Some mEquals }
         [ SynMemberDefn.Member(SynBinding (None, SynBindingKind.Normal, false, false, $1, xmlDoc, valSynData, declPat, None, expr, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, synBindingTrivia), m) ] }
-        
-  | opt_attributes opt_access STATIC typeKeyword tyconDefn 
+
+  | opt_attributes opt_access STATIC typeKeyword tyconDefn
      {  if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
         let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
         [ SynMemberDefn.NestedType($5 leadingKeyword, None, rhs2 parseState 1 5) ] }
@@ -1912,7 +1912,7 @@ classDefnMember:
 
 /* A 'val' definition in an object type definition */
 valDefnDecl:
-  | VAL opt_mutable opt_access ident COLON  typ 
+  | VAL opt_mutable opt_access ident COLON typ
      {  let mVal = rhs parseState 1
         let mRhs = rhs2 parseState 4 6
         let mValDecl = rhs2 parseState 1 6
@@ -1920,7 +1920,7 @@ valDefnDecl:
             let isStatic = Option.isSome mStaticOpt
             let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
             let mValDecl = unionRanges rangeStart mValDecl |> unionRangeWithXmlDoc xmlDoc
-            let leadingKeyword = 
+            let leadingKeyword =
                 match mStaticOpt with
                 | None -> SynLeadingKeyword.Val mVal
                 | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
@@ -1949,7 +1949,7 @@ autoPropsDefnDecl:
 
 /* An optional type on an auto-property definition */
 opt_typ:
-   | /* EMPTY */ { None } 
+   | /* EMPTY */ { None }
    | COLON typ { Some $2 }
 
 
@@ -1976,7 +1976,7 @@ atomicPatternLongIdent:
 
        let underscore = ident("_", rhs parseState 2)
        let mDot = rhs parseState 3
-       Some($1), prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) mDot $4 } 
+       Some($1), prependIdentInLongIdentWithTrivia (SynIdent(underscore, None)) mDot $4 }
 
   | access pathOp
      { (Some($1), $2) }
@@ -1987,7 +1987,7 @@ opt_access:
      { None }
 
   | access
-     { Some($1) } 
+     { Some($1) }
 
 
 access:
@@ -2019,7 +2019,7 @@ opt_interfaceImplDefn:
      { None }
 
 
-opt_classDefn: 
+opt_classDefn:
   | WITH classDefnBlock declEnd
      { let mWithKwd = rhs parseState 1
        (Some mWithKwd), $2 }
@@ -2029,13 +2029,13 @@ opt_classDefn:
 
 
 /* An 'inherits' definition in an object type definition */
-inheritsDefn: 
+inheritsDefn:
   | INHERIT atomTypeNonAtomicDeprecated optBaseSpec
-     { let mDecl = unionRanges (rhs parseState 1) (($2): SynType).Range 
+     { let mDecl = unionRanges (rhs parseState 1) (($2): SynType).Range
        SynMemberDefn.Inherit($2, $3, mDecl) }
 
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType optBaseSpec
-     { let mDecl = unionRanges (rhs parseState 1) $4.Range 
+     { let mDecl = unionRanges (rhs parseState 1) $4.Range
        SynMemberDefn.ImplicitInherit($2, $4, $5, mDecl) }
 
   | INHERIT ends_coming_soon_or_recover
@@ -2043,59 +2043,59 @@ inheritsDefn:
        if not $2 then errorR(Error(FSComp.SR.parsTypeNameCannotBeEmpty(), mDecl))
        SynMemberDefn.Inherit(SynType.LongIdent(SynLongIdent([], [], [])), None, mDecl) }
 
-optAsSpec: 
+optAsSpec:
   | asSpec
-      { Some($1) } 
+      { Some($1) }
 
   | /* EMPTY */
       { None }
 
-asSpec: 
+asSpec:
   | AS ident
-     { rhs parseState 1, $2 } 
+     { rhs parseState 1, $2 }
 
-optBaseSpec: 
+optBaseSpec:
   | baseSpec
-     { Some($1) } 
+     { Some($1) }
 
   | /* EMPTY */
      { None }
 
-baseSpec: 
-  | AS ident 
-      { if ($2).idText <> "base" then 
-             errorR(Error(FSComp.SR.parsInheritDeclarationsCannotHaveAsBindings(), rhs2 parseState 1 2)) 
-        ident("base", rhs parseState 2) } 
-        
-  | AS BASE 
-      { errorR(Error(FSComp.SR.parsInheritDeclarationsCannotHaveAsBindings(), rhs2 parseState 1 2)) 
-        ident("base", rhs parseState 2) } 
+baseSpec:
+  | AS ident
+      { if ($2).idText <> "base" then
+             errorR(Error(FSComp.SR.parsInheritDeclarationsCannotHaveAsBindings(), rhs2 parseState 1 2))
+        ident("base", rhs parseState 2) }
+
+  | AS BASE
+      { errorR(Error(FSComp.SR.parsInheritDeclarationsCannotHaveAsBindings(), rhs2 parseState 1 2))
+        ident("base", rhs parseState 2) }
 
 
 /* The members in an object expression or interface implementation */
 objectImplementationBlock:
-  | OBLOCKBEGIN objectImplementationMembers oblockend  
+  | OBLOCKBEGIN objectImplementationMembers oblockend
       { $2 }
 
-  | OBLOCKBEGIN objectImplementationMembers recover 
+  | OBLOCKBEGIN objectImplementationMembers recover
       { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileObjectMembers())
         $2 }
 
-  | objectImplementationMembers 
+  | objectImplementationMembers
       { $1 }
 
 
 /* The members in an object expression or interface implementation */
-objectImplementationMembers:  
-  | objectImplementationMember opt_seps objectImplementationMembers 
+objectImplementationMembers:
+  | objectImplementationMember opt_seps objectImplementationMembers
       { $1 @  $3 }
 
-  | objectImplementationMember opt_seps 
+  | objectImplementationMember opt_seps
       { $1 }
 
 
 /* One member in an object expression or interface implementation */
-objectImplementationMember: 
+objectImplementationMember:
   | opt_attributes staticMemberOrMemberOrOverride memberCore opt_ODECLEND
      { let rangeStart = rhs parseState 1
        $3 None $2 $1 rangeStart }
@@ -2104,10 +2104,10 @@ objectImplementationMember:
      { let rangeStart = rhs parseState 1
        $3 $1 $2 rangeStart }
 
-  | opt_attributes staticMemberOrMemberOrOverride error 
-      { [] } 
+  | opt_attributes staticMemberOrMemberOrOverride error
+      { [] }
 
-  | opt_attributes error memberCore opt_ODECLEND 
+  | opt_attributes error memberCore opt_ODECLEND
       { [] }
 
 
@@ -2115,51 +2115,51 @@ staticMemberOrMemberOrOverride:
   | STATIC MEMBER
       { let mStatic = rhs parseState 1
         let mMember = rhs parseState 2
-        ImplementStaticMemberFlags, (SynLeadingKeyword.StaticMember(mStatic, mMember)) }  
-  | MEMBER 
+        ImplementStaticMemberFlags, (SynLeadingKeyword.StaticMember(mStatic, mMember)) }
+  | MEMBER
       { let mMember = rhs parseState 1
         OverrideMemberFlags, (SynLeadingKeyword.Member mMember) }
-  | OVERRIDE 
+  | OVERRIDE
       { let mOverride = rhs parseState 1
         OverrideMemberFlags, (SynLeadingKeyword.Override mOverride) }
 
 
 /* The core of the right-hand-side of a simple type definition */
-tyconDefnOrSpfnSimpleRepr: 
+tyconDefnOrSpfnSimpleRepr:
 
   /* type MyAlias = SomeTypeProvider<@"foo">    is a common error, special-case it */
-  | opt_attributes opt_access path LQUOTE STRING recover     
-     { errorR(Error(FSComp.SR.parsUnexpectedQuotationOperatorInTypeAliasDidYouMeanVerbatimString(), rhs parseState 4)) 
-       SynTypeDefnSimpleRepr.TypeAbbrev (ParserDetail.ErrorRecovery, SynType.LongIdent($3), unionRanges (rhs parseState 1) $3.Range)  }
+  | opt_attributes opt_access path LQUOTE STRING recover
+     { errorR(Error(FSComp.SR.parsUnexpectedQuotationOperatorInTypeAliasDidYouMeanVerbatimString(), rhs parseState 4))
+       SynTypeDefnSimpleRepr.TypeAbbrev(ParserDetail.ErrorRecovery, SynType.LongIdent($3), unionRanges (rhs parseState 1) $3.Range)  }
 
   /* A type abbreviation */
   | opt_attributes opt_access typ
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsTypeAbbreviationsCannotHaveVisibilityDeclarations(), rhs parseState 2))
-       SynTypeDefnSimpleRepr.TypeAbbrev (ParserDetail.Ok, $3, unionRanges (rhs parseState 1) $3.Range) }
+       SynTypeDefnSimpleRepr.TypeAbbrev(ParserDetail.Ok, $3, unionRanges (rhs parseState 1) $3.Range) }
 
   /* A union type definition */
   | opt_attributes opt_access unionTypeRepr
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
        let rangesOf3 = $3 |> List.map (function Choice1Of2 ec -> ec.Range | Choice2Of2 uc -> uc.Range)
-       let mWhole = (rhs2 parseState 1 2, rangesOf3) ||> List.fold unionRanges 
+       let mWhole = (rhs2 parseState 1 2, rangesOf3) ||> List.fold unionRanges
        if $3 |> List.exists (function Choice1Of2 _ -> true | _ -> false) then (
-           if Option.isSome $2 then errorR(Error(FSComp.SR.parsEnumTypesCannotHaveVisibilityDeclarations(), rhs parseState 2));
-           SynTypeDefnSimpleRepr.Enum ($3 |> List.choose (function 
-                                              | Choice1Of2 data ->  
-                                                Some(data) 
-                                              | Choice2Of2(SynUnionCase(range=m)) -> 
+           if Option.isSome $2 then errorR(Error(FSComp.SR.parsEnumTypesCannotHaveVisibilityDeclarations(), rhs parseState 2))
+           SynTypeDefnSimpleRepr.Enum($3 |> List.choose (function
+                                              | Choice1Of2 data ->
+                                                Some(data)
+                                              | Choice2Of2(SynUnionCase(range=m)) ->
                                                 errorR(Error(FSComp.SR.parsAllEnumFieldsRequireValues(), m)); None),
                            mWhole)
-       ) else 
-           SynTypeDefnSimpleRepr.Union ($2,
+       ) else
+           SynTypeDefnSimpleRepr.Union($2,
                             $3 |> List.choose (function Choice2Of2 data -> Some(data) | Choice1Of2 _ -> failwith "huh?"),
                             mWhole) }
 
   /* A record type definition */
   | opt_attributes opt_access braceFieldDeclList
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesIllegalHere(), rhs parseState 1))
-       SynTypeDefnSimpleRepr.Record ($2, $3, lhs parseState) }
+       SynTypeDefnSimpleRepr.Record($2, $3, lhs parseState) }
 
   /* An inline-assembly type definition, for FSharp.Core library only */
   | opt_attributes opt_access LPAREN HASH string HASH rparen
@@ -2169,19 +2169,19 @@ tyconDefnOrSpfnSimpleRepr:
        if Option.isSome $2 then errorR(Error(FSComp.SR.parsInlineAssemblyCannotHaveVisibilityDeclarations(), rhs parseState 2))
        let s, _ = $5
        let ilType = ParseAssemblyCodeType s parseState.LexBuffer.ReportLibraryOnlyFeatures parseState.LexBuffer.LanguageVersion (rhs parseState 5)
-       SynTypeDefnSimpleRepr.LibraryOnlyILAssembly (box ilType, mLhs)  }
+       SynTypeDefnSimpleRepr.LibraryOnlyILAssembly(box ilType, mLhs)  }
 
 
 /* The core of a record type definition */
 braceFieldDeclList:
-  | LBRACE  recdFieldDeclList rbrace
+  | LBRACE recdFieldDeclList rbrace
      { $2 }
 
-  | LBRACE  recdFieldDeclList recover
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace()) 
+  | LBRACE recdFieldDeclList recover
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())
        $2 }
 
-  | LBRACE  error rbrace
+  | LBRACE error rbrace
      { [] }
 
 anonRecdType:
@@ -2192,87 +2192,87 @@ anonRecdType:
 
 /* The core of a record type definition */
 braceBarFieldDeclListCore:
-  | LBRACE_BAR  recdFieldDeclList bar_rbrace
+  | LBRACE_BAR recdFieldDeclList bar_rbrace
      { $2 }
 
-  | LBRACE_BAR  recdFieldDeclList recover
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar()) 
+  | LBRACE_BAR recdFieldDeclList recover
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())
        $2 }
 
   | LBRACE_BAR error bar_rbrace
      { [] }
 
-classOrInterfaceOrStruct: 
-  | CLASS 
-     { SynTypeDefnKind.Class } 
+classOrInterfaceOrStruct:
+  | CLASS
+     { SynTypeDefnKind.Class }
 
   | INTERFACE
-     { SynTypeDefnKind.Interface } 
+     { SynTypeDefnKind.Interface }
 
   | STRUCT
      { SynTypeDefnKind.Struct }
 
-interfaceMember: 
-  | INTERFACE { } 
-  | OINTERFACE_MEMBER    { }
+interfaceMember:
+  | INTERFACE { }
+  | OINTERFACE_MEMBER { }
 
-tyconNameAndTyparDecls:  
-  | opt_access path 
+tyconNameAndTyparDecls:
+  | opt_access path
       { None, $2.LongIdent, false, $1 }
 
-  | opt_access prefixTyparDecls  path
+  | opt_access prefixTyparDecls path
       { Some $2, $3.LongIdent, false, $1 }
 
-  | opt_access path postfixTyparDecls 
+  | opt_access path postfixTyparDecls
       { Some $3, $2.LongIdent, true, $1 }
 
 prefixTyparDecls:
   | typar
-      { SynTyparDecls.SinglePrefix (SynTyparDecl([], $1), rhs parseState 1) }
+      { SynTyparDecls.SinglePrefix(SynTyparDecl([], $1), rhs parseState 1) }
 
   | LPAREN typarDeclList rparen
-      { SynTyparDecls.PrefixList (List.rev $2, rhs2 parseState 1 3) }
+      { SynTyparDecls.PrefixList(List.rev $2, rhs2 parseState 1 3) }
 
-typarDeclList: 
-  | typarDeclList COMMA typarDecl { $3 :: $1 } 
+typarDeclList:
+  | typarDeclList COMMA typarDecl { $3 :: $1 }
   | typarDecl { [$1] }
 
-typarDecl : 
-  | opt_attributes typar 
+typarDecl :
+  | opt_attributes typar
       { SynTyparDecl($1, $2) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
-postfixTyparDecls: 
-  | opt_HIGH_PRECEDENCE_TYAPP LESS typarDeclList opt_typeConstraints GREATER 
+postfixTyparDecls:
+  | opt_HIGH_PRECEDENCE_TYAPP LESS typarDeclList opt_typeConstraints GREATER
       { let m = rhs2 parseState 2 5
         if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), m))
-        SynTyparDecls.PostfixList (List.rev $3, $4, m) }
+        SynTyparDecls.PostfixList(List.rev $3, $4, m) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
-explicitValTyparDeclsCore: 
-  | typarDeclList COMMA DOT_DOT 
+explicitValTyparDeclsCore:
+  | typarDeclList COMMA DOT_DOT
       { (List.rev $1, true) }
 
-  | typarDeclList 
+  | typarDeclList
       { (List.rev $1, false) }
 
   | /* EMPTY */
       { ([], false) }
 
-explicitValTyparDecls: 
-  | opt_HIGH_PRECEDENCE_TYAPP LESS explicitValTyparDeclsCore opt_typeConstraints GREATER 
+explicitValTyparDecls:
+  | opt_HIGH_PRECEDENCE_TYAPP LESS explicitValTyparDeclsCore opt_typeConstraints GREATER
       { let m = rhs2 parseState 2 5
         if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), m))
-        let tps, flex = $3 
-        let tps = SynTyparDecls.PostfixList (tps, $4, m)
+        let tps, flex = $3
+        let tps = SynTyparDecls.PostfixList(tps, $4, m)
         SynValTyparDecls(Some tps, flex) }
 
-opt_explicitValTyparDecls: 
-  | explicitValTyparDecls 
-      { $1 } 
-  |       
+opt_explicitValTyparDecls:
+  | explicitValTyparDecls
+      { $1 }
+  |
       { SynValTyparDecls(None, true) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
@@ -2281,43 +2281,43 @@ opt_typeConstraints:
   | /* EMPTY */
      { [] }
 
-  | WHEN typeConstraints 
+  | WHEN typeConstraints
      { List.rev $2 }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
-typeConstraints: 
+typeConstraints:
   | typeConstraints AND typeConstraint
-     { $3 :: $1 } 
+     { $3 :: $1 }
 
   | typeConstraint
      { [$1] }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
-typeConstraint: 
-  | DEFAULT typar COLON typ 
+typeConstraint:
+  | DEFAULT typar COLON typ
      { if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyError (lhs parseState)
        SynTypeConstraint.WhereTyparDefaultsToType($2, $4, lhs parseState) }
 
-  | typar COLON_GREATER typ 
+  | typar COLON_GREATER typ
      { SynTypeConstraint.WhereTyparSubtypeOfType($1, $3, lhs parseState) }
 
-  | typar COLON STRUCT 
+  | typar COLON STRUCT
      { SynTypeConstraint.WhereTyparIsValueType($1, lhs parseState) }
 
-  | typar COLON IDENT STRUCT 
-     { if $3 <> "not" then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedIdentifier($3))  
+  | typar COLON IDENT STRUCT
+     { if $3 <> "not" then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedIdentifier($3))
        SynTypeConstraint.WhereTyparIsReferenceType($1, lhs parseState) }
 
-  | typar COLON NULL 
+  | typar COLON NULL
      { SynTypeConstraint.WhereTyparSupportsNull($1, lhs parseState) }
 
-  | typar COLON LPAREN classMemberSpfn rparen 
+  | typar COLON LPAREN classMemberSpfn rparen
      { let tp = $1
        SynTypeConstraint.WhereTyparSupportsMember(SynType.Var(tp, tp.Range), $4, lhs parseState) }
 
-  | LPAREN typeAlts rparen COLON LPAREN classMemberSpfn rparen 
+  | LPAREN typeAlts rparen COLON LPAREN classMemberSpfn rparen
      { let mParen = rhs2 parseState 1 3
        let t = SynType.Paren($2, mParen)
        SynTypeConstraint.WhereTyparSupportsMember(t, $6, lhs parseState) }
@@ -2327,14 +2327,14 @@ typeConstraint:
        SynTypeConstraint.WhereTyparIsDelegate($1, args, unionRanges $1.Range mWhole) }
 
   | typar COLON IDENT typeArgsNoHpaDeprecated
-     { match $3 with 
+     { match $3 with
        | "enum" ->
            let _ltm, _gtm, args, _commas, mWhole = $4
            SynTypeConstraint.WhereTyparIsEnum($1, args, unionRanges $1.Range mWhole)
        | nm -> raiseParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedIdentifier(nm)) }
 
-  | typar COLON IDENT 
-     { match $3 with 
+  | typar COLON IDENT
+     { match $3 with
        | "comparison" -> SynTypeConstraint.WhereTyparIsComparable($1, lhs parseState)
        | "equality" -> SynTypeConstraint.WhereTyparIsEquatable($1, lhs parseState)
        | "unmanaged" -> SynTypeConstraint.WhereTyparIsUnmanaged($1, lhs parseState)
@@ -2356,23 +2356,23 @@ typeAlts:
 unionTypeRepr:
   /* Note the next three rules are required to disambiguate this from type x = y */
   /* Attributes can only appear on a single constructor if you've used a | */
-  | barAndgrabXmlDoc attrUnionCaseDecls  
+  | barAndgrabXmlDoc attrUnionCaseDecls
      { $2 $1 }
 
-  | firstUnionCaseDeclOfMany barAndgrabXmlDoc attrUnionCaseDecls  
+  | firstUnionCaseDeclOfMany barAndgrabXmlDoc attrUnionCaseDecls
      { $1 :: $3 $2 }
 
-  | firstUnionCaseDecl 
-     { [$1] } 
+  | firstUnionCaseDecl
+     { [$1] }
 
-barAndgrabXmlDoc: 
+barAndgrabXmlDoc:
   | BAR
      { let mBar = rhs parseState 1
        grabXmlDoc(parseState, [], 1), mBar }
 
-attrUnionCaseDecls: 
+attrUnionCaseDecls:
   | attrUnionCaseDecl barAndgrabXmlDoc attrUnionCaseDecls
-     { (fun xmlDocAndBar -> $1 xmlDocAndBar  :: $3 $2) } 
+     { (fun xmlDocAndBar -> $1 xmlDocAndBar :: $3 $2) }
 
   | attrUnionCaseDecl
      { (fun xmlDocAndBar -> [ $1 xmlDocAndBar ]) }
@@ -2385,7 +2385,7 @@ attrUnionCaseDecl:
         (fun (xmlDoc, mBar) ->
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2 (SynUnionCase ($1, $3, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access recover
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
@@ -2393,7 +2393,7 @@ attrUnionCaseDecl:
             let id = SynIdent(mkSynId mBar.EndRange "", None)
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mBar
-            Choice2Of2 (SynUnionCase ( $1, id, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2 (SynUnionCase ($1, id, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access unionCaseName OF unionCaseRepr
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
@@ -2401,7 +2401,7 @@ attrUnionCaseDecl:
         (fun (xmlDoc, mBar) ->
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.Fields $5, xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2 (SynUnionCase ($1, $3, SynUnionCaseKind.Fields $5, xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access OF unionCaseRepr
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
@@ -2430,50 +2430,50 @@ attrUnionCaseDecl:
   | opt_attributes opt_access unionCaseName OF recover
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
         let mDecl = rhs2 parseState 1 4
-        (fun (xmlDoc, mBar) -> 
+        (fun (xmlDoc, mBar) ->
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2 (SynUnionCase ($1, $3, SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access unionCaseName COLON topType
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsUnionCasesCannotHaveVisibilityDeclarations(), rhs parseState 2))
         if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyWarning(lhs parseState)
         let mDecl = rhs2 parseState 1 5
-        (fun (xmlDoc, mBar) -> 
+        (fun (xmlDoc, mBar) ->
             let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice2Of2 (SynUnionCase ( $1, $3, SynUnionCaseKind.FullType $5, xmlDoc, None, mDecl, trivia))) }
+            Choice2Of2 (SynUnionCase ($1, $3, SynUnionCaseKind.FullType $5, xmlDoc, None, mDecl, trivia))) }
 
   | opt_attributes opt_access unionCaseName EQUALS atomicExpr
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsEnumFieldsCannotHaveVisibilityDeclarations(), rhs parseState 2))
         let mEquals = rhs parseState 4
         let mDecl = rhs2 parseState 1 5
-        (fun (xmlDoc, mBar) -> 
+        (fun (xmlDoc, mBar) ->
             let trivia: SynEnumCaseTrivia = { BarRange = Some mBar; EqualsRange = mEquals }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
-            Choice1Of2 (SynEnumCase ( $1, $3, fst $5, xmlDoc, mDecl, trivia))) } 
+            Choice1Of2 (SynEnumCase ($1, $3, fst $5, xmlDoc, mDecl, trivia))) }
 
 /* The name of a union case */
-unionCaseName: 
-  | nameop  
-      { $1 } 
+unionCaseName:
+  | nameop
+      { $1 }
 
-  | LPAREN COLON_COLON rparen  
-      { let lpr = rhs parseState 1
-        let rpr = rhs parseState 3 
-        SynIdent(ident(opNameCons, rhs parseState 2), Some(IdentTrivia.OriginalNotationWithParen(lpr, "::", rpr))) }  
-
-  | LPAREN LBRACK RBRACK  rparen  
+  | LPAREN COLON_COLON rparen
       { let lpr = rhs parseState 1
         let rpr = rhs parseState 3
-        SynIdent(ident(opNameNil, rhs2 parseState 2 3), Some(IdentTrivia.OriginalNotationWithParen(lpr, "[]", rpr))) }  
+        SynIdent(ident(opNameCons, rhs parseState 2), Some(IdentTrivia.OriginalNotationWithParen(lpr, "::", rpr))) }
 
-firstUnionCaseDeclOfMany: 
+  | LPAREN LBRACK RBRACK rparen
+      { let lpr = rhs parseState 1
+        let rpr = rhs parseState 3
+        SynIdent(ident(opNameNil, rhs2 parseState 2 3), Some(IdentTrivia.OriginalNotationWithParen(lpr, "[]", rpr))) }
+
+firstUnionCaseDeclOfMany:
   | ident opt_OBLOCKSEP
       { let trivia: SynUnionCaseTrivia = { BarRange = None }
         let xmlDoc = grabXmlDoc(parseState, [], 1)
         let mDecl = (rhs parseState 1) |> unionRangeWithXmlDoc xmlDoc
-        Choice2Of2 (SynUnionCase ( [], (SynIdent($1, None)), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
+        Choice2Of2 (SynUnionCase ([], (SynIdent($1, None)), SynUnionCaseKind.Fields [], xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS atomicExpr opt_OBLOCKSEP
       { let mEquals = rhs parseState 2
@@ -2534,22 +2534,22 @@ unionCaseReprElement:
 
 unionCaseRepr:
   | braceFieldDeclList
-     { errorR(Deprecated(FSComp.SR.parsConsiderUsingSeparateRecordType(), lhs parseState)) 
+     { errorR(Deprecated(FSComp.SR.parsConsiderUsingSeparateRecordType(), lhs parseState))
        $1 }
 
-  | unionCaseReprElements 
+  | unionCaseReprElements
      { $1 }
 
 /* A list of field declarations in a record type */
-recdFieldDeclList: 
-  | recdFieldDecl seps recdFieldDeclList 
-     { $1 :: $3 } 
+recdFieldDeclList:
+  | recdFieldDecl seps recdFieldDeclList
+     { $1 :: $3 }
 
-  | recdFieldDecl opt_seps           
+  | recdFieldDecl opt_seps
      { [$1] }
 
 /* A field declaration in a record type */
-recdFieldDecl: 
+recdFieldDecl:
   | opt_attributes fieldDecl
      { let mWhole = rhs2 parseState 1 2
        let fld = $2 $1 false mWhole None
@@ -2559,18 +2559,18 @@ recdFieldDecl:
        SynField (a, b, c, d, e, xmlDoc, None, mWhole, trivia) }
 
 /* Part of a field or val declaration in a record type or object type */
-fieldDecl: 
-  | opt_mutable opt_access ident COLON  typ 
+fieldDecl:
+  | opt_mutable opt_access ident COLON typ
      { fun attrs stat mWhole leadingKeyword ->
            let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, mWhole)
            SynField(attrs, stat, Some $3, $5, $1, xmlDoc, $2, mWhole, { LeadingKeyword = leadingKeyword }) }
 
 /* An exception definition */
-exconDefn: 
-  | exconCore opt_classDefn 
+exconDefn:
+  | exconCore opt_classDefn
      { let mWith, optClassDefn = $2
-       SynExceptionDefn($1, mWith, optClassDefn, ($1.Range, optClassDefn) ||> unionRangeWithListBy (fun cd -> cd.Range) ) }
-  
+       SynExceptionDefn($1, mWith, optClassDefn, ($1.Range, optClassDefn) ||> unionRangeWithListBy (fun cd -> cd.Range)) }
+
 /* Part of an exception definition */
 exconCore:
   | EXCEPTION opt_attributes opt_access exconIntro exconRepr
@@ -2583,18 +2583,18 @@ exconCore:
   | EXCEPTION opt_attributes opt_access recover
       { let m =
             match $3 with
-            | Some access -> unionRanges (rhs parseState 1) access.Range 
+            | Some access -> unionRanges (rhs parseState 1) access.Range
             | _ ->
 
             match $2 with
             | [] -> rhs parseState 1
-            | attrs -> ((rhs parseState 1), attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range) 
+            | attrs -> ((rhs parseState 1), attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
 
         let id = SynIdent(mkSynId m.EndRange "", None)
         let unionCase = SynUnionCase([], id, SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, m, { BarRange = None })
 
         SynExceptionDefnRepr($2, unionCase, None, PreXmlDoc.Empty, $3, m) }
-  
+
 /* Part of an exception definition */
 exconIntro:
   | ident
@@ -2606,7 +2606,7 @@ exconIntro:
   | ident OF recover
       { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
-exconRepr: 
+exconRepr:
   | /* EMPTY */
      { None }
 
@@ -2614,12 +2614,12 @@ exconRepr:
      { Some ($2.LongIdent) }
 
 /*-------------------------------------------------------------------------*/
-/* F# Definitions, Types, Patterns and Expressions  */
+/* F# Definitions, Types, Patterns and Expressions */
 
 /* A 'let ...' or 'do ...' statement in the non-#light syntax */
-defnBindings: 
-  | LET opt_rec localBindings 
-      { let mLetKwd = rhs parseState 1 
+defnBindings:
+  | LET opt_rec localBindings
+      { let mLetKwd = rhs parseState 1
         let isUse = $1
         let isRec = $2
         let leadingKeyword =
@@ -2629,10 +2629,10 @@ defnBindings:
                 SynLeadingKeyword.Let(mLetKwd)
 
         let localBindingsLastRangeOpt, localBindingsBuilder = $3
-        
+
         // Calculate the precise range of the binding set, up to the end of the last r.h.s. expression
-        let bindingSetRange = 
-            match localBindingsLastRangeOpt with 
+        let bindingSetRange =
+            match localBindingsLastRangeOpt with
             | None -> rhs2 parseState 1 2 (* there was some error - this will be an approximate range *)
             | Some lastRange -> unionRanges mLetKwd lastRange
 
@@ -2642,7 +2642,7 @@ defnBindings:
                 let xmlDoc = grabXmlDoc(parseState, attrs, 1)
                 // apply the builder
                 let binds = localBindingsBuilder xmlDoc attrs vis leadingKeyword
-                if not isRec && not (isNilOrSingleton binds) then 
+                if not isRec && not (isNilOrSingleton binds) then
                       reportParseErrorAt mLetKwd (FSComp.SR.parsLetAndForNonRecBindings())
                 [], binds),
             bindingSetRange) }
@@ -2654,18 +2654,18 @@ defnBindings:
 
 /* A 'do ...' statement in the non-#light syntax */
 doBinding:
-  | DO typedSequentialExprBlock 
-      { let mDoKwd = rhs parseState 1 
+  | DO typedSequentialExprBlock
+      { let mDoKwd = rhs parseState 1
         let mWhole = unionRanges mDoKwd $2.Range
-        // any attributes prior to the 'let' are left free, e.g. become top-level attributes 
-        // associated with the module, 'main' function or assembly depending on their target 
+        // any attributes prior to the 'let' are left free, e.g. become top-level attributes
+        // associated with the module, 'main' function or assembly depending on their target
         BindingSetPreAttrs(mDoKwd, false, false, (fun attrs vis -> attrs, [mkSynDoBinding (vis, mDoKwd, $2, mWhole)]), mWhole) }
 
 
 /* A 'let ....' binding in the #light syntax */
-hardwhiteLetBindings: 
+hardwhiteLetBindings:
   | OLET opt_rec localBindings hardwhiteDefnBindingsTerminator
-      { let mLetKwd = rhs parseState 1 
+      { let mLetKwd = rhs parseState 1
         let isUse = $1
         let isRec = $2
         let leadingKeyword =
@@ -2679,17 +2679,17 @@ hardwhiteLetBindings:
                 SynLeadingKeyword.Let(mLetKwd)
 
         let report, mIn = $4
-        report (if isUse then "use" else "let") mLetKwd  // report unterminated error 
-        
+        report (if isUse then "use" else "let") mLetKwd // report unterminated error
+
         let localBindingsLastRangeOpt, localBindingsBuilder = $3
-        
+
         // Calculate the precise range of the binding set, up to the end of the last r.h.s. expression
-        let bindingSetRange = 
-            match localBindingsLastRangeOpt with 
+        let bindingSetRange =
+            match localBindingsLastRangeOpt with
             | None -> rhs parseState 1 (* there was some error - this will be an approximate range *)
             | Some lastRange -> unionRanges mLetKwd lastRange
 
-        // the first binding swallow any attributes prior to the 'let' 
+        // the first binding swallow any attributes prior to the 'let'
         BindingSetPreAttrs(mLetKwd, isRec, isUse,
           (fun attrs vis ->
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
@@ -2703,18 +2703,18 @@ hardwhiteLetBindings:
 
 
 /* A 'do ...' statement */
-hardwhiteDoBinding: 
-  | ODO typedSequentialExprBlock hardwhiteDefnBindingsTerminator          
-      { let mDoKwd = rhs parseState 1 
-        let bindingSetRange = unionRanges mDoKwd $2.Range 
-        let seqPt = DebugPointAtBinding.NoneAtDo 
-        // any attributes prior to the 'let' are left free, e.g. become top-level attributes 
-        // associated with the module, 'main' function or assembly depending on their target 
+hardwhiteDoBinding:
+  | ODO typedSequentialExprBlock hardwhiteDefnBindingsTerminator
+      { let mDoKwd = rhs parseState 1
+        let bindingSetRange = unionRanges mDoKwd $2.Range
+        let seqPt = DebugPointAtBinding.NoneAtDo
+        // any attributes prior to the 'let' are left free, e.g. become top-level attributes
+        // associated with the module, 'main' function or assembly depending on their target
         BindingSetPreAttrs(mDoKwd, false, false, (fun attrs vis -> attrs, [mkSynDoBinding (vis, mDoKwd, $2, bindingSetRange)]), bindingSetRange), $2 }
 
 
 /* The bindings in a class type definition */
-classDefnBindings: 
+classDefnBindings:
   | defnBindings
      { $1 }
 
@@ -2722,7 +2722,7 @@ classDefnBindings:
      { $1 }
 
   | hardwhiteLetBindings
-     { let b, m, _ = $1 in b } 
+     { let b, m, _ = $1 in b }
 
   | hardwhiteDoBinding
      { fst $1 }
@@ -2736,156 +2736,156 @@ hardwhiteDefnBindingsTerminator:
        let mIn = if (mToken.EndColumn - mToken.StartColumn) = 2 then Some mToken else None
        (fun _ m -> ()), mIn }
 
-  |  recover 
+  |  recover
      { (fun kwd m ->
-         let msg = 
-             match kwd with 
-             | "let!" -> FSComp.SR.parsUnmatchedLetBang() 
-             | "use!" -> FSComp.SR.parsUnmatchedUseBang() 
-             | "use" -> FSComp.SR.parsUnmatchedUse() 
+         let msg =
+             match kwd with
+             | "let!" -> FSComp.SR.parsUnmatchedLetBang()
+             | "use!" -> FSComp.SR.parsUnmatchedUseBang()
+             | "use" -> FSComp.SR.parsUnmatchedUse()
              | _ (*"let" *) -> FSComp.SR.parsUnmatchedLet()
          reportParseErrorAt m msg), None }
 
 /* An 'extern' DllImport function definition in C-style syntax */
-cPrototype: 
-  | EXTERN cRetType opt_access ident opt_HIGH_PRECEDENCE_APP LPAREN externArgs rparen 
-      { let mExtern = rhs parseState 1 
-        let rty, vis, nm, args  = $2, $3, $4, $7
-        let nmm = rhs parseState 3 
-        let argsm = rhs parseState 6 
+cPrototype:
+  | EXTERN cRetType opt_access ident opt_HIGH_PRECEDENCE_APP LPAREN externArgs rparen
+      { let mExtern = rhs parseState 1
+        let rty, vis, nm, args = $2, $3, $4, $7
+        let nmm = rhs parseState 3
+        let argsm = rhs parseState 6
         let mBindLhs = lhs parseState
         let mWhole = lhs parseState
-        let mRhs = lhs parseState 
+        let mRhs = lhs parseState
         let rhsExpr =
-            SynExpr.App (
+            SynExpr.App(
                 ExprAtomicFlag.NonAtomic,
                 false,
-                SynExpr.Ident (ident("failwith", rhs parseState 6)),
-                SynExpr.Const (SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
+                SynExpr.Ident(ident("failwith", rhs parseState 6)),
+                SynExpr.Const(SynConst.String("extern was not given a DllImport attribute", SynStringKind.Regular, rhs parseState 8), rhs parseState 8),
                 mRhs)
         (fun attrs _ ->
-            let bindingPat = SynPat.LongIdent (SynLongIdent([nm], [], [None]), None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
+            let bindingPat = SynPat.LongIdent(SynLongIdent([nm], [], [None]), None, Some noInferredTypars, SynArgPats.Pats [SynPat.Tuple(false, args, argsm)], vis, nmm)
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let xmlDoc = grabXmlDoc(parseState, attrs, 1)
             let trivia = { LeadingKeyword = SynLeadingKeyword.Extern mExtern; InlineKeyword = None; EqualsRange = None }
             let binding =
-                mkSynBinding 
-                    (xmlDoc, bindingPat) 
+                mkSynBinding
+                    (xmlDoc, bindingPat)
                     (vis, false, false, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, Some (None, rty), rhsExpr, mRhs, [], attrs, None, trivia)
             [], [binding]) }
 
 /* A list of arguments in an 'extern' DllImport function definition */
-externArgs: 
-  | externMoreArgs 
+externArgs:
+  | externMoreArgs
      { List.rev $1 }
 
-  | externArg 
+  | externArg
      { [$1] }
-  |       
+  |
      { [] }
-  
+
 
 /* Part of the list of arguments in an 'extern' DllImport function definition */
-externMoreArgs: 
-  | externMoreArgs COMMA externArg 
+externMoreArgs:
+  | externMoreArgs COMMA externArg
      { $3 :: $1 }
 
-  | externArg COMMA externArg 
+  | externArg COMMA externArg
      { [$3; $1] }
 
 
 /* A single argument in an 'extern' DllImport function definition */
-externArg: 
-  | opt_attributes cType       
+externArg:
+  | opt_attributes cType
      { let m = lhs parseState in SynPat.Typed(SynPat.Wild m, $2, m) |> addAttribs $1 }
 
-  | opt_attributes cType ident 
-     { let m = lhs parseState in SynPat.Typed(SynPat.Named (SynIdent($3, None), false, None, m), $2, m) |> addAttribs $1 }
+  | opt_attributes cType ident
+     { let m = lhs parseState in SynPat.Typed(SynPat.Named(SynIdent($3, None), false, None, m), $2, m) |> addAttribs $1 }
 
 /* An type in an 'extern' DllImport function definition */
-cType: 
-  | path      
+cType:
+  | path
      { let m = $1.Range
-       SynType.App(SynType.LongIdent($1), None, [], [], None, false, m) } 
+       SynType.App(SynType.LongIdent($1), None, [], [], None, false, m) }
 
-  | cType opt_HIGH_PRECEDENCE_APP LBRACK RBRACK 
-     { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("[]", m)], [], [None])), None, [$1], [], None, true, m) } 
+  | cType opt_HIGH_PRECEDENCE_APP LBRACK RBRACK
+     { let m = lhs parseState
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("[]", m)], [], [None])), None, [$1], [], None, true, m) }
 
-  | cType STAR 
-     { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [ Some (IdentTrivia.OriginalNotation "*") ])), None, [$1], [], None, true, m) } 
+  | cType STAR
+     { let m = lhs parseState
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [ Some (IdentTrivia.OriginalNotation "*") ])), None, [$1], [], None, true, m) }
 
-  | cType AMP  
-     { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [ Some (IdentTrivia.OriginalNotation "&") ])), None, [$1], [], None, true, m) } 
+  | cType AMP
+     { let m = lhs parseState
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("byref", m)], [], [ Some (IdentTrivia.OriginalNotation "&") ])), None, [$1], [], None, true, m) }
 
-  | VOID STAR 
-     { let m = lhs parseState 
-       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [ Some (IdentTrivia.OriginalNotation "void*") ])), None, [], [], None, true, m) } 
+  | VOID STAR
+     { let m = lhs parseState
+       SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeint", m)], [], [ Some (IdentTrivia.OriginalNotation "void*") ])), None, [], [], None, true, m) }
 
 
 /* A return type in an 'extern' DllImport function definition */
-cRetType: 
-  | opt_attributes cType 
+cRetType:
+  | opt_attributes cType
      { SynReturnInfo(($2, SynArgInfo($1, false, None)), rhs parseState 2) }
 
-  | opt_attributes VOID  
-     { let m = rhs parseState 2 
-       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [ Some (IdentTrivia.OriginalNotation "void") ])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) } 
+  | opt_attributes VOID
+     { let m = rhs parseState 2
+       SynReturnInfo((SynType.App(SynType.LongIdent(SynLongIdent([ident("unit", m)], [], [ Some (IdentTrivia.OriginalNotation "void") ])), None, [], [], None, false, m), SynArgInfo($1, false, None)), m) }
 
 
-localBindings: 
-  | attr_localBinding moreLocalBindings 
+localBindings:
+  | attr_localBinding moreLocalBindings
       { let (moreBindings, moreBindingRanges) = List.unzip $2
         let moreLocalBindingsLastRange = if moreBindingRanges.IsEmpty then None else Some (List.last moreBindingRanges)
-        match $1 with 
-        | Some (localBindingRange, attrLocalBindingBuilder) -> 
-           let lastRange = 
-               match moreLocalBindingsLastRange with 
-               | None -> localBindingRange 
+        match $1 with
+        | Some (localBindingRange, attrLocalBindingBuilder) ->
+           let lastRange =
+               match moreLocalBindingsLastRange with
+               | None -> localBindingRange
                | Some m -> m
            Some lastRange, (fun xmlDoc attrs vis leadingKeyword -> attrLocalBindingBuilder xmlDoc attrs vis leadingKeyword true ::  moreBindings)
-        | None -> 
+        | None ->
            moreLocalBindingsLastRange, (fun _xmlDoc _attrs _vis _leadingKeyword -> moreBindings) }
 
 
-moreLocalBindings: 
-  | AND attr_localBinding moreLocalBindings 
+moreLocalBindings:
+  | AND attr_localBinding moreLocalBindings
       { let leadingKeyword = SynLeadingKeyword.And(rhs parseState 1)
-        (match $2 with 
+        (match $2 with
          | Some (localBindingRange, attrLocalBindingBuilder) ->
             let xmlDoc = grabXmlDoc(parseState, [], 1)
             let xmlDoc = if xmlDoc.IsEmpty then grabXmlDoc(parseState, [], 2) else xmlDoc
             (attrLocalBindingBuilder xmlDoc [] None leadingKeyword false, localBindingRange) :: $3
          | None -> $3) }
 
-  | %prec prec_no_more_attr_bindings 
+  | %prec prec_no_more_attr_bindings
       { [] }
 
 
 /* A single binding, possibly with custom attributes */
-attr_localBinding: 
-  | opt_attributes localBinding 
+attr_localBinding:
+  | opt_attributes localBinding
       { let attrs2 = $1
         let localBindingRange, localBindingBuilder = $2
         let attrLocalBindingBuilder = (fun xmlDoc attrs vis leadingKeyword _ -> localBindingBuilder xmlDoc (attrs@attrs2) vis leadingKeyword)
         Some(localBindingRange, attrLocalBindingBuilder) }
 
-  | error 
+  | error
       { None }
 
 
 /* A single binding in an expression or definition */
-localBinding: 
-  | opt_inline opt_mutable bindingPattern  opt_topReturnTypeWithTypeConstraints EQUALS  typedExprWithStaticOptimizationsBlock 
+localBinding:
+  | opt_inline opt_mutable bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS typedExprWithStaticOptimizationsBlock
       { let (expr:SynExpr), opts = $6
         let mEquals = rhs parseState 5
-        let mRhs = expr.Range 
-        let optReturnType = $4 
-        let bindingPat, mBindLhs = $3 
+        let mRhs = expr.Range
+        let optReturnType = $4
+        let bindingPat, mBindLhs = $3
         let localBindingRange = unionRanges (rhs2 parseState 1 5) mRhs
-        let localBindingBuilder = 
+        let localBindingBuilder =
           (fun xmlDoc attrs vis (leadingKeyword: SynLeadingKeyword) ->
             let mWhole = (unionRanges leadingKeyword.Range mRhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let spBind = if IsDebugPointBinding bindingPat expr then DebugPointAtBinding.Yes mWhole else DebugPointAtBinding.NoneAtLet
@@ -2894,12 +2894,12 @@ localBinding:
             mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mWholeBindLhs, spBind, optReturnType, expr, mRhs, opts, attrs, None, trivia))
         localBindingRange, localBindingBuilder }
 
-  | opt_inline opt_mutable bindingPattern  opt_topReturnTypeWithTypeConstraints EQUALS  error
-      { let mWhole = rhs2 parseState 1 5 
+  | opt_inline opt_mutable bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS error
+      { let mWhole = rhs2 parseState 1 5
         let mRhs = rhs parseState 5
-        let optReturnType = $4 
+        let optReturnType = $4
         let bindingPat, mBindLhs = $3
-        let localBindingBuilder = 
+        let localBindingBuilder =
           (fun xmlDoc attrs vis leadingKeyword ->
             let mEquals = rhs parseState 5
             let zeroWidthAtEnd = mEquals.EndRange
@@ -2909,124 +2909,124 @@ localBinding:
             mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
         mWhole, localBindingBuilder }
 
-  | opt_inline opt_mutable bindingPattern  opt_topReturnTypeWithTypeConstraints recover
+  | opt_inline opt_mutable bindingPattern opt_topReturnTypeWithTypeConstraints recover
       { if not $5 then reportParseErrorAt (rhs parseState 5) (FSComp.SR.parsUnexpectedEndOfFileDefinition())
-        let optReturnType = $4 
+        let optReturnType = $4
         let mWhole = rhs2 parseState 1 (match optReturnType with None -> 3 | _ -> 4)
-        let mRhs = mWhole.EndRange  // zero-width range at end of last good token
-        let bindingPat, mBindLhs = $3 
-        let localBindingBuilder = 
+        let mRhs = mWhole.EndRange // zero-width range at end of last good token
+        let bindingPat, mBindLhs = $3
+        let localBindingBuilder =
           (fun xmlDoc attrs vis (leadingKeyword: SynLeadingKeyword) ->
-            let spBind = DebugPointAtBinding.Yes (unionRanges leadingKeyword.Range mRhs)
+            let spBind = DebugPointAtBinding.Yes(unionRanges leadingKeyword.Range mRhs)
             let trivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = None }
             let rhsExpr = arbExpr("localBinding2", mRhs)
             mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
         mWhole, localBindingBuilder }
 
 /* A single expression with an optional type annotation, and an optional static optimization block */
-typedExprWithStaticOptimizationsBlock: 
-  | OBLOCKBEGIN typedExprWithStaticOptimizations oblockend 
+typedExprWithStaticOptimizationsBlock:
+  | OBLOCKBEGIN typedExprWithStaticOptimizations oblockend
       { $2 }
 
-  | OBLOCKBEGIN typedExprWithStaticOptimizations recover 
+  | OBLOCKBEGIN typedExprWithStaticOptimizations recover
       { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFile())
         let a, b = $2
         (exprFromParseError a, b) }
 
-  | typedExprWithStaticOptimizations 
+  | typedExprWithStaticOptimizations
       { $1 }
 
-typedExprWithStaticOptimizations : 
+typedExprWithStaticOptimizations :
   | typedSequentialExpr opt_staticOptimizations
       { $1, List.rev $2 }
 
-opt_staticOptimizations: 
+opt_staticOptimizations:
   | opt_staticOptimizations staticOptimization
-      { $2 :: $1 } 
+      { $2 :: $1 }
 
   | /* EMPTY */
       { [] }
 
-staticOptimization: 
+staticOptimization:
   | WHEN staticOptimizationConditions EQUALS typedSequentialExprBlock
       { ($2, $4) }
 
-staticOptimizationConditions: 
+staticOptimizationConditions:
   | staticOptimizationConditions AND staticOptimizationCondition
-      { $3 :: $1 } 
+      { $3 :: $1 }
 
   | staticOptimizationCondition
       { [$1 ] }
 
-staticOptimizationCondition: 
+staticOptimizationCondition:
   | typar COLON typ
       { SynStaticOptimizationConstraint.WhenTyparTyconEqualsTycon($1, $3, lhs parseState) }
 
   | typar STRUCT
       { SynStaticOptimizationConstraint.WhenTyparIsStruct($1, lhs parseState) }
 
-rawConstant: 
+rawConstant:
   | INT8
     { if snd $1 then errorR(Error(FSComp.SR.lexOutsideEightBitSigned(), lhs parseState))
-      SynConst.SByte (fst $1) } 
+      SynConst.SByte(fst $1) }
 
   | UINT8
-    { SynConst.Byte $1 } 
+    { SynConst.Byte $1 }
 
   | INT16
     { if snd $1 then errorR(Error(FSComp.SR.lexOutsideSixteenBitSigned(), lhs parseState))
-      SynConst.Int16 (fst $1) } 
+      SynConst.Int16 (fst $1) }
 
   | UINT16
-    { SynConst.UInt16 $1 } 
+    { SynConst.UInt16 $1 }
 
   | INT32
     { if snd $1 then errorR(Error(FSComp.SR.lexOutsideThirtyTwoBitSigned(), lhs parseState))
-      SynConst.Int32 (fst $1) } 
+      SynConst.Int32 (fst $1) }
 
   | UINT32
-    { SynConst.UInt32 $1 } 
+    { SynConst.UInt32 $1 }
 
   | INT64
     { if snd $1 then errorR(Error(FSComp.SR.lexOutsideSixtyFourBitSigned(), lhs parseState))
-      SynConst.Int64 (fst $1) } 
+      SynConst.Int64 (fst $1) }
 
   | UINT64
-    { SynConst.UInt64 $1 } 
+    { SynConst.UInt64 $1 }
 
   | NATIVEINT
     { if snd $1 then errorR(Error(FSComp.SR.lexOutsideNativeSigned(), lhs parseState))
-      SynConst.IntPtr (fst $1) } 
+      SynConst.IntPtr(fst $1) }
 
   | UNATIVEINT
-    { SynConst.UIntPtr $1 } 
+    { SynConst.UIntPtr $1 }
 
   | IEEE32
-    { SynConst.Single $1 } 
+    { SynConst.Single $1 }
 
   | IEEE64
-    { SynConst.Double $1 } 
+    { SynConst.Double $1 }
 
   | CHAR
-    { SynConst.Char $1 } 
+    { SynConst.Char $1 }
 
   | DECIMAL
-    { SynConst.Decimal $1 } 
+    { SynConst.Decimal $1 }
 
   | BIGNUM
-    { SynConst.UserNum $1 } 
+    { SynConst.UserNum $1 }
 
   | string
     { let s, synStringKind = $1
-      SynConst.String (s, synStringKind, lhs parseState) } 
+      SynConst.String(s, synStringKind, lhs parseState) }
 
   | sourceIdentifier
     { let c,v = $1
-      SynConst.SourceIdentifier (c, v, lhs parseState) }
+      SynConst.SourceIdentifier(c, v, lhs parseState) }
 
   | BYTEARRAY
     { let (v, synByteStringKind, _) = $1
-      SynConst.Bytes (v, synByteStringKind, lhs parseState) }
+      SynConst.Bytes(v, synByteStringKind, lhs parseState) }
 
 rationalConstant:
   | INT32 INFIX_STAR_DIV_MOD_OP INT32
@@ -3035,7 +3035,7 @@ rationalConstant:
       if (snd $1) || (snd $3) then errorR(Error(FSComp.SR.lexOutsideThirtyTwoBitSigned(), lhs parseState))
       SynRationalConst.Rational(fst $1, fst $3, lhs parseState) }
 
-  | MINUS INT32 INFIX_STAR_DIV_MOD_OP INT32 
+  | MINUS INT32 INFIX_STAR_DIV_MOD_OP INT32
     { if $3 <> "/" then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure())
       if fst $4 = 0 then reportParseErrorAt (rhs parseState 4) (FSComp.SR.parsIllegalDenominatorForMeasureExponent())
       if (snd $2) || (snd $4) then errorR(Error(FSComp.SR.lexOutsideThirtyTwoBitSigned(), lhs parseState))
@@ -3062,7 +3062,7 @@ atomicRationalConstant:
   | MINUS atomicUnsignedRationalConstant
     { SynRationalConst.Negate($2) }
 
-constant: 
+constant:
   | rawConstant
     { $1, rhs parseState 1 }
 
@@ -3078,7 +3078,7 @@ bindingPattern:
 // and use allowed patterns only at a later analysis stage reporting errors along the way.
 simplePattern:
   | ident
-      { let m = rhs parseState 1 
+      { let m = rhs parseState 1
         SynPat.Named(SynIdent($1, None), false, None, m) }
 
   | QMARK ident
@@ -3134,14 +3134,14 @@ simplePatterns:
 
 
 headBindingPattern:
-  | headBindingPattern AS constrPattern 
+  | headBindingPattern AS constrPattern
       { SynPat.As($1, $3, rhs2 parseState 1 3) }
 
-  | headBindingPattern BAR headBindingPattern  
+  | headBindingPattern BAR headBindingPattern
       { let mBar = rhs parseState 2
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
-  | headBindingPattern COLON_COLON  headBindingPattern 
+  | headBindingPattern COLON_COLON headBindingPattern
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }
 
@@ -3150,10 +3150,10 @@ headBindingPattern:
         let m = (rhs parseState 1, pats) ||> unionRangeWithListBy (fun p -> p.Range)
         SynPat.Tuple(false, List.rev pats, m) }
 
-  | conjPatternElements   %prec pat_conj
+  | conjPatternElements %prec pat_conj
       { SynPat.Ands(List.rev $1, lhs parseState) }
 
-  | constrPattern 
+  | constrPattern
       { $1 }
 
 tuplePatternElements:
@@ -3188,11 +3188,11 @@ tuplePatternElements:
         let pat2 = SynPat.Wild(commaRange.EndRange)
         [pat2; pat1] }
 
-conjPatternElements: 
-  | conjPatternElements AMP headBindingPattern 
+conjPatternElements:
+  | conjPatternElements AMP headBindingPattern
      { $3 :: $1 }
 
-  | headBindingPattern AMP headBindingPattern 
+  | headBindingPattern AMP headBindingPattern
      { $3 :: $1 :: [] }
 
 namePatPairs:
@@ -3215,55 +3215,55 @@ namePatPair:
 constrPattern:
   | atomicPatternLongIdent explicitValTyparDecls
       { let vis, lid = $1
-        SynPat.LongIdent (lid, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
+        SynPat.LongIdent(lid, None, Some $2, SynArgPats.Pats [], vis, lhs parseState) }
 
   | atomicPatternLongIdent explicitValTyparDecls atomicPatsOrNamePatPairs %prec pat_app
       { let vis, lid = $1
         let args, argsM = $3
         let m = unionRanges (rhs2 parseState 1 2) argsM
-        SynPat.LongIdent (lid, None, Some $2, args, vis, m) }
+        SynPat.LongIdent(lid, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $4
         let m = unionRanges (rhs2 parseState 1 2) argsM
-        SynPat.LongIdent (lid, None, Some $2, args, vis, m) }
+        SynPat.LongIdent(lid, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent explicitValTyparDecls HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $4
         let m = unionRanges (rhs2 parseState 1 2) argsM
-        SynPat.LongIdent (lid, None, Some $2, args, vis, m) }
+        SynPat.LongIdent(lid, None, Some $2, args, vis, m) }
 
   | atomicPatternLongIdent atomicPatsOrNamePatPairs %prec pat_app
       { let vis, lid = $1
         let args, argsM = $2
         let m = unionRanges (rhs parseState 1) argsM
-        SynPat.LongIdent (lid, None, None, args, vis, m) }
+        SynPat.LongIdent(lid, None, None, args, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_PAREN_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $3
         let m = unionRanges (rhs parseState 1) argsM
-        SynPat.LongIdent (lid, None, None, args, vis, m) }
+        SynPat.LongIdent(lid, None, None, args, vis, m) }
 
   | atomicPatternLongIdent HIGH_PRECEDENCE_BRACK_APP atomicPatsOrNamePatPairs
       { let vis, lid = $1
         let args, argsM = $3
         let m = unionRanges (rhs parseState 1) argsM
-        SynPat.LongIdent (lid, None, None, args, vis, m) }
+        SynPat.LongIdent(lid, None, None, args, vis, m) }
 
-  | COLON_QMARK atomTypeOrAnonRecdType  %prec pat_isinst 
+  | COLON_QMARK atomTypeOrAnonRecdType %prec pat_isinst
       { SynPat.IsInst($2, lhs parseState) }
 
-  | atomicPattern 
+  | atomicPattern
       { $1 }
 
 atomicPatsOrNamePatPairs:
   | LPAREN namePatPairs rparen
       { let mParen = rhs2 parseState 1 3
         let pats, m = $2
-        let trivia = { ParenRange = mParen } 
+        let trivia = { ParenRange = mParen }
         SynArgPats.NamePatPairs(pats, m, trivia), snd $2 }
 
   | atomicPatterns
@@ -3271,63 +3271,63 @@ atomicPatsOrNamePatPairs:
         let mAll = (mParsed.StartRange, $1) ||> unionRangeWithListBy (fun p -> p.Range)
         SynArgPats.Pats $1, mAll }
 
-atomicPatterns: 
-  | atomicPattern atomicPatterns %prec pat_args 
-      { $1 :: $2 } 
+atomicPatterns:
+  | atomicPattern atomicPatterns %prec pat_args
+      { $1 :: $2 }
 
-  | atomicPattern HIGH_PRECEDENCE_BRACK_APP atomicPatterns 
+  | atomicPattern HIGH_PRECEDENCE_BRACK_APP atomicPatterns
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSuccessivePatternsShouldBeSpacedOrTupled())
-        $1 :: $3 } 
+        $1 :: $3 }
 
-  | atomicPattern HIGH_PRECEDENCE_PAREN_APP atomicPatterns 
+  | atomicPattern HIGH_PRECEDENCE_PAREN_APP atomicPatterns
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSuccessivePatternsShouldBeSpacedOrTupled())
-        $1 :: $3 } 
+        $1 :: $3 }
 
   | atomicPattern
       { [$1] }
 
 
 atomicPattern:
-  | quoteExpr 
-      { SynPat.QuoteExpr($1, lhs parseState) } 
+  | quoteExpr
+      { SynPat.QuoteExpr($1, lhs parseState) }
 
   | CHAR DOT_DOT CHAR
-      { SynPat.DeprecatedCharRange ($1, $3, rhs2 parseState 1 3) }
+      { SynPat.DeprecatedCharRange($1, $3, rhs2 parseState 1 3) }
 
   | LBRACE recordPatternElementsAux rbrace
-      { let rs, m = $2 in SynPat.Record (rs, rhs2 parseState 1 3) }
+      { let rs, m = $2 in SynPat.Record(rs, rhs2 parseState 1 3) }
 
   | LBRACK listPatternElements RBRACK
       { SynPat.ArrayOrList(false, $2, lhs parseState) }
 
-  | LBRACK_BAR listPatternElements  BAR_RBRACK
+  | LBRACK_BAR listPatternElements BAR_RBRACK
       { SynPat.ArrayOrList(true, $2, lhs parseState) }
 
-  | UNDERSCORE 
-      { SynPat.Wild (lhs parseState) }
+  | UNDERSCORE
+      { SynPat.Wild(lhs parseState) }
 
-  | QMARK ident 
-      { SynPat.OptionalVal($2, lhs parseState) } 
+  | QMARK ident
+      { SynPat.OptionalVal($2, lhs parseState) }
 
-  | atomicPatternLongIdent %prec prec_atompat_pathop 
-      { let vis, lidwd = $1 
-        if not (isNilOrSingleton lidwd.LongIdent) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.LongIdent).idText then 
+  | atomicPatternLongIdent %prec prec_atompat_pathop
+      { let vis, lidwd = $1
+        if not (isNilOrSingleton lidwd.LongIdent) || String.isLeadingIdentifierCharacterUpperCase (List.head lidwd.LongIdent).idText then
             mkSynPatMaybeVar lidwd vis (lhs parseState)
-        else 
+        else
            let synIdent = List.head lidwd.IdentsWithTrivia
            let (SynIdent(id, _)) = synIdent
-           SynPat.Named (synIdent, false, vis, id.idRange) }
+           SynPat.Named(synIdent, false, vis, id.idRange) }
 
-  | constant 
-      { SynPat.Const (fst $1, snd $1) }
+  | constant
+      { SynPat.Const(fst $1, snd $1) }
 
-  | FALSE  
-      { SynPat.Const(SynConst.Bool false, lhs parseState) } 
+  | FALSE
+      { SynPat.Const(SynConst.Bool false, lhs parseState) }
 
-  | TRUE  
-      { SynPat.Const(SynConst.Bool true, lhs parseState) } 
+  | TRUE
+      { SynPat.Const(SynConst.Bool true, lhs parseState) }
 
-  | NULL 
+  | NULL
       { SynPat.Null(lhs parseState) }
 
   | LPAREN parenPatternBody rparen
@@ -3341,7 +3341,7 @@ atomicPattern:
         patFromParseError parenPat }
 
   | LPAREN error rparen
-      { let innerPat = patFromParseError (SynPat.Wild (rhs parseState 2))
+      { let innerPat = patFromParseError (SynPat.Wild(rhs parseState 2))
         SynPat.Paren(innerPat, lhs parseState) }
 
   | LPAREN recover
@@ -3355,22 +3355,22 @@ atomicPattern:
       { SynPat.Tuple(true, List.rev $3, lhs parseState) }
 
   | STRUCT LPAREN tupleParenPatternElements recover
-      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen()); 
+      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen())
         SynPat.Tuple(true, List.rev $3, lhs parseState) }
 
-  | STRUCT LPAREN error rparen 
-      { (* silent recovery *) SynPat.Wild (lhs parseState) }
+  | STRUCT LPAREN error rparen
+      { (* silent recovery *) SynPat.Wild(lhs parseState) }
 
-  | STRUCT LPAREN recover 
-      {  reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen()); 
-         SynPat.Wild (lhs parseState)}  
+  | STRUCT LPAREN recover
+      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen())
+        SynPat.Wild(lhs parseState) }
 
-parenPatternBody: 
-  | parenPattern 
-      { (fun m -> $1) } 
+parenPatternBody:
+  | parenPattern
+      { (fun m -> $1) }
 
   | /* EMPTY */
-      { (fun m -> SynPat.Const(SynConst.Unit, m)) } 
+      { (fun m -> SynPat.Const(SynConst.Unit, m)) }
 
 /* This duplicates out 'patterns' in order to give type annotations */
 /* the desired precedence w.r.t. patterns, tuple patterns in particular. */
@@ -3398,10 +3398,10 @@ parenPatternBody:
 /* duplicating the entire expression grammar, or making a fairly severe breaking change */
 /* to the language. */
 parenPattern:
-  | parenPattern AS constrPattern 
+  | parenPattern AS constrPattern
       { SynPat.As($1, $3, rhs2 parseState 1 3) }
 
-  | parenPattern BAR parenPattern  
+  | parenPattern BAR parenPattern
       { let mBar = rhs parseState 2
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
@@ -3422,11 +3422,11 @@ parenPattern:
         let ty = SynType.FromParseError(mColon.EndRange)
         SynPat.Typed($1, ty, unionRanges $1.Range mColon) }
 
-  | attributes parenPattern  %prec paren_pat_attribs
-      { let mLhs = lhs parseState 
-        SynPat.Attrib($2, $1, mLhs) } 
+  | attributes parenPattern %prec paren_pat_attribs
+      { let mLhs = lhs parseState
+        SynPat.Attrib($2, $1, mLhs) }
 
-  | parenPattern COLON_COLON  parenPattern 
+  | parenPattern COLON_COLON parenPattern
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }
 
@@ -3463,59 +3463,59 @@ tupleParenPatternElements:
         let pat1 = SynPat.Wild(commaRange.StartRange)
         let pat2 = SynPat.Wild(commaRange.EndRange)
         [pat2; pat1] }
-  
-conjParenPatternElements: 
-  | conjParenPatternElements AMP parenPattern 
+
+conjParenPatternElements:
+  | conjParenPatternElements AMP parenPattern
       { $3 :: $1 }
 
-  | parenPattern AMP parenPattern 
+  | parenPattern AMP parenPattern
       { $3 :: $1 :: [] }
 
 recordPatternElementsAux: /* Fix 1190 */
-  | recordPatternElement opt_seps                      
+  | recordPatternElement opt_seps
       { [$1], lhs parseState }
 
-  | recordPatternElement seps recordPatternElementsAux 
+  | recordPatternElement seps recordPatternElementsAux
       { let r = $1 in let (rs, dropMark) = $3 in (r :: rs), lhs parseState }
 
-recordPatternElement:  
-  | path EQUALS parenPattern 
+recordPatternElement:
+  | path EQUALS parenPattern
     { let mEquals = rhs parseState 2
       (List.frontAndBack $1.LongIdent, mEquals, $3) }
 
 listPatternElements:
-  | /* EMPTY */                                      
+  | /* EMPTY */
       { [] }
 
-  | parenPattern opt_seps                 
+  | parenPattern opt_seps
       { [$1] }
 
-  | parenPattern seps listPatternElements 
+  | parenPattern seps listPatternElements
       { $1 :: $3 }
 
 /* The lexfilter likes to insert OBLOCKBEGIN/OBLOCKEND pairs */
-typedSequentialExprBlock: 
-  | OBLOCKBEGIN typedSequentialExpr oblockend 
+typedSequentialExprBlock:
+  | OBLOCKBEGIN typedSequentialExpr oblockend
       { $2 }
 
-  | OBLOCKBEGIN typedSequentialExpr recover 
+  | OBLOCKBEGIN typedSequentialExpr recover
       { if not $3 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedEndOfFileExpression())
         exprFromParseError $2 }
 
-  | typedSequentialExpr 
+  | typedSequentialExpr
       { $1 }
 
 /* The lexfilter likes to insert OBLOCKBEGIN/OBLOCKEND pairs */
-declExprBlock: 
-  | OBLOCKBEGIN typedSequentialExpr oblockend 
+declExprBlock:
+  | OBLOCKBEGIN typedSequentialExpr oblockend
       { $2 }
 
-  | declExpr 
+  | declExpr
       { $1 }
 
 /* For some constructs the lex filter can't be sure to insert a matching OBLOCKEND, e.g. "function a -> b | c -> d" all in one line */
 /* for these it only inserts a trailing ORIGHT_BLOCK_END */
-typedSequentialExprBlockR: 
+typedSequentialExprBlockR:
   | typedSequentialExpr ORIGHT_BLOCK_END
     { fun _ -> $1 }
 
@@ -3527,12 +3527,12 @@ typedSequentialExprBlockR:
 
 typedSequentialExpr:
   | sequentialExpr COLON typeWithTypeConstraints
-      { SynExpr.Typed ($1, $3, unionRanges $1.Range $3.Range) }
+      { SynExpr.Typed($1, $3, unionRanges $1.Range $3.Range) }
 
   | sequentialExpr COLON recover
     { let mColon = rhs parseState 2
       let ty = SynType.FromParseError(mColon.EndRange)
-      SynExpr.Typed ($1, ty, unionRanges $1.Range mColon) }
+      SynExpr.Typed($1, ty, unionRanges $1.Range mColon) }
 
   | sequentialExpr
     { $1 }
@@ -3543,19 +3543,19 @@ typedSequentialExprEOF:
 
 sequentialExpr:
   | declExpr seps sequentialExpr
-      { SynExpr.Sequential (DebugPointAtSequential.SuppressNeither, true, $1, $3, unionRanges $1.Range $3.Range) } 
+      { SynExpr.Sequential(DebugPointAtSequential.SuppressNeither, true, $1, $3, unionRanges $1.Range $3.Range) }
 
-  | declExpr seps                         
-      { $1 }  
+  | declExpr seps
+      { $1 }
 
-  | declExpr             %prec SEMICOLON 
-      { $1 } 
+  | declExpr %prec SEMICOLON
+      { $1 }
 
-  | declExpr THEN sequentialExpr %prec prec_then_before 
-      { SynExpr.Sequential (DebugPointAtSequential.SuppressNeither, false, $1, $3, unionRanges $1.Range $3.Range ) }
+  | declExpr THEN sequentialExpr %prec prec_then_before
+      { SynExpr.Sequential(DebugPointAtSequential.SuppressNeither, false, $1, $3, unionRanges $1.Range $3.Range) }
 
-  | declExpr OTHEN OBLOCKBEGIN typedSequentialExpr oblockend %prec prec_then_before 
-      { SynExpr.Sequential (DebugPointAtSequential.SuppressNeither, false, $1, $4, unionRanges $1.Range $4.Range) }
+  | declExpr OTHEN OBLOCKBEGIN typedSequentialExpr oblockend %prec prec_then_before
+      { SynExpr.Sequential(DebugPointAtSequential.SuppressNeither, false, $1, $4, unionRanges $1.Range $4.Range) }
 
   | hardwhiteLetBindings %prec prec_args_error
      { let hwlb, m, mIn = $1
@@ -3569,9 +3569,9 @@ sequentialExpr:
 /* The contract for using this is that (a) if EOF occurs then the */
 /* the using production must report an error and (b) the using production */
 /* can report an error anyway if it is helpful, e.g. "unclosed '('" (giving two errors) */
-recover: 
+recover:
    | error
-      { debugPrint("recovering via error"); true }  
+      { debugPrint("recovering via error"); true }
 
    | EOF
       { debugPrint("recovering via EOF"); false }
@@ -3596,43 +3596,43 @@ moreBinders:
       { [] }
 
 declExpr:
-  | defnBindings IN typedSequentialExpr  %prec expr_let 
+  | defnBindings IN typedSequentialExpr %prec expr_let
      { let mIn = rhs parseState 2 |> Some
        mkLocalBindings (unionRanges (rhs2 parseState 1 2) $3.Range, $1, mIn, $3) }
 
-  | defnBindings IN error        %prec expr_let
+  | defnBindings IN error %prec expr_let
      { let mIn = rhs parseState 2 |> Some
        mkLocalBindings (rhs2 parseState 1 2, $1, mIn, arbExpr("declExpr1", (rhs parseState 3))) }
 /*
     FSComp.SR.parsNoMatchingInForLet() -- leave this in for now - it's an unused error string
 */
 
-  | hardwhiteLetBindings typedSequentialExprBlock  %prec expr_let 
+  | hardwhiteLetBindings typedSequentialExprBlock %prec expr_let
      { let hwlb, m, mIn = $1
        mkLocalBindings (unionRanges m $2.Range, hwlb, mIn, $2) }
 
-  | hardwhiteLetBindings error        %prec expr_let
+  | hardwhiteLetBindings error %prec expr_let
      { let hwlb, m, mIn = $1
        reportParseErrorAt (match hwlb with (BindingSetPreAttrs(m, _, _, _, _))  -> m) (FSComp.SR.parsErrorInReturnForLetIncorrectIndentation())
        mkLocalBindings (m, hwlb, mIn, arbExpr("declExpr2", (rhs parseState 2))) }
 
-  | hardwhiteLetBindings OBLOCKSEP typedSequentialExprBlock  %prec expr_let 
+  | hardwhiteLetBindings OBLOCKSEP typedSequentialExprBlock %prec expr_let
      { let hwlb, m, mIn = $1
        mkLocalBindings (unionRanges m $3.Range, hwlb, mIn, $3) }
 
-  | hardwhiteLetBindings OBLOCKSEP error        %prec expr_let
+  | hardwhiteLetBindings OBLOCKSEP error %prec expr_let
      { let hwlb, m, mIn = $1
        //reportParseErrorAt (match hwlb with (BindingSetPreAttrs(m, _, _, _, _))  -> m) (FSComp.SR.parsErrorInReturnForLetIncorrectIndentation())
        mkLocalBindings (unionRanges m (rhs parseState 3), hwlb, mIn, arbExpr("declExpr3", (rhs parseState 3))) }
 
   | hardwhiteDoBinding %prec expr_let
      { let e = snd $1
-       SynExpr.Do (e, unionRanges (rhs parseState 1).StartRange e.Range) }
+       SynExpr.Do(e, unionRanges (rhs parseState 1).StartRange e.Range) }
 
   | anonMatchingExpr %prec expr_function
       { $1 }
 
-  | anonLambdaExpr  %prec expr_fun 
+  | anonLambdaExpr %prec expr_fun
       { $1 }
 
   | MATCH typedSequentialExpr withClauses %prec expr_match
@@ -3640,26 +3640,26 @@ declExpr:
         let mWith, (clauses, mLast) = $3
         let spBind = DebugPointAtBinding.Yes(unionRanges mMatch mWith)
         let trivia = { MatchKeyword = mMatch; WithKeyword = mWith }
-        SynExpr.Match (spBind, $2, clauses, unionRanges mMatch mLast, trivia) }
+        SynExpr.Match(spBind, $2, clauses, unionRanges mMatch mLast, trivia) }
 
   | MATCH typedSequentialExpr recover %prec expr_match
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileMatch())
         // Produce approximate expression during error recovery
         exprFromParseError $2 }
 
-  | MATCH_BANG typedSequentialExpr     withClauses              %prec expr_match 
+  | MATCH_BANG typedSequentialExpr withClauses %prec expr_match
       { let mMatch = (rhs parseState 1)
-        let mWith, (clauses, mLast) = $3 
+        let mWith, (clauses, mLast) = $3
         let spBind = DebugPointAtBinding.Yes(unionRanges mMatch mWith)
         let trivia = { MatchBangKeyword = mMatch; WithKeyword = mWith }
-        SynExpr.MatchBang (spBind, $2, clauses, unionRanges mMatch mLast, trivia) }
+        SynExpr.MatchBang(spBind, $2, clauses, unionRanges mMatch mLast, trivia) }
 
-  | MATCH_BANG typedSequentialExpr     recover               %prec expr_match 
+  | MATCH_BANG typedSequentialExpr recover %prec expr_match
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileMatch())
-        // Produce approximate expression during error recovery 
+        // Produce approximate expression during error recovery
         exprFromParseError $2 }
 
-  | TRY typedSequentialExprBlockR withClauses %prec expr_try 
+  | TRY typedSequentialExprBlockR withClauses %prec expr_try
       { let mTry = rhs parseState 1
         let expr = $2 mTry
         let spTry = DebugPointAtTry.Yes mTry
@@ -3673,7 +3673,7 @@ declExpr:
               TryToWithRange = mTryToWith
               WithKeyword = mWith
               WithToEndRange = mWithToLast }
-        SynExpr.TryWith (expr, clauses, mTryToLast, spTry, spWith, trivia) }
+        SynExpr.TryWith(expr, clauses, mTryToLast, spTry, spWith, trivia) }
 
   | TRY typedSequentialExprBlockR recover %prec expr_try
       { let mTry = rhs parseState 1
@@ -3689,7 +3689,7 @@ declExpr:
               TryToWithRange = mWhole
               WithKeyword = mEnd
               WithToEndRange = mWhole }
-        SynExpr.TryWith (expr, [], mWhole, spTry, spWith, trivia) }
+        SynExpr.TryWith(expr, [], mWhole, spTry, spWith, trivia) }
 
   | TRY typedSequentialExprBlockR FINALLY typedSequentialExprBlock %prec expr_try
       { let mTry = rhs parseState 1
@@ -3700,21 +3700,21 @@ declExpr:
         let spFinally = DebugPointAtFinally.Yes mFinally
         let mTryToLast = unionRanges mTry finallyExpr.Range
         let trivia = { TryKeyword = mTry; FinallyKeyword = mFinally }
-        SynExpr.TryFinally (tryExpr, finallyExpr, mTryToLast, spTry, spFinally, trivia) }
+        SynExpr.TryFinally(tryExpr, finallyExpr, mTryToLast, spTry, spFinally, trivia) }
 
-  | IF declExpr ifExprCases %prec expr_if 
+  | IF declExpr ifExprCases %prec expr_if
       { let mIf = rhs parseState 1
         $3 $2 mIf false }
 
-  | IF declExpr recover %prec expr_if 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIncompleteIf()) 
-        // Produce an approximate expression during error recovery. 
-        // Include expressions to make sure they get type checked in case that generates useful results for intellisense. 
-        // Generate a throwAway for the expression so it isn't forced to have a type 'bool' 
-        // from the context it is used in. 
+  | IF declExpr recover %prec expr_if
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIncompleteIf())
+        // Produce an approximate expression during error recovery.
+        // Include expressions to make sure they get type checked in case that generates useful results for intellisense.
+        // Generate a throwAway for the expression so it isn't forced to have a type 'bool'
+        // from the context it is used in.
         exprFromParseError $2 }
 
-  | IF recover %prec expr_if 
+  | IF recover %prec expr_if
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIncompleteIf())
         // Produce an approximate expression during error recovery. There can still be value in doing this even
         // for this pathological case.
@@ -3722,177 +3722,177 @@ declExpr:
         let mEnd = m.EndRange
         let spIfToThen = DebugPointAtBinding.Yes mEnd
         let trivia = { IfKeyword = m; IsElif = false; ThenKeyword = m; ElseKeyword = None; IfToThenRange = m }
-        exprFromParseError (SynExpr.IfThenElse (arbExpr("ifGuard1", mEnd), arbExpr("thenBody1", mEnd), None, spIfToThen, true, m, trivia)) }
+        exprFromParseError (SynExpr.IfThenElse(arbExpr("ifGuard1", mEnd), arbExpr("thenBody1", mEnd), None, spIfToThen, true, m, trivia)) }
 
-  | LAZY declExpr %prec expr_lazy 
-      { SynExpr.Lazy ($2, unionRanges (rhs parseState 1) $2.Range) }
+  | LAZY declExpr %prec expr_lazy
+      { SynExpr.Lazy($2, unionRanges (rhs parseState 1) $2.Range) }
 
-  | ASSERT declExpr %prec expr_assert 
-      { SynExpr.Assert ($2, unionRanges (rhs parseState 1) $2.Range) }
+  | ASSERT declExpr %prec expr_assert
+      { SynExpr.Assert($2, unionRanges (rhs parseState 1) $2.Range) }
 
-  | ASSERT %prec expr_assert 
+  | ASSERT %prec expr_assert
       { raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsAssertIsNotFirstClassValue()) }
 
-  | OLAZY declExprBlock %prec expr_lazy 
-      { SynExpr.Lazy ($2, unionRanges (rhs parseState 1) $2.Range) }
+  | OLAZY declExprBlock %prec expr_lazy
+      { SynExpr.Lazy($2, unionRanges (rhs parseState 1) $2.Range) }
 
-  | OASSERT declExprBlock %prec expr_assert 
-      { SynExpr.Assert ($2, unionRanges (rhs parseState 1) $2.Range) }
+  | OASSERT declExprBlock %prec expr_assert
+      { SynExpr.Assert($2, unionRanges (rhs parseState 1) $2.Range) }
 
-  | OASSERT %prec expr_assert 
+  | OASSERT %prec expr_assert
       { raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsAssertIsNotFirstClassValue()) }
 
-  | WHILE declExpr doToken typedSequentialExprBlock doneDeclEnd 
+  | WHILE declExpr doToken typedSequentialExprBlock doneDeclEnd
       { let mWhileHeader = unionRanges (rhs parseState 1) $2.Range
-        let spWhile = DebugPointAtWhile.Yes mWhileHeader 
+        let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileAll = unionRanges (rhs parseState 1) $4.Range
-        SynExpr.While (spWhile, $2, $4, mWhileAll) }
-      
-  | WHILE declExpr doToken typedSequentialExprBlock recover 
+        SynExpr.While(spWhile, $2, $4, mWhileAll) }
+
+  | WHILE declExpr doToken typedSequentialExprBlock recover
       { if not $5 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileWhile())
         let mWhileHeader = unionRanges (rhs parseState 1) $2.Range
-        let spWhile = DebugPointAtWhile.Yes mWhileHeader 
+        let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileAll = unionRanges (rhs parseState 1) $4.Range
-        exprFromParseError (SynExpr.While (spWhile, $2, $4, mWhileAll)) }
+        exprFromParseError (SynExpr.While(spWhile, $2, $4, mWhileAll)) }
 
-  | WHILE declExpr doToken error doneDeclEnd 
-      { // silent recovery 
+  | WHILE declExpr doToken error doneDeclEnd
+      { // silent recovery
         let mWhileHeader = unionRanges (rhs parseState 1) $2.Range
-        let spWhile = DebugPointAtWhile.Yes mWhileHeader 
+        let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileBodyArb = unionRanges (rhs parseState 4) (rhs parseState 5)
         let mWhileAll = unionRanges (rhs parseState 1) (rhs parseState 5)
-        SynExpr.While (spWhile, $2, arbExpr("whileBody1", mWhileBodyArb), mWhileAll) }
+        SynExpr.While(spWhile, $2, arbExpr("whileBody1", mWhileBodyArb), mWhileAll) }
 
-  | WHILE declExpr recover 
+  | WHILE declExpr recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsWhileDoExpected())
         let mWhileHeader = unionRanges (rhs parseState 1) $2.Range
-        let spWhile = DebugPointAtWhile.Yes mWhileHeader 
+        let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileBodyArb = rhs parseState 3
         let mWhileAll = unionRanges (rhs parseState 1) (rhs parseState 3)
-        exprFromParseError (SynExpr.While (spWhile, $2, arbExpr("whileBody2", mWhileBodyArb), mWhileAll))  }
+        exprFromParseError (SynExpr.While(spWhile, $2, arbExpr("whileBody2", mWhileBodyArb), mWhileAll))  }
 
-  | WHILE recover 
+  | WHILE recover
       { if not $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileWhile())
         arbExpr("whileLoop1", rhs parseState 1)  }
 
-  | WHILE error doneDeclEnd 
+  | WHILE error doneDeclEnd
       { //silent recovery
         let mWhileHeader = rhs parseState 1
-        let spWhile = DebugPointAtWhile.Yes mWhileHeader 
+        let spWhile = DebugPointAtWhile.Yes mWhileHeader
         let mWhileBodyArb = rhs parseState 3
         let mWhileAll = unionRanges (rhs parseState 1) (rhs parseState 3)
-        exprFromParseError (SynExpr.While (spWhile, arbExpr("whileGuard1", mWhileHeader), arbExpr("whileBody3", mWhileBodyArb), mWhileAll))  }
+        exprFromParseError (SynExpr.While(spWhile, arbExpr("whileGuard1", mWhileHeader), arbExpr("whileBody3", mWhileBodyArb), mWhileAll))  }
 
-  | FOR forLoopBinder doToken typedSequentialExprBlock doneDeclEnd 
+  | FOR forLoopBinder doToken typedSequentialExprBlock doneDeclEnd
       { let mFor = rhs parseState 1
         let mDo = rhs parseState 3
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, _, spIn) = $2 
-        SynExpr.ForEach (spFor, spIn, SeqExprOnly false, true, a, b, $4, unionRanges (rhs parseState 1) $4.Range) }
+        let (a, b, _, spIn) = $2
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, $4, unionRanges (rhs parseState 1) $4.Range) }
 
   | FOR forLoopBinder doToken typedSequentialExprBlock ends_coming_soon_or_recover
       { if not $5 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, _, spIn) = $2 
+        let (a, b, _, spIn) = $2
         let mForLoopAll = unionRanges (rhs parseState 1) $4.Range
-        SynExpr.ForEach (spFor, spIn, SeqExprOnly false, true, a, b, $4, mForLoopAll) }  
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, $4, mForLoopAll) }
 
-  | FOR forLoopBinder doToken error doneDeclEnd 
+  | FOR forLoopBinder doToken error doneDeclEnd
       { // Silent recovery
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, _, spIn) = $2 
+        let (a, b, _, spIn) = $2
         let mForLoopBodyArb = rhs parseState 5
         let mForLoopAll = rhs2 parseState 1 5
-        SynExpr.ForEach (spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody2a", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody2a", mForLoopBodyArb), mForLoopAll) }
 
-  | FOR forLoopBinder doToken ends_coming_soon_or_recover 
+  | FOR forLoopBinder doToken ends_coming_soon_or_recover
       { if not $4 then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsExpectedExpressionAfterToken())
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, _, spIn) = $2 
+        let (a, b, _, spIn) = $2
         let mForLoopBodyArb = rhs parseState 3
         let mForLoopAll = rhs2 parseState 1 3
-        SynExpr.ForEach (spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody2", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody2", mForLoopBodyArb), mForLoopAll) }
 
   | FOR forLoopBinder ends_coming_soon_or_recover
-      { let (a, b, ok, spIn) = $2 
+      { let (a, b, ok, spIn) = $2
         if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsForDoExpected())
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
         let mForLoopBodyArb = rhs parseState 3
         let mForLoopAll = rhs2 parseState 1 3
-        SynExpr.ForEach (spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody1", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, a, b, arbExpr("forLoopBody1", mForLoopBodyArb), mForLoopAll) }
 
-  | FOR forLoopBinder opt_OBLOCKSEP arrowThenExprR %prec expr_let 
-     { let spFor = DebugPointAtFor.Yes (rhs parseState 1)
+  | FOR forLoopBinder opt_OBLOCKSEP arrowThenExprR %prec expr_let
+     { let spFor = DebugPointAtFor.Yes(rhs parseState 1)
        let (a, b, _, spIn) = $2
-       SynExpr.ForEach (spFor, spIn, SeqExprOnly true, true, a, b, $4, unionRanges (rhs parseState 1) $4.Range) }
+       SynExpr.ForEach(spFor, spIn, SeqExprOnly true, true, a, b, $4, unionRanges (rhs parseState 1) $4.Range) }
 
-  | FOR forLoopRange  doToken typedSequentialExprBlock doneDeclEnd 
+  | FOR forLoopRange doToken typedSequentialExprBlock doneDeclEnd
       { let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, c, d, e, spTo) = $2 
+        let (a, b, c, d, e, spTo) = $2
         let mForLoopAll = unionRanges (rhs parseState 1) $4.Range
-        SynExpr.For (spFor, spTo, a, b, c, d, e, $4, mForLoopAll) }
+        SynExpr.For(spFor, spTo, a, b, c, d, e, $4, mForLoopAll) }
 
-  | FOR forLoopRange  doToken typedSequentialExprBlock recover 
+  | FOR forLoopRange doToken typedSequentialExprBlock recover
       { if not $5 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
         // Still produce an expression
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, c, d, e, spTo) = $2 
+        let (a, b, c, d, e, spTo) = $2
         let mForLoopAll = unionRanges (rhs parseState 1) $4.Range
-        exprFromParseError (SynExpr.For (spFor, spTo, a, b, c, d, e, $4, mForLoopAll)) }
+        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, $4, mForLoopAll)) }
 
-  | FOR forLoopRange  doToken error doneDeclEnd 
-      { // silent recovery 
+  | FOR forLoopRange doToken error doneDeclEnd
+      { // silent recovery
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, c, d, e, spTo) = $2 
+        let (a, b, c, d, e, spTo) = $2
         let mForLoopBodyArb = rhs parseState 5
         let mForLoopAll = rhs2 parseState 1 5
-        SynExpr.For (spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll) }
 
-  | FOR forLoopRange  doToken recover
+  | FOR forLoopRange doToken recover
       { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, c, d, e, spTo) = $2 
+        let (a, b, c, d, e, spTo) = $2
         let mForLoopBodyArb = rhs parseState 3
         let mForLoopAll = rhs2 parseState 1 3
-        exprFromParseError (SynExpr.For (spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll)) }
+        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll)) }
 
   | FOR forLoopRange recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
-        let (a, b, c, d, e, spTo) = $2 
+        let (a, b, c, d, e, spTo) = $2
         let mForLoopBodyArb = (rhs parseState 2).EndRange
         let mForLoopAll = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.For (spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll)) }
+        exprFromParseError (SynExpr.For(spFor, spTo, a, b, c, d, e, arbExpr("declExpr11", mForLoopBodyArb), mForLoopAll)) }
 
-  | FOR error doToken typedSequentialExprBlock doneDeclEnd 
-      { // silent recovery 
+  | FOR error doToken typedSequentialExprBlock doneDeclEnd
+      { // silent recovery
         let mFor = rhs parseState 1
         let spToFake = DebugPointAtInOrTo.Yes mFor
         let mForLoopAll = unionRanges (rhs parseState 1) $4.Range
         let spFor = DebugPointAtFor.Yes mFor
-        SynExpr.For (spFor, spToFake, mkSynId mFor "_loopVar", None, arbExpr("startLoopRange1", mFor), true, arbExpr("endLoopRange1", rhs parseState 3), $4, mForLoopAll) }
+        SynExpr.For(spFor, spToFake, mkSynId mFor "_loopVar", None, arbExpr("startLoopRange1", mFor), true, arbExpr("endLoopRange1", rhs parseState 3), $4, mForLoopAll) }
 
   | FOR ends_coming_soon_or_recover
       { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsIdentifierExpected())
         arbExpr("declExpr12", (rhs parseState 1)) }
 
-  | FOR parenPattern error doneDeclEnd 
+  | FOR parenPattern error doneDeclEnd
       { reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsInOrEqualExpected())
         let mFor = rhs parseState 1
         let spFor = DebugPointAtFor.Yes mFor
         let spInFake = DebugPointAtInOrTo.Yes mFor
         let mForLoopBodyArb = rhs parseState 4
         let mForLoopAll = rhs2 parseState 1 4
-        SynExpr.ForEach (spFor, spInFake, SeqExprOnly false, true, $2, arbExpr("forLoopCollection", mFor), arbExpr("forLoopBody3", mForLoopBodyArb), mForLoopAll) }
+        SynExpr.ForEach(spFor, spInFake, SeqExprOnly false, true, $2, arbExpr("forLoopCollection", mFor), arbExpr("forLoopBody3", mForLoopBodyArb), mForLoopAll) }
 
   | FOR parenPattern recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileFor())
@@ -3902,21 +3902,21 @@ declExpr:
         let spIn = DebugPointAtInOrTo.Yes mIn
         let mForLoopBodyArb = (rhs parseState 2).EndRange
         let mForLoopAll = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.ForEach (spFor, spIn, SeqExprOnly false, true, $2, arbExpr("forLoopCollection", mFor), arbExpr("forLoopBody3", mForLoopBodyArb), mForLoopAll)) }
+        exprFromParseError (SynExpr.ForEach(spFor, spIn, SeqExprOnly false, true, $2, arbExpr("forLoopCollection", mFor), arbExpr("forLoopBody3", mForLoopBodyArb), mForLoopAll)) }
 
   | YIELD declExpr
-     { SynExpr.YieldOrReturn (($1, not $1), $2, unionRanges (rhs parseState 1) $2.Range) } 
+     { SynExpr.YieldOrReturn(($1, not $1), $2, unionRanges (rhs parseState 1) $2.Range) }
 
   | YIELD_BANG declExpr
-     { SynExpr.YieldOrReturnFrom (($1, not $1), $2, unionRanges (rhs parseState 1) $2.Range) } 
+     { SynExpr.YieldOrReturnFrom(($1, not $1), $2, unionRanges (rhs parseState 1) $2.Range) }
 
   | YIELD recover
      { let mYieldAll = rhs parseState 1
-       SynExpr.YieldOrReturn (($1, not $1), arbExpr("yield", mYieldAll), mYieldAll) } 
+       SynExpr.YieldOrReturn(($1, not $1), arbExpr("yield", mYieldAll), mYieldAll) }
 
   | YIELD_BANG recover
      { let mYieldAll = rhs parseState 1
-       SynExpr.YieldOrReturnFrom (($1, not $1), arbExpr("yield!", mYieldAll), mYieldAll) } 
+       SynExpr.YieldOrReturnFrom(($1, not $1), arbExpr("yield!", mYieldAll), mYieldAll) }
 
   | BINDER headBindingPattern EQUALS typedSequentialExprBlock IN opt_OBLOCKSEP moreBinders typedSequentialExprBlock %prec expr_let
      { let spBind = DebugPointAtBinding.Yes(rhs2 parseState 1 5)
@@ -3927,38 +3927,38 @@ declExpr:
 
   | OBINDER headBindingPattern EQUALS typedSequentialExprBlock hardwhiteDefnBindingsTerminator opt_OBLOCKSEP moreBinders typedSequentialExprBlock %prec expr_let
      { let report, mIn = $5
-       report (if $1 = "use" then "use!" else "let!") (rhs parseState 1)  // report unterminated error 
+       report (if $1 = "use" then "use!" else "let!") (rhs parseState 1)  // report unterminated error
        let spBind = DebugPointAtBinding.Yes(unionRanges (rhs parseState 1) $4.Range)
        let mEquals = rhs parseState 3
        let m = unionRanges (rhs parseState 1) $8.Range
        let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = Some mEquals }
        SynExpr.LetOrUseBang(spBind, ($1 = "use"), true, $2, $4, $7, $8, m, trivia) }
 
-  | OBINDER headBindingPattern EQUALS typedSequentialExprBlock hardwhiteDefnBindingsTerminator opt_OBLOCKSEP error %prec expr_let 
-     { // error recovery that allows intellisense when writing incomplete computation expressions 
-       let spBind = DebugPointAtBinding.Yes(unionRanges (rhs parseState 1) $4.Range) 
+  | OBINDER headBindingPattern EQUALS typedSequentialExprBlock hardwhiteDefnBindingsTerminator opt_OBLOCKSEP error %prec expr_let
+     { // error recovery that allows intellisense when writing incomplete computation expressions
+       let spBind = DebugPointAtBinding.Yes(unionRanges (rhs parseState 1) $4.Range)
        let mEquals = rhs parseState 3
        let mAll = unionRanges (rhs parseState 1) (rhs parseState 7)
        let m = $4.Range.EndRange // zero-width range
        let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = Some mEquals }
        SynExpr.LetOrUseBang(spBind, ($1 = "use"), true, $2, $4, [], SynExpr.ImplicitZero m, mAll, trivia) }
 
-  | DO_BANG typedSequentialExpr IN opt_OBLOCKSEP typedSequentialExprBlock %prec expr_let 
+  | DO_BANG typedSequentialExpr IN opt_OBLOCKSEP typedSequentialExprBlock %prec expr_let
      { let spBind = DebugPointAtBinding.NoneAtDo
        let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = None }
        SynExpr.LetOrUseBang(spBind, false, true, SynPat.Const(SynConst.Unit, $2.Range), $2, [], $5, unionRanges (rhs parseState 1) $5.Range, trivia) }
 
-  | ODO_BANG typedSequentialExprBlock hardwhiteDefnBindingsTerminator %prec expr_let 
-     { SynExpr.DoBang ($2, unionRanges (rhs parseState 1) $2.Range) }
+  | ODO_BANG typedSequentialExprBlock hardwhiteDefnBindingsTerminator %prec expr_let
+     { SynExpr.DoBang($2, unionRanges (rhs parseState 1) $2.Range) }
 
   | FIXED declExpr
-     { SynExpr.Fixed ($2, (unionRanges (rhs parseState 1) $2.Range)) } 
+     { SynExpr.Fixed($2, (unionRanges (rhs parseState 1) $2.Range)) }
 
   | RARROW typedSequentialExprBlockR
-     { errorR(Error(FSComp.SR.parsArrowUseIsLimited(), lhs parseState)) 
+     { errorR(Error(FSComp.SR.parsArrowUseIsLimited(), lhs parseState))
        let mArrow = rhs parseState 1
        let expr = $2 mArrow
-       SynExpr.YieldOrReturn ((true, true), expr, (unionRanges mArrow expr.Range)) }
+       SynExpr.YieldOrReturn((true, true), expr, (unionRanges mArrow expr.Range)) }
 
   | declExpr COLON_QMARK typ
       { SynExpr.TypeTest($1, $3, unionRanges $1.Range $3.Range) }
@@ -3977,7 +3977,7 @@ declExpr:
         SynExpr.Upcast($1, ty, unionRanges $1.Range mOp) }
 
   | declExpr COLON_QMARK_GREATER typ
-     { SynExpr.Downcast ($1, $3, unionRanges $1.Range $3.Range) }
+     { SynExpr.Downcast($1, $3, unionRanges $1.Range $3.Range) }
 
   | declExpr COLON_QMARK_GREATER recover
       { let mOp = rhs parseState 2
@@ -3986,11 +3986,11 @@ declExpr:
 
   | declExpr COLON_EQUALS declExpr
      { mkSynInfix (rhs parseState 2) $1 ":=" $3 }
-  
+
   | minusExpr LARROW declExprBlock
      { mkSynAssign $1 $3 }
 
-  | tupleExpr  %prec expr_tuple
+  | tupleExpr %prec expr_tuple
      { let exprs, commas = $1
        let exprs, commas =
            // Nested non-struct tuple is only possible during error recovery,
@@ -3999,10 +3999,10 @@ declExpr:
            | SynExpr.Tuple(false, _, _, _) :: _ -> normalizeTupleExpr exprs commas
            | _ -> exprs, commas
 
-       SynExpr.Tuple (false, List.rev exprs, List.rev commas, (commas.Head, exprs) ||> unionRangeWithListBy (fun e -> e.Range) ) }
+       SynExpr.Tuple(false, List.rev exprs, List.rev commas, (commas.Head, exprs) ||> unionRangeWithListBy (fun e -> e.Range)) }
 
   | declExpr JOIN_IN declExpr
-     { SynExpr.JoinIn ($1, rhs parseState 2, $3, unionRanges $1.Range $3.Range) }
+     { SynExpr.JoinIn($1, rhs parseState 2, $3, unionRanges $1.Range $3.Range) }
 
   | declExpr BAR_BAR declExpr
      { mkSynInfix (rhs parseState 2) $1 "||" $3 }
@@ -4035,7 +4035,7 @@ declExpr:
      { mkSynInfix (rhs parseState 2) $1 "<" $3 }
 
   | declExpr LESS recover
-     { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("<"))  
+     { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("<"))
        exprFromParseError (mkSynInfix (rhs parseState 2) $1 "<" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr GREATER declExpr
@@ -4048,9 +4048,9 @@ declExpr:
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
 
   | declExpr COLON_COLON declExpr
-     { let tupExpr = SynExpr.Tuple (false, [$1;$3], [rhs parseState 2], unionRanges $1.Range $3.Range)
+     { let tupExpr = SynExpr.Tuple(false, [$1;$3], [rhs parseState 2], unionRanges $1.Range $3.Range)
        let identExpr = mkSynOperator (rhs parseState 2) "::"
-       SynExpr.App (ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range $3.Range) }
+       SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range $3.Range) }
 
   | declExpr PLUS_MINUS_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4068,93 +4068,93 @@ declExpr:
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
 
   | declExpr JOIN_IN OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("in")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("in"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "@in" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr BAR_BAR OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("||")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("||"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "||" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_BAR_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr OR OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("or")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("or"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "or" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr AMP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("&")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("&"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "&" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr AMP_AMP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("&&")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("&&"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "&&" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_AMP_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr EQUALS OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("=")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("="))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "=" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_COMPARE_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr DOLLAR OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("$")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("$"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "$" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr LESS OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("<")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("<"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "<" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr GREATER OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression(">")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression(">"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 ">" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_AT_HAT_OP OBLOCKEND_COMING_SOON  %prec infix_at_hat_op_binary
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr PERCENT_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr COLON_COLON OBLOCKEND_COMING_SOON
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("::"))
        let identExpr = mkSynOperator (rhs parseState 2) "::"
-       let tupExpr = SynExpr.Tuple (false, [$1;(arbExpr("declExprInfix", (rhs parseState 3).StartRange))], [rhs parseState 2], unionRanges $1.Range (rhs parseState 3).StartRange)
-       SynExpr.App (ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range (rhs parseState 3).StartRange) }
+       let tupExpr = SynExpr.Tuple(false, [$1;(arbExpr("declExprInfix", (rhs parseState 3).StartRange))], [rhs parseState 2], unionRanges $1.Range (rhs parseState 3).StartRange)
+       SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, unionRanges $1.Range (rhs parseState 3).StartRange) }
 
   | declExpr PLUS_MINUS_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr MINUS OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("-")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("-"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "-" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr STAR OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("*")) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression("*"))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 "*" (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_STAR_DIV_MOD_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
   | declExpr INFIX_STAR_STAR_OP OBLOCKEND_COMING_SOON
-     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2)) 
+     { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnfinishedExpression($2))
        exprFromParseError(mkSynInfix (rhs parseState 2) $1 $2 (arbExpr("declExprInfix", (rhs parseState 3).StartRange))) }
 
-  | declExpr DOT_DOT declExpr 
+  | declExpr DOT_DOT declExpr
       { let wholem = rhs2 parseState 1 3
         let mOperator = rhs parseState 2
         SynExpr.IndexRange(Some $1, mOperator, Some $3, rhs parseState 1, rhs parseState 3, wholem) }
 
-  | declExpr DOT_DOT %prec open_range_expr   
+  | declExpr DOT_DOT %prec open_range_expr
       { let wholem = rhs2 parseState 1 2
         let mOperator = rhs parseState 2
         SynExpr.IndexRange(Some $1, mOperator, None, rhs parseState 1, mOperator, wholem) }
@@ -4163,8 +4163,8 @@ declExpr:
       { let wholem = rhs2 parseState 1 2
         let mOperator = rhs parseState 1
         SynExpr.IndexRange(None, mOperator, Some $2, mOperator, rhs parseState 2, wholem) }
-      
-  | STAR 
+
+  | STAR
       { let m = rhs parseState 1
         SynExpr.IndexRange(None, m, None, m, m, m) }
 
@@ -4182,37 +4182,37 @@ dynamicArg:
         SynExpr.Paren($2, lpr, Some rpr, m) }
 
 withClauses:
-  | WITH withPatternClauses       
+  | WITH withPatternClauses
       { rhs parseState 1, $2 }
 
-  | OWITH withPatternClauses OEND 
+  | OWITH withPatternClauses OEND
       { rhs parseState 1, $2 }
 
-  | OWITH withPatternClauses recover 
+  | OWITH withPatternClauses recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileWith())
         rhs parseState 1, $2 }
 
 withPatternClauses:
-  | patternClauses 
+  | patternClauses
       { $1 None }
 
-  | BAR patternClauses 
+  | BAR patternClauses
       { let mBar = rhs parseState 1 |> Some
         $2 mBar }
 
-  | BAR error 
-      { // silent recovery 
+  | BAR error
+      { // silent recovery
         let mLast = rhs parseState 1
         [], mLast }
 
-  | error  
-      { // silent recovery 
+  | error
+      { // silent recovery
         let mLast = rhs parseState 1
         [], mLast }
 
 
-patternAndGuard: 
-  | parenPattern patternGuard 
+patternAndGuard:
+  | parenPattern patternGuard
       { $1, $2 }
 
 patternClauses:
@@ -4242,10 +4242,10 @@ patternClauses:
        fun _mBar ->
            (SynMatchClause(pat, guard, arbExpr ("patternClauses1", m.EndRange), m, DebugPointAtTarget.Yes, SynMatchClauseTrivia.Zero) :: clauses), mLast }
 
-  | patternAndGuard patternResult BAR recover 
+  | patternAndGuard patternResult BAR recover
      { let pat, guard = $1
        let mArrow, resultExpr = $2
-       let mLast = rhs parseState 3 
+       let mLast = rhs parseState 3
        let m = unionRanges resultExpr.Range pat.Range
        fun mBar ->
            [SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar })], mLast }
@@ -4264,8 +4264,8 @@ patternClauses:
        fun mBar ->
            [SynMatchClause(pat, guard, arbExpr ("patternClauses2", m.EndRange), m, DebugPointAtTarget.Yes, { ArrowRange = None; BarRange = mBar })], m }
 
-patternGuard: 
-  | WHEN declExpr 
+patternGuard:
+  | WHEN declExpr
      { Some $2 }
 
   | /* EMPTY */
@@ -4276,9 +4276,9 @@ patternResult:
       { let mArrow = rhs parseState 1
         let expr = $2 mArrow
         mArrow, expr }
- 
-ifExprCases: 
-  | ifExprThen ifExprElifs 
+
+ifExprCases:
+  | ifExprThen ifExprElifs
       { let exprThen, mThen = $1
         let mElse, elseExpr = $2
         (fun exprGuard mIf isElif ->
@@ -4287,37 +4287,37 @@ ifExprCases:
             let mIfToEndOfLastBranch = unionRanges mIf lastBranch.Range
             let spIfToThen = DebugPointAtBinding.Yes(mIfToThen)
             let trivia = { IfKeyword = mIf; IsElif = isElif; ThenKeyword = mThen; ElseKeyword = mElse; IfToThenRange = mIfToThen }
-            SynExpr.IfThenElse (exprGuard, exprThen, elseExpr, spIfToThen, false, mIfToEndOfLastBranch, trivia)) }
+            SynExpr.IfThenElse(exprGuard, exprThen, elseExpr, spIfToThen, false, mIfToEndOfLastBranch, trivia)) }
 
-ifExprThen: 
-  | THEN  declExpr %prec prec_then_if 
+ifExprThen:
+  | THEN declExpr %prec prec_then_if
       { $2, rhs parseState 1 }
 
-  | OTHEN  OBLOCKBEGIN typedSequentialExpr oblockend %prec prec_then_if 
+  | OTHEN OBLOCKBEGIN typedSequentialExpr oblockend %prec prec_then_if
       { $3, rhs parseState 1 }
 
-  | OTHEN  OBLOCKBEGIN typedSequentialExpr recover %prec prec_then_if 
+  | OTHEN OBLOCKBEGIN typedSequentialExpr recover %prec prec_then_if
       { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileThen())
         exprFromParseError $3, rhs parseState 1 }
 
-ifExprElifs: 
+ifExprElifs:
   | /* EMPTY */
       { None, None }
 
-  | ELSE declExpr 
+  | ELSE declExpr
       { let mElse = rhs parseState 1
         Some mElse, Some $2 }
 
-  | OELSE  OBLOCKBEGIN typedSequentialExpr oblockend 
+  | OELSE OBLOCKBEGIN typedSequentialExpr oblockend
       { let mElse = rhs parseState 1
         Some mElse, Some $3 }
 
-  | OELSE  OBLOCKBEGIN typedSequentialExpr recover 
+  | OELSE OBLOCKBEGIN typedSequentialExpr recover
       { let mElse = rhs parseState 1
         if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElse())
         Some mElse, Some (exprFromParseError $3) }
 
-  | ELIF declExpr ifExprCases 
+  | ELIF declExpr ifExprCases
       { let mElif = rhs parseState 1
         // verify if `ELIF` is not a merged token
         let length = mElif.EndColumn - mElif.StartColumn
@@ -4328,7 +4328,7 @@ ifExprElifs:
         else
             None, Some ($3 $2 mElif true) }
 
-  | ELIF declExpr recover      
+  | ELIF declExpr recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileElif())
         None, Some (exprFromParseError $2) }
 
@@ -4361,20 +4361,20 @@ tupleExpr:
         if not $2 then reportParseErrorAt commaRange (FSComp.SR.parsExpectedExpressionAfterToken ())
         [arbExpr ("tupleExpr4", commaRange.EndRange); arbExpr ("tupleExpr5", commaRange.StartRange)], [commaRange] }
 
-minusExpr: 
+minusExpr:
   | INFIX_AT_HAT_OP minusExpr
     { if $1 <> "^" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidPrefixOperator())
       let m = (rhs2 parseState 1 2)
       SynExpr.IndexFromEnd($2, m) }
 
-  | MINUS minusExpr   %prec expr_prefix_plus_minus
+  | MINUS minusExpr %prec expr_prefix_plus_minus
       { mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) "~-" $2 }
 
-  | PLUS_MINUS_OP minusExpr  
+  | PLUS_MINUS_OP minusExpr
       { if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt $2.Range (FSComp.SR.parsInvalidPrefixOperator())
-        mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~" + ($1)) $2 } 
+        mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~" + ($1)) $2 }
 
-  | ADJACENT_PREFIX_OP minusExpr 
+  | ADJACENT_PREFIX_OP minusExpr
       { if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt $2.Range (FSComp.SR.parsInvalidPrefixOperator())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~" + ($1)) $2 }
 
@@ -4382,74 +4382,74 @@ minusExpr:
       { if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt $2.Range (FSComp.SR.parsInvalidPrefixOperator())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) $2.Range) ("~" + ($1)) $2 }
 
-  | AMP  minusExpr    
-      { SynExpr.AddressOf (true, $2, rhs parseState 1, unionRanges (rhs parseState 1) $2.Range) } 
+  | AMP minusExpr
+      { SynExpr.AddressOf(true, $2, rhs parseState 1, unionRanges (rhs parseState 1) $2.Range) }
 
-  | AMP_AMP  minusExpr   
-      { SynExpr.AddressOf (false, $2, rhs parseState 1, unionRanges (rhs parseState 1) $2.Range) } 
+  | AMP_AMP minusExpr
+      { SynExpr.AddressOf(false, $2, rhs parseState 1, unionRanges (rhs parseState 1) $2.Range) }
 
-  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType DOT atomicExprQualification 
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType DOT atomicExprQualification
       { errorR (Error (FSComp.SR.parsNewExprMemberAccess (), rhs parseState 6))
-        let newExpr = SynExpr.New (false, $2, $4, unionRanges (rhs parseState 1) $4.Range)
+        let newExpr = SynExpr.New(false, $2, $4, unionRanges (rhs parseState 1) $4.Range)
         $6 newExpr (lhs parseState) (rhs parseState 5) }
 
-  | NEW atomTypeNonAtomicDeprecated  opt_HIGH_PRECEDENCE_APP atomicExprAfterType 
-      { SynExpr.New (false, $2, $4, unionRanges (rhs parseState 1) $4.Range) }
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType
+      { SynExpr.New(false, $2, $4, unionRanges (rhs parseState 1) $4.Range) }
 
-  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP error   
-      { SynExpr.New (false, $2, arbExpr("minusExpr", (rhs parseState 4)), unionRanges (rhs parseState 1) ($2).Range) }
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP error
+      { SynExpr.New(false, $2, arbExpr("minusExpr", (rhs parseState 4)), unionRanges (rhs parseState 1) ($2).Range) }
 
   | NEW error
       { arbExpr("minusExpr2", (rhs parseState 1)) }
 
-  | UPCAST  minusExpr 
-      { SynExpr.InferredUpcast ($2, unionRanges (rhs parseState 1) $2.Range) }   
+  | UPCAST minusExpr
+      { SynExpr.InferredUpcast($2, unionRanges (rhs parseState 1) $2.Range) }
 
-  | DOWNCAST  minusExpr 
-      { SynExpr.InferredDowncast ($2, unionRanges (rhs parseState 1) $2.Range)}   
+  | DOWNCAST minusExpr
+      { SynExpr.InferredDowncast($2, unionRanges (rhs parseState 1) $2.Range) }
 
-  | appExpr 
+  | appExpr
       { $1 }
 
 appExpr:
   | appExpr argExpr %prec expr_app
-      { SynExpr.App (ExprAtomicFlag.NonAtomic, false, $1, $2, unionRanges $1.Range $2.Range)  }
+      { SynExpr.App(ExprAtomicFlag.NonAtomic, false, $1, $2, unionRanges $1.Range $2.Range)  }
 
   | atomicExpr
-      { let arg, _ = $1 
+      { let arg, _ = $1
         arg }
 
 argExpr:
-  | ADJACENT_PREFIX_OP atomicExpr 
-      { let arg2, hpa2 = $2 
+  | ADJACENT_PREFIX_OP atomicExpr
+      { let arg2, hpa2 = $2
         if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt arg2.Range (FSComp.SR.parsInvalidPrefixOperator())
         if hpa2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         mkSynPrefix (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) ("~" + ($1)) arg2 }
 
-   | atomicExpr 
-      { let arg, hpa = $1 
+   | atomicExpr
+      { let arg, hpa = $1
         if hpa then reportParseErrorAt arg.Range (FSComp.SR.parsSuccessiveArgsShouldBeSpacedOrTupled())
         arg }
-    
+
 atomicExpr:
   | atomicExpr HIGH_PRECEDENCE_BRACK_APP atomicExpr
-      { let arg1, _ = $1 
-        let arg2, hpa = $3 
-        SynExpr.App (ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), hpa }
+      { let arg1, _ = $1
+        let arg2, hpa = $3
+        SynExpr.App(ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), hpa }
 
   | atomicExpr HIGH_PRECEDENCE_PAREN_APP atomicExpr
-      { let arg1, _ = $1 
-        let arg2, _ = $3 
-        SynExpr.App (ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), true  }
+      { let arg1, _ = $1
+        let arg2, _ = $3
+        SynExpr.App(ExprAtomicFlag.Atomic, false, arg1, arg2, unionRanges arg1.Range arg2.Range), true }
 
   | atomicExpr HIGH_PRECEDENCE_TYAPP typeArgsActual
-      { let arg1, _ = $1 
+      { let arg1, _ = $1
         let mLessThan, mGreaterThan, _, args, commas, mTypeArgs = $3
         let mWholeExpr = unionRanges arg1.Range mTypeArgs
-        SynExpr.TypeApp (arg1, mLessThan, args, commas, mGreaterThan, mTypeArgs, mWholeExpr), false }
+        SynExpr.TypeApp(arg1, mLessThan, args, commas, mGreaterThan, mTypeArgs, mWholeExpr), false }
 
-  | PREFIX_OP atomicExpr  
-      { let arg2, hpa2 = $2 
+  | PREFIX_OP atomicExpr
+      { let arg2, hpa2 = $2
         if not (IsValidPrefixOperatorUse $1) then reportParseErrorAt arg2.Range (FSComp.SR.parsInvalidPrefixOperator())
         mkSynPrefixPrim (rhs parseState 1) (unionRanges (rhs parseState 1) arg2.Range) $1 arg2, hpa2 }
 
@@ -4462,17 +4462,17 @@ atomicExpr:
   | RESERVED
       { arbExpr ("unfinished identifier", rhs parseState 1), false }
 
-  | atomicExpr DOT atomicExprQualification 
-      { let arg1, hpa1 = $1 
+  | atomicExpr DOT atomicExprQualification
+      { let arg1, hpa1 = $1
         $3 arg1 (lhs parseState) (rhs parseState 2), hpa1 }
 
-  | BASE DOT atomicExprQualification 
-      { let arg1 = SynExpr.Ident (ident("base", rhs parseState 1))
+  | BASE DOT atomicExprQualification
+      { let arg1 = SynExpr.Ident(ident("base", rhs parseState 1))
         $3 arg1 (lhs parseState) (rhs parseState 2), false }
 
-  | QMARK nameop 
+  | QMARK nameop
       { let (SynIdent(ident, trivia)) = $2
-        SynExpr.LongIdent (true, SynLongIdent([ident], [], [trivia]), None, rhs parseState 2), false }
+        SynExpr.LongIdent(true, SynLongIdent([ident], [], [trivia]), None, rhs parseState 2), false }
 
   | atomicExpr QMARK dynamicArg
       { let m = rhs2 parseState 1 3
@@ -4488,50 +4488,50 @@ atomicExpr:
   | identExpr
       { $1, false }
 
-  | LBRACK listExprElements RBRACK 
+  | LBRACK listExprElements RBRACK
       { $2 (lhs parseState), false }
 
-  | LBRACK listExprElements recover 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
+  | LBRACK listExprElements recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket())
         exprFromParseError ($2 (rhs2 parseState 1 2)), false }
 
-  | LBRACK error RBRACK 
-      { // silent recovery 
-        SynExpr.ArrayOrList (false, [ ], lhs parseState), false  } 
+  | LBRACK error RBRACK
+      { // silent recovery
+        SynExpr.ArrayOrList(false, [ ], lhs parseState), false }
 
   | LBRACK recover
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
-        // silent recovery 
-        exprFromParseError (SynExpr.ArrayOrList (false, [ ], rhs parseState 1)), false  } 
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket())
+        // silent recovery
+        exprFromParseError (SynExpr.ArrayOrList(false, [ ], rhs parseState 1)), false }
 
   | STRUCT LPAREN tupleExpr rparen
       { let exprs, commas = $3
         let m = rhs2 parseState 1 4
-        SynExpr.Tuple (true, List.rev exprs, List.rev commas, m), false }
+        SynExpr.Tuple(true, List.rev exprs, List.rev commas, m), false }
 
   | STRUCT LPAREN tupleExpr recover
-      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedBracket());
+      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedBracket())
         let exprs, commas = $3
         let m = (rhs parseState 1, exprs) ||> unionRangeWithListBy (fun e -> e.Range)
-        SynExpr.Tuple (true, List.rev exprs, List.rev commas, m), false }
+        SynExpr.Tuple(true, List.rev exprs, List.rev commas, m), false }
 
-  | atomicExprAfterType 
+  | atomicExprAfterType
       { $1, false }
 
 atomicExprQualification:
-  | identOrOp 
-      { let idm = rhs parseState 1 
+  | identOrOp
+      { let idm = rhs parseState 1
         (fun e mLhs mDot -> mkSynDot mDot mLhs e $1) }
 
   | GLOBAL
-      { (fun e mLhs mDot -> 
-            reportParseErrorAt (rhs parseState 3) (FSComp.SR.nrGlobalUsedOnlyAsFirstName()) 
+      { (fun e mLhs mDot ->
+            reportParseErrorAt (rhs parseState 3) (FSComp.SR.nrGlobalUsedOnlyAsFirstName())
             let fixedLhsm = mkRange mLhs.FileName mLhs.Start mDot.End // previous mLhs is wrong after 'recover'
             mkSynDotMissing mDot fixedLhsm e) }
 
   | /* empty */
-      { (fun e mLhs mDot -> 
-            reportParseErrorAt mDot (FSComp.SR.parsMissingQualificationAfterDot()) 
+      { (fun e mLhs mDot ->
+            reportParseErrorAt mDot (FSComp.SR.parsMissingQualificationAfterDot())
             let fixedLhsm = mkRange mLhs.FileName mLhs.Start mDot.End // previous mLhs is wrong after 'recover'
             mkSynDotMissing mDot fixedLhsm e) }
   | recover
@@ -4540,69 +4540,69 @@ atomicExprQualification:
             let fixedLhsm = mkRange mLhs.FileName mLhs.Start mDot.End // previous mLhs is wrong after 'recover'
             // Include 'e' in the returned expression but throw it away
             mkSynDotMissing mDot fixedLhsm e) }
-  | LPAREN COLON_COLON rparen DOT INT32  
-      { (fun e mLhs mDot -> 
+  | LPAREN COLON_COLON rparen DOT INT32
+      { (fun e mLhs mDot ->
             if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyError(lhs parseState)
-            SynExpr.LibraryOnlyUnionCaseFieldGet (e, mkSynCaseName mLhs opNameCons, (fst $5), mLhs)) }
+            SynExpr.LibraryOnlyUnionCaseFieldGet(e, mkSynCaseName mLhs opNameCons, (fst $5), mLhs)) }
 
-  | LPAREN  typedSequentialExpr rparen  
+  | LPAREN typedSequentialExpr rparen
       { let lpr = rhs parseState 1
         let rpr = rhs parseState 3
-        (fun e mLhs mDot -> 
-            // Check for expr.( * )
+        (fun e mLhs mDot ->
+            // Check for expr.(*)
             // Note that "*" is parsed as an expression (it is allowed in "foo.[3,*]")
             match $2 with
-            | SynExpr.IndexRange (None, mOperator, None, _m1, _m2, _) ->
+            | SynExpr.IndexRange(None, mOperator, None, _m1, _m2, _) ->
                 mkSynDot mDot mLhs e (SynIdent(ident(CompileOpName "*", mOperator), Some(IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr))))
             | _ ->
                 if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
-                    mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (lhs parseState) 
+                    mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (lhs parseState)
                 else
-                    mlCompatWarning (FSComp.SR.parsParenFormIsForML()) (lhs parseState) 
+                    mlCompatWarning (FSComp.SR.parsParenFormIsForML()) (lhs parseState)
                 mkSynDotParenGet mLhs mDot e $2) }
 
-  | LBRACK  typedSequentialExpr RBRACK
+  | LBRACK typedSequentialExpr RBRACK
       { (fun e mLhs mDot -> mkSynDotBrackGet mLhs mDot e $2) }
 
-  | LBRACK  typedSequentialExpr recover
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket()) 
+  | LBRACK typedSequentialExpr recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket())
         (fun e mLhs mDot -> exprFromParseError (mkSynDotBrackGet mLhs mDot e $2)) }
 
-  | LBRACK  error RBRACK  
+  | LBRACK error RBRACK
       { let mArg = rhs2 parseState 1 3
         (fun e mLhs mDot -> mkSynDotBrackGet mLhs mDot e (arbExpr("indexerExpr1", mArg))) }
 
-  | LBRACK  recover
+  | LBRACK recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracket())
-        let mArg = (rhs parseState 1).EndRange 
+        let mArg = (rhs parseState 1).EndRange
         (fun e mLhs mDot -> exprFromParseError (mkSynDotBrackGet mLhs mDot e (arbExpr("indexerExpr2", mArg)))) }
 
 /* the start of atomicExprAfterType must not overlap with the valid postfix tokens of the type syntax, e.g. new List<T>(...) */
 atomicExprAfterType:
-  | constant 
-      { SynExpr.Const (fst $1, snd $1) }
+  | constant
+      { SynExpr.Const(fst $1, snd $1) }
 
-  | parenExpr 
+  | parenExpr
       { $1 }
 
-  | braceExpr 
+  | braceExpr
       { $1 }
 
-  | braceBarExpr 
+  | braceBarExpr
       { $1 }
 
   | interpolatedString
       { let parts, synStringKind = $1
         SynExpr.InterpolatedString(parts, synStringKind, rhs parseState 1) }
 
-  | NULL 
-      { SynExpr.Null (lhs parseState) } 
+  | NULL
+      { SynExpr.Null(lhs parseState) }
 
-  | FALSE  
-      { SynExpr.Const (SynConst.Bool false, lhs parseState) } 
+  | FALSE
+      { SynExpr.Const(SynConst.Bool false, lhs parseState) }
 
-  | TRUE  
-      { SynExpr.Const (SynConst.Bool true, lhs parseState) } 
+  | TRUE
+      { SynExpr.Const(SynConst.Bool true, lhs parseState) }
 
   | quoteExpr
       { $1 }
@@ -4612,69 +4612,69 @@ atomicExprAfterType:
 
   | beginEndExpr
       { $1 }
-  
+
 beginEndExpr:
-  | BEGIN typedSequentialExpr END 
-      { SynExpr.Paren ($2, rhs parseState 1, Some(rhs parseState 3), rhs2 parseState 1 3) } 
+  | BEGIN typedSequentialExpr END
+      { SynExpr.Paren($2, rhs parseState 1, Some(rhs parseState 3), rhs2 parseState 1 3) }
 
-  | BEGIN typedSequentialExpr recover 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBegin()); exprFromParseError $2 } 
+  | BEGIN typedSequentialExpr recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBegin()); exprFromParseError $2 }
 
-  | BEGIN error END 
-      { (* silent recovery *) arbExpr("beginEndExpr", (lhs parseState))  } 
+  | BEGIN error END
+      { (* silent recovery *) arbExpr("beginEndExpr", (lhs parseState))  }
 
-  | BEGIN END 
-      { mkSynUnit (lhs parseState) } 
+  | BEGIN END
+      { mkSynUnit (lhs parseState) }
 
 quoteExpr:
-  | LQUOTE typedSequentialExpr RQUOTE 
+  | LQUOTE typedSequentialExpr RQUOTE
       { if $1 <> $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsMismatchedQuote(fst $1))
-        (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, lhs parseState)) } 
+        (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, lhs parseState)) }
 
-  | LQUOTE typedSequentialExpr recover 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))  
-        let mExpr = rhs2 parseState 1 2
-        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, mExpr))  } 
-
-  | LQUOTE error RQUOTE 
-      { (* silent recovery *) SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }  
-
-  | LQUOTE recover 
+  | LQUOTE typedSequentialExpr recover
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))
-        exprFromParseError (SynExpr.Quote (mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }  
+        let mExpr = rhs2 parseState 1 2
+        exprFromParseError (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, $2, false, mExpr))  }
+
+  | LQUOTE error RQUOTE
+      { (* silent recovery *) SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr", (rhs parseState 2)), false, lhs parseState)  }
+
+  | LQUOTE recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatched(fst $1))
+        exprFromParseError (SynExpr.Quote(mkSynIdGet (lhs parseState) (CompileOpName (fst $1)), snd $1, arbExpr("quoteExpr2", (rhs parseState 1).EndRange), false, rhs parseState 1))  }
 
 arrayExpr:
-  | LBRACK_BAR arrayExprElements BAR_RBRACK 
-      {  $2 (lhs parseState) } 
+  | LBRACK_BAR arrayExprElements BAR_RBRACK
+      {  $2 (lhs parseState) }
 
-  | LBRACK_BAR arrayExprElements recover 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar()) 
+  | LBRACK_BAR arrayExprElements recover
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())
         exprFromParseError ($2 (rhs2 parseState 1 2)) }
 
-  | LBRACK_BAR error BAR_RBRACK 
-      {  (* silent recovery *) SynExpr.ArrayOrList (true, [ ], lhs parseState) }  
+  | LBRACK_BAR error BAR_RBRACK
+      {  (* silent recovery *) SynExpr.ArrayOrList(true, [ ], lhs parseState) }
 
   | LBRACK_BAR recover
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())  
-        (* silent recovery *) 
-        exprFromParseError (SynExpr.ArrayOrList (true, [ ], rhs parseState 1)) }  
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBracketBar())
+        (* silent recovery *)
+        exprFromParseError (SynExpr.ArrayOrList(true, [ ], rhs parseState 1)) }
 
 parenExpr:
-  | LPAREN rparen 
-      { SynExpr.Const (SynConst.Unit, (rhs2 parseState 1 2)) } 
+  | LPAREN rparen
+      { SynExpr.Const(SynConst.Unit, (rhs2 parseState 1 2)) }
 
   | LPAREN parenExprBody rparen
       { let m = rhs2 parseState 1 3
-        SynExpr.Paren ($2 m, rhs parseState 1, Some(rhs parseState 3), m) }
+        SynExpr.Paren($2 m, rhs parseState 1, Some(rhs parseState 3), m) }
 
   | LPAREN parenExprBody ends_other_than_rparen_coming_soon_or_recover
       { if not $3 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
         let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).End
-        SynExpr.Paren (exprFromParseError ($2 mLhs), rhs parseState 1, None, mLhs) }
+        SynExpr.Paren(exprFromParseError ($2 mLhs), rhs parseState 1, None, mLhs) }
 
-  | LPAREN error rparen 
+  | LPAREN error rparen
       { // silent recovery
-        SynExpr.Paren (arbExpr("parenExpr1", (rhs parseState 1).EndRange), (rhs parseState 1), Some(rhs parseState 3), (rhs2 parseState 1 3)) } 
+        SynExpr.Paren(arbExpr("parenExpr1", (rhs parseState 1).EndRange), (rhs parseState 1), Some(rhs parseState 3), (rhs2 parseState 1 3)) }
 
   | LPAREN TYPE_COMING_SOON
       { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
@@ -4691,34 +4691,34 @@ parenExpr:
         let mLhs = unionRangeWithPos (rhs parseState 1) (rhs parseState 2).Start
         arbExpr("parenExpr2rbcs", mLhs) }
 
-  | LPAREN OBLOCKEND_COMING_SOON 
+  | LPAREN OBLOCKEND_COMING_SOON
       { let lparenRange = (rhs parseState 1)
         reportParseErrorAt lparenRange (FSComp.SR.parsUnmatchedParen())
         SynExpr.Paren(arbExpr("parenExpr2obecs", lparenRange.EndRange), lparenRange, None, lparenRange) }
 
-  | LPAREN recover %prec prec_atomexpr_lparen_error 
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen()) 
-        arbExpr("parenExpr2", (lhs parseState))  }  
+  | LPAREN recover %prec prec_atomexpr_lparen_error
+      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen())
+        arbExpr("parenExpr2", (lhs parseState))  }
 
         // This is really what we should be doing, but it fails because param info expects the range of the expression
         // to extend all the way over the "recover", to the end of the file if necessary
-        // 
+        //
         // let mLeftParen = rhs parseState 1
         //let mLhs = if $2 then unionRangeWithPos mLeftParen (rhs parseState 2).Start else mLeftParen
-        //arbExpr("parenExpr2", mLhs)  }  
+        //arbExpr("parenExpr2", mLhs)  }
 
 parenExprBody:
-  | typars COLON LPAREN classMemberSpfn rparen  typedSequentialExpr 
-      { (fun m -> SynExpr.TraitCall ($1, $4, $6, m)) } /* disambiguate: x $a.id(x) */
+  | typars COLON LPAREN classMemberSpfn rparen typedSequentialExpr
+      { (fun m -> SynExpr.TraitCall($1, $4, $6, m)) } /* disambiguate: x $a.id(x) */
 
   | typedSequentialExpr
-      { (fun _m -> $1) } 
+      { (fun _m -> $1) }
 
-  | inlineAssemblyExpr 
+  | inlineAssemblyExpr
       { $1 }
 
 typars:
-  | typar 
+  | typar
       { SynType.Var($1, rhs parseState 1) }
 
   | LPAREN typarAlts rparen
@@ -4735,105 +4735,105 @@ typarAlts:
       { SynType.Var($1, rhs parseState 1) }
 
 braceExpr:
-  | LBRACE braceExprBody rbrace 
+  | LBRACE braceExprBody rbrace
      {  let m, r = $2 in r (rhs2 parseState 1 3) }
 
-  | LBRACE braceExprBody recover 
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())  
-       let m, r = $2 
+  | LBRACE braceExprBody recover
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())
+       let m, r = $2
        // Note, we can't use 'exprFromParseError' because the extra syntax node interferes with some syntax-directed transformations for computation expressions
        r (unionRanges (rhs parseState 1) m) }
 
-  | LBRACE error rbrace 
-     { // silent recovery 
-       arbExpr("braceExpr", rhs2 parseState 1 3)  }  
+  | LBRACE error rbrace
+     { // silent recovery
+       arbExpr("braceExpr", rhs2 parseState 1 3)  }
 
   | LBRACE recover
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())  
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBrace())
        // Note, we can't use 'exprFromParseError' because the extra syntax node interferes with some syntax-directed transformations for computation expressions
-       SynExpr.Record (None, None, [], rhs parseState 1) }
+       SynExpr.Record(None, None, [], rhs parseState 1) }
 
-  | LBRACE rbrace 
-     {  let m = rhs2 parseState 1 2 
-        SynExpr.Record (None, None, [], m) }
+  | LBRACE rbrace
+     {  let m = rhs2 parseState 1 2
+        SynExpr.Record(None, None, [], m) }
 
 braceExprBody:
-  | recdExpr 
-     {  (lhs parseState), (fun m -> let a, b, c = $1 in SynExpr.Record (a, b, c, m)) }
+  | recdExpr
+     {  (lhs parseState), (fun m -> let a, b, c = $1 in SynExpr.Record(a, b, c, m)) }
 
-  | objExpr 
+  | objExpr
      { $1 }
 
-  | computationExpr 
+  | computationExpr
      { $1 }
 
-listExprElements: 
+listExprElements:
   | sequentialExpr
-     { (fun mLhs -> SynExpr.ArrayOrListComputed (false, $1, mLhs)) }
+     { (fun mLhs -> SynExpr.ArrayOrListComputed(false, $1, mLhs)) }
 
-  | 
-     { (fun mLhs -> SynExpr.ArrayOrList (false, [ ], mLhs)) }
+  |
+     { (fun mLhs -> SynExpr.ArrayOrList(false, [ ], mLhs)) }
 
-arrayExprElements: 
+arrayExprElements:
   | sequentialExpr
-     { (fun mLhs -> SynExpr.ArrayOrListComputed (true, $1, mLhs)) }
+     { (fun mLhs -> SynExpr.ArrayOrListComputed(true, $1, mLhs)) }
 
-  | 
-     { (fun mLhs -> SynExpr.ArrayOrList (true, [ ], mLhs)) }
+  |
+     { (fun mLhs -> SynExpr.ArrayOrList(true, [ ], mLhs)) }
 
-computationExpr: 
+computationExpr:
   | sequentialExpr
-     { $1.Range, (fun mLhs -> SynExpr.ComputationExpr (false, $1, mLhs)) }
+     { $1.Range, (fun mLhs -> SynExpr.ComputationExpr(false, $1, mLhs)) }
 
 arrowThenExprR:
   | RARROW typedSequentialExprBlockR
       { let mArrow = rhs parseState 1
         let expr = $2 mArrow
-        SynExpr.YieldOrReturn ((true, false), expr, unionRanges mArrow expr.Range) }
+        SynExpr.YieldOrReturn((true, false), expr, unionRanges mArrow expr.Range) }
 
-forLoopBinder: 
-  | parenPattern IN declExpr 
-     { ($1, $3, true, DebugPointAtInOrTo.Yes (rhs parseState 2)) }
+forLoopBinder:
+  | parenPattern IN declExpr
+     { ($1, $3, true, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
 
   | parenPattern IN ends_coming_soon_or_recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedExpressionAfterToken())
-       ($1, arbExpr("forLoopBinder", (rhs parseState 2)), false, DebugPointAtInOrTo.Yes (rhs parseState 2)) }
+       ($1, arbExpr("forLoopBinder", (rhs parseState 2)), false, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
 
   | parenPattern ends_coming_soon_or_recover
      { if not $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInOrEqualExpected())
-       ($1, arbExpr("forLoopBinder2", (rhs parseState 1).EndRange), false, DebugPointAtInOrTo.Yes (rhs parseState 2)) }
+       ($1, arbExpr("forLoopBinder2", (rhs parseState 1).EndRange), false, DebugPointAtInOrTo.Yes(rhs parseState 2)) }
 
-forLoopRange: 
-  | parenPattern EQUALS declExpr forLoopDirection declExpr 
+forLoopRange:
+  | parenPattern EQUALS declExpr forLoopDirection declExpr
       { let mEquals = rhs parseState 2
-        let spTo = DebugPointAtInOrTo.Yes (rhs parseState 4)
+        let spTo = DebugPointAtInOrTo.Yes(rhs parseState 4)
         idOfPat parseState (rhs parseState 1) $1, Some mEquals, $3, $4, $5, spTo }
 
-forLoopDirection: 
-  | TO     { true } 
+forLoopDirection:
+  | TO { true }
 
   | DOWNTO { false }
 
 inlineAssemblyExpr:
-  | HASH string opt_inlineAssemblyTypeArg optCurriedArgExprs  optInlineAssemblyReturnTypes HASH 
+  | HASH string opt_inlineAssemblyTypeArg optCurriedArgExprs optInlineAssemblyReturnTypes HASH
       { if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyWarning (lhs parseState)
         let (s, _), sm = $2, rhs parseState 2
         (fun m ->
             let ilInstrs = ParseAssemblyCodeInstructions s parseState.LexBuffer.ReportLibraryOnlyFeatures parseState.LexBuffer.LanguageVersion sm
-            SynExpr.LibraryOnlyILAssembly (box ilInstrs, $3, List.rev $4, $5, m)) }
+            SynExpr.LibraryOnlyILAssembly(box ilInstrs, $3, List.rev $4, $5, m)) }
 
 optCurriedArgExprs:
-  | optCurriedArgExprs argExpr  %prec expr_args
+  | optCurriedArgExprs argExpr %prec expr_args
       { $2 :: $1 }
 
   | /* EMPTY */
       { [] }
 
-opt_atomicExprAfterType: 
+opt_atomicExprAfterType:
   | /* EMPTY */
       { None }
 
-  | atomicExprAfterType 
+  | atomicExprAfterType
       { Some($1) }
 
 opt_inlineAssemblyTypeArg:
@@ -4847,18 +4847,18 @@ optInlineAssemblyReturnTypes:
   | /* EMPTY */
      { [] }
 
-  | COLON typ 
+  | COLON typ
      { [$2] }
 
-  | COLON LPAREN rparen  
+  | COLON LPAREN rparen
      {  [] }
 
 recdExpr:
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP opt_atomicExprAfterType recdExprBindings opt_seps_recd
-     { let arg = match $4 with None -> mkSynUnit (lhs parseState) | Some e -> e 
+     { let arg = match $4 with None -> mkSynUnit (lhs parseState) | Some e -> e
        let l = List.rev $5
        let dummyField = mkRecdField (SynLongIdent([], [], [])) // dummy identifier, it will be discarded
-       let l = rebindRanges (dummyField, None, None) l $6 
+       let l = rebindRanges (dummyField, None, None) l $6
        let (SynExprRecordField(_, _, _, inheritsSep)) = List.head l
        let bindings = List.tail l
        (Some ($2, arg, rhs2 parseState 2 4, inheritsSep, rhs parseState 1), None, bindings) }
@@ -4868,8 +4868,8 @@ recdExpr:
 
 recdExprCore:
   | appExpr EQUALS declExprBlock recdExprBindings opt_seps_recd
-     { match $1 with 
-       | LongOrSingleIdent(false, (SynLongIdent _ as f), None, m) ->  
+     { match $1 with
+       | LongOrSingleIdent(false, (SynLongIdent _ as f), None, m) ->
             let f = mkRecdField f
             let mEquals = rhs parseState 2
             let l = List.rev $4
@@ -4890,11 +4890,11 @@ recdExprCore:
 
   | UNDERSCORE EQUALS
     { let m = rhs parseState 1
-      reportParseErrorAt m (FSComp.SR.parsUnderscoreInvalidFieldName())      
+      reportParseErrorAt m (FSComp.SR.parsUnderscoreInvalidFieldName())
       let f = mkUnderscoreRecdField m
       let mEquals = rhs parseState 2
       reportParseErrorAt (rhs2 parseState 1 2) (FSComp.SR.parsFieldBinding())
-      
+
       (None, [ SynExprRecordField(f, Some mEquals, None, None) ]) }
 
   | UNDERSCORE EQUALS declExprBlock recdExprBindings opt_seps_recd
@@ -4945,12 +4945,12 @@ pathOrUnderscore :
   | path
     { mkRecdField $1 }
 
-  | UNDERSCORE 
+  | UNDERSCORE
     { let m = rhs parseState 1
       reportParseErrorAt m (FSComp.SR.parsUnderscoreInvalidFieldName())
       mkUnderscoreRecdField m }
 
-recdExprBindings: 
+recdExprBindings:
   | recdExprBindings seps_recd recdBinding
      { ($3, Some $2) :: $1 }
 
@@ -4982,7 +4982,7 @@ recdBinding:
 
 /* There is a minor conflict between
        seq { new ty() }  // sequence expression with one very odd 'action' expression
-  and 
+  and
        { new ty() }   // object expression with no interfaces and no overrides
 Hence we make sure the latter is not permitted by the grammar
 */
@@ -4991,68 +4991,68 @@ objExpr:
      { let mNewExpr = rhs parseState 1
        let fullRange = match $4 with [] -> (rhs parseState 1) | _ -> (rhs2 parseState 1 4)
        let mWithKwd, bindings, members = $2
-       fullRange, (fun m -> let (a, b) = $1 in SynExpr.ObjExpr (a, b, Some mWithKwd, bindings, members, $4, mNewExpr, m)) }
+       fullRange, (fun m -> let (a, b) = $1 in SynExpr.ObjExpr(a, b, Some mWithKwd, bindings, members, $4, mNewExpr, m)) }
 
   | objExprBaseCall opt_OBLOCKSEP objExprInterfaces
-     { let mNewExpr = rhs parseState 1 
+     { let mNewExpr = rhs parseState 1
        let fullRange = match $3 with [] -> (rhs parseState 1) | _ -> (rhs2 parseState 1 3)
-       fullRange, (fun m -> let (a, b) = $1 in SynExpr.ObjExpr (a, b, None, [], [], $3, mNewExpr, m)) }
+       fullRange, (fun m -> let (a, b) = $1 in SynExpr.ObjExpr(a, b, None, [], [], $3, mNewExpr, m)) }
 
   | NEW atomTypeNonAtomicDeprecated
-     { let mNewExpr = rhs parseState 1 
-       (rhs2 parseState 1 2), (fun m -> let (a, b) = $2, None in SynExpr.ObjExpr (a, b, None, [], [], [], mNewExpr, m)) }
+     { let mNewExpr = rhs parseState 1
+       (rhs2 parseState 1 2), (fun m -> let (a, b) = $2, None in SynExpr.ObjExpr(a, b, None, [], [], [], mNewExpr, m)) }
 
 objExprBaseCall:
-  | NEW atomTypeNonAtomicDeprecated  opt_HIGH_PRECEDENCE_APP atomicExprAfterType baseSpec
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType baseSpec
      { ($2, Some($4, Some($5))) }
 
-  | NEW atomTypeNonAtomicDeprecated  opt_HIGH_PRECEDENCE_APP atomicExprAfterType 
+  | NEW atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType
      { ($2, Some($4, None)) }
 
   | NEW atomTypeNonAtomicDeprecated
      { $2, None }
- 
 
 
-opt_objExprBindings: 
+
+opt_objExprBindings:
   | objExprBindings
      { let mWithKwd, bindings, members = $1 in Some mWithKwd, bindings, members }
 
   | /* EMPTY */
      { None, [], [] }
 
-objExprBindings: 
-  | WITH localBindings 
+objExprBindings:
+  | WITH localBindings
       { let mWithKwd = (rhs parseState 1)
-        let _localBindingsLastRange, localBindingsBuilder = $2 
+        let _localBindingsLastRange, localBindingsBuilder = $2
         mWithKwd, (localBindingsBuilder PreXmlDoc.Empty [] None SynLeadingKeyword.Synthetic), [] }
 
   | OWITH localBindings OEND
       { let mWithKwd = (rhs parseState 1)
-        let _localBindingsLastRange, localBindingsBuilder = $2 
+        let _localBindingsLastRange, localBindingsBuilder = $2
         mWithKwd, (localBindingsBuilder PreXmlDoc.Empty [] None SynLeadingKeyword.Synthetic), [] }
 
   | WITH objectImplementationBlock opt_declEnd
       { let mWithKwd = rhs parseState 1
         let memberDefns =
-            $2 |> 
-            (List.choose (function 
-                              | (SynMemberDefn.Member _ | SynMemberDefn.GetSetMember _ ) as memberDefn -> Some memberDefn 
+            $2 |>
+            (List.choose (function
+                              | (SynMemberDefn.Member _ | SynMemberDefn.GetSetMember _) as memberDefn -> Some memberDefn
                               | SynMemberDefn.AutoProperty(range = m) -> errorR(Error(FSComp.SR.parsIllegalMemberVarInObjectImplementation(), m)); None
-                              | x -> errorR(Error(FSComp.SR.parsMemberIllegalInObjectImplementation(), x.Range)); None)) 
+                              | x -> errorR(Error(FSComp.SR.parsMemberIllegalInObjectImplementation(), x.Range)); None))
         mWithKwd, [], memberDefns }
 
 objExprInterfaces:
   | objExprInterface opt_objExprInterfaces { $1 :: $2 }
 
 opt_objExprInterfaces:
-  | %prec prec_interfaces_prefix 
+  | %prec prec_interfaces_prefix
      { [] }
 
-  | objExprInterface opt_objExprInterfaces 
+  | objExprInterface opt_objExprInterfaces
      { $1 :: $2 }
 
-  | error opt_objExprInterfaces 
+  | error opt_objExprInterfaces
      { (* silent recovery *) $2 }
 
 objExprInterface:
@@ -5071,55 +5071,55 @@ braceBarExpr:
 braceBarExprCore:
   | LBRACE_BAR recdExprCore bar_rbrace
      { let orig, flds = $2
-       let flds = 
-           flds |> List.choose (function 
+       let flds =
+           flds |> List.choose (function
              | SynExprRecordField((synLongIdent, _), mEquals, Some e, _) when orig.IsSome -> Some (synLongIdent, mEquals, e) // copy-and-update, long identifier signifies nesting
              | SynExprRecordField((SynLongIdent([ _id ], _, _) as synLongIdent, _), mEquals, Some e, _) -> Some (synLongIdent, mEquals, e) // record construction, long identifier not valid
-             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> Some (synLongIdent, mEquals, arbExpr("anonField", synLongIdent.Range)) 
+             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> Some (synLongIdent, mEquals, arbExpr("anonField", synLongIdent.Range))
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
        let mLeftBrace = rhs parseState 1
        let mRightBrace = rhs parseState 3
-       (fun (mStruct: range option) -> 
+       (fun (mStruct: range option) ->
             let m = match mStruct with | None -> unionRanges mLeftBrace mRightBrace | Some mStruct -> unionRanges mStruct mRightBrace
-            SynExpr.AnonRecd (mStruct.IsSome, orig, flds, m, { OpeningBraceRange = mLeftBrace })) }
+            SynExpr.AnonRecd(mStruct.IsSome, orig, flds, m, { OpeningBraceRange = mLeftBrace })) }
 
-  | LBRACE_BAR recdExprCore recover 
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())  
-       let orig, flds = $2 
-       let flds = 
-           flds |> List.map (function 
-             | SynExprRecordField((synLongIdent, _), mEquals, Some e, _) -> (synLongIdent, mEquals, e) 
-             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> (synLongIdent, mEquals, arbExpr("anonField", synLongIdent.Range))) 
+  | LBRACE_BAR recdExprCore recover
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())
+       let orig, flds = $2
+       let flds =
+           flds |> List.map (function
+             | SynExprRecordField((synLongIdent, _), mEquals, Some e, _) -> (synLongIdent, mEquals, e)
+             | SynExprRecordField((synLongIdent, _), mEquals, None, _) -> (synLongIdent, mEquals, arbExpr("anonField", synLongIdent.Range)))
        let mLeftBrace = rhs parseState 1
        let mExpr = rhs parseState 2
-       (fun (mStruct: range option) -> 
+       (fun (mStruct: range option) ->
            let m = match mStruct with | None -> unionRanges mLeftBrace mExpr | Some mStruct -> unionRanges mStruct mExpr
-           SynExpr.AnonRecd (mStruct.IsSome, orig, flds, m, { OpeningBraceRange = mLeftBrace })) }
+           SynExpr.AnonRecd(mStruct.IsSome, orig, flds, m, { OpeningBraceRange = mLeftBrace })) }
 
   | LBRACE_BAR error bar_rbrace
-     { // silent recovery 
+     { // silent recovery
        let mLeftBrace = rhs parseState 1
        let mRightBrace = rhs parseState 3
-       (fun (mStruct: range option) -> 
+       (fun (mStruct: range option) ->
            let m = match mStruct with | None -> unionRanges mLeftBrace mRightBrace | Some mStruct -> unionRanges mStruct mRightBrace
-           arbExpr("braceBarExpr", m)) }  
+           arbExpr("braceBarExpr", m)) }
 
   | LBRACE_BAR recover
-     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())  
+     { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedBraceBar())
        let mLeftBrace = rhs parseState 1
-       (fun (mStruct: range option) -> 
+       (fun (mStruct: range option) ->
            let m = match mStruct with | None -> mLeftBrace | Some mStruct -> unionRanges mStruct mLeftBrace
-           SynExpr.AnonRecd (mStruct.IsSome, None, [], m, { OpeningBraceRange = mLeftBrace })) }
+           SynExpr.AnonRecd(mStruct.IsSome, None, [], m, { OpeningBraceRange = mLeftBrace })) }
 
-  | LBRACE_BAR bar_rbrace 
+  | LBRACE_BAR bar_rbrace
      { let mLeftBrace = rhs parseState 1
        let mRightBrace = rhs parseState 2
-       (fun (mStruct: range option) -> 
+       (fun (mStruct: range option) ->
            let m = match mStruct with | None -> unionRanges mLeftBrace mRightBrace | Some mStruct -> unionRanges mStruct mRightBrace
-           SynExpr.AnonRecd (mStruct.IsSome, None, [], m, { OpeningBraceRange = mLeftBrace })) }
+           SynExpr.AnonRecd(mStruct.IsSome, None, [], m, { OpeningBraceRange = mLeftBrace })) }
 
-anonLambdaExpr: 
-  | FUN atomicPatterns RARROW typedSequentialExprBlock 
+anonLambdaExpr:
+  | FUN atomicPatterns RARROW typedSequentialExprBlock
      { let mAll = unionRanges (rhs parseState 1) $4.Range
        let mArrow = Some (rhs parseState 3)
        mkSynFunMatchLambdas parseState.SynArgNameGenerator false mAll $2 mArrow $4 }
@@ -5161,34 +5161,34 @@ anonLambdaExpr:
   | OFUN error OEND
      { exprFromParseError (mkSynFunMatchLambdas parseState.SynArgNameGenerator false (rhs parseState 1) [] None (arbExpr("anonLambdaExpr5", (rhs parseState 2)))) }
 
-anonMatchingExpr: 
+anonMatchingExpr:
   | FUNCTION withPatternClauses %prec expr_function
      { let clauses, mLast = $2
        let mAll = unionRanges (rhs parseState 1) mLast
-       SynExpr.MatchLambda (false, (rhs parseState 1), clauses, DebugPointAtBinding.NoneAtInvisible, mAll) }
+       SynExpr.MatchLambda(false, (rhs parseState 1), clauses, DebugPointAtBinding.NoneAtInvisible, mAll) }
 
   | OFUNCTION withPatternClauses OEND %prec expr_function
      { let clauses, mLast = $2
        let mAll = unionRanges (rhs parseState 1) mLast
-       SynExpr.MatchLambda (false, (rhs parseState 1), clauses, DebugPointAtBinding.NoneAtInvisible, mAll) }
+       SynExpr.MatchLambda(false, (rhs parseState 1), clauses, DebugPointAtBinding.NoneAtInvisible, mAll) }
 
 /*--------------------------------------------------------------------------*/
 /* TYPE ALGEBRA                                                             */
 
 typeWithTypeConstraints:
-  | typ %prec prec_wheretyp_prefix 
+  | typ %prec prec_wheretyp_prefix
      { $1 }
 
-  | typ WHEN typeConstraints 
+  | typ WHEN typeConstraints
      { SynType.WithGlobalConstraints($1, List.rev $3, lhs parseState) }
 
-topTypeWithTypeConstraints: 
-  | topType 
+topTypeWithTypeConstraints:
+  | topType
      { $1 }
 
-  | topType WHEN typeConstraints 
-     { let ty, arity = $1 
-       // nb. it doesn't matter where the constraints go in the structure of the type. 
+  | topType WHEN typeConstraints
+     { let ty, arity = $1
+       // nb. it doesn't matter where the constraints go in the structure of the type.
        SynType.WithGlobalConstraints(ty, List.rev $3, lhs parseState), arity }
 
 opt_topReturnTypeWithTypeConstraints:
@@ -5219,7 +5219,7 @@ topType:
        let rty = SynType.FromParseError(mArrow.EndRange)
        SynType.Fun(dty, rty, lhs parseState, { ArrowRange = mArrow }), SynValInfo([dmdata], SynInfo.unnamedRetVal) }
 
-  | topTupleType 
+  | topTupleType
      { let ty, rmdata = $1 in ty, (SynValInfo([], (match rmdata with [md] -> md | _ -> SynInfo.unnamedRetVal))) }
 
 topTupleType:
@@ -5244,7 +5244,7 @@ topTupleType:
         let path = SynTupleTypeSegment.Type ty :: SynTupleTypeSegment.Star mStar :: (List.map fst $2)
         mkSynTypeTuple path, List.choose snd $2 }
 
-  | topAppType                 
+  | topAppType
      { let ty, mdata = $1 in ty, [mdata] }
 
 topTupleTypeElements:
@@ -5265,7 +5265,7 @@ topTupleTypeElements:
         reportParseErrorAt mStar (FSComp.SR.parsExpectingType ())
         (SynTupleTypeSegment.Type ty, None) :: (SynTupleTypeSegment.Star mStar, None) :: $2 }
 
-  | topAppType %prec prec_toptuptyptail_prefix 
+  | topAppType %prec prec_toptuptyptail_prefix
      { let t, argInfo = $1
        [ SynTupleTypeSegment.Type t, Some argInfo ] }
 
@@ -5326,7 +5326,7 @@ topAppType:
         let ty = SynType.FromParseError(mColon.EndRange)
         SynType.SignatureParameter([], true, Some $2, ty, m), SynArgInfo([], true, Some $2) }
 
-  | appType 
+  | appType
      { $1, SynArgInfo([], false, None) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
@@ -5445,33 +5445,33 @@ tupleOrQuotTypeElements:
       { [ SynTupleTypeSegment.Type $1 ] }
 
 appTypeCon:
-  | path %prec prec_atomtyp_path 
+  | path %prec prec_atomtyp_path
     { SynType.LongIdent($1) }
 
-  | typar 
+  | typar
     { SynType.Var($1, lhs parseState) }
 
 appTypeConPower:
   | appTypeCon INFIX_AT_HAT_OP atomicRationalConstant
-    { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedInfixOperator());
+    { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedInfixOperator())
       if $2 = "^-" then SynType.MeasurePower($1, SynRationalConst.Negate($3), lhs parseState)
       else SynType.MeasurePower($1, $3, lhs parseState)  }
 
-  | appTypeCon 
+  | appTypeCon
     { $1 }
 
 appType:
-  | appType arrayTypeSuffix 
+  | appType arrayTypeSuffix
       {  SynType.Array($2, $1, lhs parseState) }
 
-  | appType HIGH_PRECEDENCE_BRACK_APP arrayTypeSuffix   /* only HPA for "name[]" allowed here */
+  | appType HIGH_PRECEDENCE_BRACK_APP arrayTypeSuffix /* only HPA for "name[]" allowed here */
       {  SynType.Array($3, $1, lhs parseState) }
 
-  | appType appTypeConPower  
+  | appType appTypeConPower
       /* note: use "rhs parseState 1" to deal with parens in "(int) list" */
       { SynType.App($2, None, [$1], [], None, true, unionRanges (rhs parseState 1) $2.Range) }
 
-  | LPAREN appTypePrefixArguments rparen  appTypeConPower
+  | LPAREN appTypePrefixArguments rparen appTypeConPower
       { let args, commas = $2
         if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
             mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (unionRanges (rhs parseState 1) $4.Range)
@@ -5479,19 +5479,19 @@ appType:
             mlCompatWarning (FSComp.SR.parsMultiArgumentGenericTypeFormDeprecated()) (unionRanges (rhs parseState 1) $4.Range)
         SynType.App($4, None, args, commas, None, true, unionRanges (rhs parseState 1) $4.Range) }
 
-  | powerType 
+  | powerType
       { $1 }
 
-  | typar COLON_GREATER typ                     
-      {  let tp, typ = $1, $3 
-         let m = lhs parseState 
-         SynType.WithGlobalConstraints(SynType.Var (tp, rhs parseState 1), [SynTypeConstraint.WhereTyparSubtypeOfType(tp, typ, m)], m)  }
+  | typar COLON_GREATER typ
+      {  let tp, typ = $1, $3
+         let m = lhs parseState
+         SynType.WithGlobalConstraints(SynType.Var(tp, rhs parseState 1), [SynTypeConstraint.WhereTyparSubtypeOfType(tp, typ, m)], m)  }
 
-  | UNDERSCORE COLON_GREATER typ %prec COLON_GREATER 
+  | UNDERSCORE COLON_GREATER typ %prec COLON_GREATER
       {  SynType.HashConstraint($3, lhs parseState) }
 
 arrayTypeSuffix:
-  | LBRACK RBRACK 
+  | LBRACK RBRACK
       { 1 }
 
   | LBRACK COMMA RBRACK
@@ -5588,20 +5588,20 @@ arrayTypeSuffix:
       { 32 }
 
 appTypePrefixArguments:
-  | typeArgActual COMMA typeArgActual typeArgListElements 
+  | typeArgActual COMMA typeArgActual typeArgListElements
       { let typeArgs, commas = $4 in $1 :: $3 :: List.rev typeArgs, (rhs parseState 2) :: (List.rev commas) }
 
-typeArgListElements: 
+typeArgListElements:
   | typeArgListElements COMMA typeArgActual
       { let typeArgs, commas = $1
-        $3 :: typeArgs, (rhs parseState 2) :: commas } 
+        $3 :: typeArgs, (rhs parseState 2) :: commas }
 
-  | typeArgListElements COMMA dummyTypeArg %prec prec_args_error  /* NOTE: no "recover" */
+  | typeArgListElements COMMA dummyTypeArg %prec prec_args_error /* NOTE: no "recover" */
      { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsMissingTypeArgs())
        let typeArgs, commas = $1
-       $3 :: typeArgs, (rhs parseState 2) :: commas } 
+       $3 :: typeArgs, (rhs parseState 2) :: commas }
 
-  |   
+  |
       { [], [] }
 
 powerType:
@@ -5609,7 +5609,7 @@ powerType:
     { $1 }
 
   | atomTypeOrAnonRecdType INFIX_AT_HAT_OP atomicRationalConstant
-     { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedInfixOperator());
+     { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedInfixOperator())
        if $2 = "^-" then SynType.MeasurePower($1, SynRationalConst.Negate($3), lhs parseState)
        else SynType.MeasurePower($1, $3, lhs parseState) }
 
@@ -5617,7 +5617,7 @@ powerType:
 /* Like appType but gives a deprecation error when a non-atomic type is used */
 /* Also, doesn't start with '{|'  */
 atomTypeNonAtomicDeprecated:
-  | LPAREN appTypePrefixArguments rparen  appTypeConPower
+  | LPAREN appTypePrefixArguments rparen appTypeConPower
       { let args, commas = $2
         if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
             mlCompatError (FSComp.SR.mlCompatMultiPrefixTyparsNoLongerSupported()) (unionRanges (rhs parseState 1) $4.Range)
@@ -5634,142 +5634,142 @@ atomTypeOrAnonRecdType:
 
   | anonRecdType
      { let flds, isStruct = $1
-       let flds2 = 
-           flds |> List.choose (function 
-             | (SynField([], false, Some id, ty, false, _xmldoc, None, _m, _trivia)) -> Some (id, ty) 
+       let flds2 =
+           flds |> List.choose (function
+             | (SynField([], false, Some id, ty, false, _xmldoc, None, _m, _trivia)) -> Some (id, ty)
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
-       SynType.AnonRecd (isStruct, flds2, rhs parseState 1) }  
+       SynType.AnonRecd(isStruct, flds2, rhs parseState 1) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
 atomType:
-  | HASH atomType 
+  | HASH atomType
      { SynType.HashConstraint($2, lhs parseState) }
 
-  | appTypeConPower %prec prec_atomtyp_path 
+  | appTypeConPower %prec prec_atomtyp_path
      { $1 }
 
-  | UNDERSCORE 
-     { SynType.Anon (lhs parseState) }
+  | UNDERSCORE
+     { SynType.Anon(lhs parseState) }
 
   | LPAREN typ rparen
-     { SynType.Paren ($2, lhs parseState) }
+     { SynType.Paren($2, lhs parseState) }
 
   | LPAREN typ recover
      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnmatchedParen ())
-       SynType.Paren ($2, lhs parseState) }
+       SynType.Paren($2, lhs parseState) }
 
-  | STRUCT LPAREN appType STAR tupleOrQuotTypeElements  rparen 
+  | STRUCT LPAREN appType STAR tupleOrQuotTypeElements rparen
     { let mStar = rhs parseState 4
       let path = SynTupleTypeSegment.Type $3 :: SynTupleTypeSegment.Star mStar :: $5
       let m = rhs2 parseState 1 6
       SynType.Tuple(true, path, m) }
 
-  | STRUCT LPAREN appType STAR tupleOrQuotTypeElements  recover
-    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen()) 
+  | STRUCT LPAREN appType STAR tupleOrQuotTypeElements recover
+    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen())
       let mStar = rhs parseState 4
       let path = SynTupleTypeSegment.Type $3 :: SynTupleTypeSegment.Star mStar :: $5
       let m = rhs2 parseState 1 5
       SynType.Tuple(true, path, m) }
 
   | STRUCT LPAREN appType STAR recover
-    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen()) 
-      SynType.Anon (lhs parseState) }
+    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen())
+      SynType.Anon(lhs parseState) }
 
   | STRUCT LPAREN appType recover
-    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen()) 
-      SynType.Anon (lhs parseState) }
+    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen())
+      SynType.Anon(lhs parseState) }
 
   | STRUCT LPAREN recover
-    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen()) 
-      SynType.Anon (lhs parseState) }
+    { reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnmatchedParen())
+      SynType.Anon(lhs parseState) }
 
-  | rawConstant 
+  | rawConstant
      { SynType.StaticConstant($1, rhs parseState 1) }
 
   | NULL
      { let m = rhs parseState 1
-       SynType.StaticConstant(SynConst.String (null, SynStringKind.Regular, m), m) }
+       SynType.StaticConstant(SynConst.String(null, SynStringKind.Regular, m), m) }
 
   | CONST atomicExpr
      {  let e, _ = $2
         SynType.StaticConstantExpr(e, lhs parseState) }
 
-  | FALSE  
-      { SynType.StaticConstant(SynConst.Bool false, lhs parseState) } 
+  | FALSE
+      { SynType.StaticConstant(SynConst.Bool false, lhs parseState) }
 
-  | TRUE  
-      { SynType.StaticConstant(SynConst.Bool true, lhs parseState) } 
+  | TRUE
+      { SynType.StaticConstant(SynConst.Bool true, lhs parseState) }
 
-  | LPAREN error rparen   
-     { (* silent recovery *) SynType.Anon (lhs parseState) }  
+  | LPAREN error rparen
+     { (* silent recovery *) SynType.Anon(lhs parseState) }
 
-  | appTypeCon typeArgsNoHpaDeprecated %prec prec_atomtyp_path 
-     { let mLessThan, mGreaterThan, args, commas, mWhole = $2 in SynType.App($1, Some(mLessThan), args, commas, mGreaterThan, false, unionRanges $1.Range mWhole) } 
+  | appTypeCon typeArgsNoHpaDeprecated %prec prec_atomtyp_path
+     { let mLessThan, mGreaterThan, args, commas, mWhole = $2 in SynType.App($1, Some(mLessThan), args, commas, mGreaterThan, false, unionRanges $1.Range mWhole) }
 
-  | atomType DOT path %prec prec_atomtyp_get_path 
-     { SynType.LongIdentApp($1, $3, None, [], [], None, unionRanges (rhs parseState 1) $3.Range) } 
+  | atomType DOT path %prec prec_atomtyp_get_path
+     { SynType.LongIdentApp($1, $3, None, [], [], None, unionRanges (rhs parseState 1) $3.Range) }
 
-  | atomType DOT path typeArgsNoHpaDeprecated %prec prec_atomtyp_get_path 
-     { let mLessThan, mGreaterThan, args, commas, mWhole = $4 
-       SynType.LongIdentApp($1, $3, Some(mLessThan), args, commas, mGreaterThan, unionRanges $1.Range mWhole) } 
+  | atomType DOT path typeArgsNoHpaDeprecated %prec prec_atomtyp_get_path
+     { let mLessThan, mGreaterThan, args, commas, mWhole = $4
+       SynType.LongIdentApp($1, $3, Some(mLessThan), args, commas, mGreaterThan, unionRanges $1.Range mWhole) }
 
   | appTypeCon DOT ends_coming_soon_or_recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
-       $1 } 
+       $1 }
 
 typeArgsNoHpaDeprecated:
   | typeArgsActual
      { let mLessThan, mGreaterThan, parsedOk, args, commas, mAll = $1
        if parsedOk then // if someone has "foo<bar" without a closing greater-than, then the lexfilter does not introduce a HPA, even though it is adjacent
            warning(Error(FSComp.SR.parsNonAdjacentTyargs(), rhs parseState 1))
-       mLessThan, mGreaterThan, args, commas, mAll } 
+       mLessThan, mGreaterThan, args, commas, mAll }
 
-  | HIGH_PRECEDENCE_TYAPP typeArgsActual 
+  | HIGH_PRECEDENCE_TYAPP typeArgsActual
      { let mLessThan, mGreaterThan, _, args, commas, mAll = $2
-       mLessThan, mGreaterThan, args, commas, mAll } 
+       mLessThan, mGreaterThan, args, commas, mAll }
 
 typeArgsActual:
-  | LESS typeArgActualOrDummyIfEmpty COMMA typeArgActualOrDummyIfEmpty typeArgListElements GREATER 
+  | LESS typeArgActualOrDummyIfEmpty COMMA typeArgActualOrDummyIfEmpty typeArgListElements GREATER
      { let typeArgs, commas = $5
-       (rhs parseState 1), Some(rhs parseState 6), true, ($2 :: $4 :: List.rev typeArgs), (rhs parseState 3) :: (List.rev commas), lhs parseState } 
+       (rhs parseState 1), Some(rhs parseState 6), true, ($2 :: $4 :: List.rev typeArgs), (rhs parseState 3) :: (List.rev commas), lhs parseState }
 
   | LESS typeArgActualOrDummyIfEmpty COMMA typeArgActualOrDummyIfEmpty typeArgListElements recover
-     { if not $6 then 
+     { if not $6 then
            reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileTypeArgs())
        else
            reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsMissingGreaterThan())
        let typeArgs, commas = $5
        let nextToken = rhs parseState 6
        let zeroWidthAtStartOfNextToken = nextToken.StartRange
-       (rhs parseState 1), None, false, ($2 :: $4 :: List.rev typeArgs), (rhs parseState 3) :: (List.rev commas), unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken } 
+       (rhs parseState 1), None, false, ($2 :: $4 :: List.rev typeArgs), (rhs parseState 3) :: (List.rev commas), unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken }
 
   | LESS typeArgActualOrDummyIfEmpty COMMA ends_coming_soon_or_recover
      { if not $4 then reportParseErrorAt (rhs parseState 4) (FSComp.SR.parsMissingTypeArgs())
        let nextToken = rhs parseState 4
        let zeroWidthAtStartOfNextToken = nextToken.StartRange
-       (rhs parseState 1), None, false, [$2], [rhs parseState 3], unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken } 
+       (rhs parseState 1), None, false, [$2], [rhs parseState 3], unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken }
 
-  | LESS typeArgActual GREATER 
-     { (rhs parseState 1), Some(rhs parseState 3), true, [$2], [], lhs parseState } 
+  | LESS typeArgActual GREATER
+     { (rhs parseState 1), Some(rhs parseState 3), true, [$2], [], lhs parseState }
 
   | LESS typeArgActual ends_coming_soon_or_recover
      { let nextToken = rhs parseState 3
        if not $3 then reportParseErrorAt nextToken (FSComp.SR.parsMissingTypeArgs())
        let zeroWidthAtStartOfNextToken = nextToken.StartRange
-       (rhs parseState 1), None, false, [$2], [], unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken } 
+       (rhs parseState 1), None, false, [$2], [], unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken }
 
-  | LESS GREATER 
-     { (rhs parseState 1), Some(rhs parseState 2), true, [], [], lhs parseState } 
+  | LESS GREATER
+     { (rhs parseState 1), Some(rhs parseState 2), true, [], [], lhs parseState }
 
   | LESS recover
-     { if not $2 then  
+     { if not $2 then
            reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsExpectedTypeAfterToken())
        else
            reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsMissingTypeArgs())
        let nextToken = rhs parseState 2
        let zeroWidthAtStartOfNextToken = nextToken.StartRange
-       (rhs parseState 1), None, false, [], [], unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken } 
+       (rhs parseState 1), None, false, [], [], unionRanges (rhs parseState 1) zeroWidthAtStartOfNextToken }
 
 typeArgActual:
   | typ
@@ -5805,13 +5805,13 @@ measureTypeArg:
      { $2 }
 
   | LESS UNDERSCORE GREATER
-     { SynMeasure.Anon (lhs parseState) }
+     { SynMeasure.Anon(lhs parseState) }
 
 measureTypeAtom:
-  | path 
+  | path
      { SynMeasure.Named($1.LongIdent, $1.Range) }
 
-  | typar 
+  | typar
      { SynMeasure.Var($1, lhs parseState) }
 
   | LPAREN measureTypeExpr rparen
@@ -5819,16 +5819,16 @@ measureTypeAtom:
        SynMeasure.Paren($2, mParen) }
 
 measureTypePower:
-  | measureTypeAtom 
+  | measureTypeAtom
       { $1 }
 
   | measureTypeAtom INFIX_AT_HAT_OP atomicRationalConstant
-     { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure());
+     { if $2 <> "^" && $2 <> "^-" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure())
        if $2 = "^-" then SynMeasure.Power($1, SynRationalConst.Negate($3), lhs parseState)
        else SynMeasure.Power($1, $3, lhs parseState) }
 
   | INT32
-     { if fst $1 <> 1 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedIntegerLiteralForUnitOfMeasure());
+     { if fst $1 <> 1 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedIntegerLiteralForUnitOfMeasure())
        SynMeasure.One }
 
 measureTypeSeq:
@@ -5846,52 +5846,52 @@ measureTypeExpr:
     { SynMeasure.Product($1, $3, lhs parseState) }
 
   | measureTypeExpr INFIX_STAR_DIV_MOD_OP measureTypeExpr
-    { if $2 <> "*" && $2 <> "/" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure());
+    { if $2 <> "*" && $2 <> "/" then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure())
       if $2 = "*" then SynMeasure.Product($1, $3, lhs parseState)
       else SynMeasure.Divide($1, $3, lhs parseState) }
 
   | INFIX_STAR_DIV_MOD_OP measureTypeExpr
-     { if $1 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure());
+     { if $1 <> "/" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedOperatorForUnitOfMeasure())
        SynMeasure.Divide(SynMeasure.One, $2, lhs parseState) }
-   
-typar: 
-  | QUOTE ident 
+
+typar:
+  | QUOTE ident
      {  let id = mkSynId (lhs parseState) ($2).idText
         SynTypar(id, TyparStaticReq.None, false) }
 
-  | INFIX_AT_HAT_OP ident 
-    {  if $1 <> "^" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.tcUnexpectedSymbolInTypeExpression($1));
+  | INFIX_AT_HAT_OP ident
+    {  if $1 <> "^" then reportParseErrorAt (rhs parseState 1) (FSComp.SR.tcUnexpectedSymbolInTypeExpression($1))
        let id = mkSynId (lhs parseState) ($2).idText
        SynTypar(id, TyparStaticReq.HeadType, false) }
 
-ident: 
-  | IDENT 
-     { ident($1, rhs parseState 1) } 
+ident:
+  | IDENT
+     { ident($1, rhs parseState 1) }
 
 /* A A.B.C path used to an identifier */
-path: 
+path:
   | GLOBAL
       { SynLongIdent([ident(MangledGlobalName, rhs parseState 1)], [], [Some (IdentTrivia.OriginalNotation "global")]) }
 
-  | ident  
+  | ident
      { SynLongIdent([$1], [], [None]) }
 
-  | path DOT ident  
-     { let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) } 
+  | path DOT ident
+     { let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid @ [$3], dotms @ [rhs parseState 2], trivia @ [None]) }
 
-  | path DOT ends_coming_soon_or_recover  
+  | path DOT ends_coming_soon_or_recover
      { if not $3 then reportParseErrorAt (rhs parseState 2) (FSComp.SR.parsExpectedNameAfterToken())
-       let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid, dotms @ [rhs parseState 2], trivia)  } 
+       let (SynLongIdent(lid, dotms, trivia)) = $1 in SynLongIdent(lid, dotms @ [rhs parseState 2], trivia)  }
 
 
 /* An operator name, with surrounding parentheses */
-opName: 
-  | LPAREN operatorName rparen  
+opName:
+  | LPAREN operatorName rparen
      { let lpr = rhs parseState 1
        let rpr = rhs parseState 3
        ident(CompileOpName $2, rhs parseState 2), IdentTrivia.OriginalNotationWithParen(lpr, $2, rpr) }
 
-  | LPAREN error rparen  
+  | LPAREN error rparen
      {  reportParseErrorAt (lhs parseState) (FSComp.SR.parsErrorParsingAsOperatorName())
         let lpr = rhs parseState 1
         let rpr = rhs parseState 3
@@ -5904,24 +5904,24 @@ opName:
        ident(CompileOpName "*", rhs parseState 1), IdentTrivia.OriginalNotationWithParen(lpr, "*", rpr) }
 
   /* active pattern name */
-  | LPAREN activePatternCaseNames BAR rparen 
+  | LPAREN activePatternCaseNames BAR rparen
      { let lpr = rhs parseState 1
        let text = ("|" + String.concat "|" (List.rev $2) + "|")
        let rpr = rhs parseState 4
        ident(text, rhs2 parseState 2 3), IdentTrivia.HasParenthesis(lpr, rpr) }
-                         
+
   /* partial active pattern name */
-  | LPAREN activePatternCaseNames BAR UNDERSCORE BAR rparen 
+  | LPAREN activePatternCaseNames BAR UNDERSCORE BAR rparen
      { let lpr = rhs parseState 1
-       let text = ("|" + String.concat "|" (List.rev $2) + "|_|" )
+       let text = ("|" + String.concat "|" (List.rev $2) + "|_|")
        let rpr = rhs parseState 6
        ident(text, rhs2 parseState 2 5), IdentTrivia.HasParenthesis(lpr, rpr) }
 
 /* An operator name, without surrounding parentheses */
-operatorName: 
-  | PREFIX_OP 
-     { if not (IsValidPrefixOperatorDefinitionName $1) then 
-           reportParseErrorAt (lhs parseState) (FSComp.SR.parsInvalidPrefixOperatorDefinition());
+operatorName:
+  | PREFIX_OP
+     { if not (IsValidPrefixOperatorDefinitionName $1) then
+           reportParseErrorAt (lhs parseState) (FSComp.SR.parsInvalidPrefixOperatorDefinition())
        $1 }
 
   | INFIX_STAR_STAR_OP
@@ -5984,9 +5984,9 @@ operatorName:
   | COLON_EQUALS
      { ":=" }
 
-  | FUNKY_OPERATOR_NAME 
-     { if $1 <> ".[]"  && $1 <> ".()" && $1 <> ".()<-" then 
-            deprecatedOperator (lhs parseState); 
+  | FUNKY_OPERATOR_NAME
+     { if $1 <> ".[]"  && $1 <> ".()" && $1 <> ".()<-" then
+            deprecatedOperator (lhs parseState)
        $1 }
 
   | PERCENT_OP
@@ -5998,19 +5998,19 @@ operatorName:
   | DOT_DOT DOT_DOT
      { ".. .." }
 
-  | LQUOTE RQUOTE 
-     { if $1 <> $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsMismatchedQuotationName(fst $1));  
-       fst $1 } 
+  | LQUOTE RQUOTE
+     { if $1 <> $2 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsMismatchedQuotationName(fst $1))
+       fst $1 }
 
 /* One part of an active pattern name */
-activePatternCaseName: 
+activePatternCaseName:
   | IDENT
-     { if not (String.isLeadingIdentifierCharacterUpperCase _1) then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsActivePatternCaseMustBeginWithUpperCase());  
-       if ($1.IndexOf('|') <> -1) then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsActivePatternCaseContainsPipe());  
+     { if not (String.isLeadingIdentifierCharacterUpperCase _1) then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsActivePatternCaseMustBeginWithUpperCase())
+       if ($1.IndexOf('|') <> -1) then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsActivePatternCaseContainsPipe())
        $1 }
 
 /* Multiple parts of an active pattern name */
-activePatternCaseNames: 
+activePatternCaseNames:
   | BAR activePatternCaseName
      { [$2] }
 
@@ -6018,34 +6018,34 @@ activePatternCaseNames:
      { $3 :: $1 }
 
 /* A single item that is an identifier or operator name */
-identOrOp: 
-  | ident  
-     { SynIdent($1, None) } 
+identOrOp:
+  | ident
+     { SynIdent($1, None) }
 
-  | opName 
+  | opName
      { let ident, trivia = $1
        SynIdent(ident, Some trivia) }
 
 /* An A.B.C path ending in an identifier or operator name */
 /* Note, only used in atomicPatternLongIdent */
-pathOp: 
-  | ident  
+pathOp:
+  | ident
      { SynLongIdent([$1], [], [None]) }
 
-  | opName 
+  | opName
      { let ident, trivia = $1
        SynLongIdent([ident], [], [Some trivia]) }
 
-  | ident DOT pathOp 
+  | ident DOT pathOp
      { prependIdentInLongIdentWithTrivia (SynIdent($1, None)) (rhs parseState 2) $3 }
 
   | ident DOT error
-     { (* silent recovery *) SynLongIdent([$1], [rhs parseState 2], [None]) }  
+     { (* silent recovery *) SynLongIdent([$1], [rhs parseState 2], [None]) }
 
 
 /* nameop is identOrOp not used as part of a path */
-nameop: 
-  | identOrOp { $1 } 
+nameop:
+  | identOrOp { $1 }
 
 identExpr:
   | ident
@@ -6059,110 +6059,110 @@ identExpr:
        let ident, trivia = $1
        SynExpr.LongIdent(false, SynLongIdent([ident], [], [Some trivia]), None, m) }
 
-topSeparator: 
-  | SEMICOLON { } 
+topSeparator:
+  | SEMICOLON { }
   | SEMICOLON_SEMICOLON { }
-  | OBLOCKSEP { }  
+  | OBLOCKSEP { }
 
-topSeparators: 
-  | topSeparator { } 
+topSeparators:
+  | topSeparator { }
   | topSeparator topSeparators { }
 
-opt_topSeparators: 
+opt_topSeparators:
   | topSeparator opt_topSeparators { }
-  | /* EMPTY */                    { } 
+  | /* EMPTY */                    { }
 
 /* Seprators in either #light or non-#light */
-seps: 
-  | OBLOCKSEP { } 
+seps:
+  | OBLOCKSEP { }
   | SEMICOLON { }
   | OBLOCKSEP SEMICOLON { }
   | SEMICOLON OBLOCKSEP { }
 
 /* An 'end' that's optional only in #light, where an ODECLEND gets inserted, and explicit 'end's get converted to OEND */
-declEnd: 
-  | ODECLEND 
-      { } 
-  | OEND 
+declEnd:
+  | ODECLEND
+      { }
+  | OEND
       {   }
-  | END 
-      { } 
+  | END
+      { }
 
 /* An 'end' that's optional in both #light and non-#light */
-opt_declEnd: 
-  | ODECLEND 
-      {} 
-  | OEND 
-      { } 
-  | END 
-      {} 
-  | /* EMPTY */    
-      {} 
+opt_declEnd:
+  | ODECLEND
+      {}
+  | OEND
+      { }
+  | END
+      {}
+  | /* EMPTY */
+      {}
 
-opt_ODECLEND: 
-  | ODECLEND    { } 
+opt_ODECLEND:
+  | ODECLEND { }
   | /* EMPTY */ { }
 
-deprecated_opt_equals: 
-  | EQUALS      { deprecatedWithError (FSComp.SR.parsNoEqualShouldFollowNamespace()) (lhs parseState); () } 
+deprecated_opt_equals:
+  | EQUALS { deprecatedWithError (FSComp.SR.parsNoEqualShouldFollowNamespace()) (lhs parseState); () }
   | /* EMPTY */ {  }
 
 opt_equals:
-  | EQUALS      { let mEquals = rhs parseState 1 in (Some mEquals) }
-  | /* EMPTY */ { None } 
-
-opt_OBLOCKSEP: 
-  | OBLOCKSEP   { }
-  | /* EMPTY */ { } 
-
-opt_seps: 
-  | seps        { }
-  | /* EMPTY */ { } 
-
-opt_rec: 
-  | REC         { true }
-  | /* EMPTY */ { false } 
-
-opt_bar: 
-  | BAR         { } 
-  | /* EMPTY */ { } 
-
-opt_inline: 
-  | INLINE      { Some (rhs parseState 1) } 
+  | EQUALS { let mEquals = rhs parseState 1 in (Some mEquals) }
   | /* EMPTY */ { None }
 
-opt_mutable: 
-  | MUTABLE     { true } 
+opt_OBLOCKSEP:
+  | OBLOCKSEP { }
+  | /* EMPTY */ { }
+
+opt_seps:
+  | seps { }
+  | /* EMPTY */ { }
+
+opt_rec:
+  | REC { true }
+  | /* EMPTY */ { false }
+
+opt_bar:
+  | BAR { }
+  | /* EMPTY */ { }
+
+opt_inline:
+  | INLINE { Some (rhs parseState 1) }
+  | /* EMPTY */ { None }
+
+opt_mutable:
+  | MUTABLE { true }
   | /* EMPTY */ { false }
 
 /* A 'do' token in either #light or non-#light */
-doToken: 
-  | DO  { }
+doToken:
+  | DO { }
   | ODO { }
 
-doneDeclEnd: 
+doneDeclEnd:
   | DONE { }
   | ODECLEND { }  /* DONE gets thrown away by the lexfilter in favour of ODECLEND */
 
-structOrBegin: 
+structOrBegin:
   | STRUCT
     { if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
           mlCompatError (FSComp.SR.mlCompatStructEndNoLongerSupported()) (lhs parseState)
       else
           mlCompatWarning (FSComp.SR.parsSyntaxModuleStructEndDeprecated()) (lhs parseState)
     }
-  | BEGIN { } 
+  | BEGIN { }
 
-sigOrBegin: 
+sigOrBegin:
   | SIG
     { if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
           mlCompatError (FSComp.SR.mlCompatSigEndNoLongerSupported())(lhs parseState)
       else
           mlCompatWarning (FSComp.SR.parsSyntaxModuleSigEndDeprecated()) (lhs parseState)
     }
-  | BEGIN { } 
+  | BEGIN { }
 
-colonOrEquals: 
+colonOrEquals:
   | COLON
     { if parseState.LexBuffer.SupportsFeature LanguageFeature.MLCompatRevisions then
           mlCompatError (FSComp.SR.mlCompatSigColonNoLongerSupported())(lhs parseState)
@@ -6170,11 +6170,11 @@ colonOrEquals:
           mlCompatWarning (FSComp.SR.parsSyntaxModuleSigEndDeprecated()) (lhs parseState)
       None
     }
-  | EQUALS { let mEquals = rhs parseState 1 in Some mEquals } 
+  | EQUALS { let mEquals = rhs parseState 1 in Some mEquals }
 
 /* A literal string or a string from a keyword like __SOURCE_FILE__ */
 string:
-  | STRING 
+  | STRING
      { let (s, synStringKind, _) = $1
        s, synStringKind }
 
@@ -6190,17 +6190,17 @@ interpolatedStringFill:
 
 interpolatedStringParts:
   | INTERP_STRING_END
-     { [ SynInterpolatedStringPart.String (fst $1, rhs parseState 1) ] }
+     { [ SynInterpolatedStringPart.String(fst $1, rhs parseState 1) ] }
 
-  | INTERP_STRING_PART interpolatedStringFill interpolatedStringParts
-     { SynInterpolatedStringPart.String (fst $1, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
+    | INTERP_STRING_PART interpolatedStringFill interpolatedStringParts
+        { SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
 
   | INTERP_STRING_PART interpolatedStringParts
-     { 
+     {
        let rbrace = parseState.InputEndPosition 1
        let lbrace = parseState.InputStartPosition 2
        reportParseErrorAt (mkSynRange rbrace lbrace) (FSComp.SR.parsEmptyFillInInterpolatedString())
-       SynInterpolatedStringPart.String (fst $1, rhs parseState 1) :: $2 }
+       SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: $2 }
 
 /* INTERP_STRING_BEGIN_END */
 /* INTERP_STRING_BEGIN_PART int32 INTERP_STRING_END */
@@ -6208,20 +6208,20 @@ interpolatedStringParts:
 interpolatedString:
   | INTERP_STRING_BEGIN_PART interpolatedStringFill interpolatedStringParts
     { let s, synStringKind, _ = $1
-      SynInterpolatedStringPart.String (s, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3, synStringKind }
+      SynInterpolatedStringPart.String(s, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3, synStringKind }
 
   | INTERP_STRING_BEGIN_END
     { let s, synStringKind, _ = $1
-      [ SynInterpolatedStringPart.String (s, rhs parseState 1) ], synStringKind }
+      [ SynInterpolatedStringPart.String(s, rhs parseState 1) ], synStringKind }
 
   | INTERP_STRING_BEGIN_PART interpolatedStringParts
-    { 
+    {
       let s, synStringKind, _ = $1
       let rbrace = parseState.InputEndPosition 1
       let lbrace = parseState.InputStartPosition 2
       reportParseErrorAt (mkSynRange rbrace lbrace) (FSComp.SR.parsEmptyFillInInterpolatedString())
-      SynInterpolatedStringPart.String (s, rhs parseState 1) :: $2, synStringKind }
-  
+      SynInterpolatedStringPart.String(s, rhs parseState 1) :: $2, synStringKind }
+
 opt_HIGH_PRECEDENCE_APP:
   | HIGH_PRECEDENCE_BRACK_APP { }
   | HIGH_PRECEDENCE_PAREN_APP { }


### PR DESCRIPTION
Semi-automatic cleanup of extra whitespaces, `;`, and `in` in the parser grammar file.