### PR TITLE
Generate signature files for resource files

### DIFF
--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -556,8 +556,7 @@ open Printf
                             |> String.concat " * "
                             |> fun parameters -> sprintf "    static member %s: %s -> %s" ident parameters returnType
 
-                    fprintfn outSignature "%s" signatureMember
-                )
+                    fprintfn outSignature "%s" signatureMember)
 
                 printMessage "Generating .resx for %s" outFileName
                 fprintfn out ""
@@ -626,7 +625,7 @@ open Printf
                             item.SetMetadata("DesignTime", "true")
                             item.SetMetadata("DependentUpon", resx)
                             item :> ITaskItem
-                        
+
                         let sourceItem =
                             let item = TaskItem(source)
                             item.SetMetadata("AutoGen", "true")

--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -368,8 +368,10 @@ open Printf
 "
 
     let StringBoilerPlateSignature =
-        "/// If set to true, then all error messages will just return the filled 'holes' delimited by ',,,'s - this is for language-neutral testing (e.g. localization-invariant baselines).
-    member SwallowResourceText: bool with get, set"
+        "    // BEGIN BOILERPLATE
+    /// If set to true, then all error messages will just return the filled 'holes' delimited by ',,,'s - this is for language-neutral testing (e.g. localization-invariant baselines).
+    member SwallowResourceText: bool with get, set
+    // END BOILERPLATE"
 
     let generateResxAndSource (fileName: string) =
         try
@@ -541,12 +543,13 @@ open Printf
                         (actualArgs.ToString())
                 
                     let signatureMember =
-                        let arrow = if Array.isEmpty holes then System.String.Empty else  " -> "
-                        
-                        holes
-                        |> Array.mapi (fun idx holeType -> sprintf "a%i: %s" idx holeType)
-                        |> String.concat " -> "
-                        |> sprintf "    static member %s: %s%sstring" ident arrow
+                        if Array.isEmpty holes then
+                            "unit -> string"
+                        else
+                            holes
+                            |> Array.mapi (fun idx holeType -> sprintf "a%i: %s" idx holeType)
+                            |> String.concat " * "
+                            |> sprintf "    static member %s: %s -> string" ident
 
                     fprintfn outSignature "%s" signatureMember
                 )

--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -370,7 +370,7 @@ open Printf
     let StringBoilerPlateSignature =
         "    // BEGIN BOILERPLATE
     /// If set to true, then all error messages will just return the filled 'holes' delimited by ',,,'s - this is for language-neutral testing (e.g. localization-invariant baselines).
-    member SwallowResourceText: bool with get, set
+    static member SwallowResourceText: bool with get, set
     // END BOILERPLATE"
 
     let generateResxAndSource (fileName: string) =

--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -541,10 +541,12 @@ open Printf
                         (actualArgs.ToString())
                 
                     let signatureMember =
+                        let arrow = if Array.isEmpty holes then System.String.Empty else  " -> "
+                        
                         holes
                         |> Array.mapi (fun idx holeType -> sprintf "a%i: %s" idx holeType)
                         |> String.concat " -> "
-                        |> sprintf "    static member %s: %s -> string" ident
+                        |> sprintf "    static member %s: %s%sstring" ident arrow
 
                     fprintfn outSignature "%s" signatureMember
                 )

--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -541,10 +541,10 @@ open Printf
                         ident
                         justPercentsFromFormatString
                         (actualArgs.ToString())
-                
+
                     let signatureMember =
                         if Array.isEmpty holes then
-                            "unit -> string"
+                            sprintf "    static member %s: unit -> string" ident
                         else
                             holes
                             |> Array.mapi (fun idx holeType -> sprintf "a%i: %s" idx holeType)

--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -543,13 +543,18 @@ open Printf
                         (actualArgs.ToString())
 
                     let signatureMember =
+                        let returnType =
+                            match optErrNum with
+                            | None -> "string"
+                            | Some _ -> "int * string"
+
                         if Array.isEmpty holes then
-                            sprintf "    static member %s: unit -> string" ident
+                            sprintf "    static member %s: unit -> %s" ident returnType
                         else
                             holes
                             |> Array.mapi (fun idx holeType -> sprintf "a%i: %s" idx holeType)
                             |> String.concat " * "
-                            |> sprintf "    static member %s: %s -> string" ident
+                            |> fun parameters -> sprintf "    static member %s: %s -> %s" ident parameters returnType
 
                     fprintfn outSignature "%s" signatureMember
                 )
@@ -560,6 +565,7 @@ open Printf
                 fprintfn out "    /// Call this method once to validate that all known resources are valid; throws if not"
 
                 fprintfn out "    static member RunStartupValidation() ="
+                fprintfn outSignature "    static member RunStartupValidation: unit -> unit"
 
                 stringInfos
                 |> Seq.iter (fun (lineNum, (optErrNum, ident), str, holes, netFormatString) ->


### PR DESCRIPTION
As signature files can benefit the graph type-checking, I'd like to generate them as well for all `*.txt` files that are transformed to `SR` code.

![image](https://user-images.githubusercontent.com/2621499/235868662-d30d5d73-c434-4b31-bcd4-e0858550dda8.png)

There are around 70 links in the Compiler project that reference `FSComp.fsi`

```mermaid
flowchart RL
    0["C:\Users\nojaf\Projects\fsharp\artifacts\obj\FSharp.Compiler.Service\Release\netstandard2.0\FSComp.fsi"]
    1["C:\Users\nojaf\Projects\fsharp\artifacts\obj\FSharp.Compiler.Service\Release\netstandard2.0\FSComp.fs"]
    52["Facilities\LanguageFeatures.fs"]
    58["Facilities\DiagnosticsLogger.fs"]
    86["AbstractIL\ilsign.fs"]
    88["AbstractIL\ilnativeres.fs"]
    94["AbstractIL\ilread.fs"]
    98["AbstractIL\ilwrite.fs"]
    100["AbstractIL\ilreflect.fs"]
    102["SyntaxTree\PrettyNaming.fs"]
    106["SyntaxTree\XmlDoc.fs"]
    112["SyntaxTree\SyntaxTreeOps.fs"]
    114["SyntaxTree\ParseHelpers.fs"]
    115["C:\Users\nojaf\Projects\fsharp\artifacts\obj\FSharp.Compiler.Service\Release\netstandard2.0\pppars.fs"]
    116["C:\Users\nojaf\Projects\fsharp\artifacts\obj\FSharp.Compiler.Service\Release\netstandard2.0\pars.fs"]
    118["SyntaxTree\LexHelpers.fs"]
    119["C:\Users\nojaf\Projects\fsharp\artifacts\obj\FSharp.Compiler.Service\Release\netstandard2.0\pplex.fs"]
    120["C:\Users\nojaf\Projects\fsharp\artifacts\obj\FSharp.Compiler.Service\Release\netstandard2.0\\lex.fs"]
    122["SyntaxTree\LexFilter.fs"]
    124["TypedTree\tainted.fs"]
    126["TypedTree\TypeProviders.fs"]
    132["TypedTree\TypedTree.fs"]
    135["TypedTree\TcGlobals.fs"]
    137["TypedTree\TypedTreeOps.fs"]
    139["TypedTree\TypedTreePickle.fs"]
    143["Checking\import.fs"]
    145["Checking\TypeHierarchy.fs"]
    147["Checking\infos.fs"]
    149["Checking\AccessibilityLogic.fs"]
    151["Checking\AttributeChecking.fs"]
    153["Checking\TypeRelations.fs"]
    155["Checking\InfoReader.fs"]
    157["Checking\NicePrint.fs"]
    159["Checking\AugmentWithHashCompare.fs"]
    161["Checking\NameResolution.fs"]
    163["Checking\SignatureConformance.fs"]
    165["Checking\MethodOverrides.fs"]
    167["Checking\MethodCalls.fs"]
    169["Checking\PatternMatchCompilation.fs"]
    171["Checking\ConstraintSolver.fs"]
    173["Checking\CheckFormatStrings.fs"]
    177["Checking\QuotationTranslator.fs"]
    179["Checking\PostInferenceChecks.fs"]
    185["Checking\CheckExpressions.fs"]
    187["Checking\CheckPatterns.fs"]
    189["Checking\CheckComputationExpressions.fs"]
    191["Checking\CheckIncrementalClasses.fs"]
    193["Checking\CheckDeclarations.fs"]
    195["Optimize\Optimizer.fs"]
    199["Optimize\InnerLambdasToTopLevelFuncs.fs"]
    205["Optimize\LowerComputedCollections.fs"]
    207["Optimize\LowerStateMachines.fs"]
    209["Optimize\LowerLocalMutables.fs"]
    217["CodeGen\IlxGen.fs"]
    219["Driver\FxResolver.fs"]
    225["DependencyManager/DependencyProvider.fs"]
    227["Driver\CompilerConfig.fs"]
    229["Driver\CompilerImports.fs"]
    231["Driver\CompilerDiagnostics.fs"]
    249["Driver\ParseAndCheckInputs.fs"]
    251["Driver\ScriptClosure.fs"]
    253["Driver\CompilerOptions.fs"]
    257["Driver\XmlDocFileWriter.fs"]
    261["Driver\StaticLinking.fs"]
    263["Driver\CreateILModule.fs"]
    265["Driver\fsc.fs"]
    269["Symbols\SymbolHelpers.fs"]
    287["Service\ServiceCompilerDiagnostics.fs"]
    290["Service\ServiceDeclarationLists.fs"]
    325["Interactive\fsi.fs"]
    1 --> 0
    52 --> 0
    58 --> 0
    86 --> 0
    88 --> 0
    94 --> 0
    98 --> 0
    100 --> 0
    102 --> 0
    106 --> 0
    112 --> 0
    114 --> 0
    115 --> 0
    116 --> 0
    118 --> 0
    119 --> 0
    120 --> 0
    122 --> 0
    124 --> 0
    126 --> 0
    132 --> 0
    135 --> 0
    137 --> 0
    139 --> 0
    143 --> 0
    145 --> 0
    147 --> 0
    149 --> 0
    151 --> 0
    153 --> 0
    155 --> 0
    157 --> 0
    159 --> 0
    161 --> 0
    163 --> 0
    165 --> 0
    167 --> 0
    169 --> 0
    171 --> 0
    173 --> 0
    177 --> 0
    179 --> 0
    185 --> 0
    187 --> 0
    189 --> 0
    191 --> 0
    193 --> 0
    195 --> 0
    199 --> 0
    205 --> 0
    207 --> 0
    209 --> 0
    217 --> 0
    219 --> 0
    225 --> 0
    227 --> 0
    229 --> 0
    231 --> 0
    249 --> 0
    251 --> 0
    253 --> 0
    257 --> 0
    261 --> 0
    263 --> 0
    265 --> 0
    269 --> 0
    287 --> 0
    290 --> 0
    325 --> 0
```

So this is a really good candidate to have a signature file.