### PR TITLE
Fix intellisense in WebApi projects

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -12,7 +12,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-   <PropertyGroup>
+  <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
@@ -35,6 +35,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
   </PropertyGroup>
 
   <PropertyGroup>
+    <Language>F#</Language>                                                                                                                         <!-- It's an F# Language project -->
     <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{F2A71F9B-5D33-465A-A702-920D77279786}</DefaultProjectTypeGuid>         <!-- F# project type -->
     <Prefer32Bit Condition="'$(Prefer32Bit)' == '' ">false</Prefer32Bit>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == '' ">false</TreatWarningsAsErrors>


### PR DESCRIPTION
The GitTool.Version  nuget package sets the language version to C# if it hasn't been set ... 
https://github.com/GitTools/GitVersion/blob/28ce1b4f5ea8d1337485b8ca9d01c80fb4c94e6d/src/GitVersion.MsBuild/msbuild/tools/GitVersion.MsBuild.props#L7

This breaks the design time build because now it thinks it's handling C# files and so calls build targets that aren't even loaded in an F# design time build.  This change allows us to specify that it is an F# project at our first chance, w/o fixing in the dotnet sdk itself, because afer all if it is loading F# props and targets, it for sure is an F# project.

It would be good, if the owners of Gittool.Version could properly fix their package, to not set the Language property, they can always update their code to handle a not set Language, without impacting all subsequent imported props and targets.

Error:
![image](https://github.com/dotnet/fsharp/assets/5175830/8e0089c6-f66d-4194-94a0-ab32e92642ee)

Fixed:
![image](https://github.com/dotnet/fsharp/assets/5175830/ea022edf-22de-4f28-93e7-5549ec8ad9d3)
