### PR TITLE
Remove FSharp.Compiler.AbstractIL.IL opens.

### DIFF
--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -10,7 +10,6 @@ open System.Collections.Concurrent
 open System.Globalization
 open System.Text
 
-open FSharp.Compiler.AbstractIL
 open Internal.Utilities.Library
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Layout

--- a/src/Compiler/SyntaxTree/XmlDoc.fs
+++ b/src/Compiler/SyntaxTree/XmlDoc.fs
@@ -13,7 +13,6 @@ open FSharp.Compiler.DiagnosticsLogger
 open FSharp.Compiler.IO
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range
-open FSharp.Compiler.AbstractIL.IL
 
 /// Represents collected XmlDoc lines
 [<RequireQualifiedAccess>]

--- a/src/Compiler/SyntaxTree/XmlDoc.fsi
+++ b/src/Compiler/SyntaxTree/XmlDoc.fsi
@@ -3,7 +3,6 @@
 namespace FSharp.Compiler.Xml
 
 open FSharp.Compiler.Text
-open FSharp.Compiler.AbstractIL.IL
 
 /// Represents collected XmlDoc lines
 [<Class>]


### PR DESCRIPTION
When working on https://github.com/dotnet/fsharp/pull/15489, I noticed that these open statements introduce unnecessary links in the graph.