### PR TITLE
Enable fast find references by default

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -127,7 +127,7 @@ type internal FSharpWorkspaceServiceFactory [<System.Composition.ImportingConstr
                             let useSyntaxTreeCache = editorOptions.LanguageServicePerformance.UseSyntaxTreeCache
 
                             let enableFastFindReferences =
-                                editorOptions.LanguageServicePerformance.EnableFastFindReferences
+                                editorOptions.LanguageServicePerformance.EnableFastFindReferencesAndRename
 
                             let isInlineParameterNameHintsEnabled =
                                 editorOptions.Advanced.IsInlineParameterNameHintsEnabled

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -81,7 +81,7 @@ type LanguageServicePerformanceOptions =
         AllowStaleCompletionResults: bool
         TimeUntilStaleCompletion: int
         EnableParallelReferenceResolution: bool
-        EnableFastFindReferences: bool
+        EnableFastFindReferencesAndRename: bool
         EnablePartialTypeChecking: bool
         UseSyntaxTreeCache: bool
     }
@@ -91,7 +91,7 @@ type LanguageServicePerformanceOptions =
             AllowStaleCompletionResults = true
             TimeUntilStaleCompletion = 2000 // In ms, so this is 2 seconds
             EnableParallelReferenceResolution = false
-            EnableFastFindReferences = FSharpExperimentalFeaturesEnabledAutomatically
+            EnableFastFindReferencesAndRename = true
             EnablePartialTypeChecking = true
             UseSyntaxTreeCache = FSharpExperimentalFeaturesEnabledAutomatically
         }
@@ -237,4 +237,4 @@ module EditorOptionsExtensions =
             this.EditorOptions.Advanced.IsBlockStructureEnabled
 
         member this.IsFastFindReferencesEnabled =
-            this.EditorOptions.LanguageServicePerformance.EnableFastFindReferences
+            this.EditorOptions.LanguageServicePerformance.EnableFastFindReferencesAndRename

--- a/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/LanguageServicePerformanceOptionControl.xaml
@@ -68,8 +68,8 @@
                 </GroupBox>
                 <GroupBox Header="{x:Static local:Strings.Find_References_Performance}">
                     <StackPanel>
-                        <CheckBox x:Name="enableFastFindReferences"
-                                  IsChecked="{Binding EnableFastFindReferences}"
+                        <CheckBox x:Name="enableFastFindReferencesAndRename"
+                                  IsChecked="{Binding EnableFastFindReferencesAndRename}"
                                   Content="{x:Static local:Strings.Enable_Fast_Find_References}"/>
                     </StackPanel>
                 </GroupBox>


### PR DESCRIPTION
I think it's time to turn this on for everyone by default. Renamed the setting so the value won't be loaded from storage.