### PR TITLE
Improve type error ranges in computed collections

### DIFF
--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -2182,10 +2182,11 @@ let TcSequenceExpression (cenv: cenv) env tpenv comp (overallTy: OverallTy) m =
                     Choice2Of2 expr, tpenv
                 else
                     let genResultTy = NewInferenceType g
-                    UnifyTypes cenv env m genOuterTy (mkSeqTy cenv.g genResultTy)
+                    let mExpr = expr.Range
+                    UnifyTypes cenv env mExpr genOuterTy (mkSeqTy cenv.g genResultTy)
                     let exprTy = tyOfExpr cenv.g expr
-                    AddCxTypeMustSubsumeType env.eContextInfo env.DisplayEnv cenv.css m  NoTrace genResultTy exprTy
-                    let resExpr = mkCallSeqSingleton cenv.g m genResultTy (mkCoerceExpr(expr, genResultTy, m, exprTy))
+                    AddCxTypeMustSubsumeType env.eContextInfo env.DisplayEnv cenv.css mExpr NoTrace genResultTy exprTy
+                    let resExpr = mkCallSeqSingleton cenv.g mExpr genResultTy (mkCoerceExpr(expr, genResultTy, mExpr, exprTy))
                     Choice1Of2 resExpr, tpenv
             else
                 let stmt, tpenv = TcStmtThatCantBeCtorBody cenv env tpenv comp

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeMismatchTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TypeMismatchTests.fs
@@ -293,3 +293,45 @@ type Derived3() =
                 (Error 856, Line 8,  Col 16, Line 8,  Col 22, "This override takes a different number of arguments to the corresponding abstract member. The following abstract members were found:" + System.Environment.NewLine + "   abstract Base.Member: int * string -> string")
                 (Error 856, Line 12, Col 16, Line 12, Col 22, "This override takes a different number of arguments to the corresponding abstract member. The following abstract members were found:" + System.Environment.NewLine + "   abstract Base.Member: int * string -> string")
                 (Error 1,   Line 16, Col 24, Line 16, Col 34, "This expression was expected to have type\n    'int'    \nbut here has type\n    'string'    ")]
+
+    [<Fact>]
+    let ``Elements in computed lists, arrays and sequences``() =
+        FSharp """
+let f1 =
+    [|
+        if true then
+            1
+        "wrong" 
+    |]
+
+let f2: int list =
+    [
+        if true then
+            "a"
+        yield! [ 3; 4 ] 
+    ]
+
+let f3 =
+    [
+        if true then
+            "a"
+            "b"
+        yield! [ 3; 4 ] 
+    ]
+
+let f4 =
+    seq {
+        1L
+        let _ = ()
+        2.5
+        3L
+    }
+        """
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 193,   Line 6,  Col 9,  Line 6,  Col 16, "Type constraint mismatch. The type \n    'string'    \nis not compatible with type\n    'int'    \n")
+            (Error 193,   Line 12, Col 13, Line 12, Col 16, "Type constraint mismatch. The type \n    'string'    \nis not compatible with type\n    'int'    \n")
+            (Error 193,   Line 21, Col 9,  Line 21, Col 24, "Type constraint mismatch. The type \n    'int list'    \nis not compatible with type\n    'string seq'    \n")
+            (Error 193,   Line 28, Col 9,  Line 28, Col 12, "Type constraint mismatch. The type \n    'float'    \nis not compatible with type\n    'int64'    \n")
+        ]

--- a/tests/fsharp/typecheck/sigs/neg24.bsl
+++ b/tests/fsharp/typecheck/sigs/neg24.bsl
@@ -21,7 +21,7 @@ neg24.fs(302,33,302,34): typecheck error FS0001: All elements of a list must be 
 
 neg24.fs(302,36,302,37): typecheck error FS0001: All elements of a list must be implicitly convertible to the type of the first element, which here is 'unit'. This element has type 'int'.
 
-neg24.fs(304,9,305,34): typecheck error FS0193: Type constraint mismatch. The type 
+neg24.fs(305,24,305,25): typecheck error FS0193: Type constraint mismatch. The type 
     'int'    
 is not compatible with type
     'unit'    

--- a/tests/fsharp/typecheck/sigs/version47/neg24.bsl
+++ b/tests/fsharp/typecheck/sigs/version47/neg24.bsl
@@ -21,7 +21,7 @@ neg24.fs(302,33,302,34): typecheck error FS0001: All elements of a list must be 
 
 neg24.fs(302,36,302,37): typecheck error FS0001: All elements of a list must be implicitly convertible to the type of the first element, which here is 'unit'. This element has type 'int'.
 
-neg24.fs(304,9,305,34): typecheck error FS0193: Type constraint mismatch. The type 
+neg24.fs(305,24,305,25): typecheck error FS0193: Type constraint mismatch. The type 
     'int'    
 is not compatible with type
     'unit'    


### PR DESCRIPTION
Fixes #15361, fixes #7670.

Before and after

![devenv_rh3jLBLjPb](https://github.com/dotnet/fsharp/assets/5063478/45dd522a-6cd0-4629-89e3-bb4db491fe8c) ![devenv_U7W79EhJHt](https://github.com/dotnet/fsharp/assets/5063478/23fa2281-3a3d-4842-8a7b-8d5104f5346b)
