### PR TITLE
Enable includeStaticParametersInTypeNames in DisplayEnv.

### DIFF
--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -2357,13 +2357,15 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     
     member x.GetValSignatureText (displayContext: FSharpDisplayContext, m: range) =
         checkIsResolved()
+        let displayEnv = { displayContext.Contents cenv.g with includeStaticParametersInTypeNames = true }
+
         let stringValOfMethInfo methInfo =
             match methInfo with
-            | FSMeth(valRef = vref) -> NicePrint.stringValOrMember (displayContext.Contents cenv.g) cenv.infoReader vref
-            | _ -> NicePrint.stringOfMethInfo cenv.infoReader m (displayContext.Contents cenv.g) methInfo
-        
+            | FSMeth(valRef = vref) -> NicePrint.stringValOrMember displayEnv cenv.infoReader vref
+            | _ -> NicePrint.stringOfMethInfo cenv.infoReader m displayEnv methInfo
+
         let stringValOfPropInfo (p: PropInfo) =
-            let t = p.GetPropertyType(cenv.amap, m ) |> NicePrint.layoutType (displayContext.Contents cenv.g) |> LayoutRender.showL
+            let t = p.GetPropertyType(cenv.amap, m ) |> NicePrint.layoutType displayEnv |> LayoutRender.showL
             let withGetSet =
                 if p.HasGetter && p.HasSetter then "with get, set"
                 elif p.HasGetter then "with get"
@@ -2375,12 +2377,12 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         match d with
         | E _ -> None
         | V v ->
-            NicePrint.stringValOrMember (displayContext.Contents cenv.g) cenv.infoReader v
+            NicePrint.stringValOrMember displayEnv cenv.infoReader v
             |> Some
         | C methInfo
         | M methInfo -> stringValOfMethInfo methInfo |> Some
         | P p -> stringValOfPropInfo p |> Some
-        
+
 
     member x.GetWitnessPassingInfo() = 
         let witnessInfos = 

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -49,7 +49,7 @@ type FSharpAccessibility =
     /// Indicates the symbol has internal accessibility.
     member IsInternal: bool
 
-    /// Indicates the symbol has protected accessibility.k
+    /// Indicates the symbol has protected accessibility.
     member IsProtected: bool
 
     /// The underlying Accessibility

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -49,7 +49,7 @@ type FSharpAccessibility =
     /// Indicates the symbol has internal accessibility.
     member IsInternal: bool
 
-    /// Indicates the symbol has protected accessibility.
+    /// Indicates the symbol has protected accessibility.k
     member IsProtected: bool
 
     /// The underlying Accessibility

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -646,3 +646,19 @@ type Foo() =
     member this.Bar (a:int) (b:int) : int = 0
 """
             (3, 19, "    member this.Bar (a:int) (b:int) : int = 0", "Bar")
+
+    [<Test>]
+    let ``Signature text for type with generic parameter in path`` () =
+        assertSignature
+            "new: builder: ImmutableArray<'T>.Builder -> ImmutableArrayViaBuilder<'T>"
+            """
+module Telplin
+
+open System
+open System.Collections.Generic
+open System.Collections.Immutable
+
+type ImmutableArrayViaBuilder<'T>(builder: ImmutableArray<'T>.Builder) =
+    class end
+"""
+            (8, 29, "type ImmutableArrayViaBuilder<'T>(builder: ImmutableArray<'T>.Builder) =", ".ctor")


### PR DESCRIPTION
I noticed that the fix of https://github.com/dotnet/fsharp/pull/15259 is not available in https://github.com/dotnet/fsharp/pull/15275 due to a missing flag.

