### PR TITLE
VS: Use IViewElementFactory as intended

### DIFF
--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -55,14 +55,13 @@ module internal QuickInfoViewProvider =
         | TaggedText (TextTag.LineBreak, _) -> Some()
         | _ -> None
 
-    let wrapContent (elements: obj list) =
-        ContainerElement(ContainerElementStyle.Wrapped, elements |> Seq.map box)
+    let wrapContent (elements: obj seq) =
+        ContainerElement(ContainerElementStyle.Wrapped, elements)
 
-    let stackContent (elements: obj list) =
-        ContainerElement(ContainerElementStyle.Stacked, elements |> Seq.map box)
+    let stackContent (elements: obj seq) =
+        ContainerElement(ContainerElementStyle.Stacked, elements)
 
-    let encloseRuns runs =
-        ClassifiedTextElement(runs |> List.rev) |> box
+    let encloseRuns runs : obj = ClassifiedTextElement(runs |> List.rev)
 
     let provideContent
         (
@@ -78,8 +77,8 @@ module internal QuickInfoViewProvider =
                 match (text: TaggedText list) with
                 | [] when runs |> List.isEmpty -> stackContent (stack |> List.rev)
                 | [] -> stackContent (encloseRuns runs :: stack |> List.rev)
-                // smaller gap instead of huge double line break
-                | LineBreak :: rest when runs |> List.isEmpty -> loop rest [] (box (Separator false) :: stack)
+                // smaller paragraph spacing instead of huge double line break
+                | LineBreak :: rest when runs |> List.isEmpty -> loop rest [] (Paragraph :: stack)
                 | LineBreak :: rest -> loop rest [] (encloseRuns runs :: stack)
                 | :? NavigableTaggedText as item :: rest when navigation.IsTargetValid item.Range ->
                     let classificationTag = layoutTagToClassificationTag item.Tag
@@ -93,17 +92,14 @@ module internal QuickInfoViewProvider =
                     let run = ClassifiedTextRun(layoutTagToClassificationTag item.Tag, item.Text)
                     loop rest (run :: runs) stack
 
-            loop text [] [] |> box
+            loop text [] []
 
         let innerElement =
             match imageId with
             | Some imageId -> wrapContent [ stackContent [ ImageElement(imageId) ]; encloseText description ]
             | None -> ContainerElement(ContainerElementStyle.Wrapped, encloseText description)
-
-        wrapContent [ stackContent [ innerElement; encloseText documentation ] ]
+        
+        wrapContent [ stackContent [ innerElement; encloseText documentation ]; CustomLinkStyle ]
 
     let stackWithSeparators elements =
-        elements
-        |> List.map box
-        |> List.intersperse (box (Separator true))
-        |> stackContent
+        elements |> List.map box |> List.intersperse Separator |> stackContent

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -98,7 +98,7 @@ module internal QuickInfoViewProvider =
             match imageId with
             | Some imageId -> wrapContent [ stackContent [ ImageElement(imageId) ]; encloseText description ]
             | None -> ContainerElement(ContainerElementStyle.Wrapped, encloseText description)
-        
+
         wrapContent [ stackContent [ innerElement; encloseText documentation ]; CustomLinkStyle ]
 
     let stackWithSeparators elements =

--- a/vsintegration/src/FSharp.Editor/QuickInfo/WpfFactories.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/WpfFactories.fs
@@ -11,7 +11,7 @@ open Microsoft.VisualStudio.Utilities
 
 open Microsoft.VisualStudio.FSharp
 
-type FSharpStyle =
+type internal FSharpStyle =
     | Separator
     | Paragraph
     | CustomLinkStyle
@@ -27,7 +27,7 @@ type FSharpStyle =
 [<Export(typeof<IViewElementFactory>)>]
 [<Name("FSharpStyle to UIElement")>]
 [<TypeConversion(typeof<FSharpStyle>, typeof<UIElement>)>]
-type WpfFSharpStyleFactory [<ImportingConstructor>] (settings: Editor.EditorOptions) =
+type internal WpfFSharpStyleFactory [<ImportingConstructor>] (settings: Editor.EditorOptions) =
     let linkStyleUpdater () =
         let key =
             if settings.QuickInfo.DisplayLinks then

--- a/vsintegration/src/FSharp.UIResources/NavStyles.xaml
+++ b/vsintegration/src/FSharp.UIResources/NavStyles.xaml
@@ -8,8 +8,8 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
-        <SolidColorBrush x:Key="inherited_brush" Color="{Binding Path=Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Hyperlink}}"/>
-        <SolidColorBrush x:Key="inherited_semi_brush" Opacity="0.3" Color="{Binding Path=Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Hyperlink}}"/>
+        <SolidColorBrush x:Key="inherited_brush" Color="{Binding Path=Inlines.FirstInline.Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Hyperlink}}"/>
+        <SolidColorBrush x:Key="inherited_semi_brush" Opacity="0.3" Color="{Binding Path=Inlines.FirstInline.Foreground.Color, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Hyperlink}}"/>
         <DashStyle x:Key="dash_dashstyle" Dashes="5 5"/>
         <DashStyle x:Key="dot_dashstyle" Dashes="1 5"/>
         <Pen x:Key="dot_pen" DashStyle="{StaticResource dot_dashstyle}" Brush="{StaticResource inherited_brush}"/>
@@ -26,7 +26,7 @@
             <TextDecoration Location="Underline" PenOffset="1" Pen="{StaticResource dot_pen}"/>
         </TextDecorationCollection>
         <TextDecorationCollection x:Key="full_deco">
-            <TextDecoration PenOffset="1" Pen="{StaticResource mouseover_pen}" />
+            <TextDecoration Location="Underline" PenOffset="1" Pen="{StaticResource mouseover_pen}" />
         </TextDecorationCollection>
         <Style x:Key="hyperlink_mouse_over" TargetType="Hyperlink">
             <Style.Triggers>


### PR DESCRIPTION
Alternative approach to styling QuickInfo, to address the issue with our `IViewElementFactory` being picked up by other packages in  VS.
Now we provide content using the cross platform objects (`ClassifiedTextElement` at al.) and let VS render them. Custom visuals are provided by our internal `FSharpStyle` so the type conversion should never be available to other VS inhabitants.
To make the links look nicer we imperatively touch up the visual tree created by VS. Maybe not a standard, but still a legit way to do this.

`FSharpStyle` overrides `ToString` to render paragraphs and separators cross platform. (To see this in action in VS on Windows just comment out `[<Export(typeof<IViewElementFactory>)>]`)


