### PR TITLE
Fix nuget localization issue

### DIFF
--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -195,8 +195,9 @@ module internal Utilities =
             psi.Arguments <- arguments
             psi.CreateNoWindow <- true
             psi.EnvironmentVariables.Remove("MSBuildSDKsPath") // Host can sometimes add this, and it can break things
+
             for varname, value in environment do
-                psi.EnvironmentVariables.Add(varname,value) // Host can sometimes add this, and it can break things
+                psi.EnvironmentVariables.Add(varname, value) // Host can sometimes add this, and it can break things
 
             psi.UseShellExecute <- false
 
@@ -292,7 +293,7 @@ module internal Utilities =
         let args = "nuget list source --format detailed"
 
         let success, stdOut, stdErr =
-            executeTool dotnetHostPath args scriptDirectory ["DOTNET_CLI_UI_LANGUAGE", "en-us"] timeout
+            executeTool dotnetHostPath args scriptDirectory [ "DOTNET_CLI_UI_LANGUAGE", "en-us" ] timeout
 #if DEBUG
         let diagnostics =
             [|

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -197,7 +197,7 @@ module internal Utilities =
             psi.EnvironmentVariables.Remove("MSBuildSDKsPath") // Host can sometimes add this, and it can break things
 
             for varname, value in environment do
-                psi.EnvironmentVariables.Add(varname, value) // Host can sometimes add this, and it can break things
+                psi.EnvironmentVariables.Add(varname, value)
 
             psi.UseShellExecute <- false
 


### PR DESCRIPTION
https://github.com/dotnet/fsharp/issues/15294#issuecomment-1578065057

In his analysis of this bug @0xBruceLiao identified that the dotnet sdk localise the source enabled/disabled indicator in:  

````
dotnet nuget list source --format detailed
````
This PR fixes the issue by setting the "DOTNET_CLI_UI_LANGUAGE" to "en-us" when executing this command during packagemanagement.

The image below demonstrates the error in the released fsi, and the fix built with this pr, on a windows localized to French because I did a bit of that at school.

![image](https://github.com/dotnet/fsharp/assets/5175830/80333e2f-b69c-4de7-bbc8-bf79da3aab76)


