### PR TITLE
Fix14779

### DIFF
--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -551,12 +551,13 @@ type internal FsiToolWindow() as this =
 {    hide()}
 #silentCd @"{dir}";;
 {if dbgBreak then "#dbgbreak" else ""}
-#{topLine} @"{filename}"
+# {topLine} @"{filename}"
 {text.ToString()}
 ;;
-#1 "stdin"
+# 1 "stdin"
 {    show()};;
 """
+
         executeTextNoHistory filename interaction
 
     let sendSelectionToFSI action =

--- a/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiSessionToolWindow.fs
@@ -553,6 +553,7 @@ type internal FsiToolWindow() as this =
 {if dbgBreak then "#dbgbreak" else ""}
 #{topLine} @"{filename}"
 {text.ToString()}
+;;
 #1 "stdin"
 {    show()};;
 """


### PR DESCRIPTION
This image shows both scenarios operating correctly

Fixes:

https://github.com/dotnet/fsharp/issues/15258
https://github.com/dotnet/fsharp/issues/14779
https://github.com/dotnet/fsharp/issues/14779 was caused by: the parser needing an End of block following the indented submission. We use ';;'. The end of block allows the parser to reset indent expectations.

https://github.com/dotnet/fsharp/issues/15258 was caused by a lack of space between the # line-number statement in the submission vsfsi prepares for submission to fsi.

Image:
![image](https://github.com/dotnet/fsharp/assets/5175830/25f5450d-9ee6-4271-accc-5f59b315f389)
