### PR TITLE
Add missing "get, set" for signatures of Properties

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1726,7 +1726,11 @@ module TastDefinitionPrinting =
 
         match pinfo.ArbitraryValRef with
         | Some vref ->
-            PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst denv infoReader vref
+            let propL = PrintTastMemberOrVals.prettyLayoutOfValOrMemberNoInst denv infoReader vref
+            if pinfo.HasGetter && pinfo.HasSetter then
+                propL ^^ wordL (tagKeyword "with") ^^ wordL (tagText "get, set")
+            else
+                propL
         | None ->
 
             let modifierAndMember =

--- a/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
+++ b/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
@@ -100,7 +100,7 @@ module Inner =
       member blah: unit -> int list
             
       /// auto-property-level docs
-      member Name: string
+      member Name: string with get, set
     
     /// module-level binding docs
     val module_member: unit
@@ -127,3 +127,55 @@ module Inner =
       /// union member
       member Thing: int
   """
+    
+    [<Test>]
+    let ``can generate signatures for autoproperties`` () = 
+        """
+namespace Sample
+
+module Inner =
+    type Facts(name1: string, name2: string) =
+
+        let mutable name3 = ""
+        let mutable value = 1
+        
+        member val SomeAutoProp = name1 with get, set
+        
+        member val SomeAutoPropWithGetOnly = name1 with get
+        
+        member this.PropWithExplGetterOnly
+            with get() = name2
+            
+        member this.PropWithExplSetterOnly
+            with set (s: string) (i: float) = name3 <- s
+
+        member this.PropWithExplGetterAndSetter
+            with set (s: string) (i: float) = name3 <- s
+            and get(j: int) = name3
+            
+        abstract Property1 : int with get, set
+        default this.Property1 with get() = value and set(v : int) = value <- v
+        """
+        |> sigShouldBe """namespace Sample
+
+  module Inner =
+
+    type Facts =
+
+      new: name1: string * name2: string -> Facts
+
+      member PropWithExplGetterAndSetter: s: string -> float with set
+
+      member PropWithExplGetterAndSetter: j: int -> string with get
+
+      member PropWithExplGetterOnly: string
+
+      member PropWithExplSetterOnly: s: string -> float with set
+
+      override Property1: int with get, set
+
+      abstract Property1: int with get, set
+
+      member SomeAutoProp: string with get, set
+
+      member SomeAutoPropWithGetOnly: string"""


### PR DESCRIPTION
This was the other issue we saw in our last amplify session: Signatures of Properties lack the `with get, set` part which can break compilation if those .fsi files are used.
It's arguably a bit too early in the call chain but because of the usage of the returned value of `ArbitraryValRef` throughout the later calls we lose the information that the property has both a getter and setter.
I hope the added test covers all cases.