### PR TITLE
Fix a bug in parameter name hints

### DIFF
--- a/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
+++ b/vsintegration/src/FSharp.Editor/Hints/InlineParameterNameHints.fs
@@ -123,7 +123,7 @@ type InlineParameterNameHints(parseResults: FSharpParseFileResults) =
             let curryRanges = getCurryRanges symbolUse
 
             let ranges =
-                if Seq.isEmpty tupleRanges then
+                if symbol.IsFunction || Seq.isEmpty tupleRanges then
                     curryRanges |> List.toSeq
                 else
                     tupleRanges

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -4,6 +4,7 @@ namespace FSharp.Editor.Tests.Hints
 
 open Xunit
 open HintTestFramework
+open FSharp.Test
 
 module InlineParameterNameHintTests =
 
@@ -599,3 +600,43 @@ None
         let actual = getParameterNameHints document
 
         Assert.Equal(expected, actual)
+
+    [<Fact>]
+    let ``Blah`` () =
+        let code =
+            """
+type X = | X of a: int list * b: string
+
+let x = X(List.map id [ 42 ], "")
+        """
+
+        let document = getFsDocument code
+
+        let expected =
+            [
+                {
+                    Content = "a = "
+                    Location = (3, 11)
+                    Tooltip = "field a"
+                }
+                {
+                    Content = "mapping = "
+                    Location = (3, 20)
+                    Tooltip = "parameter mapping"
+                }
+                {
+                    Content = "list = "
+                    Location = (3, 23)
+                    Tooltip = "parameter list"
+                }
+                {
+                    Content = "b = "
+                    Location = (3, 31)
+                    Tooltip = "field b"
+                }
+            ]
+
+        let actual = getParameterNameHints document
+
+        actual |> Assert.shouldBeEquivalentTo expected
+

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -602,7 +602,7 @@ None
         Assert.Equal(expected, actual)
 
     [<Fact>]
-    let ``Blah`` () =
+    let ``Hints are shown correctly in type constructors mixed with functions`` () =
         let code =
             """
 type X = | X of a: int list * b: string

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/InlineParameterNameHintTests.fs
@@ -639,4 +639,3 @@ let x = X(List.map id [ 42 ], "")
         let actual = getParameterNameHints document
 
         actual |> Assert.shouldBeEquivalentTo expected
-


### PR DESCRIPTION
closes #15138

Was:
![image](https://user-images.githubusercontent.com/5451366/235188033-256b9acf-37c5-47b7-9b98-116be8433c99.png)

Is:
![image](https://user-images.githubusercontent.com/5451366/235188325-2299fa2a-e509-42d3-b077-ab73a599b38e.png)
