### PR TITLE
Parser: recover on unfinished `type` declarations

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -2556,8 +2556,9 @@ module EstablishTypeDefinitionCores =
                 | SynModuleDecl.Types (typeSpecs, _) -> 
                     for SynTypeDefn(typeInfo=SynComponentInfo(typeParams=synTypars; longId=ids); typeRepr=trepr) in typeSpecs do 
                         if TyparsAllHaveMeasureDeclEarlyCheck cenv env synTypars then
-                            match trepr with 
-                            | SynTypeDefnRepr.ObjectModel(kind=SynTypeDefnKind.Augmentation _) -> ()
+                            match trepr, ids with 
+                            | SynTypeDefnRepr.ObjectModel(kind=SynTypeDefnKind.Augmentation _), _ -> ()
+                            | _, [] -> ()
                             | _ -> yield (List.last ids).idText
                 | _ -> () ]
             |> set
@@ -4831,7 +4832,8 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
               let defn = TMDefRec(true, [], [decl], binds |> List.map ModuleOrNamespaceBinding.Binding, m)
               return ([defn], [], []), env, env
 
-      | SynModuleDecl.Types (typeDefs, m) -> 
+      | SynModuleDecl.Types (typeDefs, m) ->
+          let typeDefs = typeDefs |> List.filter (function (SynTypeDefn(typeInfo = SynComponentInfo(longId = []))) -> false | _ -> true)
           let scopem = unionRanges m scopem
           let mutRecDefns = typeDefs |> List.map MutRecShape.Tycon
           let mutRecDefnsChecked, envAfter = TcDeclarations.TcMutRecDefinitions cenv env parent typeNames tpenv m scopem None mutRecDefns false

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -1467,8 +1467,8 @@ type Exception with
                     ctxt.ShiftTokens
                     |> List.map Parser.tokenTagToTokenId
                     |> List.filter (function
-                        | EndOfStructuredConstructToken
                         | Parser.TOKEN_error
+                        | Parser.TOKEN_OBLOCKSEP
                         | Parser.TOKEN_EOF -> false
                         | _ -> true)
                     |> List.map tokenIdToText

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -1467,8 +1467,8 @@ type Exception with
                     ctxt.ShiftTokens
                     |> List.map Parser.tokenTagToTokenId
                     |> List.filter (function
+                        | EndOfStructuredConstructToken
                         | Parser.TOKEN_error
-                        | Parser.TOKEN_OBLOCKSEP
                         | Parser.TOKEN_EOF -> false
                         | _ -> true)
                     |> List.map tokenIdToText

--- a/src/Compiler/SyntaxTree/LexFilter.fs
+++ b/src/Compiler/SyntaxTree/LexFilter.fs
@@ -751,6 +751,9 @@ type LexFilterImpl (
             |  CtxtSeqBlock(FirstInSeqBlock, _, _), (CtxtDo _ as limitCtxt) :: CtxtSeqBlock _ :: (CtxtTypeDefns _ | CtxtModuleBody _) :: _ ->
                 PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
 
+            |  CtxtSeqBlock(FirstInSeqBlock, _, _), CtxtWithAsAugment _ :: (CtxtTypeDefns _ as limitCtxt) :: _ ->
+                PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
+
             | _, CtxtSeqBlock _ :: rest when not strict -> undentationLimit strict rest
             | _, CtxtParen _ :: rest when not strict -> undentationLimit strict rest
 
@@ -2308,7 +2311,7 @@ type LexFilterImpl (
             if debug then dprintf "WITH\n"
             if debug then dprintf "WITH --> NO MATCH, pushing CtxtWithAsAugment (type augmentation), stack = %A" stack
             pushCtxt tokenTup (CtxtWithAsAugment tokenStartPos)
-            pushCtxtSeqBlock tokenTup AddBlockEnd
+            tryPushCtxtSeqBlock tokenTup AddBlockEnd
             returnToken tokenLexbufState token
 
         | FUNCTION, _ ->

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -139,7 +139,7 @@ type SynTypeDefnLeadingKeyword =
         match this with
         | SynTypeDefnLeadingKeyword.Type range
         | SynTypeDefnLeadingKeyword.And range -> range
-        | SynTypeDefnLeadingKeyword.StaticType(staticRange, typeRange) -> Range.unionRanges staticRange typeRange
+        | SynTypeDefnLeadingKeyword.StaticType (staticRange, typeRange) -> Range.unionRanges staticRange typeRange
         | SynTypeDefnLeadingKeyword.Synthetic -> failwith "Getting range from synthetic keyword"
 
 [<NoEquality; NoComparison>]

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -135,6 +135,13 @@ type SynTypeDefnLeadingKeyword =
     | StaticType of staticRange: range * typeRange: range
     | Synthetic
 
+    member this.Range =
+        match this with
+        | SynTypeDefnLeadingKeyword.Type range
+        | SynTypeDefnLeadingKeyword.And range -> range
+        | SynTypeDefnLeadingKeyword.StaticType(staticRange, typeRange) -> Range.unionRanges staticRange typeRange
+        | SynTypeDefnLeadingKeyword.Synthetic -> failwith "Getting range from synthetic keyword"
+
 [<NoEquality; NoComparison>]
 type SynTypeDefnTrivia =
     {

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -219,10 +219,16 @@ type SynPatListConsTrivia =
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynTypeDefnLeadingKeyword =
     | Type of range
+
     | And of range
-    // Can happen in SynMemberDefn.NestedType or SynMemberSig.NestedType
+
+    /// Can happen in SynMemberDefn.NestedType or SynMemberSig.NestedType
     | StaticType of staticRange: range * typeRange: range
+
+    /// Produced during type checking, should not be used in actual parsed trees.
     | Synthetic
+
+    member Range: range
 
 /// Represents additional information for SynTypeDefn
 [<NoEquality; NoComparison>]

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -1540,7 +1540,8 @@ typeNameInfo:
   | opt_attributes tyconNameAndTyparDecls opt_typeConstraints
      { let typars, lid, fixity, vis = $2
        let xmlDoc = grabXmlDoc(parseState, $1, 1)
-       SynComponentInfo ($1, typars, $3, lid, xmlDoc, fixity, vis, rangeOfLid lid) }
+       let m = match lid with [] -> rhs parseState 2 | _ -> rangeOfLid lid
+       SynComponentInfo ($1, typars, $3, lid, xmlDoc, fixity, vis, m) }
 
 /* Part of a set of type definitions */
 tyconDefnList:
@@ -2316,6 +2317,9 @@ tyconNameAndTyparDecls:
 
   | opt_access path postfixTyparDecls
       { Some $3, $2.LongIdent, true, $1 }
+
+  | opt_access recover
+      { None, [], false, $1 }
 
 prefixTyparDecls:
   | typar

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -1605,7 +1605,8 @@ tyconDefn:
        let mEquals = rhs parseState 7
        // Gets the XML doc comments prior to the implicit constructor
        let xmlDoc = grabXmlDoc(parseState, $2, 2)
-       let memberCtorPattern = SynMemberDefn.ImplicitCtor(vis, $2, spats, Option.map snd az, xmlDoc, rangeOfLid lid, { AsKeyword = Option.map fst az })
+       let m = match lid with [] -> rhs parseState 1 | _ -> rangeOfLid lid
+       let memberCtorPattern = SynMemberDefn.ImplicitCtor(vis, $2, spats, Option.map snd az, xmlDoc, m, { AsKeyword = Option.map fst az })
        let tcDefRepr =
          match tcDefRepr with
          | SynTypeDefnRepr.ObjectModel (k, cspec, m) -> SynTypeDefnRepr.ObjectModel(k, memberCtorPattern :: cspec, m)

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/codepage/codepage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/codepage/codepage.fs
@@ -202,5 +202,6 @@ Parameter name: codepage")
         |> shouldFail
         |> withDiagnostics [
             (Error 10, Line 7, Col 10, Line 7, Col 11, "Unexpected character '�' in type name")
+            (Error 552, Line 7, Col 10, Line 8, Col 33, "Only class types may take value arguments")
             (Error 10, Line 9, Col 14, Line 9, Col 17, "Unexpected keyword 'end' in implementation file")
         ]

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/codepage/codepage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/codepage/codepage.fs
@@ -203,5 +203,5 @@ Parameter name: codepage")
         |> withDiagnostics [
             (Error 10, Line 7, Col 10, Line 7, Col 11, "Unexpected character '�' in type name")
             (Error 552, Line 7, Col 10, Line 8, Col 33, "Only class types may take value arguments")
-            (Error 10, Line 9, Col 14, Line 9, Col 17, "Unexpected keyword 'end' in implementation file")
+            (Error 10, Line 9, Col 14, Line 9, Col 17, "Unexpected keyword 'end' in implementation file. Expected incomplete structured construct at or before this point or other token.")
         ]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/OffsideExceptions/RelaxWhitespace2.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/OffsideExceptions/RelaxWhitespace2.fs
@@ -3568,7 +3568,7 @@ and             ^a
          > () = 
             member inline __.X = ()
         with
-        static member inline Y = ()
+            static member inline Y = ()
         
 type TypeWithALongName< ^a
     when ^a:(static member(+):'a * 'a -> 'a )

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -9814,6 +9814,8 @@ FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTr
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Type
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Int32 Tag
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Int32 get_Tag()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: System.String ToString()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -9814,6 +9814,8 @@ FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTr
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Tags
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+Type
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Int32 Tag
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: Int32 get_Tag()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword: System.String ToString()

--- a/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
+++ b/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
@@ -978,7 +978,7 @@ module Test =
         | UCase1
         | UCase2 with
 
-    static member M() = ()
+        static member M() = ()
 
 open type Test.TestUnion
 
@@ -1004,7 +1004,7 @@ module Test =
         | UCase1 of 'T
         | UCase2 with
 
-    static member M() = ()
+        static member M() = ()
 
 open type Test.TestUnion<int>
 

--- a/tests/fsharp/typecheck/sigs/neg29.bsl
+++ b/tests/fsharp/typecheck/sigs/neg29.bsl
@@ -2,3 +2,7 @@
 neg29.fs(5,19,6,16): parse error FS0010: Incomplete structured construct at or before this point in type name. Expected '>' or other token.
 
 neg29.fs(9,1,9,1): parse error FS0010: Incomplete structured construct at or before this point in implementation file
+
+neg29.fs(6,19,6,20): parse error FS0010: Unexpected symbol '(' in expression
+
+neg29.fs(6,18,6,19): parse error FS3156: Unexpected token '>' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/Try with - Missing expr 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Try with - Missing expr 05.fs.bsl
@@ -18,4 +18,4 @@ ImplFile
         CodeComments = [] }, set []))
 
 (5,0)-(5,6) parse error Expecting expression
-(5,0)-(5,6) parse error Unexpected keyword 'module' in definition. Expected incomplete structured construct at or before this point or other token.
+(5,0)-(5,6) parse error Unexpected keyword 'module' in definition

--- a/tests/service/data/SyntaxTree/Expression/Try with - Missing expr 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Try with - Missing expr 05.fs.bsl
@@ -18,4 +18,4 @@ ImplFile
         CodeComments = [] }, set []))
 
 (5,0)-(5,6) parse error Expecting expression
-(5,0)-(5,6) parse error Unexpected keyword 'module' in definition
+(5,0)-(5,6) parse error Unexpected keyword 'module' in definition. Expected incomplete structured construct at or before this point or other token.

--- a/tests/service/data/SyntaxTree/Expression/Typed 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Typed 01.fs.bsl
@@ -8,4 +8,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,1)-(3,2) parse error Unexpected symbol ':' in definition. Expected incomplete structured construct at or before this point or other token.
+(3,1)-(3,2) parse error Unexpected symbol ':' in definition

--- a/tests/service/data/SyntaxTree/Expression/Typed 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Typed 01.fs.bsl
@@ -8,4 +8,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,1)-(3,2) parse error Unexpected symbol ':' in definition
+(3,1)-(3,2) parse error Unexpected symbol ':' in definition. Expected incomplete structured construct at or before this point or other token.

--- a/tests/service/data/SyntaxTree/Expression/Typed 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Typed 02.fs.bsl
@@ -8,4 +8,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,1)-(3,2) parse error Unexpected symbol ':' in definition. Expected incomplete structured construct at or before this point or other token.
+(3,1)-(3,2) parse error Unexpected symbol ':' in definition

--- a/tests/service/data/SyntaxTree/Expression/Typed 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Typed 02.fs.bsl
@@ -8,4 +8,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,1)-(3,2) parse error Unexpected symbol ':' in definition
+(3,1)-(3,2) parse error Unexpected symbol ':' in definition. Expected incomplete structured construct at or before this point or other token.

--- a/tests/service/data/SyntaxTree/Member/Interface 06.fs
+++ b/tests/service/data/SyntaxTree/Member/Interface 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    interface I with
+
+    let _ = ()

--- a/tests/service/data/SyntaxTree/Member/Interface 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Interface 06.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Interface 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Interface
+                        (LongIdent (SynLongIdent ([I], [], [None])),
+                         Some (4,16--4,20), Some [], (4,4--4,20));
+                      LetBindings
+                        ([SynBinding
+                            (None, Normal, false, false, [],
+                             PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                             SynValData
+                               (None,
+                                SynValInfo ([], SynArgInfo ([], false, None)),
+                                None), Wild (6,8--6,9), None,
+                             Const (Unit, (6,12--6,14)), (6,8--6,9),
+                             Yes (6,4--6,14),
+                             { LeadingKeyword = Let (6,4--6,7)
+                               InlineKeyword = None
+                               EqualsRange = Some (6,10--6,11) })], false, false,
+                         (6,4--6,14))], (4,4--6,14)), [], None, (3,5--6,14),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,14) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.

--- a/tests/service/data/SyntaxTree/Member/Interface 07.fs
+++ b/tests/service/data/SyntaxTree/Member/Interface 07.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    interface I
+
+    member this.P = 1

--- a/tests/service/data/SyntaxTree/Member/Interface 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Interface 07.fs.bsl
@@ -1,0 +1,47 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Interface 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Interface
+                        (LongIdent (SynLongIdent ([I], [], [None])), None, None,
+                         (4,4--4,15));
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P], [(6,15--6,16)], [None; None]), None,
+                               None, Pats [], None, (6,11--6,17)), None,
+                            Const (Int32 1, (6,20--6,21)), (6,11--6,17),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (6,4--6,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (6,18--6,19) }), (6,4--6,21))],
+                     (4,4--6,21)), [], None, (3,5--6,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi
@@ -1,5 +1,0 @@
-
-namespace X
-
-type Foo with
-member Meh : unit -> unit

--- a/tests/service/data/SyntaxTree/SignatureType/With 01.fsi
+++ b/tests/service/data/SyntaxTree/SignatureType/With 01.fsi
@@ -1,0 +1,4 @@
+namespace X
+
+type Foo with
+    member Meh: unit -> unit

--- a/tests/service/data/SyntaxTree/SignatureType/With 01.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/With 01.fsi.bsl
@@ -1,30 +1,28 @@
 SigFile
   (ParsedSigFileInput
-     ("/root/SignatureType/SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword.fsi",
-      QualifiedNameOfFile SynTypeDefnSigShouldContainsTheRangeOfTheWithKeyword,
-      [], [],
+     ("/root/SignatureType/With 01.fsi", QualifiedNameOfFile With 01, [], [],
       [SynModuleOrNamespaceSig
          ([X], false, DeclaredNamespace,
           [Types
              ([SynTypeDefnSig
                  (SynComponentInfo
                     ([], None, [], [Foo],
-                     PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
-                     false, None, (4,5--4,8)),
-                  Simple (None (4,5--5,25), (4,5--5,25)),
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,8)),
+                  Simple (None (3,5--4,28), (3,5--4,28)),
                   [Member
                      (SynValSig
                         ([], SynIdent (Meh, None), SynValTyparDecls (None, true),
                          Fun
                            (LongIdent (SynLongIdent ([unit], [], [None])),
                             LongIdent (SynLongIdent ([unit], [], [None])),
-                            (5,13--5,25), { ArrowRange = (5,18--5,20) }),
+                            (4,16--4,28), { ArrowRange = (4,21--4,23) }),
                          SynValInfo
                            ([[SynArgInfo ([], false, None)]],
                             SynArgInfo ([], false, None)), false, false,
-                         PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, None, (5,0--5,25),
-                         { LeadingKeyword = Member (5,0--5,6)
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, None, (4,4--4,28),
+                         { LeadingKeyword = Member (4,4--4,10)
                            InlineKeyword = None
                            WithKeyword = None
                            EqualsRange = None }),
@@ -33,12 +31,12 @@ SigFile
                         IsOverrideOrExplicitImpl = false
                         IsFinal = false
                         GetterOrSetterIsCompilerGenerated = false
-                        MemberKind = Member }, (5,0--5,25),
-                      { GetSetKeywords = None })], (4,5--5,25),
-                  { LeadingKeyword = Type (4,0--4,4)
+                        MemberKind = Member }, (4,4--4,28),
+                      { GetSetKeywords = None })], (3,5--4,28),
+                  { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = None
-                    WithKeyword = Some (4,9--4,13) })], (4,0--5,25))],
-          PreXmlDocEmpty, [], None, (2,0--5,25),
-          { LeadingKeyword = Namespace (2,0--2,9) })],
+                    WithKeyword = Some (3,9--3,13) })], (3,0--4,28))],
+          PreXmlDocEmpty, [], None, (1,0--4,28),
+          { LeadingKeyword = Namespace (1,0--1,9) })],
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/And 01.fs
+++ b/tests/service/data/SyntaxTree/Type/And 01.fs
@@ -1,0 +1,7 @@
+module Module
+
+type A = int
+
+and
+
+and C = int

--- a/tests/service/data/SyntaxTree/Type/And 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/And 01.fs.bsl
@@ -1,0 +1,45 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/And 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (3,9--3,12)), (3,9--3,12)), [], None, (3,5--3,12),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [],
+                     PreXmlDoc ((7,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (7,0--7,3)),
+                  Simple (None (7,0--7,3), (7,0--7,3)), [], None, (7,0--7,3),
+                  { LeadingKeyword = And (5,0--5,3)
+                    EqualsRange = None
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [C],
+                     PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (7,4--7,5)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (7,8--7,11)), (7,8--7,11)), [], None, (7,4--7,11),
+                  { LeadingKeyword = And (7,0--7,3)
+                    EqualsRange = Some (7,6--7,7)
+                    WithKeyword = None })], (3,0--7,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(7,0)-(7,3) parse error Unexpected keyword 'and' in type name

--- a/tests/service/data/SyntaxTree/Type/And 02.fs
+++ b/tests/service/data/SyntaxTree/Type/And 02.fs
@@ -1,0 +1,7 @@
+module Module
+
+type A = int
+
+and B
+
+and C = int

--- a/tests/service/data/SyntaxTree/Type/And 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/And 02.fs.bsl
@@ -1,0 +1,43 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/And 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (3,9--3,12)), (3,9--3,12)), [], None, (3,5--3,12),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [B],
+                     PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (5,4--5,5)),
+                  Simple (None (5,4--5,5), (5,4--5,5)), [], None, (5,4--5,5),
+                  { LeadingKeyword = And (5,0--5,3)
+                    EqualsRange = None
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [C],
+                     PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (7,4--7,5)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (7,8--7,11)), (7,8--7,11)), [], None, (7,4--7,11),
+                  { LeadingKeyword = And (7,0--7,3)
+                    EqualsRange = Some (7,6--7,7)
+                    WithKeyword = None })], (3,0--7,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/And 03.fs
+++ b/tests/service/data/SyntaxTree/Type/And 03.fs
@@ -1,0 +1,7 @@
+module Module
+
+type A = int
+
+and B =
+
+and C = int

--- a/tests/service/data/SyntaxTree/Type/And 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/And 03.fs.bsl
@@ -1,0 +1,45 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/And 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (3,9--3,12)), (3,9--3,12)), [], None, (3,5--3,12),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [B],
+                     PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (5,4--5,5)),
+                  ObjectModel (Unspecified, [], (7,0--7,0)), [], None,
+                  (5,4--7,0), { LeadingKeyword = And (5,0--5,3)
+                                EqualsRange = Some (5,6--5,7)
+                                WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [C],
+                     PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (7,4--7,5)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (7,8--7,11)), (7,8--7,11)), [], None, (7,4--7,11),
+                  { LeadingKeyword = And (7,0--7,3)
+                    EqualsRange = Some (7,6--7,7)
+                    WithKeyword = None })], (3,0--7,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,7) parse error A type definition requires one or more members or other declarations. If you intend to define an empty class, struct or interface, then use 'type ... = class end', 'interface end' or 'struct end'.

--- a/tests/service/data/SyntaxTree/Type/And 04.fs
+++ b/tests/service/data/SyntaxTree/Type/And 04.fs
@@ -1,0 +1,5 @@
+module Module
+
+type A = int
+
+and

--- a/tests/service/data/SyntaxTree/Type/And 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/And 04.fs.bsl
@@ -1,0 +1,33 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/And 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (3,9--3,12)), (3,9--3,12)), [], None, (3,5--3,12),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [],
+                     PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (6,0--6,0)),
+                  Simple (None (6,0--6,0), (6,0--6,0)), [], None, (6,0--6,0),
+                  { LeadingKeyword = And (5,0--5,3)
+                    EqualsRange = None
+                    WithKeyword = None })], (3,0--6,0))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,0), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,0) parse error Incomplete structured construct at or before this point in type name

--- a/tests/service/data/SyntaxTree/Type/And 05.fs
+++ b/tests/service/data/SyntaxTree/Type/And 05.fs
@@ -1,0 +1,5 @@
+module Module
+
+type A = int
+
+and B

--- a/tests/service/data/SyntaxTree/Type/And 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/And 05.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/And 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (3,9--3,12)), (3,9--3,12)), [], None, (3,5--3,12),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [B],
+                     PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (5,4--5,5)),
+                  Simple (None (5,4--5,5), (5,4--5,5)), [], None, (5,4--5,5),
+                  { LeadingKeyword = And (5,0--5,3)
+                    EqualsRange = None
+                    WithKeyword = None })], (3,0--5,5))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,5), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/And 06.fs
+++ b/tests/service/data/SyntaxTree/Type/And 06.fs
@@ -1,0 +1,5 @@
+module Module
+
+type A = int
+
+and B =

--- a/tests/service/data/SyntaxTree/Type/And 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/And 06.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/And 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [A],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (3,9--3,12)), (3,9--3,12)), [], None, (3,5--3,12),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [B],
+                     PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (5,4--5,5)),
+                  ObjectModel (Unspecified, [], (5,6--5,6)), [], None,
+                  (5,4--5,7), { LeadingKeyword = And (5,0--5,3)
+                                EqualsRange = Some (5,6--5,7)
+                                WithKeyword = None })], (3,0--5,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,0) parse error Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.
+(5,4)-(5,7) parse error A type definition requires one or more members or other declarations. If you intend to define an empty class, struct or interface, then use 'type ... = class end', 'interface end' or 'struct end'.

--- a/tests/service/data/SyntaxTree/Type/Type 01.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 01.fs
@@ -1,0 +1,5 @@
+module Module
+
+type
+
+()

--- a/tests/service/data/SyntaxTree/Type/Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 01.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--5,0)),
+                  Simple (None (3,5--5,0), (3,5--5,0)), [], None, (3,5--5,0),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = None
+                    WithKeyword = None })], (3,0--5,0));
+           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,5)-(5,0) parse error Incomplete structured construct at or before this point in type name

--- a/tests/service/data/SyntaxTree/Type/Type 02.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 02.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T
+
+()

--- a/tests/service/data/SyntaxTree/Type/Type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 02.fs.bsl
@@ -1,0 +1,20 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple (None (3,5--3,6), (3,5--3,6)), [], None, (3,5--3,6),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = None
+                    WithKeyword = None })], (3,0--3,6));
+           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Type 03.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 03.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T =
+
+()

--- a/tests/service/data/SyntaxTree/Type/Type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 03.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Unspecified, [], (5,0--5,0)), [], None,
+                  (3,5--5,0), { LeadingKeyword = Type (3,0--3,4)
+                                EqualsRange = Some (3,7--3,8)
+                                WithKeyword = None })], (3,0--5,0));
+           Expr (Const (Unit, (5,0--5,2)), (5,0--5,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,5)-(3,8) parse error A type definition requires one or more members or other declarations. If you intend to define an empty class, struct or interface, then use 'type ... = class end', 'interface end' or 'struct end'.

--- a/tests/service/data/SyntaxTree/Type/Type 04.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 04.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T1 =
+
+type T2 = int

--- a/tests/service/data/SyntaxTree/Type/Type 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 04.fs.bsl
@@ -1,0 +1,34 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T1],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,7)),
+                  ObjectModel (Unspecified, [], (5,0--5,0)), [], None,
+                  (3,5--5,0), { LeadingKeyword = Type (3,0--3,4)
+                                EqualsRange = Some (3,8--3,9)
+                                WithKeyword = None })], (3,0--5,0));
+           Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T2],
+                     PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (5,5--5,7)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (5,10--5,13)), (5,10--5,13)), [], None, (5,5--5,13),
+                  { LeadingKeyword = Type (5,0--5,4)
+                    EqualsRange = Some (5,8--5,9)
+                    WithKeyword = None })], (5,0--5,13))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,13), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,5)-(3,9) parse error A type definition requires one or more members or other declarations. If you intend to define an empty class, struct or interface, then use 'type ... = class end', 'interface end' or 'struct end'.

--- a/tests/service/data/SyntaxTree/Type/Type 05.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 05.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T1 =
+
+and T2 = int

--- a/tests/service/data/SyntaxTree/Type/Type 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 05.fs.bsl
@@ -1,0 +1,33 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T1],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,7)),
+                  ObjectModel (Unspecified, [], (5,0--5,0)), [], None,
+                  (3,5--5,0), { LeadingKeyword = Type (3,0--3,4)
+                                EqualsRange = Some (3,8--3,9)
+                                WithKeyword = None });
+               SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T2],
+                     PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (5,4--5,6)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (5,9--5,12)), (5,9--5,12)), [], None, (5,4--5,12),
+                  { LeadingKeyword = And (5,0--5,3)
+                    EqualsRange = Some (5,7--5,8)
+                    WithKeyword = None })], (3,0--5,12))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,12), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,5)-(3,9) parse error A type definition requires one or more members or other declarations. If you intend to define an empty class, struct or interface, then use 'type ... = class end', 'interface end' or 'struct end'.

--- a/tests/service/data/SyntaxTree/Type/Type 06.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 06.fs
@@ -1,0 +1,3 @@
+module Module
+
+type =

--- a/tests/service/data/SyntaxTree/Type/Type 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 06.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Unspecified, [], (3,5--3,5)), [], None,
+                  (3,5--3,6), { LeadingKeyword = Type (3,0--3,4)
+                                EqualsRange = Some (3,5--3,6)
+                                WithKeyword = None })], (3,0--3,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,0)-(4,0) parse error Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.
+(3,5)-(3,6) parse error Unexpected symbol '=' in type name
+(3,5)-(3,6) parse error A type definition requires one or more members or other declarations. If you intend to define an empty class, struct or interface, then use 'type ... = class end', 'interface end' or 'struct end'.

--- a/tests/service/data/SyntaxTree/Type/Type 07.fs
+++ b/tests/service/data/SyntaxTree/Type/Type 07.fs
@@ -1,0 +1,4 @@
+module Module
+
+type =
+    member this.P = 1

--- a/tests/service/data/SyntaxTree/Type/Type 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Type 07.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Type 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P], [(4,15--4,16)], [None; None]), None,
+                               None, Pats [], None, (4,11--4,17)), None,
+                            Const (Int32 1, (4,20--4,21)), (4,11--4,17),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (4,4--4,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (4,18--4,19) }), (4,4--4,21))],
+                     (4,4--4,21)), [], None, (3,5--4,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,5--3,6)
+                    WithKeyword = None })], (3,0--4,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,5)-(3,6) parse error Unexpected symbol '=' in type name

--- a/tests/service/data/SyntaxTree/Type/With 01.fs
+++ b/tests/service/data/SyntaxTree/Type/With 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T with
+    member this.P = 1
+
+2

--- a/tests/service/data/SyntaxTree/Type/With 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/With 01.fs.bsl
@@ -1,0 +1,43 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/With 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Augmentation (3,7--3,11), [], (3,5--4,21)),
+                  [Member
+                     (SynBinding
+                        (None, Normal, false, false, [],
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         SynValData
+                           (Some { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                            SynValInfo
+                              ([[SynArgInfo ([], false, None)]; []],
+                               SynArgInfo ([], false, None)), None),
+                         LongIdent
+                           (SynLongIdent
+                              ([this; P], [(4,15--4,16)], [None; None]), None,
+                            None, Pats [], None, (4,11--4,17)), None,
+                         Const (Int32 1, (4,20--4,21)), (4,11--4,17),
+                         NoneAtInvisible, { LeadingKeyword = Member (4,4--4,10)
+                                            InlineKeyword = None
+                                            EqualsRange = Some (4,18--4,19) }),
+                      (4,4--4,21))], None, (3,5--4,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = None
+                    WithKeyword = None })], (3,0--4,21));
+           Expr (Const (Int32 2, (6,0--6,1)), (6,0--6,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/With 02.fs
+++ b/tests/service/data/SyntaxTree/Type/With 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T with
+member this.P = 1
+
+2

--- a/tests/service/data/SyntaxTree/Type/With 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/With 02.fs.bsl
@@ -19,4 +19,4 @@ ImplFile
         CodeComments = [] }, set []))
 
 (4,0)-(4,6) parse error Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.
-(4,0)-(4,6) parse error Unexpected keyword 'member' in definition
+(4,0)-(4,6) parse error Unexpected keyword 'member' in definition. Expected incomplete structured construct at or before this point or other token.

--- a/tests/service/data/SyntaxTree/Type/With 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/With 02.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/With 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Augmentation (3,7--3,11), [], (3,5--3,11)), [],
+                  None, (3,5--3,11), { LeadingKeyword = Type (3,0--3,4)
+                                       EqualsRange = None
+                                       WithKeyword = None })], (3,0--3,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,0)-(4,6) parse error Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.
+(4,0)-(4,6) parse error Unexpected keyword 'member' in definition

--- a/tests/service/data/SyntaxTree/Type/With 03.fs
+++ b/tests/service/data/SyntaxTree/Type/With 03.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T with
+
+2

--- a/tests/service/data/SyntaxTree/Type/With 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/With 03.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/With 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel (Augmentation (3,7--3,11), [], (3,5--3,11)), [],
+                  None, (3,5--3,11), { LeadingKeyword = Type (3,0--3,4)
+                                       EqualsRange = None
+                                       WithKeyword = None })], (3,0--3,11));
+           Expr (Const (Int32 2, (5,0--5,1)), (5,0--5,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,1) parse error Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.

--- a/tests/service/data/SyntaxTree/Type/With 04.fs
+++ b/tests/service/data/SyntaxTree/Type/With 04.fs
@@ -1,0 +1,8 @@
+module Module
+
+type U =
+    | A with
+
+    member this.P = 1
+
+2

--- a/tests/service/data/SyntaxTree/Type/With 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/With 04.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/With 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,7)), (4,4--4,7)),
+                  [Member
+                     (SynBinding
+                        (None, Normal, false, false, [],
+                         PreXmlDoc ((6,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         SynValData
+                           (Some { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                            SynValInfo
+                              ([[SynArgInfo ([], false, None)]; []],
+                               SynArgInfo ([], false, None)), None),
+                         LongIdent
+                           (SynLongIdent
+                              ([this; P], [(6,15--6,16)], [None; None]), None,
+                            None, Pats [], None, (6,11--6,17)), None,
+                         Const (Int32 1, (6,20--6,21)), (6,11--6,17),
+                         NoneAtInvisible, { LeadingKeyword = Member (6,4--6,10)
+                                            InlineKeyword = None
+                                            EqualsRange = Some (6,18--6,19) }),
+                      (6,4--6,21))], None, (3,5--6,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = Some (4,8--4,12) })], (3,0--6,21));
+           Expr (Const (Int32 2, (8,0--8,1)), (8,0--8,1))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/With 05.fs
+++ b/tests/service/data/SyntaxTree/Type/With 05.fs
@@ -1,0 +1,8 @@
+module Module
+
+type U =
+    | A with
+
+member this.P = 1
+
+2

--- a/tests/service/data/SyntaxTree/Type/With 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/With 05.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/With 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,7)), (4,4--4,7)), [], None, (3,5--4,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = Some (4,8--4,12) })], (3,0--4,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,6) parse error Possible incorrect indentation: this token is offside of context started at position (3:1). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,6) parse error Unexpected keyword 'member' in definition. Expected incomplete structured construct at or before this point or other token.

--- a/vsintegration/tests/FSharp.Editor.Tests/DocumentDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/DocumentDiagnosticAnalyzerTests.fs
@@ -130,16 +130,6 @@ let b =
         )
 
     [<Fact>]
-    member public this.Error_Type_WithoutName() =
-        this.VerifyErrorBetweenMarkers(
-            fileContents =
-                """
-type (*start*)=(*end*)
-                """,
-            expectedMessage = "Unexpected symbol '=' in type name"
-        )
-
-    [<Fact>]
     member public this.AbstractClasses_Constructors_PositiveTests_1() =
         this.VerifyNoErrors(
             """


### PR DESCRIPTION
Various unfinished `type` cases:

```fsharp
type T with

()
```

```fsharp
type
```

```fsharp
type T =
```

```fsharp
type T1 = int
and
```

```fsharp
type T1 = int
and T2 = 
```

```fsharp
type T1 = int
and
and T3 = int
```

Unfinished types ending with `with` and `=` are recovered due to the new indentation rules.