### PR TITLE
Fix15254

### DIFF
--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -1561,7 +1561,7 @@ namespace Microsoft.FSharp.Core
             // and devirtualizes calls to it based on "T".
             let GenericEqualityERIntrinsic (x : 'T) (y : 'T) : bool =
                 GenericEqualityObj true fsEqualityComparerNoHashingER ((box x), (box y))
-                
+
             /// Implements generic equality between two values using "comp" for recursive calls.
             //
             // The compiler optimizer is aware of this function  (see use of generic_equality_withc_inner_vref in opt.fs)
@@ -1621,13 +1621,14 @@ namespace Microsoft.FSharp.Core
                   when 'T : float   = (# "ceq" x y : bool #)
                   when 'T : float32 = (# "ceq" x y : bool #)
                   when 'T : char    = (# "ceq" x y : bool #)
+                  when 'T : voidptr = (# "ceq" x y : bool #)
                   when 'T : nativeint  = (# "ceq" x y : bool #)
                   when 'T : unativeint  = (# "ceq" x y : bool #)
                   when 'T : string  = System.String.Equals((# "" x : string #),(# "" y : string #))
                   when 'T : decimal = System.Decimal.op_Equality((# "" x:decimal #), (# "" y:decimal #))
                   when 'T : DateTime = DateTime.Equals((# "" x : DateTime #), (# "" y : DateTime #))
-    
-                  
+
+
             /// A compiler intrinsic generated during optimization of calls to GenericEqualityIntrinsic on tuple values.
             //
             // If no static optimization applies, this becomes GenericEqualityIntrinsic.
@@ -1646,9 +1647,10 @@ namespace Microsoft.FSharp.Core
                   when 'T : uint16  = (# "ceq" x y : bool #)
                   when 'T : uint32  = (# "ceq" x y : bool #)
                   when 'T : uint64  = (# "ceq" x y : bool #)
-                  when 'T : float   = (# "ceq" x y : bool #)        
-                  when 'T : float32 = (# "ceq" x y : bool #)          
+                  when 'T : float   = (# "ceq" x y : bool #)
+                  when 'T : float32 = (# "ceq" x y : bool #)
                   when 'T : char    = (# "ceq" x y : bool #)
+                  when 'T : voidptr = (# "ceq" x y : bool #)
                   when 'T : nativeint  = (# "ceq" x y : bool #)
                   when 'T : unativeint  = (# "ceq" x y : bool #)
                   when 'T : string  = System.String.Equals((# "" x : string #),(# "" y : string #))                  

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/GenericComparison.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/GenericComparison.fs
@@ -211,6 +211,16 @@ module GenericComparison =
         compilation
         |> verifyCompilation
 
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"NativeIntComparison.fs"|])>]
+    let ``NativeIntComparison_fs`` compilation =
+        compilation
+        |> asExe
+        |> withOptimize
+        |> withEmbeddedPdb
+        |> withEmbedAllSource
+        |> compileAndRun
+        |> shouldSucceed
+
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"VoidPtrComparison.fs"|])>]
     let ``VoidPtrComparison_fs`` compilation =
         compilation

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/GenericComparison.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/GenericComparison.fs
@@ -210,3 +210,13 @@ module GenericComparison =
     let ``Equals09_fsx`` compilation =
         compilation
         |> verifyCompilation
+
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"VoidPtrComparison.fs"|])>]
+    let ``VoidPtrComparison_fs`` compilation =
+        compilation
+        |> asExe
+        |> withOptimize
+        |> withEmbeddedPdb
+        |> withEmbedAllSource
+        |> compileAndRun
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/NativeIntComparison.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/NativeIntComparison.fs
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/dotnet/fsharp/issues/15254
+#nowarn "52"
+
+open System
+
+let default_nativeint = Unchecked.defaultof<nativeint>
+let intptr_nativeint = IntPtr.Zero
+let isSame = intptr_nativeint = default_nativeint
+
+if not (isSame) then raise (new Exception "default_nativeint and intptr_nativeint compare is incorrect")

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/VoidPtrComparison.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/VoidPtrComparison.fs
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/dotnet/fsharp/issues/15254
+#nowarn "52"
+
+open System
+
+let default_voidptr = Unchecked.defaultof<voidptr>
+let intptr_voidptr = IntPtr.Zero.ToPointer()
+let isSame = intptr_voidptr = default_voidptr
+
+if not (isSame) then raise (new Exception "default_voidptr and intptr_voidptr compare is incorrect")


### PR DESCRIPTION
This issue : https://github.com/dotnet/fsharp/issues/15254

causes a runtime error (BadImageFormatException) when compiling code that relies on generic compare of the voidptr type.

This PR addresses that by updating the GenericEqualityIntrinsic to provide a compare implementation.

Consider examining sorting and hashing to ensure that voidptr is adequately handled. 