### PR TITLE
Fix #15313 - The compiler automatically generates an IsReadOnlyAttribute on downlevel frameworks even if we have already defined it.

### DIFF
--- a/src/Compiler/Driver/CreateILModule.fs
+++ b/src/Compiler/Driver/CreateILModule.fs
@@ -303,8 +303,11 @@ module MainModuleBuilder =
 
         RequireCompilationThread ctok
 
+        let isEmbeddableTypeWithLocalSourceImplementation (td:ILTypeDef) =
+            (TcGlobals.IsInEmbeddableKnownSet td.Name) && not (codegenResults.ilTypeDefs |> List.exists(fun r -> r.Name = td.Name))
+
         let ilTypeDefs =
-            mkILTypeDefs (codegenResults.ilTypeDefs @ tcGlobals.tryRemoveEmbeddedILTypeDefs ())
+            mkILTypeDefs (codegenResults.ilTypeDefs @ (tcGlobals.tryRemoveEmbeddedILTypeDefs ()|> List.filter isEmbeddableTypeWithLocalSourceImplementation))
 
         let mainModule =
             let hashAlg =

--- a/src/Compiler/Driver/CreateILModule.fs
+++ b/src/Compiler/Driver/CreateILModule.fs
@@ -303,11 +303,16 @@ module MainModuleBuilder =
 
         RequireCompilationThread ctok
 
-        let isEmbeddableTypeWithLocalSourceImplementation (td:ILTypeDef) =
-            (TcGlobals.IsInEmbeddableKnownSet td.Name) && not (codegenResults.ilTypeDefs |> List.exists(fun r -> r.Name = td.Name))
+        let isEmbeddableTypeWithLocalSourceImplementation (td: ILTypeDef) =
+            (TcGlobals.IsInEmbeddableKnownSet td.Name)
+            && not (codegenResults.ilTypeDefs |> List.exists (fun r -> r.Name = td.Name))
 
         let ilTypeDefs =
-            mkILTypeDefs (codegenResults.ilTypeDefs @ (tcGlobals.tryRemoveEmbeddedILTypeDefs ()|> List.filter isEmbeddableTypeWithLocalSourceImplementation))
+            mkILTypeDefs (
+                codegenResults.ilTypeDefs
+                @ (tcGlobals.tryRemoveEmbeddedILTypeDefs ()
+                   |> List.filter isEmbeddableTypeWithLocalSourceImplementation)
+            )
 
         let mainModule =
             let hashAlg =


### PR DESCRIPTION
Compilations where an IsReadOnlyAttribute is provided in source code fails due to an embedded IsReadOnlyAttribute.

Fix https://github.com/dotnet/fsharp/issues/15313

This fixes the issue by: filtering out and not embedding attributes which are provided in source code.

