### PR TITLE
An extra integration test for GTD

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,7 @@ stages:
         enableSourceBuild: false
         enableTelemetry: true
         helixRepo: dotnet/fsharp
+        continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
         jobs:
           # Determinism, we want to run it only in PR builds
         - job: Determinism_Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: eq(variables['_testKind'], 'testIntegration')
+            condition: eq(variables['_testKind'], 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,7 +319,6 @@ stages:
         enableSourceBuild: true
         enableTelemetry: true
         helixRepo: dotnet/fsharp
-        continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
         jobs:
 
         # Windows With Compressed Metadata
@@ -366,6 +365,11 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
+            condition: ne(variables['_testKind'], 'testIntegration')
+          - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
+            displayName: Build / Integration Test
+            continueOnError: true
+            condition: eq(variables['_testKind'], 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,6 +319,7 @@ stages:
         enableSourceBuild: true
         enableTelemetry: true
         helixRepo: dotnet/fsharp
+        continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
         jobs:
 
         # Windows With Compressed Metadata
@@ -355,7 +356,6 @@ stages:
                 inttests_release:
                   _configuration: Release
                   _testKind: testIntegration
-          continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
           steps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,6 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: $(buildConfiguration)
             continueOnError: eq(variables._testKind, 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,11 +365,8 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            condition: ne(variables['_testKind'], 'testIntegration')
-          - ${{ if eq(variables['_testKind'], 'testIntegration') }}:
-            - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
-              displayName: Build / Test
-              continueOnError: true
+            continueOnError: $(buildConfiguration)
+            continueOnError: eq(variables._testKind, 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -363,6 +363,7 @@ stages:
             displayName: Setup VS Hive
             condition: or(eq(variables['_testKind'], 'testVs'), eq(variables['_testKind'], 'testIntegration'))
 
+          # yes, this is miserable, but - https://github.com/dotnet/arcade/issues/13239
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
             condition: ne(variables['_testKind'], 'testIntegration')
@@ -370,6 +371,7 @@ stages:
             displayName: Build / Integration Test
             continueOnError: true
             condition: eq(variables['_testKind'], 'testIntegration')
+            
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,7 +206,6 @@ stages:
         enableSourceBuild: false
         enableTelemetry: true
         helixRepo: dotnet/fsharp
-        continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
         jobs:
           # Determinism, we want to run it only in PR builds
         - job: Determinism_Debug
@@ -320,7 +319,7 @@ stages:
         enableSourceBuild: true
         enableTelemetry: true
         helixRepo: dotnet/fsharp
-        continueOnError: eq(variables['_testKind'], 'testIntegration')
+        continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
         jobs:
 
         # Windows With Compressed Metadata

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -355,6 +355,7 @@ stages:
                 inttests_release:
                   _configuration: Release
                   _testKind: testIntegration
+          continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
           steps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            condition: eq(variables['_testKind'], 'testIntegration')
+            continueOnError: eq(variables['_testKind'], 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            condition: and(succeededOrFailed(), eq(variables['_testKind'], 'testIntegration'))
+            continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,7 +319,6 @@ stages:
         enableSourceBuild: true
         enableTelemetry: true
         helixRepo: dotnet/fsharp
-        continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
         jobs:
 
         # Windows With Compressed Metadata
@@ -356,6 +355,7 @@ stages:
                 inttests_release:
                   _configuration: Release
                   _testKind: testIntegration
+
           steps:
           - checkout: self
             clean: true
@@ -366,7 +366,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
+            continueOnError: true
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: eq(variables['_testKind'], 'testIntegration')
+            continueOnError: variables['_testKind'] == 'testIntegration'
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: "eq(variables['_testKind'], 'testIntegration')"
+            continueOnError: eq(variables["_testKind"], "testIntegration")
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: eq($(_testKind), 'testIntegration')
+            continueOnError: eq(variables['_testKind'], 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -362,10 +362,16 @@ stages:
           - powershell: eng\SetupVSHive.ps1
             displayName: Setup VS Hive
             condition: or(eq(variables['_testKind'], 'testVs'), eq(variables['_testKind'], 'testIntegration'))
-
+          - script: |
+              if [ "$( _testKind )" == "testIntegration" ]; then
+                echo "##vso[task.setvariable variable=shouldContinueOnError]true"
+              else
+                echo "##vso[task.setvariable variable=shouldContinueOnError]false"
+              fi
+            displayName: 'Set continueOnError value based on _testKind'
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: ${{ eq(variables['_testKind'], 'testIntegration') }}
+            continueOnError: $(shouldContinueOnError)
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: eq(variables._testKind, 'testIntegration')
+            continueOnError: eq($(_testKind), 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -355,7 +355,6 @@ stages:
                 inttests_release:
                   _configuration: Release
                   _testKind: testIntegration
-
           steps:
           - checkout: self
             clean: true
@@ -366,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: true
+            condition: and(succeededOrFailed(), eq(variables['_testKind'], 'testIntegration'))
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -366,10 +366,10 @@ stages:
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
             condition: ne(variables['_testKind'], 'testIntegration')
-          - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
-            displayName: Build / Test
-            continueOnError: true
-            condition: eq(variables['_testKind'], 'testIntegration')
+          - ${{ if eq(variables['_testKind'], 'testIntegration') }}:
+            - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
+              displayName: Build / Test
+              continueOnError: true
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,6 +319,7 @@ stages:
         enableSourceBuild: true
         enableTelemetry: true
         helixRepo: dotnet/fsharp
+        continueOnError: eq(variables['_testKind'], 'testIntegration')
         jobs:
 
         # Windows With Compressed Metadata
@@ -355,7 +356,6 @@ stages:
                 inttests_release:
                   _configuration: Release
                   _testKind: testIntegration
-          continueOnError: eq(variables['_testKind'], 'testIntegration')
           steps:
           - checkout: self
             clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -355,6 +355,7 @@ stages:
                 inttests_release:
                   _configuration: Release
                   _testKind: testIntegration
+          continueOnError: eq(variables['_testKind'], 'testIntegration')
           steps:
           - checkout: self
             clean: true
@@ -365,7 +366,6 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: eq(variables["_testKind"], "testIntegration")
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ stages:
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: variables['_testKind'] == 'testIntegration'
+            continueOnError: "eq(variables['_testKind'], 'testIntegration')"
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -362,16 +362,14 @@ stages:
           - powershell: eng\SetupVSHive.ps1
             displayName: Setup VS Hive
             condition: or(eq(variables['_testKind'], 'testVs'), eq(variables['_testKind'], 'testIntegration'))
-          - script: |
-              if [ "$( _testKind )" == "testIntegration" ]; then
-                echo "##vso[task.setvariable variable=shouldContinueOnError]true"
-              else
-                echo "##vso[task.setvariable variable=shouldContinueOnError]false"
-              fi
-            displayName: 'Set continueOnError value based on _testKind'
+
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
             displayName: Build / Test
-            continueOnError: $(shouldContinueOnError)
+            condition: ne(variables['_testKind'], 'testIntegration')
+          - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
+            displayName: Build / Test
+            continueOnError: true
+            condition: eq(variables['_testKind'], 'testIntegration')
           - task: PublishTestResults@2
             displayName: Publish Test Results
             inputs:

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -639,6 +639,7 @@ try {
     }
     
     if ($testIntegration) {
+        Write-Error 'Pipeline failed due to intentional error.'
         TestUsingXUnit -testProject "$RepoRoot\vsintegration\tests\FSharp.Editor.IntegrationTests\FSharp.Editor.IntegrationTests.csproj" -targetFramework $desktopTargetFramework -testadapterpath "$ArtifactsDir\bin\FSharp.Editor.IntegrationTests\"
     }
 

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -471,10 +471,6 @@ function EnablePreviewSdks() {
 }
 
 try {
-    if ($testIntegration) {
-        Write-Error 'Pipeline failed due to intentional error.'
-    }
-    
     $script:BuildCategory = "Build"
     $script:BuildMessage = "Failure preparing build"
 

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -471,6 +471,10 @@ function EnablePreviewSdks() {
 }
 
 try {
+    if ($testIntegration) {
+        Write-Error 'Pipeline failed due to intentional error.'
+    }
+    
     $script:BuildCategory = "Build"
     $script:BuildMessage = "Failure preparing build"
 
@@ -639,7 +643,6 @@ try {
     }
     
     if ($testIntegration) {
-        Write-Error 'Pipeline failed due to intentional error.'
         TestUsingXUnit -testProject "$RepoRoot\vsintegration\tests\FSharp.Editor.IntegrationTests\FSharp.Editor.IntegrationTests.csproj" -targetFramework $desktopTargetFramework -testadapterpath "$ArtifactsDir\bin\FSharp.Editor.IntegrationTests\"
     }
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -160,7 +160,7 @@
     <MicrosoftVisualStudioTextInternalVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextInternalVersion>
     <MicrosoftVisualStudioComponentModelHostVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioComponentModelHostVersion>
     <NuGetSolutionRestoreManagerInteropVersion>5.6.0</NuGetSolutionRestoreManagerInteropVersion>
-    <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.149-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
+    <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.169-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>
     <MicrosoftVisualStudioExtensibilityTestingXunitVersion>$(MicrosoftVisualStudioExtensibilityTestingVersion)</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
     <!-- Visual Studio Threading packags -->

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/GoToDefinitionTests.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/GoToDefinitionTests.cs
@@ -33,6 +33,7 @@ let increment = add 1
         await Shell.ExecuteCommandAsync(VSStd97CmdID.GotoDefn, TestToken);
         var actualText = await Editor.GetCurrentLineTextAsync(TestToken);
         
+        Assert.True(false);
         Assert.Contains(expectedText, actualText);
     }
 

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/GoToDefinitionTests.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/GoToDefinitionTests.cs
@@ -35,4 +35,60 @@ let increment = add 1
         
         Assert.Contains(expectedText, actualText);
     }
+
+    [IdeFact]
+    public async Task FsiAndFsFilesGoToCorrespondentDefinitions()
+    {
+        var template = WellKnownProjectTemplates.FSharpNetCoreClassLibrary;
+
+        var fsi = """
+module Module
+
+type SomeType =
+| Number of int
+| Letter of char
+
+val id: t: SomeType -> SomeType
+""";
+        var fs = """
+module Module
+
+type SomeType =
+    | Number of int
+    | Letter of char
+
+let id (t: SomeType) = t
+""";
+
+        await SolutionExplorer.CreateSingleProjectSolutionAsync("Library", template, TestToken);
+        await SolutionExplorer.RestoreNuGetPackagesAsync(TestToken);
+
+        // hack: when asked to add a file, VS API seems to insert it in the alphabetical order
+        // so adding Module.fsi and Module.fs we'll end up having signature file below the code file
+        // and this won't work. But it's possible to achieve having the right file order via their renaming
+        await SolutionExplorer.AddFileAsync("Library", "AModule.fsi", fsi, TestToken);
+        await SolutionExplorer.AddFileAsync("Library", "Module.fs", fs, TestToken);
+        await SolutionExplorer.RenameFileAsync("Library", "AModule.fsi", "Module.fsi", TestToken);
+        await SolutionExplorer.BuildSolutionAsync(TestToken);
+
+        await SolutionExplorer.OpenFileAsync("Library", "Module.fsi", TestToken);
+        await Editor.PlaceCaretAsync("SomeType ->", TestToken);
+        await Shell.ExecuteCommandAsync(VSStd97CmdID.GotoDefn, TestToken);
+        var expectedText = "type SomeType =";
+        var expectedWindow = "Module.fsi";
+        var actualText = await Editor.GetCurrentLineTextAsync(TestToken);
+        var actualWindow = await Shell.GetActiveWindowCaptionAsync(TestToken);
+        Assert.Equal(expectedText, actualText);
+        Assert.Equal(expectedWindow, actualWindow);
+
+        await SolutionExplorer.OpenFileAsync("Library", "Module.fs", TestToken);
+        await Editor.PlaceCaretAsync("SomeType)", TestToken);
+        await Shell.ExecuteCommandAsync(VSStd97CmdID.GotoDefn, TestToken);
+        expectedText = "type SomeType =";
+        expectedWindow = "Module.fs";
+        actualText = await Editor.GetCurrentLineTextAsync(TestToken);
+        actualWindow = await Shell.GetActiveWindowCaptionAsync(TestToken);
+        Assert.Equal(expectedText, actualText);
+        Assert.Equal(expectedWindow, actualWindow);
+    }
 }

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/GoToDefinitionTests.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/GoToDefinitionTests.cs
@@ -33,7 +33,6 @@ let increment = add 1
         await Shell.ExecuteCommandAsync(VSStd97CmdID.GotoDefn, TestToken);
         var actualText = await Editor.GetCurrentLineTextAsync(TestToken);
         
-        Assert.True(false);
         Assert.Contains(expectedText, actualText);
     }
 

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -35,25 +35,6 @@ internal partial class SolutionExplorerInProcess
         var solutionPath = CreateTemporaryPath();
         await CreateSolutionAsync(solutionPath, solutionName, cancellationToken);
     }
-    
-    public async Task OpenFileAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
-    {
-        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-        var filePath = await GetAbsolutePathForProjectRelativeFilePathAsync(projectName, relativeFilePath, cancellationToken);
-        if (!File.Exists(filePath))
-        {
-            throw new FileNotFoundException(filePath);
-        }
-
-        VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, filePath, VSConstants.LOGVIEWID.Code_guid, out _, out _, out _, out var view);
-
-        // Reliably set focus using NavigateToLineAndColumn
-        var textManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
-        ErrorHandler.ThrowOnFailure(view.GetBuffer(out var textLines));
-        ErrorHandler.ThrowOnFailure(view.GetCaretPos(out var line, out var column));
-        ErrorHandler.ThrowOnFailure(textManager.NavigateToLineAndColumn(textLines, VSConstants.LOGVIEWID.Code_guid, line, column, line, column));
-    }
 
     private async Task CreateSolutionAsync(string solutionPath, string solutionName, CancellationToken cancellationToken)
     {
@@ -205,19 +186,6 @@ internal partial class SolutionExplorerInProcess
     private string CreateTemporaryPath()
     {
         return Path.Combine(Path.GetTempPath(), "fsharp-test", Path.GetRandomFileName());
-    }
-
-    private async Task<string> GetAbsolutePathForProjectRelativeFilePathAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
-    {
-        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-        var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
-        var solution = dte.Solution;
-        Assumes.Present(solution);
-
-        var project = solution.Projects.Cast<EnvDTE.Project>().First(x => x.Name == projectName);
-        var projectPath = Path.GetDirectoryName(project.FullName);
-        return Path.Combine(projectPath, relativeFilePath);
     }
 
     private async Task<EnvDTE.Project> GetProjectAsync(string nameOrFileName, CancellationToken cancellationToken)

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/InProcess/SolutionExplorerInProcess_Files.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/InProcess/SolutionExplorerInProcess_Files.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Extensibility.Testing;
+
+internal partial class SolutionExplorerInProcess
+{
+    public async Task OpenFileAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var filePath = await GetAbsolutePathForProjectRelativeFilePathAsync(projectName, relativeFilePath, cancellationToken);
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException(filePath);
+        }
+
+        VsShellUtilities.OpenDocument(ServiceProvider.GlobalProvider, filePath, VSConstants.LOGVIEWID.Code_guid, out _, out _, out _, out var view);
+
+        // Reliably set focus using NavigateToLineAndColumn
+        var textManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
+        ErrorHandler.ThrowOnFailure(view.GetBuffer(out var textLines));
+        ErrorHandler.ThrowOnFailure(view.GetCaretPos(out var line, out var column));
+        ErrorHandler.ThrowOnFailure(textManager.NavigateToLineAndColumn(textLines, VSConstants.LOGVIEWID.Code_guid, line, column, line, column));
+    }
+
+    public async Task AddFileAsync(string projectName, string fileName, string contents, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var project = await GetProjectAsync(projectName, cancellationToken);
+        var projectDirectory = Path.GetDirectoryName(project.FullName);
+        var filePath = Path.Combine(projectDirectory, fileName);
+        var directoryPath = Path.GetDirectoryName(filePath);
+        
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(filePath, contents);
+        
+        _ = project.ProjectItems.AddFromFile(filePath);
+    }
+
+    public async Task RenameFileAsync(string projectName, string oldFileName, string newFileName, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        var projectItem = await GetProjectItemAsync(projectName, oldFileName, cancellationToken);
+
+        projectItem.Name = newFileName;
+    }
+
+    private async Task<string> GetAbsolutePathForProjectRelativeFilePathAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+        var solution = dte.Solution;
+
+        var project = solution.Projects.Cast<EnvDTE.Project>().First(x => x.Name == projectName);
+        var projectPath = Path.GetDirectoryName(project.FullName);
+        return Path.Combine(projectPath, relativeFilePath);
+    }
+
+    private async Task<EnvDTE.ProjectItem> GetProjectItemAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var solution = (await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken)).Solution;
+        var projects = solution.Projects.Cast<EnvDTE.Project>();
+        var project = projects.FirstOrDefault(x => x.Name == projectName);
+        var projectPath = Path.GetDirectoryName(project.FullName);
+        var fullFilePath = Path.Combine(projectPath, relativeFilePath);
+        var projectItems = project.ProjectItems.Cast<EnvDTE.ProjectItem>();
+        var document = projectItems.FirstOrDefault(d => d.get_FileNames(1).Equals(fullFilePath));
+
+        return document;
+    }
+}


### PR DESCRIPTION
Verifying navigation flows within signature and code files.

Inspired by the changes here #15087 

![image](https://user-images.githubusercontent.com/5451366/233180717-b24dfe1c-3038-4e1b-8739-72400300afe6.png)


Also, actually making CI succeed on int test failure. The previous way wasn't working (compile time x runtime YAML variables).
The current way is lame but see [this issue](https://github.com/dotnet/arcade/issues/13239).