### PR TITLE
Fix find references bug in VS for operators which start with '>'

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -361,7 +361,7 @@ module internal Tokenizer =
     type FSharpTokenInfo with
 
         member token.IsIdentifier = (token.CharClass = FSharpTokenCharKind.Identifier)
-        member token.IsOperator = (token.ColorClass = FSharpTokenColorKind.Operator)
+        member token.IsOperator = (token.CharClass = FSharpTokenCharKind.Operator)
         member token.IsPunctuation = (token.ColorClass = FSharpTokenColorKind.Punctuation)
         member token.IsString = (token.ColorClass = FSharpTokenColorKind.String)
         member token.IsComment = (token.ColorClass = FSharpTokenColorKind.Comment)


### PR DESCRIPTION
This fixes #15376. The issue is caused by the VS tokenizer where it considers the first '>' token in as a punctuation not an operator which leads to no symbols to be found.