### PR TITLE
Improve diagnostics for malformed anonymous record types

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4353,9 +4353,6 @@ and TcTypeOrMeasure kindOpt (cenv: cenv) newOk checkConstraints occ (iwsam: Warn
     | SynType.Tuple(isStruct, segments, m) ->
         TcTupleType kindOpt cenv newOk checkConstraints occ env tpenv isStruct segments m
 
-    | SynType.AnonRecd(_, [],m) ->
-        error(Error((FSComp.SR.tcAnonymousTypeInvalidInDeclaration()), m))
-
     | SynType.AnonRecd(isStruct, args, m) ->
         TcAnonRecdType cenv newOk checkConstraints occ env tpenv isStruct args m
 

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4353,6 +4353,10 @@ and TcTypeOrMeasure kindOpt (cenv: cenv) newOk checkConstraints occ (iwsam: Warn
     | SynType.Tuple(isStruct, segments, m) ->
         TcTupleType kindOpt cenv newOk checkConstraints occ env tpenv isStruct segments m
 
+    | SynType.AnonRecd(fields = []) ->
+        // The parser takes care of error messages
+        NewErrorType(), tpenv
+
     | SynType.AnonRecd(isStruct, args, m) ->
         TcAnonRecdType cenv newOk checkConstraints occ env tpenv isStruct args m
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5879,10 +5879,7 @@ atomTypeOrAnonRecdType:
            flds |> List.choose (function
              | (SynField([], false, Some id, ty, false, _xmldoc, None, _m, _trivia)) -> Some(id, ty)
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
-
-       match flds2 with
-       | [] -> SynType.FromParseError(rhs parseState 1)
-       | _ -> SynType.AnonRecd(isStruct, flds2, rhs parseState 1) }
+       SynType.AnonRecd(isStruct, flds2, rhs parseState 1) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5879,7 +5879,10 @@ atomTypeOrAnonRecdType:
            flds |> List.choose (function
              | (SynField([], false, Some id, ty, false, _xmldoc, None, _m, _trivia)) -> Some(id, ty)
              | _ -> reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsInvalidAnonRecdType()); None)
-       SynType.AnonRecd(isStruct, flds2, rhs parseState 1) }
+
+       match flds2 with
+       | [] -> SynType.FromParseError(rhs parseState 1)
+       | _ -> SynType.AnonRecd(isStruct, flds2, rhs parseState 1) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/6872.

Ditched the error from type checking as it had been nonsensical in the first place.

![devenv_R9ZkQvqtgW](https://github.com/dotnet/fsharp/assets/5063478/0752a877-334d-4b26-b210-0d480f4d2a21)