### PR TITLE
Local activity tracing for tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,7 +97,7 @@
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
-    <SystemDiagnosticsDiagnosticSourceVersion>6.0.0</SystemDiagnosticsDiagnosticSourceVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>7.0.0</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -66,7 +66,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)"  GeneratePathProperty="true" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)">
@@ -78,6 +78,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
     <PackageReference Include="Microsoft.NETCore.App.Ref" Version="6.0.0" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -106,7 +107,5 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
-
-  <ItemGroup />
 
 </Project>


### PR DESCRIPTION
This change makes it easy to see Activity traces when locally running tests or benchmarks with `ProjectGeneration`. 

1. [Start Jaeger `all-in-one`](https://www.jaegertracing.io/docs/1.45/getting-started/#all-in-one) either with docker or from a [binary distribution](https://www.jaegertracing.io/download/)
2. Run a test or benchmark that uses [`ProjectWorkflowBuilder`](https://github.com/dotnet/fsharp/blob/e267bb9f8d590feed1b94b469d78cfce61afecad/tests/FSharp.Test.Utilities/ProjectGeneration.fs#LL535C3-L535C3) (e.g. [these](https://github.com/dotnet/fsharp/blob/e267bb9f8d590feed1b94b469d78cfce61afecad/tests/FSharp.Compiler.ComponentTests/FSharpChecker/CommonWorkflows.fs))
3. Open [localhost:16686](http://localhost:16686)
4. Select **F#** service and hit **Find Traces**

Examples:
![image](https://github.com/dotnet/fsharp/assets/217092/415e9fc3-b043-4020-941f-988d67eba70f)

![image](https://github.com/dotnet/fsharp/assets/217092/8de9325d-a8a7-4ed5-9fdf-3db0c2e67cb7)

