### PR TITLE
Fix pretty print error for pointer type

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Scripting/Interactive.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Scripting/Interactive.fs
@@ -16,6 +16,13 @@ module ``Interactive tests`` =
         |> withEvalValueEquals 2
 
     [<Fact>]
+    let ``Pretty print void pointer``() =
+        Fsx "System.IntPtr.Zero.ToPointer()"
+        |> runFsi
+        |> shouldSucceed
+        |> withStdOutContains "val it: voidptr = 0n"
+
+    [<Fact>]
     let ``EntryPoint attribute in FSI should produce a compiler warning`` () =
         Fsx "[<EntryPoint>] let myFunc _ = 0"
         |> eval

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -962,15 +962,18 @@ module rec Compiler =
                                     opts.Add($"-I:\"{(outputDirectory.Value.FullName)}\"")
                         | _ -> ()
                     opts.ToArray()
-                let errors = CompilerAssert.RunScriptWithOptionsAndReturnResult options source
+                let errors, stdOut = CompilerAssert.RunScriptWithOptionsAndReturnResult options source
 
+                let executionOutputwithStdOut: RunOutput option =
+                    ExecutionOutput { StdOut = stdOut; ExitCode = 0; StdErr = "" }
+                    |> Some
                 let result =
                     { OutputPath   = None
                       Dependencies = []
                       Adjust       = 0
                       Diagnostics  = []
                       PerFileErrors= []
-                      Output       = None
+                      Output       = executionOutputwithStdOut
                       Compilation  = cUnit }
 
                 if errors.Count > 0 then

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -940,10 +940,10 @@ Updated automatically, please check diffs in your pull request, changes must be 
         | Choice2Of2 ex -> errorMessages.Add(ex.Message)
         | _ -> ()
 
-        errorMessages
+        errorMessages, outStream.ToString()
 
     static member RunScriptWithOptions options (source: string) (expectedErrorMessages: string list) =
-        let errorMessages = CompilerAssert.RunScriptWithOptionsAndReturnResult options source
+        let errorMessages, _ = CompilerAssert.RunScriptWithOptionsAndReturnResult options source
         if expectedErrorMessages.Length <> errorMessages.Count then
             Assert.Fail(sprintf "Expected error messages: %A \n\n Actual error messages: %A" expectedErrorMessages errorMessages)
         else


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/8003

If argument is of type System.Reflection.Pointer, it will be unboxed and cast to `nativeint` for pretty printing