### PR TITLE
Fix package build

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -238,8 +238,9 @@ function Update-Arguments() {
     }
 }
 
-function BuildSolution([string] $solutionName) {
-    Write-Host "${solutionName}:"
+
+function BuildSolution([string] $solutionName, $nopack) {
+        Write-Host "${solutionName}:"
 
     $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "Build.$solutionName.binlog") } else { "" }
 
@@ -255,6 +256,8 @@ function BuildSolution([string] $solutionName) {
     $BUILDING_USING_DOTNET_ORIG = $env:BUILDING_USING_DOTNET
 
     $env:BUILDING_USING_DOTNET="false"
+
+    $pack = if ($nopack -eq $False) {""} else {$pack}
 
     MSBuild $toolsetBuildProj `
         $bl `
@@ -536,17 +539,17 @@ try {
     $script:BuildMessage = "Failure building product"
     if ($restore -or $build -or $rebuild -or $pack -or $sign -or $publish -and -not $skipBuild) {
         if ($noVisualStudio) {
-            BuildSolution "FSharp.sln"
+            BuildSolution "FSharp.sln" $False
         }
         else {
-            BuildSolution "VisualFSharp.sln"
+            BuildSolution "VisualFSharp.sln" $False
         }
     }
 
     if ($pack) {
         $properties_storage = $properties
         $properties += "/p:GenerateSbom=false"
-        BuildSolution "Microsoft.FSharp.Compiler.sln"
+        BuildSolution "Microsoft.FSharp.Compiler.sln" $True
         $properties = $properties_storage
     }
     if ($build) {

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -93,7 +93,7 @@
 
   <Target Name="PackDependentProjectsCore">
     <PropertyGroup>
-      <DependentPackagesDir>$([MSBuild]::NormalizeDirectory( '$(ArtifactsDir)', 'packages', '$(Configuration)', 'Dependecies' ))</DependentPackagesDir>
+      <DependentPackagesDir>$([MSBuild]::NormalizeDirectory( '$(ArtifactsDir)', 'packages', '$(Configuration)', 'Dependency' ))</DependentPackagesDir>
     </PropertyGroup>
     <MSBuild Projects="@(DependentProjects)" Targets="Pack" Properties="Restore=true;BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);ArtifactsPackagesDir=$(DependentPackagesDir)" />
   </Target>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -43,9 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DependentProjects Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj">
-        <AdditionalProperties>TargetFrameworks=netstandard2.1;netstandard2.0</AdditionalProperties>
-    </DependentProjects>
     <DependentProjects Include="$(MSBuildThisFileDirectory)..\FSharp.Build\FSharp.Build.fsproj">
         <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
     </DependentProjects>
@@ -54,6 +51,9 @@
     </DependentProjects>
     <DependentProjects Include="$(MSBuildThisFileDirectory)..\FSharp.DependencyManager.Nuget\FSharp.DependencyManager.Nuget.fsproj">
         <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
+    </DependentProjects>
+    <DependentProjects Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj">
+        <AdditionalProperties>TargetFrameworks=netstandard2.1;netstandard2.0</AdditionalProperties>
     </DependentProjects>
     <DependentProjects Include="$(MSBuildThisFileDirectory)..\Compiler\FSharp.Compiler.Service.fsproj">
         <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
@@ -64,13 +64,43 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
 
+  <!--
+     The targets below manages Arcade Release/Shipping nuget package manahement.
+     This is particularly tricky because we generate fsharp.core and fsharp.compiler.service 
+     nupkgs and embedd both the shipping and release nuget packages inside the final 
+     microsoft.fsharp.compiler.nupkg which we insert into the dotnet sdk
+  -->
+  <Target Name="PackageReleaseDependentPackages" AfterTargets="Pack" Condition="'$(DotNetFinalVersionKind)' == ''">
+    <Message Text="Building release versions of NuGet packages" Importance="high" />
+
+    <Error Text="PreReleaseVersionLabel must be non-empty when using NuGet Repack tool." Condition="'$(PreReleaseVersionLabel)' == ''" />
+    
+    <ItemGroup>
+      <_BuiltPackages Include="$(DependentPackagesDir)Shipping\*.nupkg" />
+    </ItemGroup>
+
+    <!-- Force references among packages to use exact versions (see https://github.com/NuGet/Home/issues/7213) -->
+    <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="release" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Release" AllowPreReleaseDependencies="true" ExactVersions="true" />
+
+    <!-- Rewrite the version ranges of per-build pre-release packages (see https://github.com/NuGet/Home/issues/7213) -->
+    <Microsoft.DotNet.Tools.UpdatePackageVersionTask Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Shipping" ExactVersions="true"/>
+  </Target>
+
+  <Target Name="PackageReleasePackages" AfterTargets="Pack" Condition="'$(DotNetFinalVersionKind)' == ''">
+    <!-- override sdk PackageReleasePackages to do nothing. -->
+  </Target>
+
+
   <Target Name="PackDependentProjectsCore">
-    <MSBuild Projects="@(DependentProjects)" Targets="Pack" Properties="Restore=true;Pack=true;BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN)" />
+    <PropertyGroup>
+      <DependentPackagesDir>$([MSBuild]::NormalizeDirectory( '$(ArtifactsDir)', 'packages', '$(Configuration)', 'Dependecies' ))</DependentPackagesDir>
+    </PropertyGroup>
+    <MSBuild Projects="@(DependentProjects)" Targets="Pack" Properties="Restore=true;BUILD_PUBLICSIGN=$(BUILD_PUBLICSIGN);ArtifactsPackagesDir=$(DependentPackagesDir)" />
   </Target>
 
   <Target Name="PackDependentProjects"
     BeforeTargets="Build"
-    DependsOnTargets="PackDependentProjectsCore;PackageReleasePackages">
+    DependsOnTargets="PackDependentProjectsCore;PackageReleaseDependentPackages">
   </Target>
 
 </Project>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -33,9 +33,9 @@
         <file src="FSharp.Compiler.Service\ReleaseCompressed\netstandard2.0\FSharp.Compiler.Service.dll"     target="lib\net7.0" />
         <file src="FSharp.Build\ReleaseCompressed\netstandard2.0\FSharp.Build.dll"                           target="lib\net7.0" />
         <file src="FSharp.DependencyManager.Nuget\ReleaseCompressed\netstandard2.0\FSharp.DependencyManager.Nuget.dll"
-                                                                                                           target="lib\net7.0" />
+                                                                                                             target="lib\net7.0" />
         <file src="FSharp.Compiler.Interactive.Settings\ReleaseCompressed\netstandard2.0\FSharp.Compiler.Interactive.Settings.dll"
-                                                                                                           target="lib\net7.0" />
+                                                                                                             target="lib\net7.0" />
 
         <!-- additional files -->
         <file src="FSharp.Compiler.Service\ReleaseCompressed\netstandard2.0\default.win32manifest"           target="contentFiles\any\any" />
@@ -48,21 +48,22 @@
         <!-- resources -->
         <file src="FSharp.Core\ReleaseCompressed\netstandard2.0\**\FSharp.Core.resources.dll"                target="lib\net7.0" />
         <file src="FSharp.Compiler.Service\ReleaseCompressed\netstandard2.0\**\FSharp.Compiler.Service.resources.dll"
-                                                                                                           target="lib\net7.0" />
+                                                                                                             target="lib\net7.0" />
         <file src="FSharp.Compiler.Interactive.Settings\ReleaseCompressed\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"
-                                                                                                           target="lib\net7.0" />
+                                                                                                             target="lib\net7.0" />
         <file src="FSharp.Build\ReleaseCompressed\netstandard2.0\**\FSharp.Build.resources.dll"              target="lib\net7.0" />
         <file src="FSharp.DependencyManager.Nuget\ReleaseCompressed\netstandard2.0\**\FSharp.DependencyManager.Nuget.resources.dll"
-                                                                                                           target="lib\net7.0" />
-        <file src="$artifactsPackagesDir$Dependecies\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"     target="contentFiles\Shipping" />
-        <file src="$artifactsPackagesDir$Dependecies\Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"             target="contentFiles\Release" />
-        <file src="$artifactsPackagesDir$Dependecies\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"
-                                                                                                           target="contentFiles\Shipping" />
-        <file src="$artifactsPackagesDir$Dependecies\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"
-                                                                                                           target="contentFiles\Release" />
+                                                                                                             target="lib\net7.0" />
+        <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"
+                                                                                                             target="contentFiles\Shipping" />
+        <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"    target="contentFiles\Release" />
+        <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"
+                                                                                                             target="contentFiles\Shipping" />
+        <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"
+                                                                                                             target="contentFiles\Release" />
         <file src="FSharp.Build\ReleaseCompressed\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"
-                                                                                                           target="contentFiles\Shipping" />
+                                                                                                             target="contentFiles\Shipping" />
         <file src="FSharp.Build\ReleaseCompressed\netstandard2.0\Release\Microsoft.FSharp.Core.NetSdk.props"
-                                                                                                           target="contentFiles\Release" />
+                                                                                                             target="contentFiles\Release" />
     </files>
 </package>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -54,11 +54,11 @@
         <file src="FSharp.Build\ReleaseCompressed\netstandard2.0\**\FSharp.Build.resources.dll"              target="lib\net7.0" />
         <file src="FSharp.DependencyManager.Nuget\ReleaseCompressed\netstandard2.0\**\FSharp.DependencyManager.Nuget.resources.dll"
                                                                                                            target="lib\net7.0" />
-        <file src="$artifactsPackagesDir$Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"     target="contentFiles\Shipping" />
-        <file src="$artifactsPackagesDir$Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"             target="contentFiles\Release" />
-        <file src="$artifactsPackagesDir$Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"
+        <file src="$artifactsPackagesDir$Dependecies\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"     target="contentFiles\Shipping" />
+        <file src="$artifactsPackagesDir$Dependecies\Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"             target="contentFiles\Release" />
+        <file src="$artifactsPackagesDir$Dependecies\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"
                                                                                                            target="contentFiles\Shipping" />
-        <file src="$artifactsPackagesDir$Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"
+        <file src="$artifactsPackagesDir$Dependecies\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"
                                                                                                            target="contentFiles\Release" />
         <file src="FSharp.Build\ReleaseCompressed\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"
                                                                                                            target="contentFiles\Shipping" />

--- a/tests/AheadOfTime/NuGet.Config
+++ b/tests/AheadOfTime/NuGet.Config
@@ -5,7 +5,7 @@
     </solution>
     <packageSources>
         <clear />
-        <add key="localPackages" value="../../artifacts/packages/Release/Shipping"/>
+        <add key="localPackages" value="../../artifacts/packages/Release/Dependency/Release"/>
         <add key="remote" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     </packageSources>
     <disabledPackageSources>


### PR DESCRIPTION
We don't need to repack the Microsoft.FSharp.Compiler bits.  Following this the bits in the nuget package should be completely identical to the ones alongside the package on disk.

Fixes [15263](https://github.com/dotnet/fsharp/issues/15263)



/cc @mmitche 