### PR TITLE
More accurate range for FS0053: Discriminated union cases and exception labels must be uppercase identifiers

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -2249,7 +2249,7 @@ module TcExceptionDeclarations =
 
     let TcExnDefnCore_Phase1A cenv env parent (SynExceptionDefnRepr(Attributes synAttrs, SynUnionCase(ident= SynIdent(id,_)), _, xmlDoc, vis, m)) =
         let attrs = TcAttributes cenv env AttributeTargets.ExnDecl synAttrs
-        if not (String.isLeadingIdentifierCharacterUpperCase id.idText) then errorR(NotUpperCaseConstructor m)
+        if not (String.isLeadingIdentifierCharacterUpperCase id.idText) then errorR(NotUpperCaseConstructor id.idRange)
         let vis, cpath = ComputeAccessAndCompPath env None m vis None parent
         let vis = TcRecdUnionAndEnumDeclarations.CombineReprAccess parent vis
         CheckForDuplicateConcreteType env (id.idText + "Exception") id.idRange

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/ExceptionDefinitions/ExceptionDefinitions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/ExceptionDefinitions/ExceptionDefinitions.fs
@@ -147,8 +147,8 @@ module ExceptionDefinition =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 53, Line 9, Col 1, Line 9, Col 19, "Discriminated union cases and exception labels must be uppercase identifiers")
-            (Error 53, Line 10, Col 1, Line 10, Col 19, "Discriminated union cases and exception labels must be uppercase identifiers")
+            (Error 53, Line 9, Col 11, Line 9, Col 12, "Discriminated union cases and exception labels must be uppercase identifiers")
+            (Error 53, Line 10, Col 11, Line 10, Col 12, "Discriminated union cases and exception labels must be uppercase identifiers")
         ]
 
     // SOURCE=E_BeginWithUppercase02.fsx                   SCFLAGS="--test:ErrorRanges"        # E_BeginWithUppercase02.fsx
@@ -310,7 +310,7 @@ module ExceptionDefinition =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 53, Line 8, Col 1, Line 8, Col 39, "Discriminated union cases and exception labels must be uppercase identifiers")
+            (Error 53, Line 8, Col 11, Line 8, Col 29, "Discriminated union cases and exception labels must be uppercase identifiers")
         ]
 
     // SOURCE=E_Undefined.fsx                     SCFLAGS=--test:ErrorRanges                   # E_Undefined.fsx

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ProposeUppercaseLabelTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ProposeUppercaseLabelTests.fs
@@ -32,13 +32,21 @@ type MyNumber = Number of int
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``Doesn't fix FS0053 for exceptions`` () =
+let ``Fix FS0053 for exceptions`` () =
     let code =
         """
 exception lowException of string
 """
 
-    let expected = None
+    let expected =
+        Some
+            {
+                Message = "Replace with 'LowException'"
+                FixedCode =
+                    """
+exception LowException of string
+"""
+            }
 
     let actual = codeFix |> tryFix code diagnostic
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/15507

Update: also fixes https://github.com/dotnet/fsharp/issues/15509