### PR TITLE
SynExpr.Wild

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -5752,6 +5752,8 @@ and TcExprUndelayed (cenv: cenv) (overallTy: OverallTy) env tpenv (synExpr: SynE
     | SynExpr.IndexRange (range=m) ->
         error(Error(FSComp.SR.tcInvalidIndexerExpression(), m))
 
+    | SynExpr.Wild _ -> failwith "No suppport for SynExpr.WildCard"
+
 and TcExprMatch (cenv: cenv) overallTy env tpenv synInputExpr spMatch synClauses =
     let inputExpr, inputTy, tpenv =
         let env = { env with eIsControlFlow = false }
@@ -8721,7 +8723,8 @@ and TcImplicitOpItemThen (cenv: cenv) overallTy env id sln tpenv mItem delayed =
         | SynExpr.Const _
         | SynExpr.Typar _
         | SynExpr.LongIdent _
-        | SynExpr.Dynamic _ -> true
+        | SynExpr.Dynamic _
+        | SynExpr.Wild _ -> true
 
         | SynExpr.Tuple (_, synExprs, _, _)
         | SynExpr.ArrayOrList (_, synExprs, _) -> synExprs |> List.forall isSimpleArgument

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -301,7 +301,8 @@ let visitSynTypeConstraint (tc: SynTypeConstraint) : FileContentEntry list =
 let visitSynExpr (e: SynExpr) : FileContentEntry list =
     let rec visit (e: SynExpr) (continuation: FileContentEntry list -> FileContentEntry list) : FileContentEntry list =
         match e with
-        | SynExpr.Const _ -> continuation []
+        | SynExpr.Const _
+        | SynExpr.Wild _ -> continuation []
         | SynExpr.Paren (expr = expr) -> visit expr continuation
         | SynExpr.Quote (operator = operator; quotedExpr = quotedExpr) ->
             visit operator (fun operatorNodes -> visit quotedExpr (fun quotedNodes -> operatorNodes @ quotedNodes |> continuation))

--- a/src/Compiler/Service/FSharpParseFileResults.fs
+++ b/src/Compiler/Service/FSharpParseFileResults.fs
@@ -641,7 +641,8 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                         | SynExpr.Ident _
                         | SynExpr.ImplicitZero _
                         | SynExpr.Const _
-                        | SynExpr.Dynamic _ -> ()
+                        | SynExpr.Dynamic _
+                        | SynExpr.Wild _ -> ()
 
                         | SynExpr.Quote (_, _, e, _, _)
                         | SynExpr.TypeTest (e, _, _)

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -785,6 +785,8 @@ module SyntaxTraversal =
 
                 | SynExpr.DiscardAfterMissingQualificationAfterDot (synExpr, _, _range) -> traverseSynExpr synExpr
 
+                | SynExpr.Wild _ -> None
+
             visitor.VisitExpr(origPath, traverseSynExpr origPath, defaultTraverse, expr)
 
         and traversePat origPath (pat: SynPat) =

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -713,6 +713,8 @@ type SynExpr =
 
     | Dynamic of funcExpr: SynExpr * qmark: range * argExpr: SynExpr * range: range
 
+    | Wild of range: range
+
     member e.Range =
         match e with
         | SynExpr.Paren (_, leftParenRange, rightParenRange, r) ->
@@ -782,9 +784,10 @@ type SynExpr =
         | SynExpr.DoBang (range = m)
         | SynExpr.Fixed (range = m)
         | SynExpr.InterpolatedString (range = m)
-        | SynExpr.Dynamic (range = m) -> m
+        | SynExpr.Dynamic (range = m)
+        | SynExpr.Typar (range = m)
+        | SynExpr.Wild (range = m) -> m
         | SynExpr.Ident id -> id.idRange
-        | SynExpr.Typar (range = m) -> m
         | SynExpr.DebugPoint (_, _, innerExpr) -> innerExpr.Range
 
     member e.RangeWithoutAnyExtraDot =

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -923,6 +923,9 @@ type SynExpr =
     /// F# syntax: f?x
     | Dynamic of funcExpr: SynExpr * qmark: range * argExpr: SynExpr * range: range
 
+    /// F# syntax: _, used in `_.Property`
+    | Wild of range: range
+
     /// Gets the syntax range of this construct
     member Range: range
 

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -800,7 +800,8 @@ let rec synExprContainsError inpExpr =
         | SynExpr.Typar _
         | SynExpr.ImplicitZero _
         | SynExpr.Const _
-        | SynExpr.Dynamic _ -> false
+        | SynExpr.Dynamic _
+        | SynExpr.Wild _ -> false
 
         | SynExpr.TypeTest (e, _, _)
         | SynExpr.Upcast (e, _, _)

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -365,6 +365,7 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 %left pat_app
 %left pat_args
 %left PREFIX_OP
+%right dot_lambda
 %left DOT QMARK
 %left HIGH_PRECEDENCE_BRACK_APP
 %left HIGH_PRECEDENCE_PAREN_APP
@@ -4795,6 +4796,13 @@ argExpr:
         arg }
 
 atomicExpr:
+  | UNDERSCORE DOT nameop %prec dot_lambda
+      { let mUnderscore = rhs parseState 1
+        let mDot = rhs parseState 2
+        let m = rhs2 parseState 1 3
+        let wildCardExpr = SynExpr.Wild mUnderscore
+        mkSynDot mDot m wildCardExpr $3, false }
+
   | atomicExpr HIGH_PRECEDENCE_BRACK_APP atomicExpr
       { let arg1, _ = $1
         let arg2, hpa = $3

--- a/tests/service/data/SyntaxTree/Expression/Wild 01.fs
+++ b/tests/service/data/SyntaxTree/Expression/Wild 01.fs
@@ -1,0 +1,3 @@
+module W
+
+_.Foo

--- a/tests/service/data/SyntaxTree/Expression/Wild 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Wild 01.fs.bsl
@@ -1,0 +1,13 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Wild 01.fs", false, QualifiedNameOfFile W, [], [],
+      [SynModuleOrNamespace
+         ([W], false, NamedModule,
+          [Expr
+             (DotGet
+                (Wild (3,0--3,1), (3,1--3,2), SynLongIdent ([Foo], [], [None]),
+                 (3,0--3,5)), (3,0--3,5))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,5), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/Wild 02.fs
+++ b/tests/service/data/SyntaxTree/Expression/Wild 02.fs
@@ -1,0 +1,3 @@
+module W
+
+_.Foo()

--- a/tests/service/data/SyntaxTree/Expression/Wild 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Wild 02.fs.bsl
@@ -1,0 +1,16 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Wild 02.fs", false, QualifiedNameOfFile W, [], [],
+      [SynModuleOrNamespace
+         ([W], false, NamedModule,
+          [Expr
+             (App
+                (Atomic, false,
+                 DotGet
+                   (Wild (3,0--3,1), (3,1--3,2),
+                    SynLongIdent ([Foo], [], [None]), (3,0--3,5)),
+                 Const (Unit, (3,5--3,7)), (3,0--3,7)), (3,0--3,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/Wild 03.fs
+++ b/tests/service/data/SyntaxTree/Expression/Wild 03.fs
@@ -1,0 +1,3 @@
+module W
+
+_.Foo().Bar

--- a/tests/service/data/SyntaxTree/Expression/Wild 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Wild 03.fs.bsl
@@ -1,0 +1,18 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Wild 03.fs", false, QualifiedNameOfFile W, [], [],
+      [SynModuleOrNamespace
+         ([W], false, NamedModule,
+          [Expr
+             (DotGet
+                (App
+                   (Atomic, false,
+                    DotGet
+                      (Wild (3,0--3,1), (3,1--3,2),
+                       SynLongIdent ([Foo], [], [None]), (3,0--3,5)),
+                    Const (Unit, (3,5--3,7)), (3,0--3,7)), (3,7--3,8),
+                 SynLongIdent ([Bar], [], [None]), (3,0--3,11)), (3,0--3,11))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))


### PR DESCRIPTION
An alternate take on the syntax of https://github.com/dotnet/fsharp/pull/13907.
This is not a total alternative, just an example of how the untyped tree could be modelled.