### PR TITLE
Fix small errors in prinf documentation

### DIFF
--- a/src/FSharp.Core/printf.fsi
+++ b/src/FSharp.Core/printf.fsi
@@ -421,7 +421,7 @@ module Printf =
     ///
     /// ksprintf (fun s -> s + ", done!") $"Write three = {1+2}"
     /// </code>
-    /// Evaluates to <c>"Write five = 5, done!"</c>.
+    /// Evaluates to <c>"Write three = 3, done!"</c>.
     /// </example>
     [<CompiledName("PrintFormatToStringThen")>]
     val ksprintf: continuation: (string -> 'Result) -> format: StringFormat<'T, 'Result> -> 'T

--- a/src/FSharp.Core/printf.fsi
+++ b/src/FSharp.Core/printf.fsi
@@ -402,7 +402,7 @@ module Printf =
     ///
     /// kprintf (fun s -> s + ", done!") $"Write three = {1+2}"
     /// </code>
-    /// Evaluates to <c>"Write five = 5, done!"</c>.
+    /// Evaluates to <c>"Write three = 3, done!"</c>.
     /// </example>
     [<CompiledName("PrintFormatThen")>]
     val kprintf: continuation: (string -> 'Result) -> format: StringFormat<'T, 'Result> -> 'T

--- a/src/FSharp.Core/printf.fsi
+++ b/src/FSharp.Core/printf.fsi
@@ -379,9 +379,9 @@ module Printf =
     ///
     /// let file = File.CreateText("out.txt")
     ///
-    /// kfprintf (fun () -> file.Close()) $"Write three = {1+2}"
+    /// kfprintf (fun () -> file.Close()) file $"Write three = {1+2}"
     /// </code>
-    /// Writes <c>"Write five = 5"</c> to <c>out.txt</c>.
+    /// Writes <c>"Write three = 3"</c> to <c>out.txt</c>.
     /// </example>
     [<CompiledName("PrintFormatToTextWriterThen")>]
     val kfprintf:


### PR DESCRIPTION
This PR fixes small errors in the documentation strings of `ksprintf`, `kprintf` and `kfprintf` that explain the expected output of example code. The errors look like copy&paste errors.