### PR TITLE
Support constraint intersection syntax

### DIFF
--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -261,6 +261,9 @@ let visitSynType (t: SynType) : FileContentEntry list =
             let continuations = List.map visit [ lhsType; rhsType ]
             Continuation.concatenate continuations continuation
         | SynType.FromParseError _ -> continuation []
+        | SynType.Intersection (types = types) ->
+            let continuations = List.map visit types
+            Continuation.concatenate continuations continuation
 
     visit t id
 

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1575,6 +1575,7 @@ featureExtendedStringInterpolation,"Extended string interpolation similar to C# 
 featureWarningWhenMultipleRecdTypeChoice,"Raises warnings when multiple record type matches were found during name resolution because of overlapping field names."
 featureImprovedImpliedArgumentNames,"Improved implied argument names"
 featureStrictIndentation,"Raises errors on incorrect indentation, allows better recovery and analysis during editing"
+featureConstraintIntersectionOnFlexibleTypes,"Constraint intersection on flexible types"
 3353,fsiInvalidDirective,"Invalid directive '#%s %s'"
 3354,tcNotAFunctionButIndexerNamedIndexingNotYetEnabled,"This value supports indexing, e.g. '%s.[index]'. The syntax '%s[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation."
 3354,tcNotAFunctionButIndexerIndexingNotYetEnabled,"This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation."
@@ -1698,3 +1699,4 @@ featureEscapeBracesInFormattableString,"Escapes curly braces before calling Form
 featureInformationalObjInferenceDiagnostic,"Diagnostic 3559 (warn when obj inferred) at informational level, off by default"
 3566,tcMultipleRecdTypeChoice,"Multiple type matches were found:\n%s\nThe type '%s' was used. Due to the overlapping field names\n%s\nconsider using type annotations or change the order of open statements."
 3567,parsMissingMemberBody,"Expecting member body"
+3568,tcConstraintIntersectionSyntaxUsedWithNonFlexibleType,"Constraint intersection syntax may only be used with flexible types."

--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -71,6 +71,7 @@ type LanguageFeature =
     | WarningWhenMultipleRecdTypeChoice
     | ImprovedImpliedArgumentNames
     | DiagnosticForObjInference
+    | ConstraintIntersectionOnFlexibleTypes
 
 /// LanguageVersion management
 type LanguageVersion(versionText) =
@@ -165,6 +166,7 @@ type LanguageVersion(versionText) =
                 LanguageFeature.ImprovedImpliedArgumentNames, previewVersion
                 LanguageFeature.DiagnosticForObjInference, previewVersion
                 LanguageFeature.StrictIndentation, previewVersion
+                LanguageFeature.ConstraintIntersectionOnFlexibleTypes, previewVersion
 
             ]
 
@@ -291,6 +293,7 @@ type LanguageVersion(versionText) =
         | LanguageFeature.ImprovedImpliedArgumentNames -> FSComp.SR.featureImprovedImpliedArgumentNames ()
         | LanguageFeature.DiagnosticForObjInference -> FSComp.SR.featureInformationalObjInferenceDiagnostic ()
         | LanguageFeature.StrictIndentation -> FSComp.SR.featureStrictIndentation ()
+        | LanguageFeature.ConstraintIntersectionOnFlexibleTypes -> FSComp.SR.featureConstraintIntersectionOnFlexibleTypes ()
 
     /// Get a version string associated with the given feature.
     static member GetFeatureVersionString feature =

--- a/src/Compiler/Facilities/LanguageFeatures.fsi
+++ b/src/Compiler/Facilities/LanguageFeatures.fsi
@@ -61,6 +61,7 @@ type LanguageFeature =
     | WarningWhenMultipleRecdTypeChoice
     | ImprovedImpliedArgumentNames
     | DiagnosticForObjInference
+    |ConstraintIntersectionOnFlexibleTypes
 
 /// LanguageVersion management
 type LanguageVersion =

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -844,6 +844,7 @@ module SyntaxTraversal =
                 | SynType.StaticConstantExpr (expr, _) -> traverseSynExpr [] expr
                 | SynType.Paren (innerType = t)
                 | SynType.SignatureParameter (usedType = t) -> traverseSynType path t
+                | SynType.Intersection (types = types) -> List.tryPick (traverseSynType path) types
                 | SynType.Anon _
                 | SynType.AnonRecd _
                 | SynType.LongIdent _

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -681,6 +681,7 @@ module ParsedInput =
             | SynType.SignatureParameter (usedType = t) -> walkType t
             | SynType.StaticConstantExpr (e, _) -> walkExpr e
             | SynType.StaticConstantNamed (ident, value, _) -> List.tryPick walkType [ ident; value ]
+            | SynType.Intersection (types = types) -> List.tryPick walkType types
             | SynType.Anon _
             | SynType.AnonRecd _
             | SynType.LongIdent _
@@ -1699,6 +1700,7 @@ module ParsedInput =
             | SynType.StaticConstantNamed (ident, value, _) ->
                 walkType ident
                 walkType value
+            | SynType.Intersection (types = types) -> List.iter walkType types
             | SynType.Anon _
             | SynType.AnonRecd _
             | SynType.Var _

--- a/src/Compiler/SyntaxTree/LexFilter.fs
+++ b/src/Compiler/SyntaxTree/LexFilter.fs
@@ -1117,7 +1117,7 @@ type LexFilterImpl (
                     //      f<{| C : int |}>x
                     //      f<x # x>x
                     //      f<x ' x>x
-                    | DEFAULT | COLON | COLON_GREATER | STRUCT | NULL | DELEGATE | AND | WHEN
+                    | DEFAULT | COLON | COLON_GREATER | STRUCT | NULL | DELEGATE | AND | WHEN | AMP
                     | DOT_DOT
                     | NEW
                     | LBRACE_BAR

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -443,6 +443,8 @@ type SynType =
 
     | FromParseError of range: range
 
+    | Intersection of typar: SynTypar option * types: SynType list * range: range
+
     member x.Range =
         match x with
         | SynType.App (range = m)
@@ -462,6 +464,7 @@ type SynType =
         | SynType.Paren (range = m)
         | SynType.SignatureParameter (range = m)
         | SynType.Or (range = m)
+        | SynType.Intersection (range = m)
         | SynType.FromParseError (range = m) -> m
         | SynType.LongIdent lidwd -> lidwd.Range
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -521,6 +521,11 @@ type SynType =
     /// A type arising from a parse error
     | FromParseError of range: range
 
+    /// F# syntax: x: #I1 & #I2
+    /// F# syntax: x: 't & #I1 & #I2
+    /// Shorthand for x: 't when 't :> I1 and 't :> I2
+    | Intersection of typar: SynTypar option * types: SynType list * range: range
+
     /// Gets the syntax range of this construct
     member Range: range
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2369,6 +2369,15 @@ typeConstraints:
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
+intersectionConstraints:
+  | intersectionConstraints AMP atomType %prec prec_no_more_attr_bindings // todo precedence
+      { $3 :: $1 }
+
+  | atomType
+      { [ $1 ] }
+
+/* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
+/* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
 typeConstraint:
   | DEFAULT typar COLON typ
      { if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyError (lhs parseState)
@@ -5653,6 +5662,15 @@ tupleOrQuotTypeElements:
   | appType %prec prec_tuptyptail_prefix
       { [ SynTupleTypeSegment.Type $1 ] }
 
+/* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
+/* See the F# specification "Lexical analysis of type applications and type parameter definitions" */
+intersectionType:
+  | typar AMP intersectionConstraints %prec prec_no_more_attr_bindings // todo precedence
+      { SynType.Intersection(Some $1, $3, lhs parseState) }
+
+  | atomType AMP intersectionConstraints %prec prec_no_more_attr_bindings // todo precedence
+    { SynType.Intersection(None, $1 :: $3, lhs parseState) }
+
 appTypeCon:
   | path %prec prec_atomtyp_path
     { SynType.LongIdent($1) }
@@ -5689,6 +5707,9 @@ appType:
         SynType.App($4, None, args, commas, None, true, unionRanges (rhs parseState 1) $4.Range) }
 
   | powerType
+      { $1 }
+
+  | intersectionType
       { $1 }
 
   | typar COLON_GREATER typ

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Povolit implicitní atribut Extension pro deklarující typy, moduly</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">využití člena výchozího rozhraní</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Atributy nejde použít pro rozšíření typů.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Implizites Erweiterungsattribut für deklarierende Typen und Module zulassen</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">standardmäßige Schnittstellenmembernutzung</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Attribute können nicht auf Typerweiterungen angewendet werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Permitir atributo Extension implícito en tipos declarativo, módulos</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">consumo de miembros de interfaz predeterminados</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Los atributos no se pueden aplicar a las extensiones de tipo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Autoriser l’attribut implicite Extension lors de la déclaration des types, modules</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">consommation par défaut des membres d'interface</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Impossible d'appliquer des attributs aux extensions de type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Consentire l'attributo estensione implicito per i tipi dichiarabili, i moduli</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">utilizzo predefinito dei membri di interfaccia</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Gli attributi non possono essere applicati a estensioni di tipo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -207,6 +207,11 @@
         <target state="translated">型、モジュールの宣言で暗黙的な拡張属性を許可する</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">既定のインターフェイス メンバーの消費</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">属性を型拡張に適用することはできません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -207,6 +207,11 @@
         <target state="translated">유형, 모듈 선언에 암시적 확장 속성 허용</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">기본 인터페이스 멤버 사용</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">형식 확장에 특성을 적용할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Zezwalaj na niejawny atrybut Rozszerzenie dla deklarujących typów, modułów</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">domyślne użycie składowej interfejsu</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Atrybutów nie można stosować do rozszerzeń typu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Permitir atributo de Extensão implícito em tipos declarativos, módulos</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">consumo de membro da interface padrão</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Os atributos não podem ser aplicados às extensões de tipo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Разрешить атрибут неявного расширения для объявляющих типов, модулей</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">использование элемента интерфейса по умолчанию</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Атрибуты не могут быть применены к расширениям типа.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Türler, modüller bildirirken örtük Extension özniteliğine izin ver</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">varsayılan arabirim üyesi tüketimi</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">Öznitelikler tür uzantılarına uygulanamaz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -207,6 +207,11 @@
         <target state="translated">允许对声明类型、模块使用隐式扩展属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">默认接口成员消耗</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">属性不可应用于类型扩展。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -207,6 +207,11 @@
         <target state="translated">允許宣告類型、模組上的隱含擴充屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureConstraintIntersectionOnFlexibleTypes">
+        <source>Constraint intersection on flexible types</source>
+        <target state="new">Constraint intersection on flexible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureDefaultInterfaceMemberConsumption">
         <source>default interface member consumption</source>
         <target state="translated">預設介面成員使用</target>
@@ -980,6 +985,11 @@
       <trans-unit id="tcAugmentationsCannotHaveAttributes">
         <source>Attributes cannot be applied to type extensions.</source>
         <target state="translated">屬性無法套用到類型延伸模組。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcConstraintIntersectionSyntaxUsedWithNonFlexibleType">
+        <source>Constraint intersection syntax may only be used with flexible types.</source>
+        <target state="new">Constraint intersection syntax may only be used with flexible types.</target>
         <note />
       </trans-unit>
       <trans-unit id="tcCopyAndUpdateRecordChangesAllFields">

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -188,6 +188,7 @@
     <Compile Include="Language\PrintfFormatTests.fs" />
 	<Compile Include="Language\InterfaceTests.fs" />
 	<Compile Include="Language\CopyAndUpdateTests.fs" />
+	<Compile Include="Language\ConstraintIntersectionTests.fs" />
     <Compile Include="ConstraintSolver\PrimitiveConstraints.fs" />
     <Compile Include="ConstraintSolver\MemberConstraints.fs" />
     <Compile Include="Interop\DeeplyNestedCSharpClasses.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Language/ConstraintIntersectionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ConstraintIntersectionTests.fs
@@ -1,0 +1,62 @@
+﻿module Language.ConstraintIntersectionTests
+
+open Xunit
+open FSharp.Test.Compiler
+open StructuredResultsAsserts
+
+[<Fact>]
+let ``Constraint intersection works in lang preview``() =
+    FSharp """
+open System
+open System.Threading.Tasks
+open System.Collections.Generic
+
+type I =
+    abstract g: unit -> unit
+    abstract h: #IDisposable & #seq<int> -> unit
+
+type F =
+    interface I with
+        member _.g () = ()
+        member _.h v =
+            for _ in v do
+                ()
+            v.Dispose ()
+
+type E () =
+    interface IDisposable with
+        member _.Dispose () = ()
+    interface IEnumerable<int> with
+        member _.GetEnumerator () = null: IEnumerator<int>
+        member _.GetEnumerator () = null: Collections.IEnumerator
+
+let x (f: 't & #I) =
+    f.g ()
+    f.h (new E ())
+    ResizeArray<'t> ()
+
+let y (f: 't & #I & #IDisposable) =
+    f.g ()
+    f.Dispose ()
+    ResizeArray<'t> ()
+
+let z (f: #I & #IDisposable & #Task<int> & #seq<string>) =
+    f.g ()
+    f.Result |> ignore<int>
+    f.Dispose ()
+    """
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldSucceed
+
+[<Fact>]
+let ``Constraint intersection does not work with non-flexible types``() =
+    FSharp """
+let y (f: #seq<int> & System.IDisposable) = ()
+    """
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withDiagnostics [
+        Error 3568, Line 2, Col 23, Line 2, Col 41, "Constraint intersection syntax may only be used with flexible types."
+    ]

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -8435,6 +8435,12 @@ FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType ge
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType innerType
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynType+Intersection: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynType+Intersection: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType] get_types()
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType] types
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTypar] get_typar()
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTypar] typar
 FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
 FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
@@ -8500,6 +8506,7 @@ FSharp.Compiler.Syntax.SynType+Tags: Int32 Array
 FSharp.Compiler.Syntax.SynType+Tags: Int32 FromParseError
 FSharp.Compiler.Syntax.SynType+Tags: Int32 Fun
 FSharp.Compiler.Syntax.SynType+Tags: Int32 HashConstraint
+FSharp.Compiler.Syntax.SynType+Tags: Int32 Intersection
 FSharp.Compiler.Syntax.SynType+Tags: Int32 LongIdent
 FSharp.Compiler.Syntax.SynType+Tags: Int32 LongIdentApp
 FSharp.Compiler.Syntax.SynType+Tags: Int32 MeasurePower
@@ -8535,6 +8542,7 @@ FSharp.Compiler.Syntax.SynType: Boolean IsArray
 FSharp.Compiler.Syntax.SynType: Boolean IsFromParseError
 FSharp.Compiler.Syntax.SynType: Boolean IsFun
 FSharp.Compiler.Syntax.SynType: Boolean IsHashConstraint
+FSharp.Compiler.Syntax.SynType: Boolean IsIntersection
 FSharp.Compiler.Syntax.SynType: Boolean IsLongIdent
 FSharp.Compiler.Syntax.SynType: Boolean IsLongIdentApp
 FSharp.Compiler.Syntax.SynType: Boolean IsMeasurePower
@@ -8554,6 +8562,7 @@ FSharp.Compiler.Syntax.SynType: Boolean get_IsArray()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsFromParseError()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsFun()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsHashConstraint()
+FSharp.Compiler.Syntax.SynType: Boolean get_IsIntersection()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsLongIdent()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsLongIdentApp()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsMeasurePower()
@@ -8573,6 +8582,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewArray(Int32, F
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFromParseError(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewHashConstraint(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewIntersection(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTypar], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.SynLongIdent)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewMeasurePower(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynRationalConst, FSharp.Compiler.Text.Range)
@@ -8592,6 +8602,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Array
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+FromParseError
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Fun
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+HashConstraint
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Intersection
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+LongIdent
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+LongIdentApp
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+MeasurePower

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -8435,6 +8435,12 @@ FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType ge
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Syntax.SynType innerType
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+HashConstraint: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynType+Intersection: FSharp.Compiler.Text.Range get_range()
+FSharp.Compiler.Syntax.SynType+Intersection: FSharp.Compiler.Text.Range range
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType] get_types()
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType] types
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTypar] get_typar()
+FSharp.Compiler.Syntax.SynType+Intersection: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTypar] typar
 FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
 FSharp.Compiler.Syntax.SynType+LongIdent: FSharp.Compiler.Syntax.SynLongIdent longDotId
 FSharp.Compiler.Syntax.SynType+LongIdentApp: FSharp.Compiler.Syntax.SynLongIdent get_longDotId()
@@ -8500,6 +8506,7 @@ FSharp.Compiler.Syntax.SynType+Tags: Int32 Array
 FSharp.Compiler.Syntax.SynType+Tags: Int32 FromParseError
 FSharp.Compiler.Syntax.SynType+Tags: Int32 Fun
 FSharp.Compiler.Syntax.SynType+Tags: Int32 HashConstraint
+FSharp.Compiler.Syntax.SynType+Tags: Int32 Intersection
 FSharp.Compiler.Syntax.SynType+Tags: Int32 LongIdent
 FSharp.Compiler.Syntax.SynType+Tags: Int32 LongIdentApp
 FSharp.Compiler.Syntax.SynType+Tags: Int32 MeasurePower
@@ -8535,6 +8542,7 @@ FSharp.Compiler.Syntax.SynType: Boolean IsArray
 FSharp.Compiler.Syntax.SynType: Boolean IsFromParseError
 FSharp.Compiler.Syntax.SynType: Boolean IsFun
 FSharp.Compiler.Syntax.SynType: Boolean IsHashConstraint
+FSharp.Compiler.Syntax.SynType: Boolean IsIntersection
 FSharp.Compiler.Syntax.SynType: Boolean IsLongIdent
 FSharp.Compiler.Syntax.SynType: Boolean IsLongIdentApp
 FSharp.Compiler.Syntax.SynType: Boolean IsMeasurePower
@@ -8554,6 +8562,7 @@ FSharp.Compiler.Syntax.SynType: Boolean get_IsArray()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsFromParseError()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsFun()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsHashConstraint()
+FSharp.Compiler.Syntax.SynType: Boolean get_IsIntersection()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsLongIdent()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsLongIdentApp()
 FSharp.Compiler.Syntax.SynType: Boolean get_IsMeasurePower()
@@ -8573,6 +8582,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewArray(Int32, F
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFromParseError(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewFun(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeFunTrivia)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewHashConstraint(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewIntersection(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynTypar], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdent(FSharp.Compiler.Syntax.SynLongIdent)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewLongIdentApp(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynType], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewMeasurePower(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynRationalConst, FSharp.Compiler.Text.Range)
@@ -8592,6 +8602,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Array
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+FromParseError
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Fun
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+HashConstraint
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Intersection
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+LongIdent
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+LongIdentApp
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+MeasurePower

--- a/tests/service/data/SyntaxTree/SynType/Constraint intersection 01.fs
+++ b/tests/service/data/SyntaxTree/SynType/Constraint intersection 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+let y (f: #I & #Task<int> & #seq<string>) = ()

--- a/tests/service/data/SyntaxTree/SynType/Constraint intersection 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Constraint intersection 01.fs.bsl
@@ -1,0 +1,56 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Constraint intersection 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None,
+                     SynValInfo
+                       ([[SynArgInfo ([], false, Some f)]],
+                        SynArgInfo ([], false, None)), None),
+                  LongIdent
+                    (SynLongIdent ([y], [], [None]), None, None,
+                     Pats
+                       [Paren
+                          (Typed
+                             (Named
+                                (SynIdent (f, None), false, None, (3,7--3,8)),
+                              Intersection
+                                (None,
+                                 [HashConstraint
+                                    (LongIdent (SynLongIdent ([I], [], [None])),
+                                     (3,10--3,12));
+                                  HashConstraint
+                                    (App
+                                       (LongIdent
+                                          (SynLongIdent ([seq], [], [None])),
+                                        Some (3,32--3,33),
+                                        [LongIdent
+                                           (SynLongIdent ([string], [], [None]))],
+                                        [], Some (3,39--3,40), false,
+                                        (3,29--3,40)), (3,28--3,40));
+                                  HashConstraint
+                                    (App
+                                       (LongIdent
+                                          (SynLongIdent ([Task], [], [None])),
+                                        Some (3,20--3,21),
+                                        [LongIdent
+                                           (SynLongIdent ([int], [], [None]))],
+                                        [], Some (3,24--3,25), false,
+                                        (3,16--3,25)), (3,15--3,25))],
+                                 (3,10--3,40)), (3,7--3,40)), (3,6--3,41))],
+                     None, (3,4--3,41)), None, Const (Unit, (3,44--3,46)),
+                  (3,4--3,41), NoneAtLet, { LeadingKeyword = Let (3,0--3,3)
+                                            InlineKeyword = None
+                                            EqualsRange = Some (3,42--3,43) })],
+              (3,0--3,46))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,46), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Constraint intersection 02.fs
+++ b/tests/service/data/SyntaxTree/SynType/Constraint intersection 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+let y (f: 't & #I & #IDisposable) = ()

--- a/tests/service/data/SyntaxTree/SynType/Constraint intersection 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Constraint intersection 02.fs.bsl
@@ -1,0 +1,41 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Constraint intersection 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Let
+             (false,
+              [SynBinding
+                 (None, Normal, false, false, [],
+                  PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                  SynValData
+                    (None,
+                     SynValInfo
+                       ([[SynArgInfo ([], false, Some f)]],
+                        SynArgInfo ([], false, None)), None),
+                  LongIdent
+                    (SynLongIdent ([y], [], [None]), None, None,
+                     Pats
+                       [Paren
+                          (Typed
+                             (Named
+                                (SynIdent (f, None), false, None, (3,7--3,8)),
+                              Intersection
+                                (Some (SynTypar (t, None, false)),
+                                 [HashConstraint
+                                    (LongIdent
+                                       (SynLongIdent ([IDisposable], [], [None])),
+                                     (3,20--3,32));
+                                  HashConstraint
+                                    (LongIdent (SynLongIdent ([I], [], [None])),
+                                     (3,15--3,17))], (3,10--3,32)), (3,7--3,32)),
+                           (3,6--3,33))], None, (3,4--3,33)), None,
+                  Const (Unit, (3,36--3,38)), (3,4--3,33), NoneAtLet,
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,34--3,35) })], (3,0--3,38))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,38), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/SynType/Constraint intersection 03.fs
+++ b/tests/service/data/SyntaxTree/SynType/Constraint intersection 03.fs
@@ -1,0 +1,4 @@
+module Module
+
+type I =
+    abstract h: #IDisposable & #seq<int> -> unit

--- a/tests/service/data/SyntaxTree/SynType/Constraint intersection 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Constraint intersection 03.fs.bsl
@@ -1,0 +1,61 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/SynType/Constraint intersection 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [I],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (h, None),
+                            SynValTyparDecls (None, true),
+                            Fun
+                              (Intersection
+                                 (None,
+                                  [HashConstraint
+                                     (LongIdent
+                                        (SynLongIdent
+                                           ([IDisposable], [], [None])),
+                                      (4,16--4,28));
+                                   HashConstraint
+                                     (App
+                                        (LongIdent
+                                           (SynLongIdent ([seq], [], [None])),
+                                         Some (4,35--4,36),
+                                         [LongIdent
+                                            (SynLongIdent ([int], [], [None]))],
+                                         [], Some (4,39--4,40), false,
+                                         (4,32--4,40)), (4,31--4,40))],
+                                  (4,16--4,40)),
+                               LongIdent (SynLongIdent ([unit], [], [None])),
+                               (4,16--4,48), { ArrowRange = (4,41--4,43) }),
+                            SynValInfo
+                              ([[SynArgInfo ([], false, None)]],
+                               SynArgInfo ([], false, None)), false, false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (4,4--4,48),
+                            { LeadingKeyword = Abstract (4,4--4,12)
+                              InlineKeyword = None
+                              WithKeyword = None
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member }, (4,4--4,48),
+                         { GetSetKeywords = None })], (4,4--4,48)), [], None,
+                  (3,5--4,48), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,48))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,48), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))


### PR DESCRIPTION
Implements https://github.com/fsharp/fslang-suggestions/issues/1262.

![devenv_FWOQ9ny9h7](https://github.com/dotnet/fsharp/assets/5063478/f4c908c4-c864-4980-ab5b-4ca13efbacba)

The parser changes could quite possibly be improved - it's not my forte.

RE: https://github.com/fsharp/fslang-suggestions/issues/1262#issuecomment-1529031385
> If we had intersection types there would be all sorts of restrictions - e.g. string & int is not possible nor any sealed type.

Elsewhere in the code, there's this check:

```fsharp
if newOk = NoNewTypars && isSealedTy g tyR then
    errorR(Error(FSComp.SR.tcInvalidConstraintTypeSealed(), m))
```

Not sure why this should only kick for `NoNewTypars`. In `TcIntersectionConstraint` new typars seemed to always be OK, so such check would have no effect. However, currently we get this, which should be sufficient anyway:

![image](https://github.com/dotnet/fsharp/assets/5063478/69d0ba5e-126a-41e8-ac1b-c74ae0fe4343)