### PR TITLE
Remove unused open in SyntaxTree.fs

### DIFF
--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -4,7 +4,6 @@ namespace rec FSharp.Compiler.Syntax
 
 open System
 open System.Diagnostics
-open Internal.Utilities.Library
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Range


### PR DESCRIPTION
I think this one can be removed as well.