### PR TITLE
Protect assembly exploration for C# extension members

### DIFF
--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -541,8 +541,9 @@ let private GetCSharpStyleIndexedExtensionMembersForTyconRef (amap: Import.Impor
       
         let csharpStyleExtensionMembers = 
             if IsTyconRefUsedForCSharpStyleExtensionMembers g m tcrefOfStaticClass || tcrefOfStaticClass.IsLocalRef then
-                GetImmediateIntrinsicMethInfosOfType (None, AccessorDomain.AccessibleFromSomeFSharpCode) g amap m ty
-                |> List.filter (IsMethInfoPlainCSharpStyleExtensionMember g m true)
+                protectAssemblyExploration [] (fun () ->
+                    GetImmediateIntrinsicMethInfosOfType (None, AccessorDomain.AccessibleFromSomeFSharpCode) g amap m ty
+                    |> List.filter (IsMethInfoPlainCSharpStyleExtensionMember g m true))
             else
                 []
 


### PR DESCRIPTION
Fixes #15158