### PR TITLE
remove support for --noframework from fsi

### DIFF
--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -1852,11 +1852,8 @@ let deprecatedFlagsBoth tcConfigB =
         )
     ]
 
-let deprecatedFlagsFsi tcConfigB = 
-    [
-        noFrameworkFlag false tcConfigB
-        yield! deprecatedFlagsBoth tcConfigB
-    ]
+let deprecatedFlagsFsi tcConfigB =
+    [ noFrameworkFlag false tcConfigB; yield! deprecatedFlagsBoth tcConfigB ]
 
 let deprecatedFlagsFsc tcConfigB =
     deprecatedFlagsBoth tcConfigB

--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -1233,9 +1233,10 @@ let noFrameworkFlag isFsc tcConfigB =
         "noframework",
         tagNone,
         OptionUnit(fun () ->
-            tcConfigB.implicitlyReferenceDotNetAssemblies <- false
-
+            // When the compilation is not fsi do nothing.
+            // It is just not a usefull option when running fsi on the coreclr or the desktop framework really.
             if isFsc then
+                tcConfigB.implicitlyReferenceDotNetAssemblies <- false
                 tcConfigB.implicitlyResolveAssemblies <- false),
         None,
         Some(FSComp.SR.optsNoframework ())
@@ -1251,7 +1252,6 @@ let advancedFlagsFsi tcConfigB =
             None,
             Some(FSComp.SR.optsClearResultsCache ())
         )
-        noFrameworkFlag false tcConfigB
     ]
 
 let advancedFlagsFsc tcConfigB =
@@ -1852,7 +1852,11 @@ let deprecatedFlagsBoth tcConfigB =
         )
     ]
 
-let deprecatedFlagsFsi tcConfigB = deprecatedFlagsBoth tcConfigB
+let deprecatedFlagsFsi tcConfigB = 
+    [
+        noFrameworkFlag false tcConfigB
+        yield! deprecatedFlagsBoth tcConfigB
+    ]
 
 let deprecatedFlagsFsc tcConfigB =
     deprecatedFlagsBoth tcConfigB

--- a/tests/fsharpqa/Source/CompilerOptions/fsc/dumpAllCommandLineOptions/dummy.fsx
+++ b/tests/fsharpqa/Source/CompilerOptions/fsc/dumpAllCommandLineOptions/dummy.fsx
@@ -30,7 +30,7 @@
 //<Expects status="success">section='- ADVANCED -             ' ! option=utf8output                     kind=OptionUnit</Expects>
 //<Expects status="success">section='- ADVANCED -             ' ! option=fullpaths                      kind=OptionUnit</Expects>
 //<Expects status="success">section='- ADVANCED -             ' ! option=lib                            kind=OptionStringList</Expects>
-//<Expects status="success">section='- ADVANCED -             ' ! option=noframework                    kind=OptionUnit</Expects>
+//<Expects status="success">section='NoSection                ' ! option=noframework                    kind=OptionUnit</Expects>
 //<Expects status="success">section='NoSection                ' ! option=typedtree                      kind=OptionUnit</Expects>
 //<Expects status="success">section='NoSection                ' ! option=typedtreefile                  kind=OptionUnit</Expects>
 //<Expects status="success">section='NoSection                ' ! option=typedtreestamps                kind=OptionUnit</Expects>
@@ -123,6 +123,7 @@
 //<Expects status="notin">section='- ADVANCED -             ' ! option=standalone                     kind=OptionUnit</Expects>
 //<Expects status="notin">section='- ADVANCED -             ' ! option=staticlink                     kind=OptionString</Expects>
 //<Expects status="notin">section='- ADVANCED -             ' ! option=pdb                            kind=OptionString</Expects>
+//<Expects status="notin">section='- ADVANCED -             ' ! option=noframework                    kind=OptionUnit</Expects>
 //<Expects status="notin">section='NoSection                ' ! option=generatehtml                   kind=OptionUnit</Expects>
 //<Expects status="notin">section='NoSection                ' ! option=htmloutputdir                  kind=OptionString</Expects>
 //<Expects status="notin">section='NoSection                ' ! option=htmlcss                        kind=OptionString</Expects>

--- a/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40-nologo.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40-nologo.437.1033.bsl
@@ -94,8 +94,6 @@ Usage: fsiAnyCpu <options> [script.fsx [<arguments>]]
                                          Default - mscorlib
 --clearResultsCache                      Clear the package manager results
                                          cache
---noframework                            Do not reference the default CLI
-                                         assemblies by default
 --exec                                   Exit fsi after loading the files or
                                          running the .fsx script given on the
                                          command line

--- a/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40.437.1033.bsl
+++ b/tests/fsharpqa/Source/CompilerOptions/fsi/help/help40.437.1033.bsl
@@ -96,8 +96,6 @@ Usage: fsiAnyCpu <options> [script.fsx [<arguments>]]
                                          Default - mscorlib
 --clearResultsCache                      Clear the package manager results
                                          cache
---noframework                            Do not reference the default CLI
-                                         assemblies by default
 --exec                                   Exit fsi after loading the files or
                                          running the .fsx script given on the
                                          command line


### PR DESCRIPTION
--noframework tells the compiler to not implicitly find and load framework assemblies.

This ability is essential for the **compiler** because, there are multiple versions of the dotnet framework, reference assemblies and runtime assemblies.  The compiler needs to be able to specifically identify which Apis are supported on the intended framework, so having it guess which assemblies to load based on incomplete information is likely to be dependent on what is installed on the target machine.  It is intended that when this switch is specified that the developer specifies the exact and complete closure of assemblies required by the compilation using the -r: path to assembly command line option.  Msbuild is the tool we use to generate these, on the desktop this closure will likely be a half a dozen or more assembly paths.  Targetting coreclr assemblies this may be 60 or more assemblies.

The option doesn't make much sense when running a script or directly interaction with Fsi.  The reason is that on the coreclr the number of specific assemblies to reference is huge, and thus very hard to type.  Even on the desktop it is not that easy.  Additionally the implementation assemblies loaded are specified by the coreclr host when it starts fsi.exe

For these reasons, I am just turning off the switch, because the switch was originally specifiable, I am leaving it valid to specify, but it will make no changes when executing fsi or dotnet fsi.

