### PR TITLE
Remove redundant match clauses

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -898,8 +898,6 @@ type internal TypeCheckInfo
             | Item.CustomOperation _ -> CompletionItemKind.CustomOperation
             // These items are not given a completion kind. This could be reviewed
             | Item.ActivePatternResult _
-            | Item.CustomOperation _
-            | Item.CtorGroup _
             | Item.ExnCase _
             | Item.ImplicitOp _
             | Item.ModuleOrNamespaces _
@@ -909,7 +907,6 @@ type internal TypeCheckInfo
             | Item.UnionCase _
             | Item.UnionCaseField _
             | Item.UnqualifiedType _
-            | Item.Value _
             | Item.NewDef _
             | Item.SetterArg _
             | Item.CustomBuilder _


### PR DESCRIPTION
Pattern compilation comes short with no warning given

```fsharp
type DU =
    | B
    | C

let g h =
    match h with
    | B -> ()
    | B
    | C -> ()

let i h =
    match h with
    | B
    | B
    | C -> ()
```