### PR TITLE
Checker: recover on unknown record fields

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -1812,7 +1812,8 @@ let BuildFieldMap (cenv: cenv) env isPartial ty (flds: ((Ident list * Ident) * '
                 let fldPath, fldId = fld
                 let frefSet = ResolveField cenv.tcSink cenv.nameResolver env.eNameResEnv ad ty fldPath fldId allFields
                 Some(fld, frefSet, fldExpr)
-            with _ ->
+            with e ->
+                errorRecoveryNoRange e
                 None
         )
 

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -7403,7 +7403,7 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
             error(Error(errorInfo, mWholeExpr))
 
         if isFSharpObjModelTy g overallTy then errorR(Error(FSComp.SR.tcTypeIsNotARecordTypeNeedConstructor(), mWholeExpr))
-        elif not (isRecdTy g overallTy) then errorR(Error(FSComp.SR.tcTypeIsNotARecordType(), mWholeExpr))
+        elif not (isRecdTy g overallTy || fldsList.IsEmpty) then errorR(Error(FSComp.SR.tcTypeIsNotARecordType(), mWholeExpr))
 
     let superInitExprOpt , tpenv =
         match inherits, GetSuperTypeOfType g cenv.amap mWholeExpr overallTy with

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -7422,6 +7422,7 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
             None, tpenv
 
     if fldsList.IsEmpty && isTyparTy g overallTy then
+        SolveTypeAsError env.DisplayEnv cenv.css mWholeExpr overallTy
         mkDefault (mWholeExpr, overallTy), tpenv
     else
         let expr, tpenv = TcRecordConstruction cenv overallTy env tpenv withExprInfoOpt overallTy fldsList mWholeExpr

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -1812,8 +1812,7 @@ let BuildFieldMap (cenv: cenv) env isPartial ty (flds: ((Ident list * Ident) * '
                 let fldPath, fldId = fld
                 let frefSet = ResolveField cenv.tcSink cenv.nameResolver env.eNameResEnv ad ty fldPath fldId allFields
                 Some(fld, frefSet, fldExpr)
-            with e ->
-                errorR e 
+            with _ ->
                 None
         )
 

--- a/src/Compiler/Checking/CheckExpressions.fsi
+++ b/src/Compiler/Checking/CheckExpressions.fsi
@@ -895,7 +895,7 @@ val BuildFieldMap:
     ty: TType ->
     flds: ((Ident list * Ident) * 'T) list ->
     m: range ->
-        TypeInst * TyconRef * Map<string, 'T> * (string * 'T) list
+        (TypeInst * TyconRef * Map<string, 'T> * (string * 'T) list) option
 
 /// Check a long identifier 'Case' or 'Case argsR' that has been resolved to an active pattern case
 val TcPatLongIdentActivePatternCase:

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -435,7 +435,10 @@ and TcPatArrayOrList warnOnUpper cenv env vFlags patEnv ty isArray args m =
 
 and TcRecordPat warnOnUpper cenv env vFlags patEnv ty fieldPats m =
     let fieldPats = fieldPats |> List.map (fun (fieldId, _, fieldPat) -> fieldId, fieldPat)
-    let tinst, tcref, fldsmap, _fldsList = BuildFieldMap cenv env true ty fieldPats m
+    match BuildFieldMap cenv env true ty fieldPats m with
+    | None -> (fun _ -> TPat_error m), patEnv
+    | Some(tinst, tcref, fldsmap, _fldsList) ->
+
     let gtyp = mkAppTy tcref tinst
     let inst = List.zip (tcref.Typars m) tinst
 

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -3684,7 +3684,7 @@ let ResolveFieldPrim sink (ncenv: NameResolver) nenv ad ty (mp, id: Ident) allFi
         let resInfo, item, rest =
             modulSearch ad () +++ tyconSearch ad +++ modulSearch AccessibleFromSomeFSharpCode +++ tyconSearch AccessibleFromSomeFSharpCode
             |> AtMostOneResult m
-            |> ForceRaise
+            |> (function Exception e -> error e | Result r -> r)
 
         if not (isNil rest) then
             errorR(Error(FSComp.SR.nrInvalidFieldLabel(), (List.head rest).idRange))

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -3684,7 +3684,7 @@ let ResolveFieldPrim sink (ncenv: NameResolver) nenv ad ty (mp, id: Ident) allFi
         let resInfo, item, rest =
             modulSearch ad () +++ tyconSearch ad +++ modulSearch AccessibleFromSomeFSharpCode +++ tyconSearch AccessibleFromSomeFSharpCode
             |> AtMostOneResult m
-            |> (function Exception e -> error e | Result r -> r)
+            |> ForceRaise
 
         if not (isNil rest) then
             errorR(Error(FSComp.SR.nrInvalidFieldLabel(), (List.head rest).idRange))

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/NameResolutionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/NameResolutionTests.fs
@@ -21,8 +21,10 @@ let r:F = { Size=3; Height=4; Wall=1 }
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 1129, Line 9, Col 31, Line 9, Col 35,
-                                 ("The record type 'F' does not contain a label 'Wall'. Maybe you want one of the following:" + System.Environment.NewLine + "   Wallis"))
+        |> withDiagnostics [
+            (Error 1129, Line 9, Col 31, Line 9, Col 35, "The record type 'F' does not contain a label 'Wall'. Maybe you want one of the following:" + System.Environment.NewLine + "   Wallis")
+            (Error 764, Line 9, Col 11, Line 9, Col 39, "No assignment given for field 'Wallis' of type 'Test.F'")
+        ]
 
     [<Fact>]
     let RecordFieldProposal () =
@@ -38,5 +40,7 @@ let r = { Size=3; Height=4; Wall=1 }
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 39, Line 9, Col 29, Line 9, Col 33,
-                                 ("The record label 'Wall' is not defined. Maybe you want one of the following:" + System.Environment.NewLine + "   Walls" + System.Environment.NewLine + "   Wallis"))
+        |> withDiagnostics [
+            (Error 39, Line 9, Col 29, Line 9, Col 33, "The record label 'Wall' is not defined. Maybe you want one of the following:" + System.Environment.NewLine + "   Walls" + System.Environment.NewLine + "   Wallis")
+            (Error 764, Line 9, Col 9, Line 9, Col 37, "No assignment given for field 'Wallis' of type 'Test.F'")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/SuggestionsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/SuggestionsTests.fs
@@ -173,8 +173,10 @@ let r = { Field1 = "hallo"; Field2 = 1 }
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 39, Line 8, Col 11, Line 8, Col 17,
-                                 ("The record label 'Field1' is not defined. Maybe you want one of the following:" + Environment.NewLine + "   MyRecord.Field1"))
+        |> withDiagnostics [
+            (Error 39, Line 8, Col 11, Line 8, Col 17, "The record label 'Field1' is not defined. Maybe you want one of the following:" + Environment.NewLine + "   MyRecord.Field1")
+            (Error 39, Line 8, Col 29, Line 8, Col 35, "The record label 'Field2' is not defined. Maybe you want one of the following:" + Environment.NewLine + "   MyRecord.Field2")
+        ]
 
     [<Fact>]
     let ``Suggest Type Parameters`` () =

--- a/tests/fsharp/typecheck/sigs/neg07.bsl
+++ b/tests/fsharp/typecheck/sigs/neg07.bsl
@@ -23,6 +23,13 @@ neg07.fs(36,11,36,27): typecheck error FS0026: This rule will never be matched
 
 neg07.fs(46,15,46,27): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1
+   R.RecordLabel2
+
+neg07.fs(46,33,46,45): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
+neg07.fs(47,17,47,55): typecheck error FS0025: Incomplete pattern matches on this expression.
+neg07.fs(47,37,47,49): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
+neg07.fs(47,59,47,60): typecheck error FS0039: The value or constructor 'a' is not defined.
+neg07.fs(47,63,47,64): typecheck error FS0039: The value or constructor 'b' is not defined.
 
 neg07.fs(47,19,47,31): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1

--- a/tests/fsharp/typecheck/sigs/neg07.bsl
+++ b/tests/fsharp/typecheck/sigs/neg07.bsl
@@ -23,16 +23,19 @@ neg07.fs(36,11,36,27): typecheck error FS0026: This rule will never be matched
 
 neg07.fs(46,15,46,27): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1
-   R.RecordLabel2
 
 neg07.fs(46,33,46,45): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
+   R.RecordLabel2
+
 neg07.fs(47,17,47,55): typecheck error FS0025: Incomplete pattern matches on this expression.
-neg07.fs(47,37,47,49): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
 neg07.fs(47,59,47,60): typecheck error FS0039: The value or constructor 'a' is not defined.
 neg07.fs(47,63,47,64): typecheck error FS0039: The value or constructor 'b' is not defined.
 
 neg07.fs(47,19,47,31): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1
+
+neg07.fs(47,37,47,49): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
+   R.RecordLabel2
 
 neg07.fs(57,10,57,17): typecheck error FS1196: The 'UseNullAsTrueValue' attribute flag may only be used with union types that have one nullary case and at least one non-nullary case
 

--- a/tests/fsharpqa/Source/Conformance/InferenceProcedures/NameResolution/RequireQualifiedAccess/E_OnRecord.fs
+++ b/tests/fsharpqa/Source/Conformance/InferenceProcedures/NameResolution/RequireQualifiedAccess/E_OnRecord.fs
@@ -3,7 +3,6 @@
 // has the RequireQualifiedAccess attribute.
 
 //<Expects id="FS0039" status="error">The record label 'Field1' is not defined\.</Expects>
-//<Expects id="FS1129" status="error">The record type 'R' does not contain a label 'F'.\.</Expects>
 
 [<RequireQualifiedAccess>]
 type R = { Field1 : int; Field2 : string }

--- a/tests/fsharpqa/Source/Conformance/InferenceProcedures/NameResolution/RequireQualifiedAccess/E_OnRecord.fs
+++ b/tests/fsharpqa/Source/Conformance/InferenceProcedures/NameResolution/RequireQualifiedAccess/E_OnRecord.fs
@@ -3,7 +3,7 @@
 // has the RequireQualifiedAccess attribute.
 
 //<Expects id="FS0039" status="error">The record label 'Field1' is not defined\.</Expects>
-//<Expects id="FS0039" status="error">The record label 'Field1' is not defined\.</Expects>
+//<Expects id="FS1129" status="error">The record type 'R' does not contain a label 'F'.\.</Expects>
 
 [<RequireQualifiedAccess>]
 type R = { Field1 : int; Field2 : string }

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -474,3 +474,18 @@ type Foo =
           (:? FSharpMemberOrFunctionOrValue as setMfv) ->
             Assert.AreNotEqual(getMfv.CurriedParameterGroups, setMfv.CurriedParameterGroups)
         | _ -> Assert.Fail "Expected symbols to be FSharpMemberOrFunctionOrValue"
+
+module Expressions =
+    [<Test>]
+    let ``Unresolved record field 01`` () =
+        let _, checkResults = getParseAndCheckResults """
+type R1 =
+    { F1: int
+      F2: int }
+
+{ F = 1
+  F2 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -479,12 +479,90 @@ module Expressions =
     [<Test>]
     let ``Unresolved record field 01`` () =
         let _, checkResults = getParseAndCheckResults """
-type R1 =
+type R =
     { F1: int
       F2: int }
 
 { F = 1
   F2 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 02`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+{ F1 = 1
+  R.F2 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 03`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+{ R.F2 = 1
+  F1 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 04`` () =
+        let _, checkResults = getParseAndCheckResults """
+type R =
+    { F1: int
+      F2: int }
+
+match Unchecked.defaultof<R> with
+{ F = 1
+  F2 = 1 } -> ()
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 05`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+match Unchecked.defaultof<R> with
+{ F = 1
+  R.F2 = 1 } -> ()
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+
+    [<Test>]
+    let ``Unresolved record field 06`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+match Unchecked.defaultof<R> with
+{ R.F2 = 1
+  F = 1 } -> ()
 """
         getSymbolUses checkResults
         |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")


### PR DESCRIPTION
```fsharp
type R1 =
    { F1: int
      F2: int }

{ F = 1
  F2 = 1 }
```

Before, no analysis of subsequent fields:

<img width="403" alt="Screenshot 2023-05-11 at 15 08 47" src="https://github.com/dotnet/fsharp/assets/3923587/71122195-d9a3-42be-bd43-6534e9a9700a">


After, unknown fields are skipped, an additional error is reported (enabling the IDE quick fix):

<img width="447" alt="Screenshot 2023-05-11 at 15 08 40" src="https://github.com/dotnet/fsharp/assets/3923587/c386465a-5940-4554-8b46-38f62927cadc">


Or even like this:

<img width="474" alt="Screenshot 2023-05-11 at 16 22 07" src="https://github.com/dotnet/fsharp/assets/3923587/c9ac9a92-2c4e-4d59-b86b-caf018396f55">
