### PR TITLE
Add ref assemblies to fsharp.compiler.service packae

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -152,4 +152,17 @@
     </PropertyGroup>
   </Target>
 
+  <!-- https://learn.microsoft.com/en-us/nuget/create-packages/select-assemblies-referenced-by-projects#packagereference-support -->
+  <PropertyGroup Condition="'$(AddReferenceAssembliesToNugetPackage)' == 'true'">
+    <NoWarn>$(NoWarn),NU5131</NoWarn>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRefAssemblyToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <Target Name="AddRefAssemblyToPackage">
+    <!-- Add reference assembly and XML documentation to 'ref/'. -->
+    <ItemGroup Condition=" Exists('$(BaseOutputPath)$(Configuration)\$(TargetFramework)\ref\$(AssemblyName).dll') ">
+      <TfmSpecificPackageFile Include="$(BaseOutputPath)$(Configuration)\$(TargetFramework)\ref\$(AssemblyName).dll" PackagePath="ref/$(TargetFramework)" />
+      <TfmSpecificPackageFile Include="$(BaseOutputPath)$(Configuration)\$(TargetFramework)\$(AssemblyName).xml" PackagePath="ref/$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/buildtools/AssemblyCheck/AssemblyCheck.fs
+++ b/buildtools/AssemblyCheck/AssemblyCheck.fs
@@ -31,7 +31,10 @@ module AssemblyCheck =
             | :? System.BadImageFormatException -> false       // uninterested in embedded pdbs for native dlls
 
         if isManagedDll then
-            if skipVerifyEmbeddedPdb.Contains(Path.GetFileName(filename).ToUpperInvariant()) then
+            if filename.Contains(Path.Combine("\\ref\\", Path.GetFileName(filename)), StringComparison.InvariantCultureIgnoreCase) then
+                // reference assemblies do not require embedded pdbs
+                true
+            elif skipVerifyEmbeddedPdb.Contains(Path.GetFileName(filename).ToUpperInvariant()) then
                 true
             else
                 use fileStream = File.OpenRead(filename)

--- a/buildtools/AssemblyCheck/SkipVerifyEmbeddedPdb.txt
+++ b/buildtools/AssemblyCheck/SkipVerifyEmbeddedPdb.txt
@@ -8,3 +8,5 @@ FSharp.Compiler.Service.Tests.dll
 FSharp.Compiler.UnitTests.dll
 FSharp.Core.UnitTests.dll
 FSharpSuite.Tests.dll
+ref\FSharp.Compiler.Service.dll
+ref\FSharp.DependencyManager.Nuget.dll

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -25,6 +25,10 @@
     <FsYaccOutputFolder>$(IntermediateOutputPath)$(TargetFramework)\</FsYaccOutputFolder>
     <FsLexOutputFolder>$(IntermediateOutputPath)$(TargetFramework)\</FsLexOutputFolder>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <!--  Add reference assemblies to the nuget package -->
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <AddReferenceAssembliesToNugetPackage>true</AddReferenceAssembliesToNugetPackage>
   </PropertyGroup>
 
   <!--  The FSharp.Compiler.Service dll provides a referencable public interface for tool builders -->

--- a/src/Compiler/FSharp.Compiler.Service.nuspec
+++ b/src/Compiler/FSharp.Compiler.Service.nuspec
@@ -19,6 +19,7 @@
     <files>
         $CommonFileElements$
 
+        <!-- Implementation -->
         <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.dll"                              target="lib\netstandard2.0" />
         <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.xml"                              target="lib\netstandard2.0" />
 
@@ -26,6 +27,13 @@
         <file src="FSharp.DependencyManager.Nuget\$Configuration$\netstandard2.0\FSharp.DependencyManager.Nuget.xml"                target="lib\netstandard2.0" />
 
         <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\default.win32manifest"                                    target="lib\netstandard2.0" />
+
+        <!-- reference assemblies -->
+        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\ref\FSharp.Compiler.Service.dll"                          target="ref\netstandard2.0" />
+        <file src="FSharp.Compiler.Service\$Configuration$\netstandard2.0\FSharp.Compiler.Service.xml"                              target="ref\netstandard2.0" />
+
+        <file src="FSharp.DependencyManager.Nuget\$Configuration$\netstandard2.0\ref\FSharp.DependencyManager.Nuget.dll"            target="ref\netstandard2.0" />
+        <file src="FSharp.DependencyManager.Nuget\$Configuration$\netstandard2.0\FSharp.DependencyManager.Nuget.xml"                target="ref\netstandard2.0" />
 
 
         <!-- resources -->

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
@@ -10,6 +10,11 @@
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
+
+    <!--  Add reference assemblies to the nuget package -->
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <AddReferenceAssembliesToNugetPackage>true</AddReferenceAssembliesToNugetPackage>
   </PropertyGroup>
 
   <!--  The FSharp.DependencyManager.Nuget dll does not provide a referencable public interface although it's used for testing -->


### PR DESCRIPTION
Here is a proposal to add ref assemblies to the fsharp.compiler.service nuget package.

The reference assembly for FSharp.Compiler.Service is almost 11 MB, the implementation is 18 MB.

The nuget package download size raises from: 8,021 KB   to: 11,019 KB

Size on disk raises from: 24.0 MB (25,214,976 bytes)  to:  36.2 MB (38,035,456 bytes)