### PR TITLE
Fix navigation for external enums, DUs and name resultion for members

### DIFF
--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -988,6 +988,10 @@ type FSharpUnionCase(cenv, v: UnionCaseRef) =
         checkIsResolved()
         v.Range
 
+    member _.DeclaringEntity =
+        checkIsResolved()
+        FSharpEntity(cenv, v.TyconRef)
+
     member _.HasFields =
         if isUnresolved() then false else
         v.UnionCase.RecdFieldsArray.Length <> 0

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -454,6 +454,9 @@ type FSharpUnionCase =
     /// Get the range of the name of the case
     member DeclarationLocation: range
 
+    /// Get the declaring entity of the case
+    member DeclaringEntity: FSharpEntity
+
     /// Indicates if the union case has field definitions
     member HasFields: bool
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -20,7 +20,7 @@ FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsCDecl
 FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsDefault
 FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsFastCall
 FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsStdCall
-FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsThisCall
+FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsThisCal
 FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean IsVarArg
 FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean get_IsCDecl()
 FSharp.Compiler.AbstractIL.IL+ILArgConvention: Boolean get_IsDefault()
@@ -5130,6 +5130,8 @@ FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpXmlDoc Xm
 FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpXmlDoc get_XmlDoc()
 FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Text.Range DeclarationLocation
 FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Text.Range get_DeclarationLocation()
+FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpEntity DeclaringEntity
+FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpEntity get_DeclaringEntity()
 FSharp.Compiler.Symbols.FSharpUnionCase: Int32 GetHashCode()
 FSharp.Compiler.Symbols.FSharpUnionCase: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpAttribute] Attributes
 FSharp.Compiler.Symbols.FSharpUnionCase: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpAttribute] get_Attributes()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -5130,6 +5130,8 @@ FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpXmlDoc Xm
 FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpXmlDoc get_XmlDoc()
 FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Text.Range DeclarationLocation
 FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Text.Range get_DeclarationLocation()
+FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpEntity DeclaringEntity
+FSharp.Compiler.Symbols.FSharpUnionCase: FSharp.Compiler.Symbols.FSharpEntity get_DeclaringEntity()
 FSharp.Compiler.Symbols.FSharpUnionCase: Int32 GetHashCode()
 FSharp.Compiler.Symbols.FSharpUnionCase: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpAttribute] Attributes
 FSharp.Compiler.Symbols.FSharpUnionCase: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpAttribute] get_Attributes()

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -467,12 +467,23 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
         use __ = statusBar.Animate()
         statusBar.Message(SR.NavigatingTo())
 
-        let textOpt =
+        let rec textOpt =
             match targetSymbolUse.Symbol with
             | :? FSharpEntity as symbol -> symbol.TryGetMetadataText() |> Option.map (fun text -> text, symbol.DisplayName)
             | :? FSharpMemberOrFunctionOrValue as symbol ->
                 symbol.ApparentEnclosingEntity.TryGetMetadataText()
                 |> Option.map (fun text -> text, symbol.ApparentEnclosingEntity.DisplayName)
+            | :? FSharpField as symbol ->
+                match symbol.DeclaringEntity with
+                | Some entity ->
+                    let text = entity.TryGetMetadataText()
+                    match text with
+                    | Some text ->
+                        Some(text, entity.DisplayName)
+                    | None -> None
+                | None -> None
+            | :? FSharpUnionCase as symbol ->
+                symbol.DeclaringEntity.TryGetMetadataText() |> Option.map (fun text -> text, symbol.DisplayName)
             | _ -> None
 
         let result =
@@ -523,6 +534,10 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                                         symbol1.DisplayName = symbol2.DisplayName
                                     | (:? FSharpMemberOrFunctionOrValue as symbol1), (:? FSharpMemberOrFunctionOrValue as symbol2) ->
                                         symbol1.DisplayName = symbol2.DisplayName
+                                        &&
+                                        (match symbol1.DeclaringEntity, symbol2.DeclaringEntity with
+                                         | Some e1, Some e2 -> e1.CompiledName = e2.CompiledName
+                                         | _ -> false)
                                         && symbol1.GenericParameters.Count = symbol2.GenericParameters.Count
                                         && symbol1.CurriedParameterGroups.Count = symbol2.CurriedParameterGroups.Count
                                         && ((symbol1.CurriedParameterGroups, symbol2.CurriedParameterGroups)
@@ -530,6 +545,15 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                                                 pg1.Count = pg2.Count
                                                 && ((pg1, pg2) ||> Seq.forall2 (fun p1 p2 -> areTypesEqual p1.Type p2.Type))))
                                         && areTypesEqual symbol1.ReturnParameter.Type symbol2.ReturnParameter.Type
+                                    | (:? FSharpField as symbol1), (:? FSharpField as symbol2) when x.IsFromDefinition ->
+                                        symbol1.DisplayName = symbol2.DisplayName
+                                        &&
+                                        (match symbol1.DeclaringEntity, symbol2.DeclaringEntity with
+                                         | Some e1, Some e2 -> e1.CompiledName = e2.CompiledName
+                                         | _ -> false)
+                                    | (:? FSharpUnionCase as symbol1), (:? FSharpUnionCase as symbol2) ->
+                                        symbol1.DisplayName = symbol2.DisplayName
+                                        && symbol1.DeclaringEntity.CompiledName = symbol2.DeclaringEntity.CompiledName
                                     | _ -> false)
                                 |> Option.map (fun x -> x.Range)
 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -477,13 +477,14 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                 match symbol.DeclaringEntity with
                 | Some entity ->
                     let text = entity.TryGetMetadataText()
+
                     match text with
-                    | Some text ->
-                        Some(text, entity.DisplayName)
+                    | Some text -> Some(text, entity.DisplayName)
                     | None -> None
                 | None -> None
             | :? FSharpUnionCase as symbol ->
-                symbol.DeclaringEntity.TryGetMetadataText() |> Option.map (fun text -> text, symbol.DisplayName)
+                symbol.DeclaringEntity.TryGetMetadataText()
+                |> Option.map (fun text -> text, symbol.DisplayName)
             | _ -> None
 
         let result =
@@ -534,10 +535,9 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                                         symbol1.DisplayName = symbol2.DisplayName
                                     | (:? FSharpMemberOrFunctionOrValue as symbol1), (:? FSharpMemberOrFunctionOrValue as symbol2) ->
                                         symbol1.DisplayName = symbol2.DisplayName
-                                        &&
-                                        (match symbol1.DeclaringEntity, symbol2.DeclaringEntity with
-                                         | Some e1, Some e2 -> e1.CompiledName = e2.CompiledName
-                                         | _ -> false)
+                                        && (match symbol1.DeclaringEntity, symbol2.DeclaringEntity with
+                                            | Some e1, Some e2 -> e1.CompiledName = e2.CompiledName
+                                            | _ -> false)
                                         && symbol1.GenericParameters.Count = symbol2.GenericParameters.Count
                                         && symbol1.CurriedParameterGroups.Count = symbol2.CurriedParameterGroups.Count
                                         && ((symbol1.CurriedParameterGroups, symbol2.CurriedParameterGroups)
@@ -547,10 +547,9 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                                         && areTypesEqual symbol1.ReturnParameter.Type symbol2.ReturnParameter.Type
                                     | (:? FSharpField as symbol1), (:? FSharpField as symbol2) when x.IsFromDefinition ->
                                         symbol1.DisplayName = symbol2.DisplayName
-                                        &&
-                                        (match symbol1.DeclaringEntity, symbol2.DeclaringEntity with
-                                         | Some e1, Some e2 -> e1.CompiledName = e2.CompiledName
-                                         | _ -> false)
+                                        && (match symbol1.DeclaringEntity, symbol2.DeclaringEntity with
+                                            | Some e1, Some e2 -> e1.CompiledName = e2.CompiledName
+                                            | _ -> false)
                                     | (:? FSharpUnionCase as symbol1), (:? FSharpUnionCase as symbol2) ->
                                         symbol1.DisplayName = symbol2.DisplayName
                                         && symbol1.DeclaringEntity.CompiledName = symbol2.DeclaringEntity.CompiledName

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -467,7 +467,7 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
         use __ = statusBar.Animate()
         statusBar.Message(SR.NavigatingTo())
 
-        let rec textOpt =
+        let textOpt =
             match targetSymbolUse.Symbol with
             | :? FSharpEntity as symbol -> symbol.TryGetMetadataText() |> Option.map (fun text -> text, symbol.DisplayName)
             | :? FSharpMemberOrFunctionOrValue as symbol ->


### PR DESCRIPTION
Adds processing of `FSharpField` and `FSharpUnionCase` when navigating to external definition.
Adds `DeclaringEntity` for the DUs.
Adds checking of declaring entity compiled names, to navigate to proper symbol in case of the nested modules.

Fixes #15160 #15159

@psfinaki No real idea of how to test it with real external definitions.