### PR TITLE
Hide changes in .xlf files on PR diff screens

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,5 +28,6 @@ targets.make text eol=lf
 *.sh text eol=lf
 
 *.bsl linguist-vendored=true
+*.xlf linguist-generated=true
 
 *.png binary

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1692,7 +1692,7 @@ featureEscapeBracesInFormattableString,"Escapes curly braces before calling Form
 3560,tcCopyAndUpdateRecordChangesAllFields,"This copy-and-update record expression changes all fields of record type '%s'. Consider using the record construction syntax instead."
 3561,chkAutoOpenAttributeInTypeAbbrev,"FSharp.Core.AutoOpenAttribute should not be aliased."
 3562,parsUnexpectedEndOfFileElif,"Unexpected end of input in 'else if' or 'elif' branch of conditional expression. Expected 'elif <expr> then <expr>' or 'else if <expr> then <expr>'."
-3563,lexInvalidIdentifier,"This is not a valid identifier"
+3563,lexInvalidIdentifier,"This is not a valid identifier."
 3564,parsMissingUnionCaseName,"Missing union case name"
 3565,parsExpectingType,"Expecting type"
 featureInformationalObjInferenceDiagnostic,"Diagnostic 3559 (warn when obj inferred) at informational level, off by default"

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -558,8 +558,8 @@
         <note />
       </trans-unit>
       <trans-unit id="lexInvalidIdentifier">
-        <source>This is not a valid identifier</source>
-        <target state="new">This is not a valid identifier</target>
+        <source>This is not a valid identifier.</source>
+        <target state="new">This is not a valid identifier.</target>
         <note />
       </trans-unit>
       <trans-unit id="lexRBraceInInterpolatedString">


### PR DESCRIPTION
Hide changes in .xlf files.
The added dot in the text is just to see how it works.