### PR TITLE
Compute ValInline.Never for externs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,9 +54,6 @@
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/artifacts/bin/fsc/Debug/net7.0/fsc.dll",
             "args": [
-                "--target:library",
-                "Lib.fsi",
-                "Lib.fs",
                 "${input:fscArgsPrompt}"
             ],
             "cwd": "${workspaceFolder}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,6 +54,9 @@
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/artifacts/bin/fsc/Debug/net7.0/fsc.dll",
             "args": [
+                "--target:library",
+                "Lib.fsi",
+                "Lib.fs",
                 "${input:fscArgsPrompt}"
             ],
             "cwd": "${workspaceFolder}",

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -2224,18 +2224,21 @@ module GeneralizationHelpers =
 //-------------------------------------------------------------------------
 
 let ComputeInlineFlag (memFlagsOption: SynMemberFlags option) isInline isMutable g attrs m =
-    let hasNoCompilerInliningAttribute() = HasFSharpAttribute g g.attrib_NoCompilerInliningAttribute attrs  
-    let isCtorOrAbstractSlot() =
+    let hasNoCompilerInliningAttribute () = HasFSharpAttribute g g.attrib_NoCompilerInliningAttribute attrs  
+
+    let isCtorOrAbstractSlot () =
         match memFlagsOption with
         | None -> false
         | Some x -> (x.MemberKind = SynMemberKind.Constructor) || x.IsDispatchSlot || x.IsOverrideOrExplicitImpl
+
+    let isExtern () = HasFSharpAttributeOpt g g.attrib_DllImportAttribute attrs
 
     let inlineFlag, reportIncorrectInlineKeywordUsage =
         // Mutable values may never be inlined
         // Constructors may never be inlined
         // Calls to virtual/abstract slots may never be inlined
         // Values marked with NoCompilerInliningAttribute or [<MethodImpl(MethodImplOptions.NoInlining)>] may never be inlined
-        if isMutable || isCtorOrAbstractSlot() || hasNoCompilerInliningAttribute() then
+        if isMutable || isCtorOrAbstractSlot() || hasNoCompilerInliningAttribute() || isExtern () then
             ValInline.Never, errorR
         elif HasMethodImplNoInliningAttribute g attrs then
             ValInline.Never, 

--- a/src/fsc/fsc.targets
+++ b/src/fsc/fsc.targets
@@ -40,8 +40,15 @@
     </NoneSubstituteText>
   </ItemGroup>
 
+    <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' != 'true'">
+    <ProjectReference Include="$(FSharpSourcesRoot)\FSharp.Core\FSharp.Core.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+  </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)../FSharp.Core/FSharp.Core.fsproj" AdditionalProperties="TargetFramework=netstandard2.0" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../FSharp.Build/FSharp.Build.fsproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../Compiler/FSharp.Compiler.Service.fsproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)../FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj" />

--- a/src/fsi/fsi.targets
+++ b/src/fsi/fsi.targets
@@ -45,8 +45,15 @@
     </NoneSubstituteText>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' != 'true'">
+    <ProjectReference Include="$(FSharpSourcesRoot)\FSharp.Core\FSharp.Core.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+  </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Core\FSharp.Core.fsproj" AdditionalProperties="TargetFramework=netstandard2.0" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Compiler\FSharp.Compiler.Service.fsproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #15269
No really good way of testing it though, since we run all of our tests in Release.

Additionally, fixes how FSharp.Core is included into fsi and fsc - project or library. This was breaking debugging under VSCode.