### PR TITLE
Add signature files for *.fsy generated files

### DIFF
--- a/buildtools/fsyacc/fsyacc.fs
+++ b/buildtools/fsyacc/fsyacc.fs
@@ -22,6 +22,7 @@ let mutable light = None
 let mutable inputCodePage = None
 let mutable lexlib = "FSharp.Text.Lexing"
 let mutable parslib = "FSharp.Text.Parsing"
+let mutable bufferTypeArgument = "'cty"
 
 let usage =
   [ ArgInfo("-o", ArgType.String (fun s -> out <- Some s), "Name the output file.");
@@ -35,7 +36,8 @@ let usage =
     ArgInfo("--tokens", ArgType.Unit (fun _ -> tokenize <- true), "Simply tokenize the specification file itself."); 
     ArgInfo("--lexlib", ArgType.String (fun s ->  lexlib <- s), "Specify the namespace for the implementation of the lexer (default: FSharp.Text.Lexing)");
     ArgInfo("--parslib", ArgType.String (fun s ->  parslib <- s), "Specify the namespace for the implementation of the parser table interpreter (default: FSharp.Text.Parsing)");
-    ArgInfo("--codepage", ArgType.Int (fun i -> inputCodePage <- Some i), "Assume input lexer specification file is encoded with the given codepage.");  ]
+    ArgInfo("--codepage", ArgType.Int (fun i -> inputCodePage <- Some i), "Assume input lexer specification file is encoded with the given codepage.")
+    ArgInfo("--buffer-type-argument", ArgType.String (fun s -> bufferTypeArgument <- s), "Generic type argument of the LexBuffer type."); ]
 
 let _ = ArgParser.Parse(usage,(fun x -> match input with Some _ -> failwith "more than one input given" | None -> input <- Some x),"fsyacc <filename>")
 
@@ -77,7 +79,8 @@ let main() =
           opens = opens
           lexlib = lexlib
           parslib = parslib
-          compat = compat }
+          compat = compat
+          bufferTypeArgument = bufferTypeArgument }
   writeSpecToFile generatorState spec compiledSpec
 
 let result = 

--- a/buildtools/fsyacc/fsyaccdriver.fs
+++ b/buildtools/fsyacc/fsyaccdriver.fs
@@ -157,7 +157,8 @@ type GeneratorState =
    compat: bool
    generate_nonterminal_name: Identifier -> string
    map_action_to_int: Action -> int
-   anyMarker: int }
+   anyMarker: int
+   bufferTypeArgument: string }
    with 
    static member Default = 
     {  input = ""
@@ -172,7 +173,8 @@ type GeneratorState =
        compat = false
        generate_nonterminal_name = generic_nt_name
        map_action_to_int = actionCoding
-       anyMarker = anyMarker }
+       anyMarker = anyMarker
+       bufferTypeArgument = "'cty" }
 
 let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compiledSpec: CompiledSpec) = 
       let output, outputi = deriveOutputFileNames (generatorState.input, generatorState.output)
@@ -299,8 +301,6 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
             id
             (match typ with Some _ -> "_fsyacc_x" | None -> "")
             (match typ with Some _ -> "Microsoft.FSharp.Core.Operators.box _fsyacc_x" | None -> "(null : System.Object)")
-
-      let tychar = "'cty" 
 
       for key,_ in spec.Types |> Seq.countBy fst |> Seq.filter (fun (_,n) -> n > 1)  do
             failwithf "%s is given multiple %%type declarations" key;
@@ -539,7 +539,7 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
           if not (types.ContainsKey id) then 
             failwith ("a %type declaration is required for start token "+id);
           let ty = types.[id] in 
-          writer.WriteLineInterface "val %s : (%s.LexBuffer<%s> -> token) -> %s.LexBuffer<%s> -> (%s) " id generatorState.lexlib tychar generatorState.lexlib tychar ty;
+          writer.WriteLineInterface "val %s : (%s.LexBuffer<%s> -> token) -> %s.LexBuffer<%s> -> (%s) " id generatorState.lexlib generatorState.bufferTypeArgument generatorState.lexlib generatorState.bufferTypeArgument ty;
 
 
 let compileSpec (spec: ParserSpec) (logger: Logger) = 

--- a/src/Compiler/AbstractIL/ilpars.fsy
+++ b/src/Compiler/AbstractIL/ilpars.fsy
@@ -4,21 +4,7 @@
 
 #nowarn "1182"  // the generated code often has unused variable "parseState"
 
-open Internal.Utilities
 open Internal.Utilities.Library
-open Internal.Utilities.Text
-
-open FSharp.Compiler.AbstractIL 
-open FSharp.Compiler.AbstractIL 
-open FSharp.Compiler.AbstractIL.AsciiConstants 
-open FSharp.Compiler.AbstractIL.Diagnostics 
-open FSharp.Compiler.AbstractIL.ILX.Types 
-open FSharp.Compiler.AbstractIL.IL 
-
-  
-let pfailwith s = 
-    stderr.WriteLine ("*** error: "+s); 
-    raise Parsing.RecoverableParseError 
 
 type ResolvedAtMethodSpecScope<'T> = 
     ResolvedAtMethodSpecScope of (ILGenericParameterDefs -> 'T)

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -161,7 +161,7 @@
       <Link>AbstractIL\illex.fsl</Link>
     </None>
     <FsYacc Include="AbstractIL\ilpars.fsy">
-      <OtherFlags>--module FSharp.Compiler.AbstractIL.AsciiParser --open FSharp.Compiler.AbstractIL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+      <OtherFlags>--module FSharp.Compiler.AbstractIL.AsciiParser --open FSharp.Compiler.AbstractIL.AsciiConstants --open FSharp.Compiler.AbstractIL.IL --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>AbstractIL\ilpars.fsy</Link>
     </FsYacc>
     <None Include="AbstractIL\ilpars.fsy">
@@ -173,6 +173,9 @@
     <Compile Include="AbstractIL\ilx.fs" />
     <Compile Include="AbstractIL\ilascii.fsi" />
     <Compile Include="AbstractIL\ilascii.fs" />
+    <Compile Include="$(FsYaccOutputFolder)ilpars.fsi">
+      <Link>AbstractIL\FsYaccOut\ilpars.fsi</Link>
+    </Compile>
     <Compile Include="$(FsYaccOutputFolder)ilpars.fs">
       <Link>AbstractIL\FsYaccOut\ilpars.fs</Link>
     </Compile>
@@ -206,7 +209,7 @@
       <Link>SyntaxTree\pplex.fsl</Link>
     </FsLex>
     <FsYacc Include="pppars.fsy">
-      <OtherFlags>--module FSharp.Compiler.PPParser --open FSharp.Compiler --open FSharp.Compiler.Syntax --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+      <OtherFlags>--module FSharp.Compiler.PPParser --open FSharp.Compiler.ParseHelpers --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>SyntaxTree\pppars.fsy</Link>
     </FsYacc>
     <FsLex Include="lex.fsl">
@@ -214,7 +217,7 @@
       <Link>SyntaxTree\lex.fsl</Link>
     </FsLex>
     <FsYacc Include="pars.fsy">
-      <OtherFlags>-v --module FSharp.Compiler.Parser --open FSharp.Compiler --open FSharp.Compiler.Syntax --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing</OtherFlags>
+      <OtherFlags>-v --module FSharp.Compiler.Parser --open FSharp.Compiler --open FSharp.Compiler.Syntax --open FSharp.Compiler.Text --internal --lexlib Internal.Utilities.Text.Lexing --parslib Internal.Utilities.Text.Parsing --buffer-type-argument char</OtherFlags>
       <Link>SyntaxTree\pars.fsy</Link>
     </FsYacc>
     <None Include="pplex.fsl">
@@ -241,8 +244,14 @@
     <Compile Include="SyntaxTree\SyntaxTreeOps.fs" />
     <Compile Include="SyntaxTree\ParseHelpers.fsi" />
     <Compile Include="SyntaxTree\ParseHelpers.fs" />
+    <Compile Include="$(FsYaccOutputFolder)pppars.fsi">
+      <Link>SyntaxTree\FsYaccOutput\pppars.fsi</Link>
+    </Compile>
     <Compile Include="$(FsYaccOutputFolder)pppars.fs">
       <Link>SyntaxTree\FsYaccOutput\pppars.fs</Link>
+    </Compile>
+    <Compile Include="$(FsYaccOutputFolder)pars.fsi">
+      <Link>SyntaxTree\FsYaccOutput\pars.fsi</Link>
     </Compile>
     <Compile Include="$(FsYaccOutputFolder)pars.fs">
       <Link>SyntaxTree\FsYaccOutput\pars.fs</Link>

--- a/src/Compiler/pppars.fsy
+++ b/src/Compiler/pppars.fsy
@@ -2,8 +2,6 @@
 
 %{
 open FSharp.Compiler.DiagnosticsLogger
-open FSharp.Compiler.ParseHelpers
-open FSharp.Compiler.Syntax
 
 let dummy       = IfdefId("DUMMY")
 


### PR DESCRIPTION
See https://github.com/fsprojects/FsLexYacc/pull/169, this allows us to use the generated signature files for `*.fsy` files.

Before:
```fsharp
--------------------------------------------------------------------------------------------------------
|Phase name                          |Elapsed |Duration| WS(MB)|  GC0  |  GC1  |  GC2  |Handles|Threads|
|------------------------------------|--------|--------|-------|-------|-------|-------|-------|-------|
|>Import mscorlib+FSharp.Core        |  0.1558|  0.1490|    116|      0|      0|      0|    282|     31|
|>Parse inputs                       |  0.5934|  0.4301|    653|      2|      1|      1|    426|     69|
|>Import non-system references       |  0.5975|  0.0015|    654|      0|      0|      0|    426|     69|
|>Typecheck                          |  4.3299|  3.7303|   4018|      5|      3|      1|    431|     70|
```

After:
```fsharp
--------------------------------------------------------------------------------------------------------
|Phase name                          |Elapsed |Duration| WS(MB)|  GC0  |  GC1  |  GC2  |Handles|Threads|
|------------------------------------|--------|--------|-------|-------|-------|-------|-------|-------|
|Import mscorlib+FSharp.Core         |  0.1545|  0.1503|    115|      0|      0|      0|    265|     28|
|Parse inputs                        |  0.5886|  0.4287|    654|      2|      1|      1|    424|     69|
|Import non-system references        |  0.5928|  0.0015|    654|      0|      0|      0|    424|     69|
|Typecheck                           |  4.0155|  3.4205|   4276|      4|      3|      1|    891|     70|
```

![image](https://github.com/dotnet/fsharp/assets/2621499/71ca7d81-08d1-417f-b8ef-51bbba91e897)
