### PR TITLE
Fix some blocking in incremental builder

### DIFF
--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -928,19 +928,15 @@ module IncrementalBuilderStateHelpers =
             return result, DateTime.UtcNow
         })
 
-    let updateStamps (state: IncrementalBuilderState) (cache: TimeStampCache) =
-        let slots = [ for slot in state.slots -> cache.GetFileTimeStamp slot.SyntaxTree.FileName |> slot.Notify ]
-        { state with slots = slots }
-
     let computeStampedFileNames (initialState: IncrementalBuilderInitialState) (state: IncrementalBuilderState) (cache: TimeStampCache) =
-        let state = 
+        let slots = 
             if initialState.useChangeNotifications then
-                state
+                state.slots
             else
-                updateStamps state cache
+               [ for slot in state.slots -> cache.GetFileTimeStamp slot.SyntaxTree.FileName |> slot.Notify ]
 
         let slots =
-            [ for slot in state.slots do
+            [ for slot in slots do
                 if slot.Notified then { slot with SyntaxTree = slot.SyntaxTree.Invalidate() } else slot ]
 
         let mapping (status, prevNode) slot =
@@ -1136,11 +1132,6 @@ type IncrementalBuilder(initialState: IncrementalBuilderInitialState, state: Inc
             do! setCurrentState currentState cache ct
         }
 
-    let checkFileTimeStampsSynchronously cache =
-        checkFileTimeStamps cache
-        |> Async.AwaitNodeCode
-        |> Async.RunSynchronously
-
     do IncrementalBuilderEventTesting.MRU.Add(IncrementalBuilderEventTesting.IBECreated)
 
     member _.TcConfig = tcConfig
@@ -1196,10 +1187,10 @@ type IncrementalBuilder(initialState: IncrementalBuilderInitialState, state: Inc
 
     member builder.TryGetCheckResultsBeforeFileInProject fileName =
         let cache = TimeStampCache defaultTimeStamp
-        checkFileTimeStampsSynchronously cache
+        let tmpState = computeStampedFileNames initialState currentState cache
 
         let slotOfFile = builder.GetSlotOfFileName fileName
-        match tryGetBeforeSlot currentState slotOfFile with
+        match tryGetBeforeSlot tmpState slotOfFile with
         | Some(boundModel, timestamp) ->
             let projectTimeStamp = builder.GetLogicalTimeStampForFileInProject(fileName)
             Some (PartialCheckResults (boundModel, timestamp, projectTimeStamp))
@@ -1281,12 +1272,12 @@ type IncrementalBuilder(initialState: IncrementalBuilderInitialState, state: Inc
 
     member _.GetLogicalTimeStampForFileInProject(slotOfFile: int) =
         let cache = TimeStampCache defaultTimeStamp
-        let tempStateJustForCheckingTimeStamps = updateStamps currentState cache
-        computeProjectTimeStamp tempStateJustForCheckingTimeStamps slotOfFile
+        let tempState = computeStampedFileNames initialState currentState cache
+        computeProjectTimeStamp tempState slotOfFile
 
     member _.GetLogicalTimeStampForProject(cache) =
-        let tempStateJustForCheckingTimeStamps = updateStamps currentState cache
-        computeProjectTimeStamp tempStateJustForCheckingTimeStamps -1
+        let tempState = computeStampedFileNames initialState currentState cache
+        computeProjectTimeStamp tempState -1
 
     member _.TryGetSlotOfFileName(fileName: string) =
         // Get the slot of the given file and force it to build.

--- a/src/Compiler/Service/IncrementalBuild.fsi
+++ b/src/Compiler/Service/IncrementalBuild.fsi
@@ -185,6 +185,8 @@ type internal IncrementalBuilder =
     /// This is safe for use from non-compiler threads but the objects returned must in many cases be accessed only from the compiler thread.
     member GetCheckResultsForFileInProjectEvenIfStale: fileName: string -> PartialCheckResults option
 
+    // TODO: Looks like the following doc does not match the actual method or it's signature.
+
     /// Get the preceding typecheck state of a slot, but only if it is up-to-date w.r.t.
     /// the timestamps on files and referenced DLLs prior to this one. Return None if the result is not available.
     /// This is a relatively quick operation.
@@ -192,8 +194,9 @@ type internal IncrementalBuilder =
     /// This is safe for use from non-compiler threads
     member AreCheckResultsBeforeFileInProjectReady: fileName: string -> bool
 
-    /// Get the preceding typecheck state of a slot, WITH checking if it is up-to-date w.r.t. However, files will not be parsed or checked.
-    /// the timestamps on files and referenced DLLs prior to this one. Return None if the result is not available or if it is not up-to-date.
+    /// Get the preceding typecheck state of a slot, WITH checking if it is up-to-date w.r.t. the timestamps of files and referenced DLLs prior to this one.
+    /// However, files will not be parsed or checked.
+    /// Return None if the result is not available or if it is not up-to-date.
     ///
     /// This is safe for use from non-compiler threads but the objects returned must in many cases be accessed only from the compiler thread.
     member TryGetCheckResultsBeforeFileInProject: fileName: string -> PartialCheckResults option


### PR DESCRIPTION
Synchronous GetLogicalTimeStamp* calls were needlessly updating `currentState`, which is guarded by a semaphore, just to find out the up-to-date timestamps.

cc: @0101