### PR TITLE
Fix cache path

### DIFF
--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -324,7 +324,7 @@ type FSharpDependencyManager(outputDirectory: string option, useResultsCache: bo
                 else
                     path
             // Build path to cache root
-            $"{getProfilePath}\\.packagemanagement\\nuget"
+            $"{getProfilePath}/.packagemanagement/nuget"
 
         let path =
             Path.Combine(Process.GetCurrentProcess().Id.ToString() + "--" + Guid.NewGuid().ToString())

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -318,7 +318,7 @@ type FSharpDependencyManager(outputDirectory: string option, useResultsCache: bo
 
                 if
                     (path.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                    ||  (path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                    || (path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
                 then
                     path.Substring(0, path.Length - 1)
                 else

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -312,7 +312,19 @@ type FSharpDependencyManager(outputDirectory: string option, useResultsCache: bo
         //   if a path was supplied if it was rooted then use the rooted path as the root
         //   if the path wasn't supplied or not rooted use the temp directory as the root.
         let specialDir =
-            Path.Combine(Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".packagemanagement", "nuget")
+            let getProfilePath =
+                // If it has a directory seperator remove it
+                let path = Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile)
+
+                if
+                    (path.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                    && not (path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                then
+                    path.Substring(0, path.Length)
+                else
+                    path
+            // Build path to cache root
+            $"{getProfilePath}\\.packagemanagement\\nuget"
 
         let path =
             Path.Combine(Process.GetCurrentProcess().Id.ToString() + "--" + Guid.NewGuid().ToString())

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -318,7 +318,7 @@ type FSharpDependencyManager(outputDirectory: string option, useResultsCache: bo
 
                 if
                     (path.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                    && not (path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                    ||  (path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
                 then
                     path.Substring(0, path.Length)
                 else

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -320,7 +320,7 @@ type FSharpDependencyManager(outputDirectory: string option, useResultsCache: bo
                     (path.EndsWith(Path.DirectorySeparatorChar.ToString()))
                     ||  (path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
                 then
-                    path.Substring(0, path.Length)
+                    path.Substring(0, path.Length - 1)
                 else
                     path
             // Build path to cache root


### PR DESCRIPTION
There appears to be circumstances where Path.Combine treats elements not at the end of the list as extensions.

This issue here:  https://github.com/dotnet/fsharp/issues/15294
contains this error:
````
#r "nuget:NBomber"
^^^^^^^^^^^^^^^^^^
stdin(1,1): error FS3217: C:\Users\woo.packagemanagement\nuget\Projects\1220--24e02601-e93e-4b40-a9bf-33a26d273aa0\Project.fsproj : error NU1101: 找不到包 NBomber。源 C:\Program Files\dotnet\library-packs, C:\Program Files\dotnet\sdk\8.0.100-preview.4.23260.5\FSharp\library-packs 中不存在具有此 ID 的包
````
The actual error is unrelated to this, however, the project was created in the wrong location:
````
C:\Users\woo.packagemanagement\nuget\Projects\1220--24e02601-e93e-4b40-a9bf-33a26d273aa0\Project.fsproj 
````
It should have been:
````
C:\Users\woo\.packagemanagement\nuget\Projects\1220--24e02601-e93e-4b40-a9bf-33a26d273aa0\Project.fsproj 
````
It seems as if there are circumstance where:
````
        let specialDir =
            Path.Combine(Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".packagemanagement", "nuget")
````
combines the .packagemanagement as a file extension.  I haven't been able to reproduce this locally.  Perhaps it is locale related.  This pr constructs the path more specifically