### PR TITLE
Refactoring and tests for the ConvertCSharpLambdaToFSharpLambda code fix

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/ConvertCSharpLambdaToFSharpLambda.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/ConvertCSharpLambdaToFSharpLambda.fs
@@ -32,7 +32,7 @@ type internal ConvertCSharpLambdaToFSharpLambdaCodeFixProvider [<ImportingConstr
             RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, lambdaBodyRange))
         |> bind3
 
-    override _.FixableDiagnosticIds = ImmutableArray.Create("FS0039", "FS0043")
+    override _.FixableDiagnosticIds = ImmutableArray.Create("FS0039")
 
     override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix(this)
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
@@ -20,7 +20,7 @@ let getRelevantDiagnostic (document: Document) errorNumber =
         return
             checkFileResults.Diagnostics
             |> Seq.where (fun d -> d.ErrorNumber = errorNumber)
-            |> Seq.exactlyOne
+            |> Seq.head
     }
 
 let tryFix (code: string) diagnostic (fixProvider: IFSharpCodeFixProvider) =

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertCSharpLambdaToFSharpLambdaTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertCSharpLambdaToFSharpLambdaTests.fs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ConvertCSharpLambdaToFSharpLambdaTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = ConvertCSharpLambdaToFSharpLambdaCodeFixProvider()
+
+let private diagnostic = 0039 // Something is not defined
+
+[<Fact>]
+let ``Fixes FS0039 for lambdas`` () =
+    let code =
+        """
+let id = x => x
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use F# lambda syntax"
+                FixedCode =
+                    """
+let id = fun x -> x
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0039 for random undefined stuff`` () =
+    let code =
+        """
+let test = x = x
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="CodeFixes\ChangeToUpcastTests.fs" />
     <Compile Include="CodeFixes\AddMissingRecToMutuallyRecFunctionsTests.fs" />
     <Compile Include="CodeFixes\WrapExpressionInParenthesesTests.fs" />
+    <Compile Include="CodeFixes\ConvertCSharpLambdaToFSharpLambdaTests.fs" />
     <Compile Include="CodeFixes\RemoveReturnOrYieldTests.fs" />
     <Compile Include="Hints\HintTestFramework.fs" />
     <Compile Include="Hints\OptionParserTests.fs" />


### PR DESCRIPTION
related: #15059 

Migrating the code fix to the code fix framework.

@baronfel since you are the author of the original code fix in FSAutoComplete ([this PR](https://github.com/fsharp/FsAutoComplete/pull/667)), do you know what F# code could trigger FS0043 and make use of this code fix? I have looked through that PR and [this PR](https://github.com/dotnet/fsharp/pull/10637) and the code but cannot find anything applicable.