### PR TITLE
Democratizing code fixes - part one

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFix/AddInstanceMemberParameter.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddInstanceMemberParameter.fs
@@ -15,10 +15,11 @@ open CancellableTasks
 type internal FSharpAddInstanceMemberParameterCodeFixProvider() =
     inherit CodeFixProvider()
 
+    static let title = SR.AddMissingInstanceMemberParameter()
+
     interface IFSharpCodeFix with
         member _.GetChangesAsync _ span =
             cancellableTask {
-                let title = SR.AddMissingInstanceMemberParameter()
                 let changes = [ TextChange(TextSpan(span.Start, 0), "x.") ]
                 return title, changes
             }

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddInstanceMemberParameter.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddInstanceMemberParameter.fs
@@ -9,17 +9,25 @@ open System.Collections.Immutable
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 
+open CancellableTasks
+
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.AddInstanceMemberParameter); Shared>]
 type internal FSharpAddInstanceMemberParameterCodeFixProvider() =
     inherit CodeFixProvider()
 
-    static let title = SR.AddMissingInstanceMemberParameter()
+    interface IFSharpCodeFix with
+        member _.GetChangesAsync _ span =
+            cancellableTask {
+                let title = SR.AddMissingInstanceMemberParameter()
+                let changes = [ TextChange(TextSpan(span.Start, 0), "x.") ]
+                return title, changes
+            }
 
     override _.FixableDiagnosticIds = ImmutableArray.Create("FS0673")
 
-    override _.RegisterCodeFixesAsync context : Task =
-        asyncMaybe {
-            do context.RegisterFsharpFix(CodeFix.AddInstanceMemberParameter, title, [| TextChange(TextSpan(context.Span.Start, 0), "x.") |])
+    override this.RegisterCodeFixesAsync context : Task =
+        cancellableTask {
+            let! title, changes = (this :> IFSharpCodeFix).GetChangesAsync context.Document context.Span
+            context.RegisterFsharpFix(CodeFix.AddInstanceMemberParameter, title, changes)
         }
-        |> Async.Ignore
-        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+        |> CancellableTask.startAsTask context.CancellationToken

--- a/vsintegration/src/FSharp.Editor/CodeFix/AddInstanceMemberParameter.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/AddInstanceMemberParameter.fs
@@ -19,10 +19,8 @@ type internal FSharpAddInstanceMemberParameterCodeFixProvider() =
 
     interface IFSharpCodeFix with
         member _.GetChangesAsync _ span =
-            cancellableTask {
-                let changes = [ TextChange(TextSpan(span.Start, 0), "x.") ]
-                return title, changes
-            }
+            let changes = [ TextChange(TextSpan(span.Start, 0), "x.") ]
+            CancellableTask.singleton (title, changes)
 
     override _.FixableDiagnosticIds = ImmutableArray.Create("FS0673")
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/ChangeToUpcast.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ChangeToUpcast.fs
@@ -9,40 +9,53 @@ open System.Collections.Immutable
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 
+open CancellableTasks
+
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.ChangeToUpcast); Shared>]
 type internal FSharpChangeToUpcastCodeFixProvider() =
     inherit CodeFixProvider()
 
     override _.FixableDiagnosticIds = ImmutableArray.Create("FS3198")
 
+    interface IFSharpCodeFix with
+        member _.GetChangesAsync document span =
+            cancellableTask {
+                let! cancellationToken = CancellableTask.getCurrentCancellationToken ()
+
+                let! sourceText = document.GetTextAsync(cancellationToken)
+                let text = sourceText.GetSubText(span).ToString()
+
+                // Only works if it's one or the other
+                let isDowncastOperator = text.Contains(":?>")
+                let isDowncastKeyword = text.Contains("downcast")
+
+                let changes =
+                    Option.guard (
+                        (isDowncastOperator || isDowncastKeyword)
+                        && not (isDowncastOperator && isDowncastKeyword)
+                    )
+                    |> Option.map (fun _ ->
+                        let replacement =
+                            if isDowncastOperator then
+                                text.Replace(":?>", ":>")
+                            else
+                                text.Replace("downcast", "upcast")
+
+                        [ TextChange(span, replacement) ])
+                    |> Option.defaultValue []
+
+                let title =
+                    if isDowncastOperator then
+                        SR.UseUpcastOperator()
+                    else
+                        SR.UseUpcastKeyword()
+
+                return title, changes
+            }
+
     override this.RegisterCodeFixesAsync context : Task =
-        asyncMaybe {
-            let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
-            let text = sourceText.GetSubText(context.Span).ToString()
-
-            // Only works if it's one or the other
-            let isDowncastOperator = text.Contains(":?>")
-            let isDowncastKeyword = text.Contains("downcast")
-
-            do!
-                Option.guard (
-                    (isDowncastOperator || isDowncastKeyword)
-                    && not (isDowncastOperator && isDowncastKeyword)
-                )
-
-            let replacement =
-                if isDowncastOperator then
-                    text.Replace(":?>", ":>")
-                else
-                    text.Replace("downcast", "upcast")
-
-            let title =
-                if isDowncastOperator then
-                    SR.UseUpcastOperator()
-                else
-                    SR.UseUpcastKeyword()
-
-            do context.RegisterFsharpFix(CodeFix.ChangeToUpcast, title, [| TextChange(context.Span, replacement) |])
+        cancellableTask {
+            let! title, changes = (this :> IFSharpCodeFix).GetChangesAsync context.Document context.Span
+            context.RegisterFsharpFix(CodeFix.ChangeToUpcast, title, changes)
         }
-        |> Async.Ignore
-        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+        |> CancellableTask.startAsTask context.CancellationToken

--- a/vsintegration/src/FSharp.Editor/CodeFix/ChangeToUpcast.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ChangeToUpcast.fs
@@ -30,19 +30,19 @@ type internal FSharpChangeToUpcastCodeFixProvider() =
                 let isDowncastKeyword = text.Contains("downcast")
 
                 let changes =
-                    Option.guard (
-                        (isDowncastOperator || isDowncastKeyword)
-                        && not (isDowncastOperator && isDowncastKeyword)
-                    )
-                    |> Option.map (fun _ ->
-                        let replacement =
-                            if isDowncastOperator then
-                                text.Replace(":?>", ":>")
-                            else
-                                text.Replace("downcast", "upcast")
+                    [
+                        if
+                            (isDowncastOperator || isDowncastKeyword)
+                            && not (isDowncastOperator && isDowncastKeyword)
+                        then
+                            let replacement =
+                                if isDowncastOperator then
+                                    text.Replace(":?>", ":>")
+                                else
+                                    text.Replace("downcast", "upcast")
 
-                        [ TextChange(span, replacement) ])
-                    |> Option.defaultValue []
+                            TextChange(span, replacement)
+                    ]
 
                 let title =
                     if isDowncastOperator then

--- a/vsintegration/src/FSharp.Editor/CodeFix/ConvertToAnonymousRecord.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ConvertToAnonymousRecord.fs
@@ -15,6 +15,8 @@ open CancellableTasks
 type internal FSharpConvertToAnonymousRecordCodeFixProvider [<ImportingConstructor>] () =
     inherit CodeFixProvider()
 
+    static let title = SR.ConvertToAnonymousRecord()
+
     override _.FixableDiagnosticIds = ImmutableArray.Create("FS0039")
 
     interface IFSharpCodeFix with
@@ -39,7 +41,6 @@ type internal FSharpConvertToAnonymousRecordCodeFixProvider [<ImportingConstruct
                         ])
                     |> Option.defaultValue []
 
-                let title = SR.ConvertToAnonymousRecord()
                 return title, changes
             }
 

--- a/vsintegration/src/FSharp.Editor/CodeFix/ConvertToAnonymousRecord.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/ConvertToAnonymousRecord.fs
@@ -3,45 +3,49 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Threading
 open System.Threading.Tasks
 open System.Collections.Immutable
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
-open Microsoft.CodeAnalysis.CodeActions
+
+open CancellableTasks
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.ConvertToAnonymousRecord); Shared>]
 type internal FSharpConvertToAnonymousRecordCodeFixProvider [<ImportingConstructor>] () =
     inherit CodeFixProvider()
 
-    static let title = SR.ConvertToAnonymousRecord()
-
     override _.FixableDiagnosticIds = ImmutableArray.Create("FS0039")
 
-    override _.RegisterCodeFixesAsync context : Task =
-        asyncMaybe {
-            let document = context.Document
+    interface IFSharpCodeFix with
+        member _.GetChangesAsync document span =
+            cancellableTask {
+                let! cancellationToken = CancellableTask.getCurrentCancellationToken ()
 
-            let! parseResults =
-                document.GetFSharpParseResultsAsync(nameof (FSharpConvertToAnonymousRecordCodeFixProvider))
-                |> liftAsync
+                let! parseResults = document.GetFSharpParseResultsAsync(nameof (FSharpConvertToAnonymousRecordCodeFixProvider))
 
-            let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
+                let! sourceText = document.GetTextAsync(cancellationToken)
 
-            let errorRange =
-                RoslynHelpers.TextSpanToFSharpRange(document.FilePath, context.Span, sourceText)
+                let errorRange =
+                    RoslynHelpers.TextSpanToFSharpRange(document.FilePath, span, sourceText)
 
-            let! recordRange = parseResults.TryRangeOfRecordExpressionContainingPos errorRange.Start
-            let! recordSpan = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, recordRange)
+                let changes =
+                    parseResults.TryRangeOfRecordExpressionContainingPos errorRange.Start
+                    |> Option.bind (fun range -> RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, range))
+                    |> Option.map (fun span ->
+                        [
+                            TextChange(TextSpan(span.Start + 1, 0), "|")
+                            TextChange(TextSpan(span.End - 1, 0), "|")
+                        ])
+                    |> Option.defaultValue []
 
-            let changes =
-                [
-                    TextChange(TextSpan(recordSpan.Start + 1, 0), "|")
-                    TextChange(TextSpan(recordSpan.End, 0), "|")
-                ]
+                let title = SR.ConvertToAnonymousRecord()
+                return title, changes
+            }
 
-            context.RegisterFsharpFix(CodeFix.ConvertToAnonymousRecord, title, changes)
+    override this.RegisterCodeFixesAsync context : Task =
+        cancellableTask {
+            let! title, changes = (this :> IFSharpCodeFix).GetChangesAsync context.Document context.Span
+            return context.RegisterFsharpFix(CodeFix.ConvertToAnonymousRecord, title, changes)
         }
-        |> Async.Ignore
-        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+        |> CancellableTask.startAsTask context.CancellationToken

--- a/vsintegration/src/FSharp.Editor/CodeFix/IFSharpCodeFix.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFix/IFSharpCodeFix.fs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Text
+
+open CancellableTasks
+
+type IFSharpCodeFix =
+    abstract member GetChangesAsync: document: Document -> span: TextSpan -> CancellableTask<string * TextChange list>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -101,6 +101,7 @@
     <Compile Include="Refactor\ChangeTypeofWithNameToNameofExpression.fs" />
     <Compile Include="Refactor\AddExplicitTypeToParameter.fs" />
     <Compile Include="Refactor\ChangeDerefToValueRefactoring.fs" />
+    <Compile Include="CodeFix\IFSharpCodeFix.fs" />
     <Compile Include="CodeFix\CodeFixHelpers.fs" />
     <Compile Include="CodeFix\AddInstanceMemberParameter.fs" />
     <Compile Include="CodeFix\AddTypeAnnotationToObjectOfIndeterminateType.fs" />

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddInstanceMemberParameterTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddInstanceMemberParameterTests.fs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.AddInstanceMemberParameterTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = FSharpAddInstanceMemberParameterCodeFixProvider()
+let private diagnostic = 0673 // This instance member needs a parameter to represent the object being invoked...
+
+[<Fact>]
+let ``Fixes FS0673`` () =
+    let code =
+        """
+type UsefulTestHarness() =
+    member FortyTwo = 42
+"""
+
+    let expected =
+        {
+            Title = "Add missing instance member parameter"
+            FixedCode =
+                """
+type UsefulTestHarness() =
+    member x.FortyTwo = 42
+"""
+        }
+
+    let actual = codeFix |> fix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeToUpcastTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeToUpcastTests.fs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ChangeToUpcastTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = FSharpChangeToUpcastCodeFixProvider()
+let private diagnostic = 3198 // The conversion is an upcast, not a downcast...
+
+// Test cases are taken from the original PR:
+// https://github.com/dotnet/fsharp/pull/10463
+
+[<Fact>]
+let ``Fixes FS3198 - operator`` () =
+    let code =
+        """
+type IFoo = abstract member Bar : unit -> unit
+type Foo() = interface IFoo with member __.Bar () = ()
+
+let Thing : IFoo = Foo() :?> IFoo
+"""
+
+    let expected =
+        {
+            Title = "Use ':>' operator"
+            FixedCode =
+                """
+type IFoo = abstract member Bar : unit -> unit
+type Foo() = interface IFoo with member __.Bar () = ()
+
+let Thing : IFoo = Foo() :> IFoo
+"""
+        }
+
+    let actual = codeFix |> fix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Fixes FS3198 - keyword`` () =
+    let code =
+        """
+type IFoo = abstract member Bar : unit -> unit
+type Foo() = interface IFoo with member __.Bar () = ()
+
+let Thing : IFoo = downcast Foo()
+"""
+
+    let expected =
+        {
+            Title = "Use 'upcast'"
+            FixedCode =
+                """
+type IFoo = abstract member Bar : unit -> unit
+type Foo() = interface IFoo with member __.Bar () = ()
+
+let Thing : IFoo = upcast Foo()
+"""
+        }
+
+    let actual = codeFix |> fix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.CodeFixTestFramework
+
+open System.Threading
+
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Text
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.CancellableTasks
+
+open FSharp.Editor.Tests.Helpers
+
+type TestCodeFix = { Title: string; FixedCode: string }
+
+let getRelevantDiagnostic (document: Document) errorNumber =
+    cancellableTask {
+        let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync "test"
+
+        return
+            checkFileResults.Diagnostics
+            |> Seq.where (fun d -> d.ErrorNumber = errorNumber)
+            |> Seq.exactlyOne
+    }
+
+let fix (code: string) diagnostic (fixProvider: IFSharpCodeFix) =
+    cancellableTask {
+        let sourceText = SourceText.From code
+        let document = RoslynTestHelpers.GetFsDocument code
+
+        let! diagnostic = getRelevantDiagnostic document diagnostic
+
+        let diagnosticSpan =
+            RoslynHelpers.FSharpRangeToTextSpan(sourceText, diagnostic.Range)
+
+        let! title, changes = fixProvider.GetChangesAsync document diagnosticSpan
+        let fixedSourceText = sourceText.WithChanges changes
+
+        return
+            {
+                Title = title
+                FixedCode = fixedSourceText.ToString()
+            }
+    }
+    |> CancellableTask.start CancellationToken.None
+    |> fun task -> task.Result

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertToAnonymousRecordTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertToAnonymousRecordTests.fs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ConvertToAnonymousRecordTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = FSharpConvertToAnonymousRecordCodeFixProvider()
+let private diagnostic = 0039 // The record label is not defined...
+
+[<Fact>]
+let ``Fixes FS0039`` () =
+    let code =
+        """
+let band = { Name = "The Velvet Underground" }
+"""
+
+    let expected =
+        {
+            Title = "Convert to Anonymous Record"
+            FixedCode =
+                """
+let band = {| Name = "The Velvet Underground" |}
+"""
+        }
+
+    let actual = codeFix |> fix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -32,6 +32,10 @@
     <Compile Include="QuickInfoTests.fs" />
     <Compile Include="TaskListServiceTests.fs" />
     <Compile Include="NavigateToSearchServiceTests.fs" />
+    <Compile Include="CodeFixes\CodeFixTestFramework.fs" />
+    <Compile Include="CodeFixes\AddInstanceMemberParameterTests.fs" />
+    <Compile Include="CodeFixes\ConvertToAnonymousRecordTests.fs" />
+    <Compile Include="CodeFixes\ChangeToUpcastTests.fs" />
     <Compile Include="Hints\HintTestFramework.fs" />
     <Compile Include="Hints\OptionParserTests.fs" />
     <Compile Include="Hints\InlineParameterNameHintTests.fs" />
@@ -55,6 +59,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
@@ -337,3 +337,13 @@ type RoslynTestHelpers private () =
         options |> RoslynTestHelpers.SetProjectOptions projId solution
 
         solution, checker
+
+    static member GetFsDocument code =
+        // without this lib some symbols are not loaded
+        let options =
+            { RoslynTestHelpers.DefaultProjectOptions with
+                OtherOptions = [| "--targetprofile:netcore" |]
+            }
+
+        RoslynTestHelpers.CreateSolution(code, options = options)
+        |> RoslynTestHelpers.GetSingleDocument


### PR DESCRIPTION
I am making code fixes great again, so that they are easy to write and to test. 

This PR is the first step with the scope of 3 random code fixes. The changes include the following:
1. Adding some basic testing framework
2. Adding some tests
3. Adjusting the code in the code fixes
4. Rewriting `asyncMaybe` to `cancellableTask`
5. Fixing recently introduced #15372 discovered along the way, to prove this all makes sense :)

Apart from fixing the bug, the code is left untouched as much as possible within the changed monads.

We'll see where things go - so this doesn't aim for perfection, other code fixes might required adjustments in the testing framework.