### PR TITLE
Parser: fix tree nodes in 'if' expression recovery rules

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3734,7 +3734,8 @@ declExpr:
         $3 $2 mIf false }
 
   | IF declExpr recover %prec expr_if
-      { let ifExpr = $2
+      { errorR (Error(FSComp.SR.parsIncompleteIf (), rhs parseState 1))
+        let ifExpr = $2
         let mIf = rhs parseState 1
         let mThen = ifExpr.Range.EndRange
         let m = unionRanges mIf mThen
@@ -3743,7 +3744,8 @@ declExpr:
         SynExpr.IfThenElse($2, arbExpr ("if1", mThen), None, spIfToThen, true, m, trivia) }
 
   | IF recover %prec expr_if
-      { let m = rhs parseState 1
+      { errorR (Error(FSComp.SR.parsIncompleteIf (), rhs parseState 1))
+        let m = rhs parseState 1
         let mEnd = m.EndRange
         let spIfToThen = DebugPointAtBinding.Yes mEnd
         let trivia = { IfKeyword = m; IsElif = false; ThenKeyword = m; ElseKeyword = None; IfToThenRange = m }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3734,22 +3734,20 @@ declExpr:
         $3 $2 mIf false }
 
   | IF declExpr recover %prec expr_if
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIncompleteIf())
-        // Produce an approximate expression during error recovery.
-        // Include expressions to make sure they get type checked in case that generates useful results for intellisense.
-        // Generate a throwAway for the expression so it isn't forced to have a type 'bool'
-        // from the context it is used in.
-        exprFromParseError $2 }
+      { let ifExpr = $2
+        let mIf = rhs parseState 1
+        let mThen = ifExpr.Range.EndRange
+        let m = unionRanges mIf mThen
+        let spIfToThen = DebugPointAtBinding.Yes m
+        let trivia = { IfKeyword = mIf; IsElif = false; ThenKeyword = mThen; ElseKeyword = None; IfToThenRange = m }
+        SynExpr.IfThenElse($2, arbExpr ("if1", mThen), None, spIfToThen, true, m, trivia) }
 
   | IF recover %prec expr_if
-      { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIncompleteIf())
-        // Produce an approximate expression during error recovery. There can still be value in doing this even
-        // for this pathological case.
-        let m = rhs parseState 1
+      { let m = rhs parseState 1
         let mEnd = m.EndRange
         let spIfToThen = DebugPointAtBinding.Yes mEnd
         let trivia = { IfKeyword = m; IsElif = false; ThenKeyword = m; ElseKeyword = None; IfToThenRange = m }
-        exprFromParseError (SynExpr.IfThenElse(arbExpr ("ifGuard1", mEnd), arbExpr ("thenBody1", mEnd), None, spIfToThen, true, m, trivia)) }
+        SynExpr.IfThenElse(arbExpr ("if2", mEnd), arbExpr ("if3", mEnd), None, spIfToThen, true, m, trivia) }
 
   | LAZY declExpr %prec expr_lazy
       { SynExpr.Lazy($2, unionRanges (rhs parseState 1) $2.Range) }
@@ -4320,12 +4318,24 @@ ifExprThen:
   | THEN declExpr %prec prec_then_if
       { $2, rhs parseState 1 }
 
+  | THEN recover %prec prec_then_if
+      { let mThen = rhs parseState 1
+        arbExpr ("ifThen1", mThen.EndRange), mThen }
+
   | OTHEN OBLOCKBEGIN typedSequentialExpr oblockend %prec prec_then_if
       { $3, rhs parseState 1 }
 
   | OTHEN OBLOCKBEGIN typedSequentialExpr recover %prec prec_then_if
       { if not $4 then reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsUnexpectedEndOfFileThen())
         exprFromParseError $3, rhs parseState 1 }
+
+  | OTHEN recover %prec prec_then_if
+      { let mThen = rhs parseState 1
+        arbExpr ("ifThen2", mThen.EndRange), mThen }
+
+  | OTHEN OBLOCKBEGIN recover %prec prec_then_if
+      { let mThen = rhs parseState 1
+        arbExpr ("ifThen3", mThen.EndRange), mThen }
 
 ifExprElifs:
   | /* EMPTY */

--- a/tests/service/data/SyntaxTree/Expression/If 01.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+if true then ()

--- a/tests/service/data/SyntaxTree/Expression/If 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 01.fs.bsl
@@ -1,0 +1,18 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (IfThenElse
+                (Const (Bool true, (3,3--3,7)), Const (Unit, (3,13--3,15)), None,
+                 Yes (3,0--3,12), false, (3,0--3,15),
+                 { IfKeyword = (3,0--3,2)
+                   IsElif = false
+                   ThenKeyword = (3,8--3,12)
+                   ElseKeyword = None
+                   IfToThenRange = (3,0--3,12) }), (3,0--3,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/If 02.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+if true then () else ()

--- a/tests/service/data/SyntaxTree/Expression/If 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 02.fs.bsl
@@ -1,0 +1,18 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (IfThenElse
+                (Const (Bool true, (3,3--3,7)), Const (Unit, (3,13--3,15)),
+                 Some (Const (Unit, (3,21--3,23))), Yes (3,0--3,12), false,
+                 (3,0--3,23), { IfKeyword = (3,0--3,2)
+                                IsElif = false
+                                ThenKeyword = (3,8--3,12)
+                                ElseKeyword = Some (3,16--3,20)
+                                IfToThenRange = (3,0--3,12) }), (3,0--3,23))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,23), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/If 03.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 03.fs
@@ -1,0 +1,5 @@
+module Module
+
+if true
+
+()

--- a/tests/service/data/SyntaxTree/Expression/If 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 03.fs.bsl
@@ -19,3 +19,4 @@ ImplFile
         CodeComments = [] }, set []))
 
 (3,8)-(5,0) parse error Incomplete structured construct at or before this point in expression
+(3,0)-(3,2) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.

--- a/tests/service/data/SyntaxTree/Expression/If 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 03.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (IfThenElse
+                (Const (Bool true, (3,3--3,7)),
+                 ArbitraryAfterError ("if1", (3,7--3,7)), None, Yes (3,0--3,7),
+                 true, (3,0--3,7), { IfKeyword = (3,0--3,2)
+                                     IsElif = false
+                                     ThenKeyword = (3,7--3,7)
+                                     ElseKeyword = None
+                                     IfToThenRange = (3,0--3,7) }), (3,0--3,7));
+           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,8)-(5,0) parse error Incomplete structured construct at or before this point in expression

--- a/tests/service/data/SyntaxTree/Expression/If 04.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 04.fs
@@ -1,0 +1,5 @@
+module Module
+
+if
+
+()

--- a/tests/service/data/SyntaxTree/Expression/If 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 04.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (IfThenElse
+                (ArbitraryAfterError ("if2", (3,2--3,2)),
+                 ArbitraryAfterError ("if3", (3,2--3,2)), None, Yes (3,2--3,2),
+                 true, (3,0--3,2), { IfKeyword = (3,0--3,2)
+                                     IsElif = false
+                                     ThenKeyword = (3,0--3,2)
+                                     ElseKeyword = None
+                                     IfToThenRange = (3,0--3,2) }), (3,0--3,2));
+           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,3)-(5,0) parse error Incomplete structured construct at or before this point in expression

--- a/tests/service/data/SyntaxTree/Expression/If 05.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 05.fs
@@ -1,0 +1,5 @@
+module Module
+
+if true then
+
+()

--- a/tests/service/data/SyntaxTree/Expression/If 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 05.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (IfThenElse
+                (Const (Bool true, (3,3--3,7)), Const (Unit, (5,0--5,2)), None,
+                 Yes (3,0--3,12), false, (3,0--5,2),
+                 { IfKeyword = (3,0--3,2)
+                   IsElif = false
+                   ThenKeyword = (3,8--3,12)
+                   ElseKeyword = None
+                   IfToThenRange = (3,0--3,12) }), (3,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,1) parse warning Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.
+(5,0)-(5,1) parse warning Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.

--- a/tests/service/data/SyntaxTree/Expression/If 06.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if true then
+
+open global

--- a/tests/service/data/SyntaxTree/Expression/If 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 06.fs.bsl
@@ -1,0 +1,26 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (IfThenElse
+                   (Const (Bool true, (4,7--4,11)),
+                    ArbitraryAfterError ("ifThen3", (4,16--4,16)), None,
+                    Yes (4,4--4,16), false, (4,4--4,16),
+                    { IfKeyword = (4,4--4,6)
+                      IsElif = false
+                      ThenKeyword = (4,12--4,16)
+                      ElseKeyword = None
+                      IfToThenRange = (4,4--4,16) }), (3,0--4,16)), (3,0--4,16))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,16), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,4) parse warning Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,4) parse warning Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,4) parse error Unexpected keyword 'open' in if/then/else expression
+(7,0)-(7,0) parse error Incomplete structured construct at or before this point in definition. Expected incomplete structured construct at or before this point or other token.
+(7,0)-(7,0) parse error Incomplete structured construct at or before this point in implementation file

--- a/tests/service/data/SyntaxTree/Expression/If 07.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 07.fs
@@ -1,0 +1,3 @@
+module Module
+
+if

--- a/tests/service/data/SyntaxTree/Expression/If 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 07.fs.bsl
@@ -1,6 +1,6 @@
 ImplFile
   (ParsedImplFileInput
-     ("/root/Expression/If 04.fs", false, QualifiedNameOfFile Module, [], [],
+     ("/root/Expression/If 07.fs", false, QualifiedNameOfFile Module, [], [],
       [SynModuleOrNamespace
          ([Module], false, NamedModule,
           [Expr
@@ -11,12 +11,11 @@ ImplFile
                                      IsElif = false
                                      ThenKeyword = (3,0--3,2)
                                      ElseKeyword = None
-                                     IfToThenRange = (3,0--3,2) }), (3,0--3,2));
-           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+                                     IfToThenRange = (3,0--3,2) }), (3,0--3,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
-          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+          (1,0--3,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,3)-(5,0) parse error Incomplete structured construct at or before this point in expression
+(4,0)-(4,0) parse error Incomplete structured construct at or before this point in expression
 (3,0)-(3,2) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.


### PR DESCRIPTION
Previously `if` expression recovery would allow the parser to continue on error but wouldn't produce `if` tree nodes. This PR fixes it by making the produced nodes similar to other places where recovery has been added recently and by producing the desired nodes.

The main case it covers is missing `then` and other nodes:
```fsharp
if true
```