### PR TITLE
Tooltips for hints

### DIFF
--- a/vsintegration/src/FSharp.Editor/Hints/Hints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/Hints.fs
@@ -2,6 +2,8 @@
 
 namespace Microsoft.VisualStudio.FSharp.Editor.Hints
 
+open System.Threading
+open Microsoft.CodeAnalysis
 open FSharp.Compiler.Text
 
 module Hints =
@@ -17,6 +19,7 @@ module Hints =
             Kind: HintKind
             Range: range
             Parts: TaggedText list
+            GetToolTip: Document -> CancellationToken -> Async<TaggedText list>
         }
 
     let serialize kind =

--- a/vsintegration/src/FSharp.Editor/Hints/Hints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/Hints.fs
@@ -19,7 +19,7 @@ module Hints =
             Kind: HintKind
             Range: range
             Parts: TaggedText list
-            GetToolTip: Document -> CancellationToken -> Async<TaggedText list>
+            GetTooltip: Document -> CancellationToken -> Async<TaggedText list>
         }
 
     let serialize kind =

--- a/vsintegration/src/FSharp.Editor/Hints/Hints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/Hints.fs
@@ -19,7 +19,7 @@ module Hints =
             Kind: HintKind
             Range: range
             Parts: TaggedText list
-            GetTooltip: Document -> CancellationToken -> Async<TaggedText list>
+            GetTooltip: Document -> Async<TaggedText list>
         }
 
     let serialize kind =

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -12,11 +12,19 @@ open Hints
 
 type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
 
+    let getToolTip _document _cancellationToken =
+        async {
+            // the hardest part
+            return [ TaggedText(TextTag.Text, "42") ]
+        // the hardest part
+        }
+
     let getParameterHint (range: range, parameter: FSharpParameter) =
         {
             Kind = HintKind.ParameterNameHint
             Range = range.StartRange
             Parts = [ TaggedText(TextTag.Text, $"{parameter.DisplayName} = ") ]
+            GetToolTip = getToolTip
         }
 
     let getFieldHint (range: range, field: FSharpField) =
@@ -24,6 +32,7 @@ type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
             Kind = HintKind.ParameterNameHint
             Range = range.StartRange
             Parts = [ TaggedText(TextTag.Text, $"{field.Name} = ") ]
+            GetToolTip = getToolTip
         }
 
     let parameterNameExists (parameter: FSharpParameter) = parameter.DisplayName <> ""

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -12,7 +12,7 @@ open Hints
 
 type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
 
-    let getToolTip _document _cancellationToken =
+    let getTooltip _document _cancellationToken =
         async {
             // the hardest part
             return [ TaggedText(TextTag.Text, "42") ]
@@ -24,7 +24,7 @@ type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
             Kind = HintKind.ParameterNameHint
             Range = range.StartRange
             Parts = [ TaggedText(TextTag.Text, $"{parameter.DisplayName} = ") ]
-            GetToolTip = getToolTip
+            GetTooltip = getTooltip
         }
 
     let getFieldHint (range: range, field: FSharpField) =
@@ -32,7 +32,7 @@ type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
             Kind = HintKind.ParameterNameHint
             Range = range.StartRange
             Parts = [ TaggedText(TextTag.Text, $"{field.Name} = ") ]
-            GetToolTip = getToolTip
+            GetTooltip = getTooltip
         }
 
     let parameterNameExists (parameter: FSharpParameter) = parameter.DisplayName <> ""

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -12,11 +12,31 @@ open Hints
 
 type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
 
-    let getTooltip _document _cancellationToken =
+    let getTooltip (symbol: FSharpSymbol) _ _ =
         async {
-            // the hardest part
-            return [ TaggedText(TextTag.Text, "42") ]
-        // the hardest part
+            // This brings little value as of now. Basically just discerns fields from parameters
+            // and fills the tooltip bubble which otherwise looks like a visual glitch.
+            //
+            // Now, we could add some type information here, like C# does, for example:
+            // (parameter) int number
+            //
+            // This would work for simple cases but can get weird in more complex ones.
+            // Consider this code:
+            //
+            // let rev list = list |> List.rev
+            // let reversed = rev [ 42 ]
+            //
+            // With the trivial implementation, the tooltip for hint before [ 42 ] will look like:
+            // parameter 'a list list
+            //
+            // Arguably, this can look confusing.
+            // Hence, I wouldn't add type info to the text until we have some coloring plugged in here.
+            //
+            // Some alignment with C# also needs to be kept in mind,
+            // e.g. taking the type in braces would be opposite to what C# does which can be confusing.
+            let text = symbol.ToString()
+
+            return [ TaggedText(TextTag.Text, text) ]
         }
 
     let getParameterHint (range: range, parameter: FSharpParameter) =
@@ -24,7 +44,7 @@ type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
             Kind = HintKind.ParameterNameHint
             Range = range.StartRange
             Parts = [ TaggedText(TextTag.Text, $"{parameter.DisplayName} = ") ]
-            GetTooltip = getTooltip
+            GetTooltip = getTooltip parameter
         }
 
     let getFieldHint (range: range, field: FSharpField) =
@@ -32,7 +52,7 @@ type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
             Kind = HintKind.ParameterNameHint
             Range = range.StartRange
             Parts = [ TaggedText(TextTag.Text, $"{field.Name} = ") ]
-            GetTooltip = getTooltip
+            GetTooltip = getTooltip field
         }
 
     let parameterNameExists (parameter: FSharpParameter) = parameter.DisplayName <> ""

--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -12,7 +12,7 @@ open Hints
 
 type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
 
-    let getTooltip (symbol: FSharpSymbol) _ _ =
+    let getTooltip (symbol: FSharpSymbol) _ =
         async {
             // This brings little value as of now. Basically just discerns fields from parameters
             // and fills the tooltip bubble which otherwise looks like a visual glitch.

--- a/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
@@ -19,7 +19,7 @@ type InlineReturnTypeHints(parseFileResults: FSharpParseFileResults, symbol: FSh
                 TaggedText(TextTag.Space, " ")
             ])
 
-    let getTooltip _ _ =
+    let getTooltip _ =
         async {
             let typeAsString = symbol.ReturnParameter.Type.TypeDefinition.ToString()
             let text = $"type {typeAsString}"

--- a/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
@@ -19,11 +19,11 @@ type InlineReturnTypeHints(parseFileResults: FSharpParseFileResults, symbol: FSh
                 TaggedText(TextTag.Space, " ")
             ])
 
-    let getTooltip _document _cancellationToken =
+    let getTooltip _ _ =
         async {
-            // the hardest part
-            return [ TaggedText(TextTag.Text, "42") ]
-        // the hardest part
+            let typeAsString = symbol.ReturnParameter.Type.TypeDefinition.ToString()
+            let text = $"type {typeAsString}"
+            return [ TaggedText(TextTag.Text, text) ]
         }
 
     let getHint symbolUse range =

--- a/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
@@ -19,7 +19,7 @@ type InlineReturnTypeHints(parseFileResults: FSharpParseFileResults, symbol: FSh
                 TaggedText(TextTag.Space, " ")
             ])
 
-    let getToolTip _document _cancellationToken =
+    let getTooltip _document _cancellationToken =
         async {
             // the hardest part
             return [ TaggedText(TextTag.Text, "42") ]
@@ -33,7 +33,7 @@ type InlineReturnTypeHints(parseFileResults: FSharpParseFileResults, symbol: FSh
                 Kind = HintKind.ReturnTypeHint
                 Range = range
                 Parts = parts
-                GetToolTip = getToolTip
+                GetTooltip = getTooltip
             })
 
     let isValidForHint (symbol: FSharpMemberOrFunctionOrValue) = symbol.IsFunction

--- a/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineReturnTypeHints.fs
@@ -19,6 +19,13 @@ type InlineReturnTypeHints(parseFileResults: FSharpParseFileResults, symbol: FSh
                 TaggedText(TextTag.Space, " ")
             ])
 
+    let getToolTip _document _cancellationToken =
+        async {
+            // the hardest part
+            return [ TaggedText(TextTag.Text, "42") ]
+        // the hardest part
+        }
+
     let getHint symbolUse range =
         getHintParts symbolUse
         |> Option.map (fun parts ->
@@ -26,6 +33,7 @@ type InlineReturnTypeHints(parseFileResults: FSharpParseFileResults, symbol: FSh
                 Kind = HintKind.ReturnTypeHint
                 Range = range
                 Parts = parts
+                GetToolTip = getToolTip
             })
 
     let isValidForHint (symbol: FSharpMemberOrFunctionOrValue) = symbol.IsFunction

--- a/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
@@ -21,11 +21,21 @@ type InlineTypeHints(parseResults: FSharpParseFileResults, symbol: FSharpMemberO
         // not sure when this can happen
         | None -> []
 
-    let getTooltip _document _cancellationToken =
+    let getTooltip _ _ =
         async {
-            // the hardest part
-            return [ TaggedText(TextTag.Text, "42") ]
-        // the hardest part
+            // Done this way because I am not sure if we want to show full-blown types everywhere,
+            // e.g. Microsoft.FSharp.Core.string instead of string.
+            // On the other hand, for user types this could be useful.
+            // Then there should be some smarter algorithm here.
+            let text =
+                if symbol.FullType.HasTypeDefinition then
+                    let typeAsString = symbol.FullType.TypeDefinition.ToString()
+                    $"type {typeAsString}"
+                else
+                    // already includes the word "type"
+                    symbol.FullType.ToString()
+
+            return [ TaggedText(TextTag.Text, text) ]
         }
 
     let getHint symbol (symbolUse: FSharpSymbolUse) =

--- a/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
@@ -21,11 +21,19 @@ type InlineTypeHints(parseResults: FSharpParseFileResults, symbol: FSharpMemberO
         // not sure when this can happen
         | None -> []
 
+    let getToolTip _document _cancellationToken =
+        async {
+            // the hardest part
+            return [ TaggedText(TextTag.Text, "42") ]
+        // the hardest part
+        }
+
     let getHint symbol (symbolUse: FSharpSymbolUse) =
         {
             Kind = HintKind.TypeHint
             Range = symbolUse.Range.EndRange
             Parts = getHintParts symbol symbolUse
+            GetToolTip = getToolTip
         }
 
     let isSolved (symbol: FSharpMemberOrFunctionOrValue) =

--- a/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
@@ -21,7 +21,7 @@ type InlineTypeHints(parseResults: FSharpParseFileResults, symbol: FSharpMemberO
         // not sure when this can happen
         | None -> []
 
-    let getTooltip _ _ =
+    let getTooltip _ =
         async {
             // Done this way because I am not sure if we want to show full-blown types everywhere,
             // e.g. Microsoft.FSharp.Core.string instead of string.

--- a/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineTypeHints.fs
@@ -21,7 +21,7 @@ type InlineTypeHints(parseResults: FSharpParseFileResults, symbol: FSharpMemberO
         // not sure when this can happen
         | None -> []
 
-    let getToolTip _document _cancellationToken =
+    let getTooltip _document _cancellationToken =
         async {
             // the hardest part
             return [ TaggedText(TextTag.Text, "42") ]
@@ -33,7 +33,7 @@ type InlineTypeHints(parseResults: FSharpParseFileResults, symbol: FSharpMemberO
             Kind = HintKind.TypeHint
             Range = symbolUse.Range.EndRange
             Parts = getHintParts symbol symbolUse
-            GetToolTip = getToolTip
+            GetTooltip = getTooltip
         }
 
     let isSolved (symbol: FSharpMemberOrFunctionOrValue) =

--- a/vsintegration/src/FSharp.Editor/Hints/NativeToRoslynHintConverter.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/NativeToRoslynHintConverter.fs
@@ -34,5 +34,5 @@ module NativeToRoslynHintConverter =
     let convert sourceText hint =
         let span = rangeToSpan hint.Range sourceText
         let displayParts = hint.Parts |> Seq.map nativeToRoslynText
-        let getDescription = hint.GetToolTip |> nativeToRoslynFunc
+        let getDescription = hint.GetTooltip |> nativeToRoslynFunc
         FSharpInlineHint(span, displayParts.ToImmutableArray(), getDescription)

--- a/vsintegration/src/FSharp.Editor/Hints/NativeToRoslynHintConverter.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/NativeToRoslynHintConverter.fs
@@ -27,9 +27,9 @@ module NativeToRoslynHintConverter =
 
     let nativeToRoslynFunc nativeFunc =
         Func<Document, CancellationToken, Task<ImmutableArray<RoslynTaggedText>>>(fun doc ct ->
-            nativeFunc doc ct
+            nativeFunc doc
             |> Async.map (List.map nativeToRoslynText >> ImmutableArray.CreateRange)
-            |> Async.StartAsTask)
+            |> fun comp -> Async.StartAsTask(comp, cancellationToken = ct))
 
     let convert sourceText hint =
         let span = rangeToSpan hint.Range sourceText

--- a/vsintegration/src/FSharp.Editor/Hints/NativeToRoslynHintConverter.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/NativeToRoslynHintConverter.fs
@@ -2,10 +2,14 @@
 
 namespace Microsoft.VisualStudio.FSharp.Editor.Hints
 
+open System
 open System.Collections.Immutable
+open System.Threading
+open System.Threading.Tasks
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.InlineHints
 open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.CodeAnalysis
 open FSharp.Compiler.Text
 open Hints
 
@@ -21,7 +25,14 @@ module NativeToRoslynHintConverter =
         let text = taggedText.Text
         RoslynTaggedText(tag, text)
 
+    let nativeToRoslynFunc nativeFunc =
+        Func<Document, CancellationToken, Task<ImmutableArray<RoslynTaggedText>>>(fun doc ct ->
+            nativeFunc doc ct
+            |> Async.map (List.map nativeToRoslynText >> ImmutableArray.CreateRange)
+            |> Async.StartAsTask)
+
     let convert sourceText hint =
         let span = rangeToSpan hint.Range sourceText
         let displayParts = hint.Parts |> Seq.map nativeToRoslynText
-        FSharpInlineHint(span, displayParts.ToImmutableArray())
+        let getDescription = hint.GetToolTip |> nativeToRoslynFunc
+        FSharpInlineHint(span, displayParts.ToImmutableArray(), getDescription)

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/HintTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/HintTestFramework.fs
@@ -15,10 +15,10 @@ module HintTestFramework =
         {
             Content: string
             Location: int * int
-            ToolTip: string
+            Tooltip: string
         }
 
-    let private convert hint toolTip =
+    let private convert hint tooltip =
         let content =
             hint.Parts |> Seq.map (fun hintPart -> hintPart.Text) |> String.concat ""
 
@@ -30,7 +30,7 @@ module HintTestFramework =
         {
             Content = content
             Location = location
-            ToolTip = toolTip
+            Tooltip = tooltip
         }
 
     let getFsDocument code =
@@ -63,9 +63,9 @@ module HintTestFramework =
         async {
             let! ct = Async.CancellationToken
 
-            let getToolTip hint =
+            let getTooltip hint =
                 async {
-                    let! roslynTexts = hint.GetToolTip document ct
+                    let! roslynTexts = hint.GetTooltip document ct
                     return roslynTexts |> Seq.map (fun roslynText -> roslynText.Text) |> String.concat ""
                 }
 
@@ -74,7 +74,7 @@ module HintTestFramework =
 
             return
                 hints
-                |> Seq.map (fun hint -> hint |> (getToolTip >> Async.RunSynchronously) |> convert hint)
+                |> Seq.map (fun hint -> hint |> (getTooltip >> Async.RunSynchronously) |> convert hint)
         }
         |> Async.RunSynchronously
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/HintTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/HintTestFramework.fs
@@ -65,7 +65,7 @@ module HintTestFramework =
 
             let getTooltip hint =
                 async {
-                    let! roslynTexts = hint.GetTooltip document ct
+                    let! roslynTexts = hint.GetTooltip document
                     return roslynTexts |> Seq.map (fun roslynText -> roslynText.Text) |> String.concat ""
                 }
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/HintTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/HintTestFramework.fs
@@ -18,7 +18,7 @@ module HintTestFramework =
             Tooltip: string
         }
 
-    let private convert hint tooltip =
+    let private convert (hint, tooltip) =
         let content =
             hint.Parts |> Seq.map (fun hintPart -> hintPart.Text) |> String.concat ""
 
@@ -71,10 +71,8 @@ module HintTestFramework =
 
             let! sourceText = document.GetTextAsync ct |> Async.AwaitTask
             let! hints = HintService.getHintsForDocument sourceText document hintKinds "test" ct
-
-            return
-                hints
-                |> Seq.map (fun hint -> hint |> (getTooltip >> Async.RunSynchronously) |> convert hint)
+            let! tooltips = hints |> Seq.map getTooltip |> Async.Parallel
+            return tooltips |> Seq.zip hints |> Seq.map convert
         }
         |> Async.RunSynchronously
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -22,6 +22,7 @@ let greeting = greet "darkness"
                 {
                     Content = "friend = "
                     Location = (2, 22)
+                    ToolTip = "42"
                 }
             ]
 
@@ -45,10 +46,12 @@ let greeting2 = greet "Liam"
                 {
                     Content = "friend = "
                     Location = (2, 23)
+                    ToolTip = "42"
                 }
                 {
                     Content = "friend = "
                     Location = (3, 23)
+                    ToolTip = "42"
                 }
             ]
 
@@ -71,10 +74,12 @@ let greeting = greet "Liam" "Noel"
                 {
                     Content = "friend1 = "
                     Location = (2, 22)
+                    ToolTip = "42"
                 }
                 {
                     Content = "friend2 = "
                     Location = (2, 29)
+                    ToolTip = "42"
                 }
             ]
 
@@ -97,10 +102,12 @@ let greeting = greet ("Liam", "Noel")
                 {
                     Content = "friend1 = "
                     Location = (2, 23)
+                    ToolTip = "42"
                 }
                 {
                     Content = "friend2 = "
                     Location = (2, 31)
+                    ToolTip = "42"
                 }
             ]
 
@@ -132,10 +139,12 @@ let odd = evenOrOdd 41
                 {
                     Content = "number = "
                     Location = (10, 22)
+                    ToolTip = "42"
                 }
                 {
                     Content = "number = "
                     Location = (11, 21)
+                    ToolTip = "42"
                 }
             ]
 
@@ -201,6 +210,7 @@ let theAnswer = System.Console.WriteLine 42
                 {
                     Content = "value = "
                     Location = (1, 42)
+                    ToolTip = "42"
                 }
             ]
 
@@ -231,23 +241,32 @@ let a = c.Normal "hmm"
                 {
                     Content = "curr1 = "
                     Location = (8, 20)
+                    ToolTip = "42"
                 }
                 {
                     Content = "curr2 = "
                     Location = (8, 27)
+                    ToolTip = "42"
                 }
-                { Content = "x = "; Location = (8, 30) }
+                {
+                    Content = "x = "
+                    Location = (8, 30)
+                    ToolTip = "42"
+                }
                 {
                     Content = "what = "
                     Location = (9, 19)
+                    ToolTip = "42"
                 }
                 {
                     Content = "what2 = "
                     Location = (9, 26)
+                    ToolTip = "42"
                 }
                 {
                     Content = "alone = "
                     Location = (10, 18)
+                    ToolTip = "42"
                 }
             ]
 
@@ -272,14 +291,17 @@ let a = C (1, "")
                 {
                     Content = "blahFirst = "
                     Location = (2, 40)
+                    ToolTip = "42"
                 }
                 {
                     Content = "blah = "
                     Location = (4, 12)
+                    ToolTip = "42"
                 }
                 {
                     Content = "blah2 = "
                     Location = (4, 15)
+                    ToolTip = "42"
                 }
             ]
 
@@ -306,14 +328,17 @@ let b = Rectangle (1, 2)
                 {
                     Content = "side = "
                     Location = (5, 16)
+                    ToolTip = "42"
                 }
                 {
                     Content = "width = "
                     Location = (6, 20)
+                    ToolTip = "42"
                 }
                 {
                     Content = "height = "
                     Location = (6, 23)
+                    ToolTip = "42"
                 }
             ]
 
@@ -340,10 +365,12 @@ let d = Circle 1
                 {
                     Content = "side1 = "
                     Location = (5, 19)
+                    ToolTip = "42"
                 }
                 {
                     Content = "side3 = "
                     Location = (5, 25)
+                    ToolTip = "42"
                 }
             ]
 
@@ -396,10 +423,12 @@ let x = "test".Split("").[0].Split("");
                 {
                     Content = "separator = "
                     Location = (1, 22)
+                    ToolTip = "42"
                 }
                 {
                     Content = "separator = "
                     Location = (1, 36)
+                    ToolTip = "42"
                 }
             ]
 
@@ -425,6 +454,7 @@ type MyType() =
                 {
                     Content = "beep = "
                     Location = (5, 37)
+                    ToolTip = "42"
                 }
             ]
 
@@ -465,14 +495,17 @@ let test sequences =
                 {
                     Content = "mapping = "
                     Location = (3, 16)
+                    ToolTip = "42"
                 }
                 {
                     Content = "mapping = "
                     Location = (3, 53)
+                    ToolTip = "42"
                 }
                 {
                     Content = "mapping = "
                     Location = (3, 92)
+                    ToolTip = "42"
                 }
             ]
 
@@ -494,6 +527,7 @@ let q = query { for x in { 1 .. 10 } do select x }
                 {
                     Content = "projection = "
                     Location = (1, 48)
+                    ToolTip = "42"
                 }
             ]
 
@@ -532,6 +566,7 @@ let fullName = getFullName name lastName
                 {
                     Content = "surname = "
                     Location = (5, 33)
+                    ToolTip = "42"
                 }
             ]
 
@@ -557,6 +592,7 @@ None
                 {
                     Content = "mapping = "
                     Location = (2, 15)
+                    ToolTip = "42"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -22,7 +22,7 @@ let greeting = greet "darkness"
                 {
                     Content = "friend = "
                     Location = (2, 22)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -46,12 +46,12 @@ let greeting2 = greet "Liam"
                 {
                     Content = "friend = "
                     Location = (2, 23)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "friend = "
                     Location = (3, 23)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -74,12 +74,12 @@ let greeting = greet "Liam" "Noel"
                 {
                     Content = "friend1 = "
                     Location = (2, 22)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "friend2 = "
                     Location = (2, 29)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -102,12 +102,12 @@ let greeting = greet ("Liam", "Noel")
                 {
                     Content = "friend1 = "
                     Location = (2, 23)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "friend2 = "
                     Location = (2, 31)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -139,12 +139,12 @@ let odd = evenOrOdd 41
                 {
                     Content = "number = "
                     Location = (10, 22)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "number = "
                     Location = (11, 21)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -210,7 +210,7 @@ let theAnswer = System.Console.WriteLine 42
                 {
                     Content = "value = "
                     Location = (1, 42)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -241,32 +241,32 @@ let a = c.Normal "hmm"
                 {
                     Content = "curr1 = "
                     Location = (8, 20)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "curr2 = "
                     Location = (8, 27)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "x = "
                     Location = (8, 30)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "what = "
                     Location = (9, 19)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "what2 = "
                     Location = (9, 26)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "alone = "
                     Location = (10, 18)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -291,17 +291,17 @@ let a = C (1, "")
                 {
                     Content = "blahFirst = "
                     Location = (2, 40)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "blah = "
                     Location = (4, 12)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "blah2 = "
                     Location = (4, 15)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -328,17 +328,17 @@ let b = Rectangle (1, 2)
                 {
                     Content = "side = "
                     Location = (5, 16)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "width = "
                     Location = (6, 20)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "height = "
                     Location = (6, 23)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -365,12 +365,12 @@ let d = Circle 1
                 {
                     Content = "side1 = "
                     Location = (5, 19)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "side3 = "
                     Location = (5, 25)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -423,12 +423,12 @@ let x = "test".Split("").[0].Split("");
                 {
                     Content = "separator = "
                     Location = (1, 22)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "separator = "
                     Location = (1, 36)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -454,7 +454,7 @@ type MyType() =
                 {
                     Content = "beep = "
                     Location = (5, 37)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -495,17 +495,17 @@ let test sequences =
                 {
                     Content = "mapping = "
                     Location = (3, 16)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "mapping = "
                     Location = (3, 53)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "mapping = "
                     Location = (3, 92)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -527,7 +527,7 @@ let q = query { for x in { 1 .. 10 } do select x }
                 {
                     Content = "projection = "
                     Location = (1, 48)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -566,7 +566,7 @@ let fullName = getFullName name lastName
                 {
                     Content = "surname = "
                     Location = (5, 33)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -592,7 +592,7 @@ None
                 {
                     Content = "mapping = "
                     Location = (2, 15)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -22,7 +22,7 @@ let greeting = greet "darkness"
                 {
                     Content = "friend = "
                     Location = (2, 22)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend"
                 }
             ]
 
@@ -46,12 +46,12 @@ let greeting2 = greet "Liam"
                 {
                     Content = "friend = "
                     Location = (2, 23)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend"
                 }
                 {
                     Content = "friend = "
                     Location = (3, 23)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend"
                 }
             ]
 
@@ -74,12 +74,12 @@ let greeting = greet "Liam" "Noel"
                 {
                     Content = "friend1 = "
                     Location = (2, 22)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend1"
                 }
                 {
                     Content = "friend2 = "
                     Location = (2, 29)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend2"
                 }
             ]
 
@@ -102,12 +102,12 @@ let greeting = greet ("Liam", "Noel")
                 {
                     Content = "friend1 = "
                     Location = (2, 23)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend1"
                 }
                 {
                     Content = "friend2 = "
                     Location = (2, 31)
-                    Tooltip = "42"
+                    Tooltip = "parameter friend2"
                 }
             ]
 
@@ -139,12 +139,12 @@ let odd = evenOrOdd 41
                 {
                     Content = "number = "
                     Location = (10, 22)
-                    Tooltip = "42"
+                    Tooltip = "parameter number"
                 }
                 {
                     Content = "number = "
                     Location = (11, 21)
-                    Tooltip = "42"
+                    Tooltip = "parameter number"
                 }
             ]
 
@@ -210,7 +210,7 @@ let theAnswer = System.Console.WriteLine 42
                 {
                     Content = "value = "
                     Location = (1, 42)
-                    Tooltip = "42"
+                    Tooltip = "parameter value"
                 }
             ]
 
@@ -241,32 +241,32 @@ let a = c.Normal "hmm"
                 {
                     Content = "curr1 = "
                     Location = (8, 20)
-                    Tooltip = "42"
+                    Tooltip = "parameter curr1"
                 }
                 {
                     Content = "curr2 = "
                     Location = (8, 27)
-                    Tooltip = "42"
+                    Tooltip = "parameter curr2"
                 }
                 {
                     Content = "x = "
                     Location = (8, 30)
-                    Tooltip = "42"
+                    Tooltip = "parameter x"
                 }
                 {
                     Content = "what = "
                     Location = (9, 19)
-                    Tooltip = "42"
+                    Tooltip = "parameter what"
                 }
                 {
                     Content = "what2 = "
                     Location = (9, 26)
-                    Tooltip = "42"
+                    Tooltip = "parameter what2"
                 }
                 {
                     Content = "alone = "
                     Location = (10, 18)
-                    Tooltip = "42"
+                    Tooltip = "parameter alone"
                 }
             ]
 
@@ -291,17 +291,17 @@ let a = C (1, "")
                 {
                     Content = "blahFirst = "
                     Location = (2, 40)
-                    Tooltip = "42"
+                    Tooltip = "parameter blahFirst"
                 }
                 {
                     Content = "blah = "
                     Location = (4, 12)
-                    Tooltip = "42"
+                    Tooltip = "parameter blah"
                 }
                 {
                     Content = "blah2 = "
                     Location = (4, 15)
-                    Tooltip = "42"
+                    Tooltip = "parameter blah2"
                 }
             ]
 
@@ -328,17 +328,17 @@ let b = Rectangle (1, 2)
                 {
                     Content = "side = "
                     Location = (5, 16)
-                    Tooltip = "42"
+                    Tooltip = "field side"
                 }
                 {
                     Content = "width = "
                     Location = (6, 20)
-                    Tooltip = "42"
+                    Tooltip = "field width"
                 }
                 {
                     Content = "height = "
                     Location = (6, 23)
-                    Tooltip = "42"
+                    Tooltip = "field height"
                 }
             ]
 
@@ -365,12 +365,12 @@ let d = Circle 1
                 {
                     Content = "side1 = "
                     Location = (5, 19)
-                    Tooltip = "42"
+                    Tooltip = "field side1"
                 }
                 {
                     Content = "side3 = "
                     Location = (5, 25)
-                    Tooltip = "42"
+                    Tooltip = "field side3"
                 }
             ]
 
@@ -423,12 +423,12 @@ let x = "test".Split("").[0].Split("");
                 {
                     Content = "separator = "
                     Location = (1, 22)
-                    Tooltip = "42"
+                    Tooltip = "parameter separator"
                 }
                 {
                     Content = "separator = "
                     Location = (1, 36)
-                    Tooltip = "42"
+                    Tooltip = "parameter separator"
                 }
             ]
 
@@ -454,7 +454,7 @@ type MyType() =
                 {
                     Content = "beep = "
                     Location = (5, 37)
-                    Tooltip = "42"
+                    Tooltip = "parameter beep"
                 }
             ]
 
@@ -495,17 +495,17 @@ let test sequences =
                 {
                     Content = "mapping = "
                     Location = (3, 16)
-                    Tooltip = "42"
+                    Tooltip = "parameter mapping"
                 }
                 {
                     Content = "mapping = "
                     Location = (3, 53)
-                    Tooltip = "42"
+                    Tooltip = "parameter mapping"
                 }
                 {
                     Content = "mapping = "
                     Location = (3, 92)
-                    Tooltip = "42"
+                    Tooltip = "parameter mapping"
                 }
             ]
 
@@ -527,7 +527,7 @@ let q = query { for x in { 1 .. 10 } do select x }
                 {
                     Content = "projection = "
                     Location = (1, 48)
-                    Tooltip = "42"
+                    Tooltip = "parameter projection"
                 }
             ]
 
@@ -566,7 +566,7 @@ let fullName = getFullName name lastName
                 {
                     Content = "surname = "
                     Location = (5, 33)
-                    Tooltip = "42"
+                    Tooltip = "parameter surname"
                 }
             ]
 
@@ -592,7 +592,7 @@ None
                 {
                     Content = "mapping = "
                     Location = (2, 15)
-                    Tooltip = "42"
+                    Tooltip = "parameter mapping"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineReturnTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineReturnTypeHintTests.fs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 module FSharp.Editor.Tests.Hints.InlineReturnTypeHintTests
 
@@ -24,17 +24,41 @@ let setConsoleOut = System.Console.SetOut
             {
                 Content = ": int "
                 Location = (1, 13)
-                Tooltip = "42"
+                Tooltip = "type int"
             }
             {
                 Content = ": int "
                 Location = (2, 13)
-                Tooltip = "42"
+                Tooltip = "type int"
             }
             {
                 Content = ": unit "
                 Location = (3, 19)
-                Tooltip = "42"
+                Tooltip = "type unit"
+            }
+        ]
+
+    Assert.Equal(expected, result)
+
+[<Fact>]
+let ``Hints are correct for user types`` () =
+    let code =
+        """
+type Answer = { Text: string }
+
+let getAnswer() = { Text = "42" }
+"""
+
+    let document = getFsDocument code
+
+    let result = getReturnTypeHints document
+
+    let expected =
+        [
+            {
+                Content = ": Answer "
+                Location = (3, 17)
+                Tooltip = "type Answer"
             }
         ]
 
@@ -57,7 +81,7 @@ type Test() =
             {
                 Content = ": int "
                 Location = (2, 24)
-                Tooltip = "42"
+                Tooltip = "type int"
             }
         ]
 
@@ -76,7 +100,7 @@ let ``Hints are shown for generic functions`` () =
             {
                 Content = ": int "
                 Location = (0, 13)
-                Tooltip = "42"
+                Tooltip = "type int"
             }
         ]
 
@@ -99,7 +123,7 @@ let ``Hints are shown for functions within expressions`` () =
             {
                 Content = ": int "
                 Location = (2, 21)
-                Tooltip = "42"
+                Tooltip = "type int"
             }
         ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineReturnTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineReturnTypeHintTests.fs
@@ -24,17 +24,17 @@ let setConsoleOut = System.Console.SetOut
             {
                 Content = ": int "
                 Location = (1, 13)
-                ToolTip = "42"
+                Tooltip = "42"
             }
             {
                 Content = ": int "
                 Location = (2, 13)
-                ToolTip = "42"
+                Tooltip = "42"
             }
             {
                 Content = ": unit "
                 Location = (3, 19)
-                ToolTip = "42"
+                Tooltip = "42"
             }
         ]
 
@@ -57,7 +57,7 @@ type Test() =
             {
                 Content = ": int "
                 Location = (2, 24)
-                ToolTip = "42"
+                Tooltip = "42"
             }
         ]
 
@@ -76,7 +76,7 @@ let ``Hints are shown for generic functions`` () =
             {
                 Content = ": int "
                 Location = (0, 13)
-                ToolTip = "42"
+                Tooltip = "42"
             }
         ]
 
@@ -99,7 +99,7 @@ let ``Hints are shown for functions within expressions`` () =
             {
                 Content = ": int "
                 Location = (2, 21)
-                ToolTip = "42"
+                Tooltip = "42"
             }
         ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineReturnTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineReturnTypeHintTests.fs
@@ -24,14 +24,17 @@ let setConsoleOut = System.Console.SetOut
             {
                 Content = ": int "
                 Location = (1, 13)
+                ToolTip = "42"
             }
             {
                 Content = ": int "
                 Location = (2, 13)
+                ToolTip = "42"
             }
             {
                 Content = ": unit "
                 Location = (3, 19)
+                ToolTip = "42"
             }
         ]
 
@@ -54,6 +57,7 @@ type Test() =
             {
                 Content = ": int "
                 Location = (2, 24)
+                ToolTip = "42"
             }
         ]
 
@@ -72,6 +76,7 @@ let ``Hints are shown for generic functions`` () =
             {
                 Content = ": int "
                 Location = (0, 13)
+                ToolTip = "42"
             }
         ]
 
@@ -94,6 +99,7 @@ let ``Hints are shown for functions within expressions`` () =
             {
                 Content = ": int "
                 Location = (2, 21)
+                ToolTip = "42"
             }
         ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
@@ -24,6 +24,7 @@ let s = { Artist = "Moby"; Title = "Porcelain" }
                 {
                     Content = ": Song"
                     Location = (3, 6)
+                    ToolTip = "42"
                 }
             ]
 
@@ -47,6 +48,7 @@ let whoSings s = s.Artist
                 {
                     Content = ": Song"
                     Location = (3, 15)
+                    ToolTip = "42"
                 }
             ]
 
@@ -156,7 +158,15 @@ let iamboring() =
 """
 
         let document = getFsDocument code
-        let expected = [ { Content = ": 'a"; Location = (2, 10) } ]
+
+        let expected =
+            [
+                {
+                    Content = ": 'a"
+                    Location = (2, 10)
+                    ToolTip = "42"
+                }
+            ]
 
         let actual = getTypeHints document
 
@@ -175,10 +185,26 @@ let zip4 (l1: 'a list) (l2: 'b list) (l3: 'c list) (l4: 'd list) =
 
         let expected =
             [
-                { Content = ": 'a"; Location = (3, 25) }
-                { Content = ": 'b"; Location = (3, 30) }
-                { Content = ": 'c"; Location = (3, 34) }
-                { Content = ": 'd"; Location = (3, 38) }
+                {
+                    Content = ": 'a"
+                    Location = (3, 25)
+                    ToolTip = "42"
+                }
+                {
+                    Content = ": 'b"
+                    Location = (3, 30)
+                    ToolTip = "42"
+                }
+                {
+                    Content = ": 'c"
+                    Location = (3, 34)
+                    ToolTip = "42"
+                }
+                {
+                    Content = ": 'd"
+                    Location = (3, 38)
+                    ToolTip = "42"
+                }
             ]
 
         let actual = getTypeHints document
@@ -261,10 +287,12 @@ type Number<'T when IAddition<'T>>(value: 'T) =
                 {
                     Content = ": Number<'T>"
                     Location = (7, 36)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": Number<'T>"
                     Location = (7, 39)
+                    ToolTip = "42"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 namespace FSharp.Editor.Tests.Hints
 
@@ -24,13 +24,35 @@ let s = { Artist = "Moby"; Title = "Porcelain" }
                 {
                     Content = ": Song"
                     Location = (3, 6)
-                    Tooltip = "42"
+                    Tooltip = "type Song"
                 }
             ]
 
         let actual = getTypeHints document
 
         Assert.Equal(expected, actual)
+
+    [<Fact>]
+    let ``Hints are correct for builtin types`` () =
+        let code =
+            """
+let songName = "Happy House"
+    """
+
+        let document = getFsDocument code
+
+        let result = getTypeHints document
+
+        let expected =
+            [
+                {
+                    Content = ": string"
+                    Location = (1, 13)
+                    Tooltip = "type string"
+                }
+            ]
+
+        Assert.Equal(expected, result)
 
     [<Fact>]
     let ``Hint is shown for a parameter`` () =
@@ -48,7 +70,7 @@ let whoSings s = s.Artist
                 {
                     Content = ": Song"
                     Location = (3, 15)
-                    Tooltip = "42"
+                    Tooltip = "type Song"
                 }
             ]
 
@@ -164,7 +186,7 @@ let iamboring() =
                 {
                     Content = ": 'a"
                     Location = (2, 10)
-                    Tooltip = "42"
+                    Tooltip = "type 'a"
                 }
             ]
 
@@ -188,22 +210,22 @@ let zip4 (l1: 'a list) (l2: 'b list) (l3: 'c list) (l4: 'd list) =
                 {
                     Content = ": 'a"
                     Location = (3, 25)
-                    Tooltip = "42"
+                    Tooltip = "type 'a"
                 }
                 {
                     Content = ": 'b"
                     Location = (3, 30)
-                    Tooltip = "42"
+                    Tooltip = "type 'b"
                 }
                 {
                     Content = ": 'c"
                     Location = (3, 34)
-                    Tooltip = "42"
+                    Tooltip = "type 'c"
                 }
                 {
                     Content = ": 'd"
                     Location = (3, 38)
-                    Tooltip = "42"
+                    Tooltip = "type 'd"
                 }
             ]
 
@@ -287,12 +309,12 @@ type Number<'T when IAddition<'T>>(value: 'T) =
                 {
                     Content = ": Number<'T>"
                     Location = (7, 36)
-                    Tooltip = "42"
+                    Tooltip = "type Number`1"
                 }
                 {
                     Content = ": Number<'T>"
                     Location = (7, 39)
-                    Tooltip = "42"
+                    Tooltip = "type Number`1"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineTypeHintTests.fs
@@ -24,7 +24,7 @@ let s = { Artist = "Moby"; Title = "Porcelain" }
                 {
                     Content = ": Song"
                     Location = (3, 6)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -48,7 +48,7 @@ let whoSings s = s.Artist
                 {
                     Content = ": Song"
                     Location = (3, 15)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -164,7 +164,7 @@ let iamboring() =
                 {
                     Content = ": 'a"
                     Location = (2, 10)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -188,22 +188,22 @@ let zip4 (l1: 'a list) (l2: 'b list) (l3: 'c list) (l4: 'd list) =
                 {
                     Content = ": 'a"
                     Location = (3, 25)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": 'b"
                     Location = (3, 30)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": 'c"
                     Location = (3, 34)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": 'd"
                     Location = (3, 38)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 
@@ -287,12 +287,12 @@ type Number<'T when IAddition<'T>>(value: 'T) =
                 {
                     Content = ": Number<'T>"
                     Location = (7, 36)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": Number<'T>"
                     Location = (7, 39)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
@@ -10,7 +10,7 @@ open FSharp.Test
 module OverallHintExperienceTests =
 
     [<Fact>]
-    let ``Current baseline hints`` () =
+    let ``Baseline hints`` () =
         let code =
             """
 type Song = { Artist: string; Title: string }
@@ -39,72 +39,72 @@ let cc = a.Normal "hmm"
                 {
                     Content = ": Song"
                     Location = (2, 18)
-                    Tooltip = "42"
+                    Tooltip = "type Song"
                 }
                 {
                     Content = ": string "
                     Location = (2, 19)
-                    Tooltip = "42"
+                    Tooltip = "type string"
                 }
                 {
                     Content = "song = "
                     Location = (4, 23)
-                    Tooltip = "42"
+                    Tooltip = "parameter song"
                 }
                 {
                     Content = ": string"
                     Location = (4, 11)
-                    Tooltip = "42"
+                    Tooltip = "type string"
                 }
                 {
                     Content = "side = "
                     Location = (10, 16)
-                    Tooltip = "42"
+                    Tooltip = "field side"
                 }
                 {
                     Content = ": Shape"
                     Location = (10, 6)
-                    Tooltip = "42"
+                    Tooltip = "type Shape"
                 }
                 {
                     Content = "width = "
                     Location = (11, 20)
-                    Tooltip = "42"
+                    Tooltip = "field width"
                 }
                 {
                     Content = "height = "
                     Location = (11, 23)
-                    Tooltip = "42"
+                    Tooltip = "field height"
                 }
                 {
                     Content = ": Shape"
                     Location = (11, 6)
-                    Tooltip = "42"
+                    Tooltip = "type Shape"
                 }
                 {
                     Content = ": int "
                     Location = (14, 36)
-                    Tooltip = "42"
+                    Tooltip = "type int"
                 }
                 {
                     Content = "blahFirst = "
                     Location = (16, 11)
-                    Tooltip = "42"
+                    Tooltip = "parameter blahFirst"
                 }
                 {
                     Content = ": C"
                     Location = (16, 6)
-                    Tooltip = "42"
+                    Tooltip = "type C"
                 }
                 {
                     Content = "what = "
                     Location = (17, 19)
-                    Tooltip = "42"
+                    Tooltip = "parameter what"
                 }
                 {
                     Content = ": int"
                     Location = (17, 7)
-                    Tooltip = "42"
+                    Tooltip = "type int"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
@@ -39,55 +39,72 @@ let cc = a.Normal "hmm"
                 {
                     Content = ": Song"
                     Location = (2, 18)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": string "
                     Location = (2, 19)
+                    ToolTip = "42"
                 }
                 {
                     Content = "song = "
                     Location = (4, 23)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": string"
                     Location = (4, 11)
+                    ToolTip = "42"
                 }
                 {
                     Content = "side = "
                     Location = (10, 16)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": Shape"
                     Location = (10, 6)
+                    ToolTip = "42"
                 }
                 {
                     Content = "width = "
                     Location = (11, 20)
+                    ToolTip = "42"
                 }
                 {
                     Content = "height = "
                     Location = (11, 23)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": Shape"
                     Location = (11, 6)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": int "
                     Location = (14, 36)
+                    ToolTip = "42"
                 }
                 {
                     Content = "blahFirst = "
                     Location = (16, 11)
+                    ToolTip = "42"
                 }
-                { Content = ": C"; Location = (16, 6) }
+                {
+                    Content = ": C"
+                    Location = (16, 6)
+                    ToolTip = "42"
+                }
                 {
                     Content = "what = "
                     Location = (17, 19)
+                    ToolTip = "42"
                 }
                 {
                     Content = ": int"
                     Location = (17, 7)
+                    ToolTip = "42"
                 }
             ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
@@ -39,72 +39,72 @@ let cc = a.Normal "hmm"
                 {
                     Content = ": Song"
                     Location = (2, 18)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": string "
                     Location = (2, 19)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "song = "
                     Location = (4, 23)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": string"
                     Location = (4, 11)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "side = "
                     Location = (10, 16)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": Shape"
                     Location = (10, 6)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "width = "
                     Location = (11, 20)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "height = "
                     Location = (11, 23)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": Shape"
                     Location = (11, 6)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": int "
                     Location = (14, 36)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "blahFirst = "
                     Location = (16, 11)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": C"
                     Location = (16, 6)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = "what = "
                     Location = (17, 19)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
                 {
                     Content = ": int"
                     Location = (17, 7)
-                    ToolTip = "42"
+                    Tooltip = "42"
                 }
             ]
 


### PR DESCRIPTION
Addresses #14268 

This PR fixes the following:
![image](https://user-images.githubusercontent.com/5451366/233415396-c66b7421-ac1e-4d96-ace5-0c36714f08e0.png)

Now we have very basic information here.
1) Types:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/5451366/234647825-baa315fc-86ba-4ffd-bd68-45e8fee8e4d6.png">

2) Parameters:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/5451366/234647911-edbe56e5-883a-44ab-9067-f4cfda7c7f55.png">

This is quite basic but better than nothing. 
The test framework now takes tooltips into the account hence this is ready for the further improvements.

