### PR TITLE
ParseAndCheckProject no longers reports all diagnostics

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -249,6 +249,7 @@
     <Compile Include="Signatures\TypeTests.fs" />
     <Compile Include="Signatures\SigGenerationRoundTripTests.fs" />
     <Compile Include="Signatures\NestedTypeTests.fs" />
+    <Compile Include="Signatures\MissingDiagnostic.fs" />
     <Compile Include="StaticLinking\StaticLinking.fs" />
     <Compile Include="FSharpChecker\CommonWorkflows.fs" />
     <Compile Include="FSharpChecker\SymbolUse.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/MissingDiagnostic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/MissingDiagnostic.fs
@@ -1,0 +1,54 @@
+﻿module FSharp.Compiler.ComponentTests.Signatures.MissingDiagnostic
+
+open Xunit
+open FSharp.Test
+open FSharp.Test.Compiler
+
+let implementation = """
+module Foo
+
+let a (b: int) : int = 'x'
+"""
+
+let signature = """
+module Foo
+
+val a: b: int -> int
+"""
+
+[<Fact>]
+let ``Compile gives errors`` () =
+    Fsi signature
+    |> withAdditionalSourceFile (FsSource implementation)
+    |> compile
+    |> shouldFail
+    |> withSingleDiagnostic (Error 1, Line 4, Col 24, Line 4,Col 27, "This expression was expected to have type
+    'int'    
+but here has type
+    'char'    ")
+
+[<Fact>]
+let ``Type check project with signature file doesn't get the diagnostic`` () =        
+    Fsi signature
+    |> withAdditionalSourceFile (FsSource implementation)
+    |> typecheckProject false
+    |> fun projectResults ->
+        projectResults.Diagnostics |> ignore
+        Assert.False (projectResults.Diagnostics |> Array.isEmpty)
+
+[<Fact>]
+let ``Type check project without signature file does get the diagnostic`` () =        
+    Fs implementation
+    |> typecheckProject false
+    |> fun projectResults ->
+        projectResults.Diagnostics |> ignore
+        Assert.False (projectResults.Diagnostics |> Array.isEmpty)
+
+[<Fact>]
+let ``Enabling enablePartialTypeChecking = true doesn't change the problem`` () =        
+    Fsi signature
+    |> withAdditionalSourceFile (FsSource implementation)
+    |> typecheckProject true
+    |> fun projectResults ->
+        projectResults.Diagnostics |> ignore
+        Assert.False (projectResults.Diagnostics |> Array.isEmpty)

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/TyparNameTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/TyparNameTests.fs
@@ -12,7 +12,7 @@ let private getGenericParametersNamesFor
     (additionalFile: SourceCodeFileKind)
     : string array =
     let typeCheckResult =
-        cUnit |> withAdditionalSourceFile additionalFile |> typecheckProject
+        cUnit |> withAdditionalSourceFile additionalFile |> typecheckProject false
 
     assert (Array.isEmpty typeCheckResult.Diagnostics)
 

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -917,7 +917,7 @@ module rec Compiler =
             CompilerAssert.TypeCheck(options, fileName, source)
         | _ -> failwith "Typecheck only supports F#"
 
-    let typecheckProject (cUnit: CompilationUnit) : FSharp.Compiler.CodeAnalysis.FSharpCheckProjectResults =
+    let typecheckProject enablePartialTypeChecking (cUnit: CompilationUnit) : FSharp.Compiler.CodeAnalysis.FSharpCheckProjectResults =
         match cUnit with
         | FS fsSource ->
             let options = fsSource.Options |> Array.ofList
@@ -935,7 +935,7 @@ module rec Compiler =
                     |> async.Return
 
             let sourceFiles = Array.map fst sourceFiles
-            CompilerAssert.TypeCheckProject(options, sourceFiles, getSourceText)
+            CompilerAssert.TypeCheckProject(options, sourceFiles, getSourceText, enablePartialTypeChecking)
         | _ -> failwith "Typecheck only supports F#"
 
     let run (result: CompilationResult) : CompilationResult =

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -858,8 +858,8 @@ Updated automatically, please check diffs in your pull request, changes must be 
     static member TypeCheckSingleError (source: string) (expectedSeverity: FSharpDiagnosticSeverity) (expectedErrorNumber: int) (expectedErrorRange: int * int * int * int) (expectedErrorMsg: string) =
         CompilerAssert.TypeCheckWithErrors source [| expectedSeverity, expectedErrorNumber, expectedErrorRange, expectedErrorMsg |]
 
-    static member TypeCheckProject(options: string array, sourceFiles: string array, getSourceText) : FSharpCheckProjectResults =
-        let checker = FSharpChecker.Create(documentSource = DocumentSource.Custom getSourceText)
+    static member TypeCheckProject(options: string array, sourceFiles: string array, getSourceText, enablePartialTypeChecking) : FSharpCheckProjectResults =
+        let checker = FSharpChecker.Create(documentSource = DocumentSource.Custom getSourceText, enablePartialTypeChecking = enablePartialTypeChecking)
         let defaultOptions = defaultProjectOptions TargetFramework.Current
         let projectOptions = { defaultOptions with OtherOptions = Array.append options defaultOptions.OtherOptions; SourceFiles = sourceFiles }
 


### PR DESCRIPTION
> A fractured flaw, a broken hue, hath beset my project's sight,
Type checking, bereft of full diagnostics, relinquishes its might,
Where once clarity and guidance did resound,
Now echoes of disarray, an enigmatic sound.

Hi all,

This is more of a question and potentially a bug report disguised as a PR.
I believe I found a regression when it comes to the compiler diagnostics of implementation files that were backed by a signature file.

See [MissingDiagnostic.fs](https://github.com/nojaf/fsharp/blob/76ee7afb1be11be588af56c87f2a991a756cfe7f/tests/FSharp.Compiler.ComponentTests/Signatures/MissingDiagnostic.fs) for a concrete example.
The diagnostic reported in the implementation file is not covered anymore by `FSharpChecker.ParseAndCheckProject`.

I suspect this is happens in `FinalizeTypeCheckTask` because 

https://github.com/dotnet/fsharp/blob/ebd758e44fb5a33963eece15222029fd27813d7d/src/Compiler/Service/IncrementalBuild.fs#L720-L723

will contain the same diagnostics that were reported in the signature file for both files.
The implementation file will wrap the signature diagnostics in https://github.com/dotnet/fsharp/blob/ebd758e44fb5a33963eece15222029fd27813d7d/src/Compiler/Service/IncrementalBuild.fs#L305-L321.

`tcDiagnosticsRev = prevTcInfo.tcDiagnosticsRev` being the culprit.

Later in `FinalizeTypeCheckTask`
`let finalInfo = Array.last tcInfos` and `let diagnostics = diagnosticsLogger.GetDiagnostics() :: finalInfo.tcDiagnosticsRev` will the wrong diagnostics.

This is breaking behaviour if you compare it against `FCS 43.7.200`.
See [MissingDiagnostic.zip](https://github.com/dotnet/fsharp/files/11676797/MissingDiagnostic.zip) sample to compare them.

Note that changing `FSharpChecker.Create(enablePartialTypeChecking = enablePartialTypeChecking)` doesn't seem to have any effect on this.

The changes in https://github.com/dotnet/fsharp/pull/14903 might be related or relevant here.
@majocha would you mind taking a look at this?
