### PR TITLE
Fix signature generation for attributes of implicit namespaces.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2346,29 +2346,32 @@ module InferredSigPrinting =
 
             if mspec.IsImplicitNamespace then
                 // The current mspec is a namespace that belongs to the `def` child (nested) module(s).                
-                let fullModuleName, def, denv =
+                let fullModuleName, def, denv, moduleAttribs =
                     let rec (|NestedModule|_|) (currentContents:ModuleOrNamespaceContents) =
                         match currentContents with
-                        | ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents)) ]) ->
-                            Some ([ yield mn.DisplayNameCore; yield! path ], contents)
-                        | ModuleOrNamespaceContents.TMDefs [ ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents)) ]) ] ->
-                            Some ([ yield mn.DisplayNameCore; yield! path ], contents)
+                        | ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents, attribs)) ]) ->
+                            Some ([ yield mn.DisplayNameCore; yield! path ], contents, List.append mn.Attribs attribs)
+                        | ModuleOrNamespaceContents.TMDefs [ ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, NestedModule(path, contents, attribs)) ]) ] ->
+                            Some ([ yield mn.DisplayNameCore; yield! path ], contents, List.append mn.Attribs attribs)
                         | ModuleOrNamespaceContents.TMDefs [ ModuleOrNamespaceContents.TMDefRec (bindings = [ ModuleOrNamespaceBinding.Module(mn, nestedModuleContents) ]) ] ->
-                            Some ([ mn.DisplayNameCore ], nestedModuleContents)
+                            Some ([ mn.DisplayNameCore ], nestedModuleContents, mn.Attribs)
                         | _ ->
                             None
 
                     match def with
-                    | NestedModule(path, nestedModuleContents) ->
+                    | NestedModule(path, nestedModuleContents, moduleAttribs) ->
                         let fullPath = mspec.DisplayNameCore :: path
-                        fullPath, nestedModuleContents, denv.AddOpenPath(fullPath)
-                    | _ -> [ mspec.DisplayNameCore ], def, denv
+                        fullPath, nestedModuleContents, denv.AddOpenPath(fullPath), moduleAttribs
+                    | _ -> [ mspec.DisplayNameCore ], def, denv, List.empty
                 
                 let nmL = List.map (tagModule >> wordL) fullModuleName |> sepListL SepL.dot
                 let nmL = layoutAccessibility denv mspec.Accessibility nmL
                 let denv = denv.AddAccessibility mspec.Accessibility
                 let basic = imdefL denv def
-                let modNameL = wordL (tagKeyword "module") ^^ nmL
+                let attribs: Attribs = List.append mspec.Attribs moduleAttribs
+                let modNameL =
+                    wordL (tagKeyword "module") ^^ nmL
+                    |> layoutAttribs denv None false mspec.TypeOrMeasureKind attribs
                 let basicL = modNameL @@ basic
                 layoutXmlDoc denv true mspec.XmlDoc basicL
             elif mspec.IsNamespace then

--- a/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
+++ b/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
@@ -127,3 +127,51 @@ module Inner =
       /// union member
       member Thing: int
   """
+
+    [<Test>]
+    let ``can generate attributes for implicit namespace`` () = 
+        """
+[<AutoOpen>]
+module A.B
+
+open System
+
+    module Say =
+        let hello name =
+            printfn "Hello %s" name
+
+        let f a = a
+        """
+        |> sigShouldBe """
+[<AutoOpen>]
+module A.B
+
+module Say =
+
+  val hello: name: string -> unit
+
+  val f: a: 'a -> 'a"""
+
+    [<Test>]
+    let ``can generate attributes for implicit namespace with multiple modules`` () = 
+        """
+[<AutoOpen>]
+module A.B.C.D
+
+open System
+
+    module Say =
+        let hello name =
+            printfn "Hello %s" name
+
+        let f a = a
+        """
+        |> sigShouldBe """
+[<AutoOpen>]
+module A.B.C.D
+
+module Say =
+
+  val hello: name: string -> unit
+
+  val f: a: 'a -> 'a"""


### PR DESCRIPTION
In yesterday's amplify session @baronfel stumbled upon this bug: An implicit namespace like
```fsharp
[<AutoOpen>]
module X.Y

```
loses it's attributes in the auto-generated signature file (--allsigs).