### PR TITLE
Notinteractive

### DIFF
--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -1880,6 +1880,8 @@ type Exception with
 
         | :? UnauthorizedAccessException as exn -> Printf.bprintf os "%s" exn.Message
 
+        | :? InvalidOperationException as exn when exn.Message.Contains "ControlledExecution.Run" -> Printf.bprintf os "%s" exn.Message
+
         | exn ->
             os.AppendString(TargetInvocationExceptionWrapperE().Format exn.Message)
 #if DEBUG

--- a/src/Compiler/Interactive/ControlledExecution.fs
+++ b/src/Compiler/Interactive/ControlledExecution.fs
@@ -56,7 +56,7 @@ type internal ControlledExecution(isInteractive: bool) =
 
     member _.TryAbort() : unit =
         match isInteractive, isRunningOnCoreClr, cts, thread with
-        | true, true, ValueSome cts, _ ->cts.Cancel()
+        | true, true, ValueSome cts, _ -> cts.Cancel()
         | true, false, _, ValueSome thread -> thread.Abort()
         | _ -> ()
 

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -4516,7 +4516,8 @@ type FsiEvaluationSession
 
     do updateBannerText () // setting the correct banner so that 'fsi -?' display the right thing
 
-    let fsiOptions = FsiCommandLineOptions(fsi, argv, tcConfigB, fsiConsoleOutput)
+    let fsiOptions =
+        FsiCommandLineOptions(fsi, argv, tcConfigB, fsiConsoleOutput)
 
     do
         match fsiOptions.WriteReferencesAndExit with
@@ -4623,7 +4624,7 @@ type FsiEvaluationSession
             resolveAssemblyRef
         )
 
-    let controlledExecution = ControlledExecution()
+    let controlledExecution = ControlledExecution(fsiOptions.Interact)
 
     let fsiInterruptController =
         FsiInterruptController(fsiOptions, controlledExecution, fsiConsoleOutput)

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -4516,8 +4516,7 @@ type FsiEvaluationSession
 
     do updateBannerText () // setting the correct banner so that 'fsi -?' display the right thing
 
-    let fsiOptions =
-        FsiCommandLineOptions(fsi, argv, tcConfigB, fsiConsoleOutput)
+    let fsiOptions = FsiCommandLineOptions(fsi, argv, tcConfigB, fsiConsoleOutput)
 
     do
         match fsiOptions.WriteReferencesAndExit with

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -8,9 +8,11 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UnitTestType>xunit</UnitTestType>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <NoWarn>$(NoWarn);44</NoWarn> <!-- Obsolete -->
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(FSharpSourcesRoot)\Compiler\Interactive\ControlledExecution.fs" />
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Utilities\RidHelpers.fs" />
     <Compile Include="DependencyManagerInteractiveTests.fs" />
     <Compile Include="DependencyManagerLineParserTests.fs" />
@@ -19,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="housing.csv"  CopyToOutputDirectory="PreserveNewest" />
+    <None Include="housing.csv" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -9,6 +9,7 @@ open System.Reflection
 open System.Runtime.InteropServices
 open System.Threading
 open System.Threading.Tasks
+open FSharp.Compiler.Interactive
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Test.ScriptHelpers
 open FSharp.Test.Utilities
@@ -41,6 +42,44 @@ type InteractiveTests() =
         let value = opt.Value
         Assert.Equal(typeof<int>, value.ReflectionType)
         Assert.Equal(3, value.ReflectionValue :?> int)
+
+    [<Fact>]
+    member _.``ExecuteScript with host providing ControlledExecution should succeed with --noninteractive``() =
+        let ce = new FSharp.Compiler.Interactive.ControlledExecution(true)
+        ce.Run(fun () ->
+            use script = new FSharpScript([|"--noninteractive"|])
+            let opt =
+                script.Eval("""
+open System
+let x = 1 + 2
+x
+                """) |> getValue
+            let value = opt.Value
+            Assert.Equal(typeof<int>, value.ReflectionType)
+            Assert.Equal(3, value.ReflectionValue :?> int)
+        )
+
+#if NETSTANDARD
+    [<Fact>]
+    member _.``ExecuteScript with host providing ControlledExecution should fail without --noninteractive``() =
+        let ce = new ControlledExecution(true)
+        ce.Run(fun () ->
+            use script = new FSharpScript()
+            let result, errors = 
+                script.Eval("""
+open System
+let x = 1 + 2
+x
+                """)
+            match result with
+            | Ok(_) -> Assert.True(false, "expected a failure")
+            | Error(ex) ->
+                Assert.IsAssignableFrom(typeof<FsiCompilationException>, ex)
+                match ex with
+                | :? FsiCompilationException as e when Option.isSome(e.ErrorInfos) -> Assert.Equal("The thread is already executing the ControlledExecution.Run method.", e.ErrorInfos.Value[0].Message)
+                | _ -> Assert.True(false, "threw incorrect exception expects: 'The thread is already executing the ControlledExecution.Run method.'")
+        )
+#endif
 
     [<Fact>]
     member _.``Capture console input``() =

--- a/tests/FSharp.Test.Utilities/ScriptHelpers.fs
+++ b/tests/FSharp.Test.Utilities/ScriptHelpers.fs
@@ -37,7 +37,6 @@ type FSharpScript(?additionalArgs: string[], ?quiet: bool, ?langVersion: LangVer
 
     let baseArgs = [|
         typeof<FSharpScript>.Assembly.Location;
-        "--noninteractive";
         "--targetprofile:" + computedProfile
         if quiet then "--quiet"
         match langVersion with


### PR DESCRIPTION
Do not start a ControlledExecution block when the script is executing in --noninteractive mode.

A thread that is executing a ControlledExecution block cannot  start a new ControlledExecution block.  This is an issue for hosts that use fsi as a library to compile and execute scripts and want to use a ControlledExecution object to halt a threads execution.  

Such hosts will typically use --noninteractive because they control the interactions with script processing.  So, with this PR, we do not create a ControlledExecution when the script is noninteractive.  Which enables the host to create a block and manage interactions.

Adds tests.

