### PR TITLE
Parser: recover on unfinished simple 'member' declarations

### DIFF
--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -1468,6 +1468,7 @@ type Exception with
                     |> List.map Parser.tokenTagToTokenId
                     |> List.filter (function
                         | Parser.TOKEN_error
+                        | Parser.TOKEN_OBLOCKSEP
                         | Parser.TOKEN_EOF -> false
                         | _ -> true)
                     |> List.map tokenIdToText

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1697,3 +1697,4 @@ featureEscapeBracesInFormattableString,"Escapes curly braces before calling Form
 3565,parsExpectingType,"Expecting type"
 featureInformationalObjInferenceDiagnostic,"Diagnostic 3559 (warn when obj inferred) at informational level, off by default"
 3566,tcMultipleRecdTypeChoice,"Multiple type matches were found:\n%s\nThe type '%s' was used. Due to the overlapping field names\n%s\nconsider using type annotations or change the order of open statements."
+3567,parsMissingMemberBody,"Expecting member body"

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -1331,7 +1331,12 @@ type SynArgInfo =
 type SynValTyparDecls = SynValTyparDecls of typars: SynTyparDecls option * canInfer: bool
 
 [<NoEquality; NoComparison>]
-type SynReturnInfo = SynReturnInfo of returnType: (SynType * SynArgInfo) * range: range
+type SynReturnInfo =
+    | SynReturnInfo of returnType: (SynType * SynArgInfo) * range: range
+
+    member this.Range =
+        match this with
+        | SynReturnInfo (range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynExceptionDefnRepr =

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -1503,7 +1503,10 @@ type SynValTyparDecls = SynValTyparDecls of typars: SynTyparDecls option * canIn
 
 /// Represents the syntactic elements associated with the "return" of a function or method.
 [<NoEquality; NoComparison>]
-type SynReturnInfo = SynReturnInfo of returnType: (SynType * SynArgInfo) * range: range
+type SynReturnInfo =
+    | SynReturnInfo of returnType: (SynType * SynArgInfo) * range: range
+
+    member Range: range
 
 /// Represents the right hand side of an exception declaration 'exception E = ... '
 [<NoEquality; NoComparison>]

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -179,6 +179,7 @@ type SynLeadingKeyword =
     | OverrideVal of overrideRange: range * valRange: range
     | Abstract of abstractRange: range
     | AbstractMember of abstractRange: range * memberRange: range
+    | Static of staticRange: range
     | StaticMember of staticRange: range * memberRange: range
     | StaticMemberVal of staticRange: range * memberRange: range * valRange: range
     | StaticAbstract of staticRange: range * abstractRange: range
@@ -206,7 +207,8 @@ type SynLeadingKeyword =
         | Default m
         | Val m
         | New m
-        | Do m -> m
+        | Do m
+        | Static m -> m
         | LetRec (m1, m2)
         | UseRec (m1, m2)
         | AbstractMember (m1, m2)

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -271,6 +271,7 @@ type SynLeadingKeyword =
     | OverrideVal of overrideRange: range * valRange: range
     | Abstract of abstractRange: range
     | AbstractMember of abstractRange: range * memberRange: range
+    | Static of staticRange: range
     | StaticMember of staticRange: range * memberRange: range
     | StaticMemberVal of staticRange: range * memberRange: range * valRange: range
     | StaticAbstract of staticRange: range * abstractRange: range

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -1811,6 +1811,25 @@ memberCore:
            let memberRange = unionRanges rangeStart mEnd |> unionRangeWithXmlDoc xmlDoc
            [ SynMemberDefn.Member (binding, memberRange) ] }
 
+  | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints recover
+     { let optReturnType = $3
+       let bindingPat, mBindLhs = $2
+       let mEnd =
+           match optReturnType with
+           | Some(_, ty) -> ty.Range.EndRange
+           | _ -> bindingPat.Range.EndRange
+       let expr = arbExpr ("memberCore2", mEnd)
+
+       fun vis flagsBuilderAndLeadingKeyword attrs rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, rangeStart)
+           let memFlagsBuilder, leadingKeyword = flagsBuilderAndLeadingKeyword
+           let memberFlags = memFlagsBuilder SynMemberKind.Member
+           let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
+           let trivia: SynBindingTrivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = None }
+           let binding = mkSynBinding (xmlDoc, bindingPat) (vis, (Option.isSome $1), false, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, optReturnType, expr, mEnd, [], attrs, Some memberFlags, trivia)
+           let memberRange = unionRanges rangeStart mEnd |> unionRangeWithXmlDoc xmlDoc
+           [ SynMemberDefn.Member (binding, memberRange) ] }
+
   /* Properties with explicit get/set, also indexer properties */
   | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints classDefnMemberGetSet
      { let mWith, (classDefnMemberGetSetElements, mAnd) = $4

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -1499,16 +1499,24 @@ memberFlags:
   | STATIC MEMBER
       { let mStatic = rhs parseState 1
         let mMember = rhs parseState 2
-        StaticMemberFlags, (SynLeadingKeyword.StaticMember(mStatic, mMember)) }
+        StaticMemberFlags, SynLeadingKeyword.StaticMember(mStatic, mMember) }
+
+ | STATIC
+      { let mStatic = rhs parseState 1
+        // todo: it should be possible to make it work better for both `abstract` and `member` in the type checker
+        StaticMemberFlags, SynLeadingKeyword.Static(mStatic) }
+
   | MEMBER
       { let mMember = rhs parseState 1
-        NonVirtualMemberFlags, (SynLeadingKeyword.Member mMember) }
+        NonVirtualMemberFlags, SynLeadingKeyword.Member mMember }
+
   | OVERRIDE
       { let mOverride = rhs parseState 1
-        OverrideMemberFlags, (SynLeadingKeyword.Override mOverride) }
+        OverrideMemberFlags, SynLeadingKeyword.Override mOverride }
+
   | DEFAULT
       { let mDefault = rhs parseState 1
-        OverrideMemberFlags, (SynLeadingKeyword.Default mDefault) }
+        OverrideMemberFlags, SynLeadingKeyword.Default mDefault }
 
 /* The name of a type in a signature or implementation, possibly with type parameters and constraints */
 typeNameInfo:
@@ -1783,6 +1791,26 @@ memberCore:
             let memberRange = unionRanges rangeStart mRhs |> unionRangeWithXmlDoc xmlDoc
             [ SynMemberDefn.Member(binding, memberRange) ]) }
 
+  | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints OBLOCKSEP
+     { let optReturnType = $3
+       let bindingPat, mBindLhs = $2
+       let mEnd =
+           match optReturnType with
+           | Some(_, ty) -> ty.Range.EndRange
+           | _ -> bindingPat.Range.EndRange
+       let expr = arbExpr ("memberCore1", mEnd)
+       errorR (Error(FSComp.SR.parsMissingMemberBody(), rhs parseState 4))
+
+       fun vis flagsBuilderAndLeadingKeyword attrs rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart(parseState, attrs, rangeStart)
+           let memFlagsBuilder, leadingKeyword = flagsBuilderAndLeadingKeyword
+           let memberFlags = memFlagsBuilder SynMemberKind.Member
+           let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
+           let trivia: SynBindingTrivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = None }
+           let binding = mkSynBinding (xmlDoc, bindingPat) (vis, (Option.isSome $1), false, mWholeBindLhs, DebugPointAtBinding.NoneAtInvisible, optReturnType, expr, mEnd, [], attrs, Some memberFlags, trivia)
+           let memberRange = unionRanges rangeStart mEnd |> unionRangeWithXmlDoc xmlDoc
+           [ SynMemberDefn.Member (binding, memberRange) ] }
+
   /* Properties with explicit get/set, also indexer properties */
   | opt_inline bindingPattern opt_topReturnTypeWithTypeConstraints classDefnMemberGetSet
      { let mWith, (classDefnMemberGetSetElements, mAnd) = $4
@@ -1845,6 +1873,26 @@ classDefnMember:
            errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
        let flags = $3
        $4 $2 flags $1 rangeStart }
+
+  | opt_attributes opt_access memberFlags recover
+      { let rangeStart = rhs parseState 1
+        if Option.isSome $2 then
+            errorR (Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+        let memFlagsBuilder, leadingKeyword = $3
+        let flags = Some(memFlagsBuilder SynMemberKind.Member)
+        let xmlDoc = grabXmlDocAtRangeStart (parseState, $1, rangeStart)
+        let trivia = { LeadingKeyword = leadingKeyword; InlineKeyword = None; EqualsRange = None }
+        let mMember = rhs parseState 3
+        let mEnd = mMember.EndRange
+        let bindingPat = patFromParseError (SynPat.Wild(mEnd))
+        let expr = arbExpr ("classDefnMember1", mEnd)
+        let mWhole = rhs2 parseState 1 3
+        let binding =
+            mkSynBinding
+                (xmlDoc, bindingPat)
+                ($2, (Option.isSome $2), false, mWhole, DebugPointAtBinding.NoneAtInvisible, None, expr, mEnd, [], $1, flags, trivia)
+
+        [SynMemberDefn.Member(binding, mWhole)] }
 
   | opt_attributes opt_access interfaceMember appType opt_interfaceImplDefn
      { if not (isNil $1) then errorR(Error(FSComp.SR.parsAttributesAreNotPermittedOnInterfaceImplementations(), rhs parseState 1))

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Neúplný výraz operátoru (například^b) nebo volání kvalifikovaného typu (příklad: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Unvollständiger Operatorausdruck (Beispiel: a^b) oder qualifizierter Typaufruf (Beispiel: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Expresión de operador incompleta (ejemplo, a^b) o invocación de tipo calificada (ejemplo: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Expression d’opérateur incomplète (exemple a^b) ou appel de type qualifié (exemple : ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Espressione operatore incompleta (ad esempio a^b) o chiamata di tipo qualificato (ad esempio: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -822,6 +822,11 @@
         <target state="translated">不完全な演算子式 (例 a^b) または修飾型の呼び出し (例: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -822,6 +822,11 @@
         <target state="translated">불완전한 연산자 식(예: a^b) 또는 정규화된 형식 호출(예: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Niekompletne wyrażenie operatora (na przykład a^b) lub wywołanie typu kwalifikowanego (przykład: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Expressão de operador incompleta (exemplo a^b) ou invocação de tipo qualificado (exemplo: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Неполное выражение оператора (например, a^b) или вызов квалифицированного типа (например, ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Eksik işleç ifadesi (örnek a^b) veya tam tür çağrısı (örnek: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -822,6 +822,11 @@
         <target state="translated">运算符表达式不完整(示例: a^b)或限定类型调用(示例: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -822,6 +822,11 @@
         <target state="translated">不完整的運算子運算式 (範例 a^b) 或限定類型調用 (範例: ^T.Name)</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsMissingMemberBody">
+        <source>Expecting member body</source>
+        <target state="new">Expecting member body</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsMissingUnionCaseName">
         <source>Missing union case name</source>
         <target state="new">Missing union case name</target>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -8172,6 +8172,8 @@ FSharp.Compiler.Syntax.SynRationalConst: Int32 Tag
 FSharp.Compiler.Syntax.SynRationalConst: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynRationalConst: System.String ToString()
 FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Syntax.SynReturnInfo NewSynReturnInfo(System.Tuple`2[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynArgInfo], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynReturnInfo: Int32 Tag
@@ -9493,6 +9495,8 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text.Range get_valRange()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text.Range overrideRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text.Range valRange
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Static: FSharp.Compiler.Text.Range get_staticRange()
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Static: FSharp.Compiler.Text.Range staticRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract: FSharp.Compiler.Text.Range abstractRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract: FSharp.Compiler.Text.Range get_abstractRange()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract: FSharp.Compiler.Text.Range get_staticRange()
@@ -9545,6 +9549,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 MemberVal
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 New
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 Override
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 OverrideVal
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 Static
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 StaticAbstract
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 StaticAbstractMember
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 StaticDo
@@ -9579,6 +9584,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsMemberVal
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsNew
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsOverride
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsOverrideVal
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStatic
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStaticAbstract
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStaticAbstractMember
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStaticDo
@@ -9605,6 +9611,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsMemberVal()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsNew()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsOverride()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsOverrideVal()
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStatic()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStaticAbstract()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStaticAbstractMember()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStaticDo()
@@ -9631,6 +9638,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.Syn
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewNew(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewOverride(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewOverrideVal(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStatic(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStaticAbstract(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStaticAbstractMember(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStaticDo(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
@@ -9658,6 +9666,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.Syn
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+New
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Override
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Static
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstractMember
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticDo

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -8172,6 +8172,8 @@ FSharp.Compiler.Syntax.SynRationalConst: Int32 Tag
 FSharp.Compiler.Syntax.SynRationalConst: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynRationalConst: System.String ToString()
 FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Syntax.SynReturnInfo NewSynReturnInfo(System.Tuple`2[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynArgInfo], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynReturnInfo: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynReturnInfo: Int32 Tag
@@ -9493,6 +9495,8 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text.Range get_valRange()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text.Range overrideRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal: FSharp.Compiler.Text.Range valRange
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Static: FSharp.Compiler.Text.Range get_staticRange()
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Static: FSharp.Compiler.Text.Range staticRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract: FSharp.Compiler.Text.Range abstractRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract: FSharp.Compiler.Text.Range get_abstractRange()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract: FSharp.Compiler.Text.Range get_staticRange()
@@ -9545,6 +9549,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 MemberVal
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 New
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 Override
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 OverrideVal
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 Static
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 StaticAbstract
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 StaticAbstractMember
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Tags: Int32 StaticDo
@@ -9579,6 +9584,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsMemberVal
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsNew
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsOverride
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsOverrideVal
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStatic
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStaticAbstract
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStaticAbstractMember
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean IsStaticDo
@@ -9605,6 +9611,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsMemberVal()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsNew()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsOverride()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsOverrideVal()
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStatic()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStaticAbstract()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStaticAbstractMember()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: Boolean get_IsStaticDo()
@@ -9631,6 +9638,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.Syn
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewNew(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewOverride(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewOverrideVal(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStatic(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStaticAbstract(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStaticAbstractMember(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword NewStaticDo(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
@@ -9658,6 +9666,7 @@ FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.Syn
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+New
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Override
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+OverrideVal
+FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Static
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstract
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticAbstractMember
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+StaticDo

--- a/tests/service/data/SyntaxTree/Member/Member - Attributes 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Member - Attributes 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member - Attributes 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member - Attributes 01.fs.bsl
@@ -1,0 +1,113 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member - Attributes 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            FromParseError (Wild (5,16--5,16), (5,16--5,16)),
+                            None,
+                            ArbitraryAfterError
+                              ("classDefnMember1", (5,16--5,16)), (5,4--5,16),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,16));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,17)-(6,4) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Member 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 01.fs.bsl
@@ -1,0 +1,112 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            FromParseError (Wild (5,16--5,16), (5,16--5,16)),
+                            None,
+                            ArbitraryAfterError
+                              ("classDefnMember1", (5,16--5,16)), (5,4--5,16),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,16));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,17)-(6,4) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Member 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member this
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 02.fs.bsl
@@ -1,0 +1,112 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            Named
+                              (SynIdent (this, None), false, None, (5,17--5,21)),
+                            None,
+                            ArbitraryAfterError ("memberCore1", (5,21--5,21)),
+                            (5,4--5,21), NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,21));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,22)-(6,4) parse error Expecting member body

--- a/tests/service/data/SyntaxTree/Member/Member 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member this.
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 03.fs.bsl
@@ -1,0 +1,113 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            Named
+                              (SynIdent (this, None), false, None, (5,17--5,21)),
+                            None,
+                            ArbitraryAfterError ("memberCore1", (5,21--5,21)),
+                            (5,4--6,4), NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,21));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,23)-(6,4) parse error Incomplete structured construct at or before this point in member definition. Expected identifier, '(', '(*)' or other token.
+(5,23)-(6,4) parse error Expecting member body

--- a/tests/service/data/SyntaxTree/Member/Member 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member this.P2
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 04.fs.bsl
@@ -1,0 +1,113 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(5,21--5,22)], [None; None]),
+                               None, None, Pats [], None, (5,17--5,24)), None,
+                            ArbitraryAfterError ("memberCore1", (5,24--5,24)),
+                            (5,4--5,24), NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,24));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,25)-(6,4) parse error Expecting member body

--- a/tests/service/data/SyntaxTree/Member/Member 05.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 05.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member this.P2 =
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 05.fs.bsl
@@ -1,0 +1,115 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(5,21--5,22)], [None; None]),
+                               None, None, Pats [], None, (5,17--5,24)), None,
+                            ArbitraryAfterError
+                              ("typedSequentialExprBlock1", (5,26--5,26)),
+                            (5,4--5,24), NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (5,25--5,26) }), (5,4--5,26));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,6) parse error Possible incorrect indentation: this token is offside of context started at position (5:11). Try indenting this token further or using standard formatting conventions.
+(6,4)-(6,6) parse error Expecting expression

--- a/tests/service/data/SyntaxTree/Member/Member 06.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member this.P2 = 2
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 06.fs.bsl
@@ -1,0 +1,111 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(5,21--5,22)], [None; None]),
+                               None, None, Pats [], None, (5,17--5,24)), None,
+                            Const (Int32 2, (5,27--5,28)), (5,4--5,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (5,25--5,26) }), (5,4--5,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Member 07.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 07.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] member this. = 2
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Member 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 07.fs.bsl
@@ -1,0 +1,111 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            Named
+                              (SynIdent (this, None), false, None, (5,17--5,21)),
+                            None, Const (Int32 2, (5,25--5,26)), (5,4--5,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (5,23--5,24) }), (5,4--5,26));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,23)-(5,24) parse error Unexpected symbol '=' in member definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Member 08.fs
+++ b/tests/service/data/SyntaxTree/Member/Member 08.fs
@@ -1,0 +1,4 @@
+module Module
+
+type INumericNorm<'T,'Measure>  = interface INumeric<'T>
+                                   member Norm : 'T -> 'Measure

--- a/tests/service/data/SyntaxTree/Member/Member 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Member 08.fs.bsl
@@ -1,0 +1,75 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Member 08.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([],
+                     Some
+                       (PostfixList
+                          ([SynTyparDecl ([], SynTypar (T, None, false));
+                            SynTyparDecl ([], SynTypar (Measure, None, false))],
+                           [], (3,17--3,30))), [], [INumericNorm],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     true, None, (3,5--3,17)),
+                  ObjectModel
+                    (Unspecified,
+                     [Interface
+                        (App
+                           (LongIdent (SynLongIdent ([INumeric], [], [None])),
+                            Some (3,52--3,53),
+                            [Var (SynTypar (T, None, false), (3,53--3,55))], [],
+                            Some (3,55--3,56), false, (3,44--3,56)), None, None,
+                         (3,34--3,56));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((4,35), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent ([Norm], [], [None]), None, None,
+                               Pats [], None, (4,42--4,46)),
+                            Some
+                              (SynBindingReturnInfo
+                                 (Fun
+                                    (Var
+                                       (SynTypar (T, None, false), (4,49--4,51)),
+                                     Var
+                                       (SynTypar (Measure, None, false),
+                                        (4,55--4,63)), (4,49--4,63),
+                                     { ArrowRange = (4,52--4,54) }),
+                                  (4,49--4,63), [],
+                                  { ColonRange = Some (4,47--4,48) })),
+                            Typed
+                              (ArbitraryAfterError ("memberCore2", (4,63--4,63)),
+                               Fun
+                                 (Var (SynTypar (T, None, false), (4,49--4,51)),
+                                  Var
+                                    (SynTypar (Measure, None, false),
+                                     (4,55--4,63)), (4,49--4,63),
+                                  { ArrowRange = (4,52--4,54) }), (4,63--4,63)),
+                            (4,42--4,46), NoneAtInvisible,
+                            { LeadingKeyword = Member (4,35--4,41)
+                              InlineKeyword = None
+                              EqualsRange = None }), (4,35--4,63))],
+                     (3,34--4,63)), [], None, (3,5--4,63),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,32--3,33)
+                    WithKeyword = None })], (3,0--4,63))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,63), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in member definition. Expected 'with', '=' or other token.

--- a/tests/service/data/SyntaxTree/Member/Static 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Static 01.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+
+    static
+
+    do ()

--- a/tests/service/data/SyntaxTree/Member/Static 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Static 01.fs.bsl
@@ -1,0 +1,55 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Static 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = false
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo ([[]], SynArgInfo ([], false, None)),
+                               None),
+                            FromParseError (Wild (5,10--5,10), (5,10--5,10)),
+                            None,
+                            ArbitraryAfterError
+                              ("classDefnMember1", (5,10--5,10)), (5,4--5,10),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Static (5,4--5,10)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,10));
+                      LetBindings
+                        ([SynBinding
+                            (None, Do, false, false, [], PreXmlDocEmpty,
+                             SynValData
+                               (None,
+                                SynValInfo ([], SynArgInfo ([], false, None)),
+                                None), Const (Unit, (7,4--7,9)), None,
+                             Const (Unit, (7,7--7,9)), (7,4--7,9), NoneAtDo,
+                             { LeadingKeyword = Do (7,4--7,6)
+                               InlineKeyword = None
+                               EqualsRange = None })], false, false, (7,4--7,9))],
+                     (5,4--7,9)), [], None, (3,5--7,9),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--7,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,11)-(7,4) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Static 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Static 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] static
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Static 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Static 02.fs.bsl
@@ -1,0 +1,111 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Static 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = false
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo ([[]], SynArgInfo ([], false, None)),
+                               None),
+                            FromParseError (Wild (5,16--5,16), (5,16--5,16)),
+                            None,
+                            ArbitraryAfterError
+                              ("classDefnMember1", (5,16--5,16)), (5,4--5,16),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Static (5,10--5,16)
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,16));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,17)-(6,4) parse error Incomplete structured construct at or before this point in member definition

--- a/tests/service/data/SyntaxTree/Member/Static 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Static 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    [<A>] member this.P1 = 1
+    [<B>] static member
+    [<C>] member this.P3 = 3

--- a/tests/service/data/SyntaxTree/Member/Static 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Static 03.fs.bsl
@@ -1,0 +1,112 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Static 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P1], [(4,21--4,22)], [None; None]),
+                               None, None, Pats [], None, (4,17--4,24)), None,
+                            Const (Int32 1, (4,27--4,28)), (4,4--4,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,10--4,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,25--4,26) }), (4,4--4,28));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([B], [], [None])
+                                   ArgExpr = Const (Unit, (5,6--5,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (5,6--5,7) }]
+                               Range = (5,4--5,9) }],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = false
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo ([[]], SynArgInfo ([], false, None)),
+                               None),
+                            FromParseError (Wild (5,23--5,23), (5,23--5,23)),
+                            None,
+                            ArbitraryAfterError
+                              ("classDefnMember1", (5,23--5,23)), (5,4--5,23),
+                            NoneAtInvisible,
+                            { LeadingKeyword =
+                               StaticMember ((5,10--5,16), (5,17--5,23))
+                              InlineKeyword = None
+                              EqualsRange = None }), (5,4--5,23));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false,
+                            [{ Attributes =
+                                [{ TypeName = SynLongIdent ([C], [], [None])
+                                   ArgExpr = Const (Unit, (6,6--6,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (6,6--6,7) }]
+                               Range = (6,4--6,9) }],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P3], [(6,21--6,22)], [None; None]),
+                               None, None, Pats [], None, (6,17--6,24)), None,
+                            Const (Int32 3, (6,27--6,28)), (6,4--6,24),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,10--6,16)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,25--6,26) }), (6,4--6,28))],
+                     (4,4--6,28)), [], None, (3,5--6,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,28))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,28), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,24)-(6,4) parse error Incomplete structured construct at or before this point in member definition


### PR DESCRIPTION
Adds parser recovery for some cases involving unfinished members:

```fsharp
type T =
    member
```

```fsharp
type T =
    member this.
```

```fsharp
type T =
    member this.P =
```

```fsharp
type T =
    member this. = 1
```

```fsharp
type T =
    static
```