### PR TITLE
Collect diagnostics from skipped implementation files, fixes #15337

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -250,6 +250,7 @@
     <Compile Include="Signatures\TypeTests.fs" />
     <Compile Include="Signatures\SigGenerationRoundTripTests.fs" />
     <Compile Include="Signatures\NestedTypeTests.fs" />
+    <Compile Include="Signatures\MissingDiagnostic.fs" />
     <Compile Include="StaticLinking\StaticLinking.fs" />
     <Compile Include="FSharpChecker\CommonWorkflows.fs" />
     <Compile Include="FSharpChecker\SymbolUse.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/MissingDiagnostic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/MissingDiagnostic.fs
@@ -1,0 +1,54 @@
+﻿module FSharp.Compiler.ComponentTests.Signatures.MissingDiagnostic
+
+open Xunit
+open FSharp.Test
+open FSharp.Test.Compiler
+
+let implementation = """
+module Foo
+
+let a (b: int) : int = 'x'
+"""
+
+let signature = """
+module Foo
+
+val a: b: int -> int
+"""
+
+[<Fact>]
+let ``Compile gives errors`` () =
+    Fsi signature
+    |> withAdditionalSourceFile (FsSource implementation)
+    |> compile
+    |> shouldFail
+    |> withSingleDiagnostic (Error 1, Line 4, Col 24, Line 4,Col 27, "This expression was expected to have type
+    'int'    
+but here has type
+    'char'    ")
+
+[<Fact>]
+let ``Type check project with signature file doesn't get the diagnostic`` () =        
+    Fsi signature
+    |> withAdditionalSourceFile (FsSource implementation)
+    |> typecheckProject false
+    |> fun projectResults ->
+        projectResults.Diagnostics |> ignore
+        Assert.False (projectResults.Diagnostics |> Array.isEmpty)
+
+[<Fact>]
+let ``Type check project without signature file does get the diagnostic`` () =        
+    Fs implementation
+    |> typecheckProject false
+    |> fun projectResults ->
+        projectResults.Diagnostics |> ignore
+        Assert.False (projectResults.Diagnostics |> Array.isEmpty)
+
+[<Fact>]
+let ``Enabling enablePartialTypeChecking = true doesn't change the problem`` () =        
+    Fsi signature
+    |> withAdditionalSourceFile (FsSource implementation)
+    |> typecheckProject true
+    |> fun projectResults ->
+        projectResults.Diagnostics |> ignore
+        Assert.False (projectResults.Diagnostics |> Array.isEmpty)

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/TyparNameTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/TyparNameTests.fs
@@ -12,7 +12,7 @@ let private getGenericParametersNamesFor
     (additionalFile: SourceCodeFileKind)
     : string array =
     let typeCheckResult =
-        cUnit |> withAdditionalSourceFile additionalFile |> typecheckProject
+        cUnit |> withAdditionalSourceFile additionalFile |> typecheckProject false
 
     assert (Array.isEmpty typeCheckResult.Diagnostics)
 

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -917,7 +917,7 @@ module rec Compiler =
             CompilerAssert.TypeCheck(options, fileName, source)
         | _ -> failwith "Typecheck only supports F#"
 
-    let typecheckProject (cUnit: CompilationUnit) : FSharp.Compiler.CodeAnalysis.FSharpCheckProjectResults =
+    let typecheckProject enablePartialTypeChecking (cUnit: CompilationUnit) : FSharp.Compiler.CodeAnalysis.FSharpCheckProjectResults =
         match cUnit with
         | FS fsSource ->
             let options = fsSource.Options |> Array.ofList
@@ -935,7 +935,7 @@ module rec Compiler =
                     |> async.Return
 
             let sourceFiles = Array.map fst sourceFiles
-            CompilerAssert.TypeCheckProject(options, sourceFiles, getSourceText)
+            CompilerAssert.TypeCheckProject(options, sourceFiles, getSourceText, enablePartialTypeChecking)
         | _ -> failwith "Typecheck only supports F#"
 
     let run (result: CompilationResult) : CompilationResult =

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -858,8 +858,8 @@ Updated automatically, please check diffs in your pull request, changes must be 
     static member TypeCheckSingleError (source: string) (expectedSeverity: FSharpDiagnosticSeverity) (expectedErrorNumber: int) (expectedErrorRange: int * int * int * int) (expectedErrorMsg: string) =
         CompilerAssert.TypeCheckWithErrors source [| expectedSeverity, expectedErrorNumber, expectedErrorRange, expectedErrorMsg |]
 
-    static member TypeCheckProject(options: string array, sourceFiles: string array, getSourceText) : FSharpCheckProjectResults =
-        let checker = FSharpChecker.Create(documentSource = DocumentSource.Custom getSourceText)
+    static member TypeCheckProject(options: string array, sourceFiles: string array, getSourceText, enablePartialTypeChecking) : FSharpCheckProjectResults =
+        let checker = FSharpChecker.Create(documentSource = DocumentSource.Custom getSourceText, enablePartialTypeChecking = enablePartialTypeChecking)
         let defaultOptions = defaultProjectOptions TargetFramework.Current
         let projectOptions = { defaultOptions with OtherOptions = Array.append options defaultOptions.OtherOptions; SourceFiles = sourceFiles }
 


### PR DESCRIPTION
`FinalizeTypeCheckTask` now collects all diagnostics, forcing type check of previously skipped implementation files.
See https://github.com/dotnet/fsharp/pull/15337
