### PR TITLE
Parser: recover on unfinished `val` fields and auto properties

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -4142,7 +4142,9 @@ module TcDeclarations =
 
                 // Convert auto properties to let bindings in the pre-list
                 let rec preAutoProps memb =
-                    match memb with 
+                    match memb with
+                    | SynMemberDefn.AutoProperty(ident = id) when id.idText = "" -> []
+
                     | SynMemberDefn.AutoProperty(attributes=Attributes attribs; isStatic=isStatic; ident=id; typeOpt=tyOpt; propKind=propKind; xmlDoc=xmlDoc; synExpr=synExpr; range=mWholeAutoProp) -> 
                         // Only the keep the field-targeted attributes
                         let attribs = attribs |> List.filter (fun a -> match a.Target with Some t when t.idText = "field" -> true | _ -> false)
@@ -4169,7 +4171,9 @@ module TcDeclarations =
 
                 // Convert auto properties to member bindings in the post-list
                 let rec postAutoProps memb =
-                    match memb with 
+                    match memb with
+                    | SynMemberDefn.AutoProperty(ident = id) when id.idText = "" -> []
+
                     | SynMemberDefn.AutoProperty(attributes=Attributes attribs; isStatic=isStatic; ident=id; typeOpt=tyOpt; propKind=propKind; memberFlags=memberFlags; memberFlagsForSet=memberFlagsForSet; xmlDoc=xmlDoc; accessibility=access; trivia = { GetSetKeywords = mGetSetOpt }) ->
                         let mMemberPortion = id.idRange
                         // Only the keep the non-field-targeted attributes

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1108,15 +1108,40 @@ let mkAutoPropDefn mVal access ident typ mEquals (expr: SynExpr) accessors xmlDo
     let memberFlags: SynMemberFlags = flags SynMemberKind.Member
     let memberFlagsForSet = flags SynMemberKind.PropertySet
     let isStatic = not memberFlags.IsInstance
-    let trivia = { LeadingKeyword = leadingKeyword; WithKeyword = mWith; EqualsRange = mEquals; GetSetKeywords = getSetOpt }
-    SynMemberDefn.AutoProperty(attribs, isStatic, ident, typ, getSet, memberFlags, memberFlagsForSet, xmlDoc, access, expr, memberRange, trivia)
+
+    let trivia =
+        {
+            LeadingKeyword = leadingKeyword
+            WithKeyword = mWith
+            EqualsRange = mEquals
+            GetSetKeywords = getSetOpt
+        }
+
+    SynMemberDefn.AutoProperty(
+        attribs,
+        isStatic,
+        ident,
+        typ,
+        getSet,
+        memberFlags,
+        memberFlagsForSet,
+        xmlDoc,
+        access,
+        expr,
+        memberRange,
+        trivia
+    )
 
 let mkValField mVal mRhs mut access ident (typ: SynType) xmlDoc rangeStart attribs mStaticOpt =
     let isStatic = Option.isSome mStaticOpt
     let mValDecl = unionRanges rangeStart typ.Range |> unionRangeWithXmlDoc xmlDoc
+
     let leadingKeyword =
         match mStaticOpt with
         | None -> SynLeadingKeyword.Val mVal
         | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
-    let fld = SynField(attribs, isStatic, Some ident, typ, mut, xmlDoc, access, mRhs, { LeadingKeyword = Some leadingKeyword })
+
+    let fld =
+        SynField(attribs, isStatic, Some ident, typ, mut, xmlDoc, access, mRhs, { LeadingKeyword = Some leadingKeyword })
+
     SynMemberDefn.ValField(fld, mValDecl)

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1099,3 +1099,24 @@ let mkSynUnionCase attributes (access: SynAccess option) id kind mDecl (xmlDoc, 
     let trivia: SynUnionCaseTrivia = { BarRange = Some mBar }
     let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
     SynUnionCase(attributes, id, kind, xmlDoc, None, mDecl, trivia)
+
+let mkAutoPropDefn mVal access ident typ mEquals (expr: SynExpr) accessors xmlDoc attribs flags rangeStart =
+    let mWith, (getSet, getSetOpt) = accessors
+    let memberRange = unionRanges rangeStart expr.Range |> unionRangeWithXmlDoc xmlDoc
+    let flags, leadingKeyword = flags
+    let leadingKeyword = appendValToLeadingKeyword mVal leadingKeyword
+    let memberFlags: SynMemberFlags = flags SynMemberKind.Member
+    let memberFlagsForSet = flags SynMemberKind.PropertySet
+    let isStatic = not memberFlags.IsInstance
+    let trivia = { LeadingKeyword = leadingKeyword; WithKeyword = mWith; EqualsRange = mEquals; GetSetKeywords = getSetOpt }
+    SynMemberDefn.AutoProperty(attribs, isStatic, ident, typ, getSet, memberFlags, memberFlagsForSet, xmlDoc, access, expr, memberRange, trivia)
+
+let mkValField mVal mRhs mut access ident (typ: SynType) xmlDoc rangeStart attribs mStaticOpt =
+    let isStatic = Option.isSome mStaticOpt
+    let mValDecl = unionRanges rangeStart typ.Range |> unionRangeWithXmlDoc xmlDoc
+    let leadingKeyword =
+        match mStaticOpt with
+        | None -> SynLeadingKeyword.Val mVal
+        | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
+    let fld = SynField(attribs, isStatic, Some ident, typ, mut, xmlDoc, access, mRhs, { LeadingKeyword = Some leadingKeyword })
+    SynMemberDefn.ValField(fld, mValDecl)

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -256,11 +256,11 @@ val mkAutoPropDefn:
     mEquals: range option ->
     expr: SynExpr ->
     accessors: range option * (SynMemberKind * GetSetKeywords option) ->
-    xmlDoc: PreXmlDoc ->
-    attribs: SynAttributes ->
-    flags: (SynMemberKind -> SynMemberFlags) * SynLeadingKeyword ->
-    rangeStart: range ->
-        SynMemberDefn
+        xmlDoc: PreXmlDoc ->
+        attribs: SynAttributes ->
+        flags: (SynMemberKind -> SynMemberFlags) * SynLeadingKeyword ->
+            rangeStart: range ->
+                SynMemberDefn
 
 val mkValField:
     mVal: range ->
@@ -270,7 +270,7 @@ val mkValField:
     ident: Ident ->
     typ: SynType ->
     xmlDoc: PreXmlDoc ->
-    range -> 
+    range ->
     SynAttributes ->
     range option ->
-    SynMemberDefn
+        SynMemberDefn

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -247,3 +247,30 @@ val mkSynUnionCase:
     mDecl: range ->
     (PreXmlDoc * range) ->
         SynUnionCase
+
+val mkAutoPropDefn:
+    mVal: range ->
+    access: SynAccess option ->
+    ident: Ident ->
+    typ: SynType option ->
+    mEquals: range option ->
+    expr: SynExpr ->
+    accessors: range option * (SynMemberKind * GetSetKeywords option) ->
+    xmlDoc: PreXmlDoc ->
+    attribs: SynAttributes ->
+    flags: (SynMemberKind -> SynMemberFlags) * SynLeadingKeyword ->
+    rangeStart: range ->
+        SynMemberDefn
+
+val mkValField:
+    mVal: range ->
+    mRhs: range ->
+    mut: bool ->
+    access: SynAccess option ->
+    ident: Ident ->
+    typ: SynType ->
+    xmlDoc: PreXmlDoc ->
+    range -> 
+    SynAttributes ->
+    range option ->
+    SynMemberDefn

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2017,42 +2017,98 @@ valDefnDecl:
   | VAL opt_mutable opt_access ident COLON typ
      { let mVal = rhs parseState 1
        let mRhs = rhs2 parseState 4 6
-       let mValDecl = rhs2 parseState 1 6
-       (fun rangeStart attribs mStaticOpt ->
-           let isStatic = Option.isSome mStaticOpt
-           let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
-           let mValDecl = unionRanges rangeStart mValDecl |> unionRangeWithXmlDoc xmlDoc
-           let leadingKeyword =
-               match mStaticOpt with
-               | None -> SynLeadingKeyword.Val mVal
-               | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
-           let fld = SynField(attribs, isStatic, Some $4, $6, $2, xmlDoc, $3, mRhs, { LeadingKeyword = Some leadingKeyword })
-           [ SynMemberDefn.ValField(fld, mValDecl) ]) }
+       fun rangeStart attribs mStaticOpt ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkValField mVal mRhs $2 $3 $4 $6 xmlDoc rangeStart attribs mStaticOpt ] }
+
+  | VAL opt_mutable opt_access ident COLON recover
+     { let mVal = rhs parseState 1
+       let mRhs = rhs2 parseState 4 6
+       let mColon = rhs parseState 5
+       let ty = SynType.FromParseError(mColon.EndRange)
+       fun rangeStart attribs mStaticOpt ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkValField mVal mRhs $2 $3 $4 ty xmlDoc rangeStart attribs mStaticOpt ] }
+
+  | VAL opt_mutable opt_access ident recover
+     { let mVal = rhs parseState 1
+       let mRhs = rhs2 parseState 4 6
+       let mColon = rhs parseState 5
+       let ty = SynType.FromParseError(mColon.EndRange)
+       fun rangeStart attribs mStaticOpt ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkValField mVal mRhs $2 $3 $4 ty xmlDoc rangeStart attribs mStaticOpt ] }
+
+  | VAL opt_mutable opt_access recover
+     { let mVal = rhs parseState 1
+       let mRhs = rhs2 parseState 4 6
+       let id = mkSynId mVal.EndRange ""
+       let mColon = rhs parseState 5
+       let ty = SynType.FromParseError(mColon.EndRange)
+       fun rangeStart attribs mStaticOpt ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkValField mVal mRhs $2 $3 id ty xmlDoc rangeStart attribs mStaticOpt ] }
 
 
 /* An auto-property definition in an object type definition */
 autoPropsDefnDecl:
   | VAL opt_mutable opt_access ident opt_typ EQUALS typedSequentialExprBlock classMemberSpfnGetSet
      { let mVal = rhs parseState 1
-       let mWith, (getSet, getSetOpt) = $8
        let mEquals = rhs parseState 6
        if $2 then
-           errorR (Error (FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 3))
-       (fun attribs flags rangeStart ->
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
+       fun attribs flags rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkAutoPropDefn mVal $3 $4 $5 (Some mEquals) $7 $8 xmlDoc attribs flags rangeStart ] }
+
+| VAL opt_mutable opt_access ident opt_typ ends_coming_soon_or_recover
+     { let mVal = rhs parseState 1
+       let mEnd =
+           match $5 with
+           | Some t -> t.Range
+           | _ -> $4.idRange
+       let expr = arbExpr ("autoProp1", mEnd.EndRange)
+       if $2 then
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
+       fun attribs flags rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkAutoPropDefn mVal $3 $4 $5 None expr (None, (SynMemberKind.Member, None)) xmlDoc attribs flags rangeStart ] }
+
+  | VAL opt_mutable opt_access ident opt_typ OBLOCKSEP
+     { let mVal = rhs parseState 1
+       let mEnd =
+           match $5 with
+           | Some t -> t.Range
+           | _ -> $4.idRange
+       let expr = arbExpr ("autoProp2", mEnd.EndRange)
+       if $2 then
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
+       fun attribs flags rangeStart ->
+           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
+           [ mkAutoPropDefn mVal $3 $4 $5 None expr (None, (SynMemberKind.Member, None)) xmlDoc attribs flags rangeStart ] }
+
+| VAL opt_mutable opt_access recover
+     { let mVal = rhs parseState 1
+       let id = mkSynId mVal.EndRange ""
+       let expr = arbExpr ("autoProp3", mVal.EndRange)
+       if $2 then
+           errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
+       fun attribs flags rangeStart ->
            let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
-           let memberRange = unionRanges rangeStart $7.Range |> unionRangeWithXmlDoc xmlDoc
-           let flags, leadingKeyword = flags
-           let leadingKeyword = appendValToLeadingKeyword mVal leadingKeyword
-           let memberFlags = flags SynMemberKind.Member
-           let memberFlagsForSet = flags SynMemberKind.PropertySet
-           let isStatic = not memberFlags.IsInstance
-           let trivia = { LeadingKeyword = leadingKeyword; WithKeyword = mWith; EqualsRange = Some mEquals; GetSetKeywords = getSetOpt }
-           [ SynMemberDefn.AutoProperty(attribs, isStatic, $4, $5, getSet, memberFlags, memberFlagsForSet, xmlDoc, $3, $7, memberRange, trivia) ]) }
+           [ mkAutoPropDefn mVal $3 id None None expr (None, (SynMemberKind.Member, None)) xmlDoc attribs flags rangeStart ] }
 
 /* An optional type on an auto-property definition */
 opt_typ:
-   | /* EMPTY */ { None }
-   | COLON typ { Some $2 }
+   | /* EMPTY */
+       { None }
+
+   | COLON typ
+       { Some $2 }
+
+   | COLON recover
+       { let mColon = rhs parseState 1
+         let ty = SynType.FromParseError(mColon.EndRange)
+         Some ty }
 
 
 atomicPatternLongIdent:

--- a/tests/service/data/SyntaxTree/Member/Auto property 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    member val P1 = 1

--- a/tests/service/data/SyntaxTree/Member/Auto property 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 01.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 01.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P1, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,20--4,21)), (4,4--4,21),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = Some (4,18--4,19)
+                           GetSetKeywords = None })], (4,4--4,21)), [], None,
+                  (3,5--4,21), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,21))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,21), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Auto property 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    member val P1 =
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 02.fs.bsl
@@ -1,0 +1,49 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 02.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P1, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None,
+                         ArbitraryAfterError
+                           ("typedSequentialExprBlock1", (4,19--4,19)),
+                         (4,4--4,19),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = Some (4,18--4,19)
+                           GetSetKeywords = None })], (4,4--4,19)), [], None,
+                  (3,5--4,19), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,19));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,1) parse error Expecting expression

--- a/tests/service/data/SyntaxTree/Member/Auto property 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 03.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    member val P1 =
+    member val P2 = 2
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 03.fs.bsl
@@ -1,0 +1,70 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 03.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P1, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None,
+                         ArbitraryAfterError
+                           ("typedSequentialExprBlock1", (4,19--4,19)),
+                         (4,4--4,19),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = Some (4,18--4,19)
+                           GetSetKeywords = None });
+                      AutoProperty
+                        ([], false, P2, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 2, (5,20--5,21)), (5,4--5,21),
+                         { LeadingKeyword =
+                            MemberVal ((5,4--5,10), (5,11--5,14))
+                           WithKeyword = None
+                           EqualsRange = Some (5,18--5,19)
+                           GetSetKeywords = None })], (4,4--5,21)), [], None,
+                  (3,5--5,21), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--5,21));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,10) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(5,4)-(5,10) parse error Expecting expression

--- a/tests/service/data/SyntaxTree/Member/Auto property 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 04.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    member val P1
+    member val P2 = 2
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 04.fs.bsl
@@ -1,0 +1,65 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 04.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P1, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, ArbitraryAfterError ("autoProp2", (4,17--4,17)),
+                         (4,4--4,17),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = None
+                           GetSetKeywords = None });
+                      AutoProperty
+                        ([], false, P2, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 2, (5,20--5,21)), (5,4--5,21),
+                         { LeadingKeyword =
+                            MemberVal ((5,4--5,10), (5,11--5,14))
+                           WithKeyword = None
+                           EqualsRange = Some (5,18--5,19)
+                           GetSetKeywords = None })], (4,4--5,21)), [], None,
+                  (3,5--5,21), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--5,21));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Auto property 05.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 05.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    member val
+    member val P2 = 2
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 05.fs.bsl
@@ -1,0 +1,67 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 05.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, , None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, ArbitraryAfterError ("autoProp3", (4,14--4,14)),
+                         (4,4--4,14),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = None
+                           GetSetKeywords = None });
+                      AutoProperty
+                        ([], false, P2, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 2, (5,20--5,21)), (5,4--5,21),
+                         { LeadingKeyword =
+                            MemberVal ((5,4--5,10), (5,11--5,14))
+                           WithKeyword = None
+                           EqualsRange = Some (5,18--5,19)
+                           GetSetKeywords = None })], (4,4--5,21)), [], None,
+                  (3,5--5,21), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--5,21));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,15)-(5,4) parse error Incomplete structured construct at or before this point in member definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 06.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    member val P: = 1
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 06.fs.bsl
@@ -1,0 +1,45 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 06.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P, Some (FromParseError (4,17--4,17)),
+                         Member, { IsInstance = true
+                                   IsDispatchSlot = false
+                                   IsOverrideOrExplicitImpl = false
+                                   IsFinal = false
+                                   GetterOrSetterIsCompilerGenerated = false
+                                   MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,20--4,21)), (4,4--4,21),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = None
+                           EqualsRange = Some (4,18--4,19)
+                           GetSetKeywords = None })], (4,4--4,21)), [], None,
+                  (3,5--4,21), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,21));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,18)-(4,19) parse error Unexpected symbol '=' in member definition

--- a/tests/service/data/SyntaxTree/Member/Field 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    val F1: int

--- a/tests/service/data/SyntaxTree/Member/Field 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 01.fs.bsl
@@ -1,0 +1,28 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--4,15),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,15))], (4,4--4,15)), [], None, (3,5--4,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,15))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,15), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Field 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 02.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    val F1:
+    val F2: int
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 02.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1, FromParseError (4,11--4,11),
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--5,4),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,11));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,12)-(5,4) parse error Incomplete structured construct at or before this point in type definition

--- a/tests/service/data/SyntaxTree/Member/Field 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 03.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    val F1
+    val F2: int
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 03.fs.bsl
@@ -1,0 +1,38 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F1, FromParseError (5,4--5,4), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--134217728,0),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--5,4));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,15));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,11)-(5,4) parse error Incomplete structured construct at or before this point in type definition. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 04.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    val
+    val F2: int
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 04.fs.bsl
@@ -1,0 +1,38 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some , FromParseError (1,13--1,13), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--134217728,0),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (1,13--4,7));
+                      ValField
+                        (SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
+                         (5,4--5,15))], (1,13--5,15)), [], None, (1,13--5,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (1,13--5,15));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,8)-(5,4) parse error Incomplete structured construct at or before this point in type definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 05.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 05.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    val F:
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 05.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F, FromParseError (4,10--4,10),
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--6,1),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--4,10))], (4,4--4,10)), [], None, (3,5--4,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,10));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition

--- a/tests/service/data/SyntaxTree/Member/Field 06.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 06.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    val F
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 06.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some F, FromParseError (6,1--6,1), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,8--134217728,0),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (4,4--6,1))], (4,4--6,1)), [], None, (3,5--6,1),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,1));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 07.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 07.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    val
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 07.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], false, Some , FromParseError (1,13--1,13), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,0--134217728,0),
+                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
+                         (1,13--4,7))], (1,13--4,7)), [], None, (1,13--4,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (1,13--4,7));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 08.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 08.fs
@@ -1,0 +1,8 @@
+module Module
+
+type T =
+    struct
+        val
+    end
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 08.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 08.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Struct,
+                     [ValField
+                        (SynField
+                           ([], false, Some , FromParseError (1,13--1,13), false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,4--134217728,0),
+                            { LeadingKeyword = Some (Val (5,8--5,11)) }),
+                         (1,13--5,11))], (4,4--6,7)), [], None, (3,5--6,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,7));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,7) parse error Unexpected keyword 'end' in member definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 09.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 09.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    static val
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 09.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 09.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], true, Some , FromParseError (1,13--1,13), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,0--134217728,0),
+                            { LeadingKeyword =
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
+                         (1,13--4,10))], (1,13--4,10)), [], None, (1,13--4,10),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (1,13--4,10));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition. Expected identifier or other token.


### PR DESCRIPTION
```fsharp
type T =
    member val P: = 1
```

```fsharp
type T =
    member val P:
```

```fsharp
type T =
    member val P
```

```fsharp
type T =
    member val
```

```fsharp
type T =
    val F:
```

```fsharp
type T =
    val F
```