### PR TITLE
Return F# signature text for C# override.

### DIFF
--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1533,8 +1533,13 @@ module InfoMemberPrinting =
                     WordL.keywordNew
                 else
                     let idL = ConvertValLogicalNameToDisplayLayout false (tagMethod >> tagNavArbValRef minfo.ArbitraryValRef >> wordL) minfo.LogicalName
-                    WordL.keywordMember ^^
-                    PrintTypes.layoutTyparDecls denv idL true minfo.FormalMethodTypars
+                    let keywordLayout =
+                        match minfo with
+                        | ILMeth(ilMethInfo = ilMethInfo) when ilMethInfo.IsAbstract ->
+                            WordL.keywordOverride
+                        | _ -> WordL.keywordMember
+
+                    keywordLayout ^^ PrintTypes.layoutTyparDecls denv idL true minfo.FormalMethodTypars
 
             let layout = layout ^^ (nameL |> addColonL)
             let layout = layoutXmlDocOfMethInfo denv infoReader minfo layout
@@ -2616,6 +2621,10 @@ let prettyLayoutOfPropInfoFreeStyle g amap m denv d =
 /// Convert a MethInfo to a string
 let stringOfMethInfo infoReader m denv minfo =
     buildString (fun buf -> InfoMemberPrinting.formatMethInfoToBufferFreeStyle infoReader m denv buf minfo)
+
+let stringOfMethInfoFSharpStyle infoReader m denv minfo =
+    InfoMemberPrinting.layoutMethInfoFSharpStyle infoReader m denv minfo
+    |> showL
 
 /// Convert MethInfos to lines separated by newline including a newline as the first character
 let multiLineStringOfMethInfos infoReader m denv minfos =

--- a/src/Compiler/Checking/NicePrint.fsi
+++ b/src/Compiler/Checking/NicePrint.fsi
@@ -81,6 +81,9 @@ val prettyLayoutOfPropInfoFreeStyle:
 
 val stringOfMethInfo: infoReader: InfoReader -> m: range -> denv: DisplayEnv -> minfo: MethInfo -> string
 
+/// Convert a MethInfo to a F# signature
+val stringOfMethInfoFSharpStyle: infoReader: InfoReader -> m: range -> denv: DisplayEnv -> minfo: MethInfo -> string
+
 val multiLineStringOfMethInfos:
     infoReader: InfoReader -> m: range -> denv: DisplayEnv -> minfos: MethInfo list -> string
 

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -2359,10 +2359,10 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         checkIsResolved()
         let displayEnv = { displayContext.Contents cenv.g with includeStaticParametersInTypeNames = true }
 
-        let stringValOfMethInfo methInfo =
+        let stringValOfMethInfo (methInfo: MethInfo) =
             match methInfo with
             | FSMeth(valRef = vref) -> NicePrint.stringValOrMember displayEnv cenv.infoReader vref
-            | _ -> NicePrint.stringOfMethInfo cenv.infoReader m displayEnv methInfo
+            | _ -> NicePrint.stringOfMethInfoFSharpStyle cenv.infoReader m displayEnv methInfo
 
         let stringValOfPropInfo (p: PropInfo) =
             let t = p.GetPropertyType(cenv.amap, m ) |> NicePrint.layoutType displayEnv |> LayoutRender.showL

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -1,5 +1,6 @@
 ﻿module Signatures.TypeTests
 
+open FSharp.Compiler.Symbols
 open Xunit
 open FsUnit
 open FSharp.Test.Compiler
@@ -131,4 +132,55 @@ module Extensions
 type System.Collections.Concurrent.ConcurrentDictionary<'key,'value> with
 
   member TryFind: key: 'key -> 'value option"""
-  
+
+[<Fact>]
+let ``ValText for C# abstract member override`` () =
+    let csharp = CSharp """
+namespace CSharp.Library
+{
+    using System;
+    using System.Globalization;
+    using System.Runtime.CompilerServices;
+    using System.Diagnostics.CodeAnalysis;
+    
+    public abstract class JsonConverter
+    {
+        public abstract void WriteJson(object writer, object? value, object serializer);
+        public abstract object? ReadJson(object reader, Type objectType, object? existingValue, object serializer);
+        public abstract bool CanConvert(Type objectType);
+        public virtual bool CanRead => true;
+        public virtual bool CanWrite => true;
+    }
+}
+"""
+
+    FSharp """
+module F    
+
+open CSharp.Library
+
+[<Sealed>]
+type EConverter () =
+    inherit JsonConverter ()
+
+    override this.WriteJson(writer, value, serializer) = failwith "todo"
+    override this.ReadJson(reader, objectType, existingValue, serializer) = failwith "todo"
+    override this.CanConvert(objectType) = failwith "todo"
+    override this.CanRead = true
+"""
+    |> withReferences [ csharp ]
+    |> typecheckResults
+    |> fun results ->
+        let writeJsonSymbolUse = results.GetSymbolUseAtLocation(10, 27, "    override this.WriteJson(writer, value, serializer) = failwith \"todo\"", [ "WriteJson" ]).Value
+        match writeJsonSymbolUse.Symbol with
+        | :? FSharpMemberOrFunctionOrValue as mfv ->
+            let valText = mfv.GetValSignatureText(writeJsonSymbolUse.DisplayContext, writeJsonSymbolUse.Range).Value
+            Assert.Equal("override WriteJson: writer: obj * value: obj * serializer: obj -> unit", valText)
+        | _ -> ()
+
+        let canReadSymbolUse = results.GetSymbolUseAtLocation(13, 25, "    override this.CanRead = true", [ "CanRead" ]).Value
+        match canReadSymbolUse.Symbol with
+        | :? FSharpMemberOrFunctionOrValue as mfv ->
+            let valText = mfv.GetValSignatureText(canReadSymbolUse.DisplayContext, canReadSymbolUse.Range).Value
+            Assert.Equal("override CanRead: bool", valText)
+        | _ -> ()


### PR DESCRIPTION
For a symbol for `WriteJson` in `override this.WriteJson(writer, value, serializer) = failwith "todo"` 

`GetValSignatureText` would return

`JsonConverter.WriteJson(writer: obj, value: obj, serializer: obj) : unit`,

after this PR it returns `override WriteJson: writer: obj * value: obj * serializer: obj -> unit`

I'll need to see if CI agrees with the `override` keyword change.
 