### PR TITLE
Make `FSharpReferencedProject` representation public

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -62,20 +62,21 @@ open FSharp.Compiler.AbstractIL.ILBinaryReader
 type FSharpUnresolvedReferencesSet = FSharpUnresolvedReferencesSet of UnresolvedAssemblyReference list
 
 [<Sealed>]
-type internal DelayedILModuleReader =
-
+type DelayedILModuleReader =
     val private name: string
     val private gate: obj
     val mutable private getStream: (CancellationToken -> Stream option)
     val mutable private result: ILModuleReader
 
-    new(name, getStream) =
+    new (name, getStream) =
         {
             name = name
             gate = obj ()
             getStream = getStream
             result = Unchecked.defaultof<_>
         }
+
+    member this.OutputFile = this.name
 
     member this.TryGetILModuleReader() =
         // fast path
@@ -117,23 +118,14 @@ type internal DelayedILModuleReader =
 [<RequireQualifiedAccess; NoComparison; CustomEquality>]
 type FSharpReferencedProject =
     | FSharpReference of projectOutputFile: string * options: FSharpProjectOptions
-    | PEReference of projectOutputFile: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+    | PEReference of getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
     | ILModuleReference of projectOutputFile: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader)
 
     member this.OutputFile =
         match this with
         | FSharpReference (projectOutputFile = projectOutputFile)
-        | PEReference (projectOutputFile = projectOutputFile)
         | ILModuleReference (projectOutputFile = projectOutputFile) -> projectOutputFile
-
-    static member CreateFSharp(projectOutputFile, options) =
-        FSharpReference(projectOutputFile, options)
-
-    static member CreatePortableExecutable(projectOutputFile, getStamp, getStream) =
-        PEReference(projectOutputFile, getStamp, DelayedILModuleReader(projectOutputFile, getStream))
-
-    static member CreateFromILModuleReader(projectOutputFile, getStamp, getReader) =
-        ILModuleReference(projectOutputFile, getStamp, getReader)
+        | PEReference (delayedReader = reader) -> reader.OutputFile
 
     override this.Equals(o) =
         match o with
@@ -141,8 +133,8 @@ type FSharpReferencedProject =
             match this, o with
             | FSharpReference (projectOutputFile1, options1), FSharpReference (projectOutputFile2, options2) ->
                 projectOutputFile1 = projectOutputFile2 && options1 = options2
-            | PEReference (projectOutputFile1, getStamp1, _), PEReference (projectOutputFile2, getStamp2, _) ->
-                projectOutputFile1 = projectOutputFile2 && (getStamp1 ()) = (getStamp2 ())
+            | PEReference (getStamp1, reader1), PEReference (getStamp2, reader2) ->
+                reader1.OutputFile = reader2.OutputFile && (getStamp1 ()) = (getStamp2 ())
             | ILModuleReference (projectOutputFile1, getStamp1, _), ILModuleReference (projectOutputFile2, getStamp2, _) ->
                 projectOutputFile1 = projectOutputFile2 && (getStamp1 ()) = (getStamp2 ())
             | _ -> false
@@ -192,8 +184,8 @@ and FSharpProjectOptions =
                    match r1, r2 with
                    | FSharpReferencedProject.FSharpReference (n1, a), FSharpReferencedProject.FSharpReference (n2, b) ->
                        n1 = n2 && FSharpProjectOptions.AreSameForChecking(a, b)
-                   | FSharpReferencedProject.PEReference (n1, getStamp1, _), FSharpReferencedProject.PEReference (n2, getStamp2, _) ->
-                       n1 = n2 && (getStamp1 ()) = (getStamp2 ())
+                   | FSharpReferencedProject.PEReference (getStamp1, reader1), FSharpReferencedProject.PEReference (getStamp2, reader2) ->
+                       reader1.OutputFile = reader2.OutputFile && (getStamp1 ()) = (getStamp2 ())
                    | _ -> false)
             && options1.LoadTime = options2.LoadTime
 

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -68,7 +68,7 @@ type DelayedILModuleReader =
     val mutable private getStream: (CancellationToken -> Stream option)
     val mutable private result: ILModuleReader
 
-    new (name, getStream) =
+    new(name, getStream) =
         {
             name = name
             gate = obj ()

--- a/src/Compiler/Service/FSharpCheckerResults.fsi
+++ b/src/Compiler/Service/FSharpCheckerResults.fsi
@@ -130,7 +130,6 @@ and [<NoComparison; CustomEquality; RequireQualifiedAccess>] FSharpReferencedPro
     /// </summary>
     member OutputFile: string
 
-
 /// Represents the use of an F# symbol from F# source code
 [<Sealed>]
 type public FSharpSymbolUse =

--- a/src/Compiler/Service/FSharpCheckerResults.fsi
+++ b/src/Compiler/Service/FSharpCheckerResults.fsi
@@ -28,13 +28,15 @@ open FSharp.Compiler.Text
 
 /// Delays the creation of an ILModuleReader
 [<Sealed>]
-type internal DelayedILModuleReader =
+type DelayedILModuleReader =
 
     new: name: string * getStream: (CancellationToken -> Stream option) -> DelayedILModuleReader
 
+    member OutputFile: string
+
     /// Will lazily create the ILModuleReader.
     /// Is only evaluated once and can be called by multiple threads.
-    member TryGetILModuleReader: unit -> Cancellable<ILModuleReader option>
+    member internal TryGetILModuleReader: unit -> Cancellable<ILModuleReader option>
 
 /// <summary>Unused in this API</summary>
 type public FSharpUnresolvedReferencesSet = internal FSharpUnresolvedReferencesSet of UnresolvedAssemblyReference list
@@ -92,10 +94,31 @@ type public FSharpProjectOptions =
     /// Compute the project directory.
     member internal ProjectDirectory: string
 
-and [<NoComparison; CustomEquality>] public FSharpReferencedProject =
-    internal
+and [<NoComparison; CustomEquality; RequireQualifiedAccess>] FSharpReferencedProject =
+
+    /// <summary>
+    /// A reference for an F# project. The physical data for it is stored/cached inside of the compiler service.
+    /// </summary>
+    /// <param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <c>-r</c> reference in the project options for this referenced project.</param>
+    /// <param name="options">The Project Options for this F# project</param>
     | FSharpReference of projectOutputFile: string * options: FSharpProjectOptions
-    | PEReference of projectOutputFile: string * getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+
+    /// <summary>
+    /// A reference for any portable executable, including F#. The stream is owned by this reference.
+    /// The stream will be automatically disposed when there are no references to FSharpReferencedProject and is GC collected.
+    /// Once the stream is evaluated, the function that constructs the stream will no longer be referenced by anything.
+    /// If the stream evaluation throws an exception, it will be automatically handled.
+    /// </summary>
+    /// <param name="getStamp">A function that calculates a last-modified timestamp for this reference. This will be used to determine if the reference is up-to-date.</param>
+    /// <param name="delayedReader">A function that opens a Portable Executable data stream for reading.</param>
+    | PEReference of getStamp: (unit -> DateTime) * delayedReader: DelayedILModuleReader
+
+    /// <summary>
+    /// A reference from an ILModuleReader.
+    /// </summary>
+    /// <param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <c>-r</c> reference in the project options for this referenced project.</param>
+    /// <param name="getStamp">A function that calculates a last-modified timestamp for this reference. This will be used to determine if the reference is up-to-date.</param>
+    /// <param name="getReader">A function that creates an ILModuleReader for reading module data.</param>
     | ILModuleReference of
         projectOutputFile: string *
         getStamp: (unit -> DateTime) *
@@ -107,35 +130,6 @@ and [<NoComparison; CustomEquality>] public FSharpReferencedProject =
     /// </summary>
     member OutputFile: string
 
-    /// <summary>
-    /// Creates a reference for an F# project. The physical data for it is stored/cached inside of the compiler service.
-    /// </summary>
-    /// <param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <c>-r</c> reference in the project options for this referenced project.</param>
-    /// <param name="options">The Project Options for this F# project</param>
-    static member CreateFSharp: projectOutputFile: string * options: FSharpProjectOptions -> FSharpReferencedProject
-
-    /// <summary>
-    /// Creates a reference for any portable executable, including F#. The stream is owned by this reference.
-    /// The stream will be automatically disposed when there are no references to FSharpReferencedProject and is GC collected.
-    /// Once the stream is evaluated, the function that constructs the stream will no longer be referenced by anything.
-    /// If the stream evaluation throws an exception, it will be automatically handled.
-    /// </summary>
-    /// <param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <c>-r</c> reference in the project options for this referenced project.</param>
-    /// <param name="getStamp">A function that calculates a last-modified timestamp for this reference. This will be used to determine if the reference is up-to-date.</param>
-    /// <param name="getStream">A function that opens a Portable Executable data stream for reading.</param>
-    static member CreatePortableExecutable:
-        projectOutputFile: string * getStamp: (unit -> DateTime) * getStream: (CancellationToken -> Stream option) ->
-            FSharpReferencedProject
-
-    /// <summary>
-    /// Creates a reference from an ILModuleReader.
-    /// </summary>
-    /// <param name="projectOutputFile">The fully qualified path to the output of the referenced project. This should be the same value as the <c>-r</c> reference in the project options for this referenced project.</param>
-    /// <param name="getStamp">A function that calculates a last-modified timestamp for this reference. This will be used to determine if the reference is up-to-date.</param>
-    /// <param name="getReader">A function that creates an ILModuleReader for reading module data.</param>
-    static member CreateFromILModuleReader:
-        projectOutputFile: string * getStamp: (unit -> DateTime) * getReader: (unit -> ILModuleReader) ->
-            FSharpReferencedProject
 
 /// Represents the use of an F# symbol from F# source code
 [<Sealed>]

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -254,7 +254,7 @@ type BackgroundCompiler
                             member x.FileName = nm
                         }
 
-                | FSharpReferencedProject.PEReference (nm, getStamp, delayedReader) ->
+                | FSharpReferencedProject.PEReference (getStamp, delayedReader) ->
                     { new IProjectReference with
                         member x.EvaluateRawContents() =
                             node {
@@ -272,7 +272,7 @@ type BackgroundCompiler
                             }
 
                         member x.TryGetLogicalTimeStamp _ = getStamp () |> Some
-                        member x.FileName = nm
+                        member x.FileName = delayedReader.OutputFile
                     }
 
                 | FSharpReferencedProject.ILModuleReference (nm, getStamp, getReader) ->

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -1945,6 +1945,9 @@ FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryRe
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+MetadataOnlyFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+ReduceMemoryFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+Shim
+FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String OutputFile
+FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String get_OutputFile()
+FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
 FSharp.Compiler.CodeAnalysis.DocumentSource+Custom: Microsoft.FSharp.Core.FSharpFunc`2[System.String,Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.ISourceText]]] Item
 FSharp.Compiler.CodeAnalysis.DocumentSource+Custom: Microsoft.FSharp.Core.FSharpFunc`2[System.String,Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.ISourceText]]] get_Item()
 FSharp.Compiler.CodeAnalysis.DocumentSource+Tags: Int32 Custom
@@ -2165,11 +2168,40 @@ FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] SourceFiles
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] get_OtherOptions()
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] get_SourceFiles()
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpOption`1[System.String], System.String[], System.String[], FSharp.Compiler.CodeAnalysis.FSharpReferencedProject[], Boolean, Boolean, System.DateTime, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.CodeAnalysis.FSharpUnresolvedReferencesSet], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Text.Range,System.String,System.String]], Microsoft.FSharp.Core.FSharpOption`1[System.Int64])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: FSharp.Compiler.CodeAnalysis.FSharpProjectOptions get_options()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: FSharp.Compiler.CodeAnalysis.FSharpProjectOptions options
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: System.String get_projectOutputFile()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: System.String projectOutputFile
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader] getReader
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader] get_getReader()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] getStamp
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] get_getStamp()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: System.String get_projectOutputFile()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: System.String projectOutputFile
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: FSharp.Compiler.CodeAnalysis.DelayedILModuleReader delayedReader
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: FSharp.Compiler.CodeAnalysis.DelayedILModuleReader get_delayedReader()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] getStamp
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] get_getStamp()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags: Int32 FSharpReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags: Int32 ILModuleReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags: Int32 PEReference
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean Equals(System.Object)
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFSharp(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions)
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFromILModuleReader(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader])
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean IsFSharpReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean IsILModuleReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean IsPEReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean get_IsFSharpReference()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean get_IsILModuleReference()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean get_IsPEReference()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject NewFSharpReference(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions)
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject NewILModuleReference(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject NewPEReference(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], FSharp.Compiler.CodeAnalysis.DelayedILModuleReader)
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 GetHashCode()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 Tag
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 get_Tag()
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String OutputFile
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String ToString()
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String get_OutputFile()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -1945,6 +1945,9 @@ FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryRe
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+MetadataOnlyFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+ReduceMemoryFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+Shim
+FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String OutputFile
+FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String get_OutputFile()
+FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
 FSharp.Compiler.CodeAnalysis.DocumentSource+Custom: Microsoft.FSharp.Core.FSharpFunc`2[System.String,Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.ISourceText]]] Item
 FSharp.Compiler.CodeAnalysis.DocumentSource+Custom: Microsoft.FSharp.Core.FSharpFunc`2[System.String,Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.ISourceText]]] get_Item()
 FSharp.Compiler.CodeAnalysis.DocumentSource+Tags: Int32 Custom
@@ -2165,11 +2168,40 @@ FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] SourceFiles
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] get_OtherOptions()
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: System.String[] get_SourceFiles()
 FSharp.Compiler.CodeAnalysis.FSharpProjectOptions: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpOption`1[System.String], System.String[], System.String[], FSharp.Compiler.CodeAnalysis.FSharpReferencedProject[], Boolean, Boolean, System.DateTime, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.CodeAnalysis.FSharpUnresolvedReferencesSet], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Text.Range,System.String,System.String]], Microsoft.FSharp.Core.FSharpOption`1[System.Int64])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: FSharp.Compiler.CodeAnalysis.FSharpProjectOptions get_options()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: FSharp.Compiler.CodeAnalysis.FSharpProjectOptions options
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: System.String get_projectOutputFile()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference: System.String projectOutputFile
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader] getReader
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader] get_getReader()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] getStamp
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] get_getStamp()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: System.String get_projectOutputFile()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference: System.String projectOutputFile
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: FSharp.Compiler.CodeAnalysis.DelayedILModuleReader delayedReader
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: FSharp.Compiler.CodeAnalysis.DelayedILModuleReader get_delayedReader()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] getStamp
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference: Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime] get_getStamp()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags: Int32 FSharpReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags: Int32 ILModuleReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags: Int32 PEReference
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean Equals(System.Object)
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFSharp(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions)
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreateFromILModuleReader(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader])
-FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject CreatePortableExecutable(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean IsFSharpReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean IsILModuleReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean IsPEReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean get_IsFSharpReference()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean get_IsILModuleReference()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Boolean get_IsPEReference()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject NewFSharpReference(System.String, FSharp.Compiler.CodeAnalysis.FSharpProjectOptions)
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject NewILModuleReference(System.String, Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,FSharp.Compiler.AbstractIL.ILBinaryReader+ILModuleReader])
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject NewPEReference(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,System.DateTime], FSharp.Compiler.CodeAnalysis.DelayedILModuleReader)
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+FSharpReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+ILModuleReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+PEReference
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: FSharp.Compiler.CodeAnalysis.FSharpReferencedProject+Tags
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 GetHashCode()
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 Tag
+FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: Int32 get_Tag()
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String OutputFile
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String ToString()
 FSharp.Compiler.CodeAnalysis.FSharpReferencedProject: System.String get_OutputFile()

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -167,7 +167,7 @@ type SyntheticProject =
                            yield! this.OtherOptions |]
                     ReferencedProjects =
                         [| for p in this.DependsOn do
-                               FSharpReferencedProject.CreateFSharp(p.OutputFilename, p.GetProjectOptions checker) |]
+                               FSharpReferencedProject.FSharpReference(p.OutputFilename, p.GetProjectOptions checker) |]
                     IsIncompleteTypeCheckEnvironment = false
                     UseScriptResolutionRules = false
                     LoadTime = DateTime()

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/CompilerServiceBenchmarks.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/CompilerServiceBenchmarks.fs
@@ -36,7 +36,7 @@ module private Helpers =
                 Array.append [|"--optimize+"; "--target:library" |] (referencedProjects |> Array.ofList |> Array.map (fun x -> "-r:" + x.ProjectFileName))
             ReferencedProjects =
                 referencedProjects
-                |> List.map (fun x -> FSharpReferencedProject.CreateFSharp (x.ProjectFileName, x))
+                |> List.map (fun x -> FSharpReferencedProject.FSharpReference(x.ProjectFileName, x))
                 |> Array.ofList
             IsIncompleteTypeCheckEnvironment = false
             UseScriptResolutionRules = false

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -43,7 +43,7 @@ namespace CSharpTest
                 |> Some
 
         let stamp = DateTime.UtcNow
-        let csRefProj = FSharpReferencedProject.CreatePortableExecutable("""Z:\csharp_test.dll""", (fun () -> stamp), getStream)
+        let csRefProj = FSharpReferencedProject.PEReference((fun () -> stamp), DelayedILModuleReader("""Z:\csharp_test.dll""", getStream))
 
         let fsOptions = CompilerAssert.DefaultProjectOptions TargetFramework.Current
         let fsOptions =

--- a/tests/service/MultiProjectAnalysisTests.fs
+++ b/tests/service/MultiProjectAnalysisTests.fs
@@ -126,8 +126,8 @@ let u = Case1 3
         let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
         { options with
             OtherOptions = Array.append options.OtherOptions [| ("-r:" + Project1A.dllName); ("-r:" + Project1B.dllName) |]
-            ReferencedProjects = [| FSharpReferencedProject.CreateFSharp(Project1A.dllName, Project1A.options);
-                                    FSharpReferencedProject.CreateFSharp(Project1B.dllName, Project1B.options); |] }
+            ReferencedProjects = [| FSharpReferencedProject.FSharpReference(Project1A.dllName, Project1A.options);
+                                    FSharpReferencedProject.FSharpReference(Project1B.dllName, Project1B.options); |] }
     let cleanFileName a = if a = fileName1 then "file1" else "??"
 
 [<Test>]
@@ -311,7 +311,7 @@ let p = ("""
             let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
             { options with
                 OtherOptions = Array.append options.OtherOptions [| for p in  projects -> ("-r:" + p.DllName) |]
-                ReferencedProjects = [| for p in projects -> FSharpReferencedProject.CreateFSharp(p.DllName, p.Options); |] }
+                ReferencedProjects = [| for p in projects -> FSharpReferencedProject.FSharpReference(p.DllName, p.Options); |] }
         { ModuleName = "JointProject"; FileName=fileName; Options = options; DllName=dllName }
 
     let cleanFileName a =
@@ -429,7 +429,7 @@ let z = Project1.x
         let options = checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
         { options with
             OtherOptions = Array.append options.OtherOptions [| ("-r:" + MultiProjectDirty1.dllName) |]
-            ReferencedProjects = [| FSharpReferencedProject.CreateFSharp(MultiProjectDirty1.dllName, MultiProjectDirty1.getOptions()) |] }
+            ReferencedProjects = [| FSharpReferencedProject.FSharpReference(MultiProjectDirty1.dllName, MultiProjectDirty1.getOptions()) |] }
 
 [<Test>]
 let ``Test multi project symbols should pick up changes in dependent projects`` () =
@@ -639,7 +639,7 @@ let v = Project2A.C().InternalMember // access an internal symbol
         let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
         { options with
             OtherOptions = Array.append options.OtherOptions [| ("-r:" + Project2A.dllName);  |]
-            ReferencedProjects = [| FSharpReferencedProject.CreateFSharp(Project2A.dllName, Project2A.options); |] }
+            ReferencedProjects = [| FSharpReferencedProject.FSharpReference(Project2A.dllName, Project2A.options); |] }
     let cleanFileName a = if a = fileName1 then "file1" else "??"
 
 //Project2A.fileSource1
@@ -663,7 +663,7 @@ let v = Project2A.C().InternalMember // access an internal symbol
         let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
         { options with
             OtherOptions = Array.append options.OtherOptions [| ("-r:" + Project2A.dllName);  |]
-            ReferencedProjects = [| FSharpReferencedProject.CreateFSharp(Project2A.dllName, Project2A.options); |] }
+            ReferencedProjects = [| FSharpReferencedProject.FSharpReference(Project2A.dllName, Project2A.options); |] }
     let cleanFileName a = if a = fileName1 then "file1" else "??"
 
 [<Test>]
@@ -756,7 +756,7 @@ let fizzBuzz = function
         let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
         { options with
             OtherOptions = Array.append options.OtherOptions [| ("-r:" + Project3A.dllName) |]
-            ReferencedProjects = [| FSharpReferencedProject.CreateFSharp(Project3A.dllName, Project3A.options) |] }
+            ReferencedProjects = [| FSharpReferencedProject.FSharpReference(Project3A.dllName, Project3A.options) |] }
     let cleanFileName a = if a = fileName1 then "file1" else "??"
 
 [<Test>]
@@ -880,7 +880,7 @@ let ``In-memory cross-project references to projects using generative type provi
              // NOTE TestProject may not actually have been compiled
               yield "-r:" + testProjectOutput|]
            ReferencedProjects =
-            [|FSharpReferencedProject.CreateFSharp(testProjectOutput, optionsTestProject )|]
+            [|FSharpReferencedProject.FSharpReference(testProjectOutput, optionsTestProject )|]
            IsIncompleteTypeCheckEnvironment = false
            UseScriptResolutionRules = false
            LoadTime = System.DateTime.Now

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -279,7 +279,9 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         match! tryComputeOptions referencedProject ct with
                         | None -> canBail <- true
                         | Some (_, projectOptions) ->
-                            referencedProjects.Add(FSharpReferencedProject.FSharpReference(referencedProject.OutputFilePath, projectOptions))
+                            referencedProjects.Add(
+                                FSharpReferencedProject.FSharpReference(referencedProject.OutputFilePath, projectOptions)
+                            )
                     elif referencedProject.SupportsCompilation then
                         let! comp = referencedProject.GetCompilationAsync(ct) |> Async.AwaitTask
                         let peRef = createPEReference referencedProject comp

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -179,7 +179,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
             let getStamp = fun () -> stamp
 
             let fsRefProj =
-                FSharpReferencedProject.CreatePortableExecutable(referencedProject.OutputFilePath, getStamp, getStream)
+                FSharpReferencedProject.PEReference(getStamp, DelayedILModuleReader(referencedProject.OutputFilePath, getStream))
 
             weakPEReferences.Add(comp, fsRefProj)
             fsRefProj
@@ -279,7 +279,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         match! tryComputeOptions referencedProject ct with
                         | None -> canBail <- true
                         | Some (_, projectOptions) ->
-                            referencedProjects.Add(FSharpReferencedProject.CreateFSharp(referencedProject.OutputFilePath, projectOptions))
+                            referencedProjects.Add(FSharpReferencedProject.FSharpReference(referencedProject.OutputFilePath, projectOptions))
                     elif referencedProject.SupportsCompilation then
                         let! comp = referencedProject.GetCompilationAsync(ct) |> Async.AwaitTask
                         let peRef = createPEReference referencedProject comp

--- a/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
+++ b/vsintegration/src/FSharp.LanguageService/ProjectSitesAndFiles.fs
@@ -188,7 +188,7 @@ type internal ProjectSitesAndFiles() =
                    match tryGetOptionsForReferencedProject projectFileName with 
                    | None -> getProjectOptionsForProjectSite (enableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, projectSiteProvider.GetProjectSite(), serviceProvider, projectFileName, useUniqueStamp) |> snd
                    | Some options -> options
-               yield projectFileName, FSharpReferencedProject.CreateFSharp(outputPath, referencedProjectOptions) |]
+               yield projectFileName, FSharpReferencedProject.FSharpReference(outputPath, referencedProjectOptions) |]
 
     and getProjectOptionsForProjectSite(enableInMemoryCrossProjectReferences, tryGetOptionsForReferencedProject, projectSite, serviceProvider, fileName, useUniqueStamp) =
         let referencedProjectFileNames, referencedProjectOptions = 

--- a/vsintegration/tests/FSharp.Editor.Tests/Helpers/ProjectOptionsBuilder.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Helpers/ProjectOptionsBuilder.fs
@@ -142,7 +142,7 @@ module internal ProjectOptionsBuilder =
                 { projectOptions with
                     Options =
                         { projectOptions.Options with
-                            ReferencedProjects = referenceList |> Array.map FSharpReferencedProject.CreateFSharp
+                            ReferencedProjects = referenceList |> Array.map FSharpReferencedProject.FSharpReference
                             OtherOptions = otherOptions
                         }
                 })


### PR DESCRIPTION
When `FSharpReferencedProject` was added, it introduced a regression for FCS users that made it impossible to check if a project options graph is the same as another one or to get some info from referenced project options.

This PR makes the type representation public, so it's possible to do both of these things again, while it doesn't open up `DelayedILModuleReader` internals (which, I guess, was the reason to hide the `FSharpReferencedProject` representation).