### PR TITLE
add review comment to sb files

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,3 +1,5 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+
 <Project>
 
   <PropertyGroup>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,3 +1,6 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
 <UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="*/*" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3435

Adds comments to source-build files asking for the inclusion of the source-build team in PRs that alter `SourceBuild*` files. Non-reviewed changes could potentially cause issues down the line, be it in the downstream repos or the product build (as has happened in the past, see https://github.com/dotnet/source-build/issues/3435#issuecomment-1570650046)