### PR TITLE
Preliminary Map.binarySearch function with tests

### DIFF
--- a/src/FSharp.Core/map.fsi
+++ b/src/FSharp.Core/map.fsi
@@ -781,3 +781,20 @@ module Map =
     /// </example>
     [<CompiledName("MaxKeyValue")>]
     val maxKeyValue: table: Map<'Key, 'T> -> 'Key * 'T
+
+    /// <summary>Returns a 3-tuple of the item with the closest key below the map, if any;
+    /// the matching item, if any; and the closest key above the map, if any.</summary>
+    ///
+    /// <param name="key">The key to search.</param>
+    /// <param name="table">The input map.</param>
+    ///
+    /// <example>
+    /// <code lang="fsharp">
+    /// let sample = Map [ (10, "a"); (12, "b"); (20, "c"); (22, "d"); (25, "e"); (28, "f")
+    ///                    (30, "g"); (36, "h"); (38, "i"); (40, "j"); (48, "k") ]
+    ///
+    /// sample |> Map.binarySearch 20 // evaluates to Some (12, "b"), Some (20, "c"), Some (25, "e")
+    /// </code>
+    /// </example>
+    [<CompiledName("BinarySearch")>]
+    val binarySearch: key: 'Key -> table: Map<'Key, 'T> -> ('Key * 'T) option * ('Key * 'T) option * ('Key * 'T) option

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/MapModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/MapModule.fs
@@ -726,3 +726,63 @@ type MapModule() =
         CheckThrowsKeyNotFoundException (fun () -> Map.maxKeyValue eptMap |> ignore)
                
         ()
+        
+    [<Fact>]
+    member _.BinarySearch() =
+        let map = Map [ (10, "a"); (12, "b"); (20, "c"); (22, "d"); (25, "e"); (28, "f")
+                        (30, "g"); (36, "h"); (38, "i"); (40, "j"); (48, "k") ]
+        // Produces the following tree at tolerance 2:
+        // 22
+        // |- 12
+        //    |- 10
+        //    |- 20
+        // |- 28
+        //    |- 25
+        //    |- 36
+        //       |- 30
+        //       |- 40
+        //          |- 38
+        //          |- 48
+        
+        // Matches exact and either side at middle of tree
+        let result = Map.binarySearch 12 map
+        let expected = Some (10, "a"), Some (12, "b"), Some (20, "c")
+        Assert.Equal(expected, result)
+        
+        // Matches exact and either side at bottom of tree
+        let result = Map.binarySearch 20 map
+        let expected = Some (12, "b"), Some (20, "c"), Some (22, "d")
+        Assert.Equal(expected, result)
+        
+        // Matches exact and either side at top of tree
+        let result = Map.binarySearch 22 map
+        let expected = Some (20, "c"), Some (22, "d"), Some (25, "e")
+        Assert.Equal(expected, result)
+        
+        // Matches on either side
+        let result = Map.binarySearch 11 map
+        let expected = Some (10, "a"), None, Some (12, "b")
+        Assert.Equal(expected, result)
+        
+        // Only matches to left
+        let result = Map.binarySearch 50 map
+        let expected = Some (48, "k"), None, None
+        Assert.Equal(expected, result)
+        
+        // Only matches to right
+        let result = Map.binarySearch 1 map
+        let expected = None, None, Some (10, "a")
+        Assert.Equal(expected, result)
+        
+        // One-element Map
+        let map = Map [ (1, "a") ]
+        let result = Map.binarySearch 1 map
+        let expected = None, Some (1, "a"), None
+        Assert.Equal(expected, result)
+        
+        // Empty Map
+        let result = Map.binarySearch 1 (Map [])
+        let expected = None, None, None
+        Assert.Equal(expected, result)
+        
+        ()


### PR DESCRIPTION
As per our discussion in [fsharp/fslang-suggestions](https://github.com/fsharp/fslang-suggestions/issues/82), I've written a `binarySearch : 'Key -> Map<'Key, 'Value> -> ('Key, 'Value) option * ('Key, 'Value) option * ('Key, 'Value) option` along with its wrapper method and a handful of tests.

This version returns a tuple of 3 options: one for the item with the closest matching key below; one for the match; and one for the item with the closest matching key above.

Several other ideas were raised in the discussion, which I think are worth considering further before committing to this shape:
- Return a DU with four cases: an exact match; a match below; a match above; and a match above or below but not exact. This would have the advantage of having only four total patterns as opposed to eight, with the disadvantage of less potentially useful information for the same computational cost.
- A `splitAt` function which would return two `Map`,s `List`s or `Seq`s, one for the items on either side of the matching key. This would be the most versatile by far, but up to O(n) more computation and memory, so it may or may not make sense to implement this as a separate function anyway.

This is my first real contribution to F# beyond just nagging for new features, so I would appreciate any detailed feedback!