### PR TITLE
Make the first union case collapsible

### DIFF
--- a/src/Compiler/Service/ServiceStructure.fs
+++ b/src/Compiler/Service/ServiceStructure.fs
@@ -642,8 +642,9 @@ module Structure =
                     rcheck Scope.RecordField Collapse.Below fr fr
                     parseAttributes attrs
 
-            | SynTypeDefnSimpleRepr.Union (_, cases, ur) ->
-                rcheck Scope.UnionDefn Collapse.Same ur ur
+            | SynTypeDefnSimpleRepr.Union (unionCases = cases) ->
+                // We're including the full union scope, so there's no need to add
+                // the representation scope (covering all the cases) separately here.
 
                 for SynUnionCase (attributes = attrs; range = cr) in cases do
                     rcheck Scope.UnionCase Collapse.Below cr cr

--- a/tests/service/StructureTests.fs
+++ b/tests/service/StructureTests.fs
@@ -86,12 +86,14 @@ module MyModule =
 let ``DU``() =
     """
 type Color =
-    | Red
+    | Red of
+        opacity: float *
+        animated: bool
     | Green
     | Blue
 """
-    => [ (2, 5, 5, 10), (2, 11, 5, 10)
-         (3, 4, 5, 10), (3, 4, 5, 10) ]
+    => [ (2, 5, 7, 10), (2, 11, 7, 10)
+         (3, 6, 5, 22), (3, 6, 5, 22) ]
 
 [<Test>]
 let ``DU with interface``() =
@@ -106,7 +108,6 @@ type Color =
             (docEventListener :> IDisposable).Dispose()
 """
     => [ (2, 5, 9, 55), (2, 11, 9, 55)
-         (3, 4, 5, 10), (3, 4, 5, 10)
          (7, 4, 9, 55), (7, 25, 9, 55)
          (8, 8, 9, 55), (8, 27, 9, 55)
          (8, 15, 9, 55), (8, 27, 9, 55) ]


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/7278.

@auduchinok, I don't see when it would be useful to include both the union and representation scopes (unless this information is used for more than just collapse nodes). They cover virtually the same range.