### PR TITLE
Prioritize anonymous record fields in completions

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -889,6 +889,7 @@ type internal TypeCheckInfo
                 match minfos with
                 | [] -> CompletionItemKind.Method false
                 | minfo :: _ -> CompletionItemKind.Method minfo.IsExtensionMember
+            | Item.AnonRecdField _
             | Item.RecdField _
             | Item.Property _ -> CompletionItemKind.Property
             | Item.Event _ -> CompletionItemKind.Event
@@ -896,7 +897,6 @@ type internal TypeCheckInfo
             | Item.Value _ -> CompletionItemKind.Field
             | Item.CustomOperation _ -> CompletionItemKind.CustomOperation
             // These items are not given a completion kind. This could be reviewed
-            | Item.AnonRecdField _
             | Item.ActivePatternResult _
             | Item.CustomOperation _
             | Item.CtorGroup _

--- a/tests/service/CompletionTests.fs
+++ b/tests/service/CompletionTests.fs
@@ -17,13 +17,6 @@ let assertHasItemWithNames names (completionInfo: DeclarationListInfo) =
     for name in names do
         Assert.That(Set.contains name itemNames, name)
 
-let assertHasExactlyNamesAndNothingElse names (completionInfo: DeclarationListInfo) =
-    let itemNames = getCompletionItemNames completionInfo |> set
-    let expectedNames = Set.ofList names
-
-    Assert.That(itemNames, Is.EqualTo expectedNames)
-
-
 [<Test>]
 let ``Expr - record - field 01 - anon module`` () =
     let info = getCompletionInfo "{ Fi }" (4, 3)  """
@@ -63,11 +56,3 @@ let record = { Field = 1 }
 {  }
 """
     assertHasItemWithNames ["Field"; "record"] info
-
-[<Test>]
-let ``Expr - array of anonymous records`` () =
-    let info = getCompletionInfo "x[0]." (3, 6) """
-let x = [ {| Name = "foo" |} ]
-x[0].
-"""  
-    assertHasExactlyNamesAndNothingElse ["Name"; "Equals"; "GetHashCode"; "GetType"; "ToString"] info

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1450,3 +1450,13 @@ let t2 (x: {| D: NestdRecTy; E: {| a: string |} |}) = {| x with E.a = "a"; D.B =
             "let t2 (x: {| D: NestdRecTy; E: {| a: string |} |}) = {| x with E.a = \"a\"; D.",
             [ "B"; "C" ]
         )
+
+    [<Fact>]
+    let ``Anonymous record fields have higher priority than methods`` () =
+        let fileContents =
+            """
+let x = [ {| Goo = 1; Foo = "foo" |} ]
+x[0].
+"""
+
+        VerifyCompletionListExactly(fileContents, "x[0].", [ "Foo"; "Goo"; "Equals"; "GetHashCode"; "GetType"; "ToString" ])


### PR DESCRIPTION
This is annoying and inconsistent with nominal records.

![image](https://github.com/dotnet/fsharp/assets/5063478/adcb3104-e9d8-4fe2-affa-53f595270fb9)