### PR TITLE
Fix DependencyManager bug

### DIFF
--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -197,7 +197,7 @@ module internal Utilities =
             psi.EnvironmentVariables.Remove("MSBuildSDKsPath") // Host can sometimes add this, and it can break things
 
             for varname, value in environment do
-                psi.EnvironmentVariables[varname] <- value
+                psi.EnvironmentVariables[ varname ] <- value
 
             psi.UseShellExecute <- false
 

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -197,7 +197,7 @@ module internal Utilities =
             psi.EnvironmentVariables.Remove("MSBuildSDKsPath") // Host can sometimes add this, and it can break things
 
             for varname, value in environment do
-                psi.EnvironmentVariables.Add(varname, value)
+                psi.EnvironmentVariables[varname] <- value
 
             psi.UseShellExecute <- false
 


### PR DESCRIPTION
When running tests locally I noticed that here when we try to add an environment variable that is already in `ProcessStartInfo.EnvironmentVariables` (in this case `DOTNET_CLI_UI_LANGUAGE`) it silently crashes and doesn't process references.