### PR TITLE
[DRAFT] Speedup startup by preparing the parsing table on a background thread

### DIFF
--- a/buildtools/fsyacc/fsyaccdriver.fs
+++ b/buildtools/fsyacc/fsyaccdriver.fs
@@ -502,7 +502,13 @@ let writeSpecToFile (generatorState: GeneratorState) (spec: ParserSpec) (compile
               | None -> ()
               writer.WriteLine "                 : %s));" (if types.ContainsKey nt then  types.[nt] else generatorState.generate_nonterminal_name nt);
           done;
-          writer.WriteLine "|]" ;
+          writer.WriteLine "|]"
+          writer.WriteLine """
+let _fsyacc_reductions_lock = obj()
+let _fsyacc_reductions_with_lock () = lock _fsyacc_reductions_lock (fun () -> _fsyacc_reductions.Value)
+let prefetchTables () = _fsyacc_reductions_with_lock() |> ignore
+"""
+          writer.WriteLineInterface "val prefetchTables : unit -> unit"
       end;
       writer.WriteLine "# %d \"%s\"" writer.OutputLineCount output;
       writer.WriteLine "let tables : %s.Tables<_> = " generatorState.parslib

--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -1191,6 +1191,16 @@ let CompileFromCommandLineArguments
                 with _ ->
                     ()
         }
+    
+    let prefetchParsingTable = Environment.GetEnvironmentVariable("FSC_PrefetchParsingTable") = "1"
+    if prefetchParsingTable then
+        printfn "Prefetching parsing tables"
+        async {
+            Parser.prefetchTables ()
+        }
+        |> Async.Start
+    else
+        printfn "NOT prefetching parsing tables"
 
     main1 (
         ctok,


### PR DESCRIPTION
This is a hacky version of a proposed change, do not merge.

# Context
I noticed that one of the parsing arrays is `lazy` and is evaluated when parsing starts.
It takes quite a bit of time.
Here is a snapshot showing the baseline - 99ms according to DotTrace, blocks further parsing work:
![image](https://github.com/dotnet/fsharp/assets/2478401/3e9c2fa2-c412-421b-ab36-baa7fbdbe96a)

# Change
I modified the `pars.fs` generator to expose a function that can prepare the `_fsyacc_reductions` value and run it in background at compiler startup, when an environment variable `FSC_PrefetchParsingTable` is set to `1`.

Here is a snapshot with this environment variable set, showing the work happening in parallel to some initial compilation steps (before parsing):
![image](https://github.com/dotnet/fsharp/assets/2478401/dc5e3ea0-c8ef-4da4-88c0-397e5ec37236)

# Next steps
Is this a reasonable change in principle? If so, will I find similar things that can be loaded in the background?

Based on https://github.com/dotnet/fsharp/blob/9c55d323c2dae199ea83dd946cf9859163b390dd/buildtools/README-fslexyacc.md?plain=1 I gather that any such in the generator needs to happen in https://github.com/fsprojects/FsLexYacc first and then be copied into the compiler.