### PR TITLE
Do not print stacktrace on fsi.exe error

### DIFF
--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -73,7 +73,7 @@ tupleRequiredInAbstractMethod,"\nA tuple type is required for one or more argume
 240,buildSignatureWithoutImplementation,"The signature file '%s' does not have a corresponding implementation file. If an implementation file exists then check the 'module' and 'namespace' declarations in the signature and implementation files match."
 241,buildArgInvalidInt,"'%s' is not a valid integer argument"
 242,buildArgInvalidFloat,"'%s' is not a valid floating point argument"
-243,buildUnrecognizedOption,"Unrecognized option: '%s'"
+243,buildUnrecognizedOption,"Unrecognized option: '%s'. Use '--help' to learn about recognized command line options."
 244,buildInvalidModuleOrNamespaceName,"Invalid module or namespace name"
 pickleErrorReadingWritingMetadata,"Error reading/writing metadata for the F# compiled DLL '%s'. Was the DLL compiled with an earlier version of the F# compiler? (error: '%s')."
 245,tastTypeOrModuleNotConcrete,"The type/module '%s' is not a concrete module or type"

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Nerozpoznaná možnost: {0}</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Nerozpoznaná možnost: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Unbekannte Option: "{0}"</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Unbekannte Option: "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Opción no reconocida: '{0}'.</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Opción no reconocida: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Option non reconnue : '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Option non reconnue : '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Opzione non riconosciuta: '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Opzione non riconosciuta: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">認識されないオプション:'{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">認識されないオプション:'{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">인식할 수 없는 옵션: '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">인식할 수 없는 옵션: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Nierozpoznana opcja: „{0}”</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Nierozpoznana opcja: „{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Opção não reconhecida: '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Opção não reconhecida: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Нераспознанный параметр: '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Нераспознанный параметр: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">Tanınmayan seçenek: '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">Tanınmayan seçenek: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">无法识别的选项:“{0}”</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">无法识别的选项:“{0}”</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -1598,8 +1598,8 @@
         <note />
       </trans-unit>
       <trans-unit id="buildUnrecognizedOption">
-        <source>Unrecognized option: '{0}'</source>
-        <target state="translated">選項無法辨認: '{0}'</target>
+        <source>Unrecognized option: '{0}'. Use '--help' to learn about recognized command line options.</source>
+        <target state="needs-review-translation">選項無法辨認: '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="buildInvalidModuleOrNamespaceName">

--- a/src/fsi/fsimain.fs
+++ b/src/fsi/fsimain.fs
@@ -148,7 +148,7 @@ let internal TrySetUnhandledExceptionMode () =
 
 #endif
 
-/// Starts the remoting server to handle interrupt reuests from a host tool.
+/// Starts the remoting server to handle interrupt requests from a host tool.
 let StartServer (fsiSession: FsiEvaluationSession) (fsiServerName) =
     let server =
 
@@ -344,11 +344,7 @@ let evaluateSession (argv: string[]) =
         // Start the session
         fsiSession.Run()
         0
-    with
-    | FSharp.Compiler.DiagnosticsLogger.StopProcessingExn _ -> 1
-    | FSharp.Compiler.DiagnosticsLogger.ReportedError _ -> 1
-    | e ->
-        eprintf "Exception by fsi.exe:\n%+A\n" e
+    with e ->
         1
 
 // Mark the main thread as STAThread since it is a GUI thread

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/checked/checked.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/checked/checked.fs
@@ -158,7 +158,7 @@ module Checked =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--checked*'")
+            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--checked*'. Use '--help' to learn about recognized command line options.")
         ]
 
     //  SOURCE=unrecogarg.fs  SCFLAGS="--checked*"  # fsc--checked*

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/checked/checked.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/checked/checked.fs
@@ -146,7 +146,7 @@ module Checked =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--Checked'")
+            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--Checked'. Use '--help' to learn about recognized command line options.")
         ]
 
     //  SOURCE=unrecogarg.fs  SCFLAGS="--checked*"  # fsc--checked*

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/cliversion.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/cliversion.fs
@@ -18,7 +18,7 @@ module cliversion =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--cliversion'")
+            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--cliversion'. Use '--help' to learn about recognized command line options.")
         ]
 
     //#   SOURCE=E_fsi_cliversion.fs  SCFLAGS="--cliversion:2.0" FSIMODE=EXEC COMPILE_ONLY=1  # fsi --cliversion:2.0
@@ -31,6 +31,6 @@ module cliversion =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--cliversion'")
+            (Error 243, Line 0, Col 1, Line 0, Col 1, "Unrecognized option: '--cliversion'. Use '--help' to learn about recognized command line options.")
         ]
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/7677

We shouldn't print a stack trace on fsi.exe internal errors

Before:
```
# dotnet fsi --foobar


error FS0243: Unrecognized option: '--foobar'

Exception by fsi.exe:
System.Exception: Error creating evaluation session: StopProcessingExn
   at Microsoft.FSharp.Core.PrintfModule.PrintFormatToStringThenFail@1448.Invoke(String message)
   at FSharp.Compiler.Interactive.Shell.FsiCommandLineOptions..ctor(FsiEvaluationSessionHostConfig fsi, String[] argv, TcConfigBuilder tcConfigB, FsiConsoleOutput fsiConsoleOutput) in D:\a\_work\1\s\src\Compiler\Interactive\fsi.fs:line 973
   at FSharp.Compiler.Interactive.Shell.FsiEvaluationSession..ctor(FsiEvaluationSessionHostConfig fsi, String[] argv, TextReader inReader, TextWriter outWriter, TextWriter errorWriter, Boolean fsiCollectible, FSharpOption`1 legacyReferenceResolver) in D:\a\_work\1\s\src\Compiler\Interactive\fsi.fs:line 3411
   at FSharp.Compiler.Interactive.Shell.FsiEvaluationSession.Create(FsiEvaluationSessionHostConfig fsiConfig, String[] argv, TextReader inReader, TextWriter outWriter, TextWriter errorWriter, FSharpOption`1 collectible, FSharpOption`1 legacyReferenceResolver) in D:\a\_work\1\s\src\Compiler\Interactive\fsi.fs:line 3775
   at Sample.FSharp.Compiler.Interactive.Main.evaluateSession@304-1.Invoke(Unit unitVar)
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at Sample.FSharp.Compiler.Interactive.Main.evaluateSession(String[] argv) in D:\a\_work\1\s\src\fsi\fsimain.fs:line 304
```

After:
```
# .\artifacts\bin\fsi\Debug\net472\fsi.exe --foobar


error FS0243: Unrecognized option: '--foobar'. Use '--help' to learn about recognized command line options.
```