### PR TITLE
Included existing NoWarn value

### DIFF
--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);75</NoWarn> <!-- InternalCommandLineOption -->
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);LOCALIZATION_FSBUILD</DefineConstants>
-    <NoWarn>NU1701;FS0075</NoWarn>
+    <NoWarn>$(NoWarn);NU1701;FS0075</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>7.0</LangVersion>  <!-- FSharp.Build may run in Visual Studio with older FSharp.Cores so don't use unshipped features -->
     <Configurations>Debug;Release;Proto;ReleaseCompressed</Configurations>  <!-- FSharp.Build may run in Visual Studio with older FSharp.Cores so don't use unshipped features -->


### PR DESCRIPTION
I have an extra value `NoWarn` value in my `Directory.Build.props.user`.
This would allow it to come through in `src/FSharp.Build/FSharp.Build.fsproj`.

PS: When do you use `<NoWarn>$(NoWarn);75</NoWarn>` versus `<NoWarn>FS0075</NoWarn>`?