### PR TITLE
Fixing code fixes, part 4

### DIFF
--- a/src/Compiler/Service/FSharpParseFileResults.fs
+++ b/src/Compiler/Service/FSharpParseFileResults.fs
@@ -170,6 +170,21 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
         let result = SyntaxTraversal.Traverse(pos, input, visitor)
         result.IsSome
 
+    member _.IsTypeName(range: range) =
+        let visitor =
+            { new SyntaxVisitorBase<_>() with
+                member _.VisitModuleDecl(_, _, synModuleDecl) =
+                    match synModuleDecl with
+                    | SynModuleDecl.Types (typeDefns, _) ->
+                        typeDefns
+                        |> Seq.exists (fun (SynTypeDefn (typeInfo, _, _, _, _, _)) -> typeInfo.Range = range)
+                        |> Some
+                    | _ -> None
+            }
+
+        let result = SyntaxTraversal.Traverse(range.Start, input, visitor)
+        result |> Option.contains true
+
     member _.TryRangeOfFunctionOrMethodBeingApplied pos =
         let rec getIdentRangeForFuncExprInApp traverseSynExpr expr pos =
             match expr with

--- a/src/Compiler/Service/FSharpParseFileResults.fsi
+++ b/src/Compiler/Service/FSharpParseFileResults.fsi
@@ -36,6 +36,9 @@ type public FSharpParseFileResults =
     /// Determines if the given position is inside a function or method application.
     member IsPosContainedInApplication: pos: pos -> bool
 
+    /// Determines if the range points to a type name in the type definition.
+    member IsTypeName: range: range -> bool
+
     /// Attempts to find the range of a function or method that is being applied. Also accounts for functions in pipelines.
     member TryRangeOfFunctionOrMethodBeingApplied: pos: pos -> range option
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -2080,6 +2080,7 @@ FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateConfiguration(FSharp.
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsBindingALambdaAtPosition(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPosContainedInApplication(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPositionContainedInACurriedParameter(FSharp.Compiler.Text.Position)
+FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsTypeName(FSharp.Compiler.Text.Range)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsTypeAnnotationGivenAtPosition(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean ParseHadErrors
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean get_ParseHadErrors()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -2080,6 +2080,7 @@ FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateConfiguration(FSharp.
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsBindingALambdaAtPosition(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPosContainedInApplication(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPositionContainedInACurriedParameter(FSharp.Compiler.Text.Position)
+FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsTypeName(FSharp.Compiler.Text.Range)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsTypeAnnotationGivenAtPosition(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean ParseHadErrors
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean get_ParseHadErrors()

--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingEqualsToTypeDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingEqualsToTypeDefinition.fs
@@ -2,45 +2,40 @@
 
 namespace Microsoft.VisualStudio.FSharp.Editor
 
-open System
 open System.Composition
-open System.Threading.Tasks
 open System.Collections.Immutable
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
+
+open CancellableTasks
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.AddMissingEqualsToTypeDefinition); Shared>]
 type internal AddMissingEqualsToTypeDefinitionCodeFixProvider() =
     inherit CodeFixProvider()
 
     static let title = SR.AddMissingEqualsToTypeDefinition()
-    override _.FixableDiagnosticIds = ImmutableArray.Create("FS3360")
 
-    override _.RegisterCodeFixesAsync context : Task =
-        asyncMaybe {
+    override _.FixableDiagnosticIds = ImmutableArray.Create "FS3360"
 
-            let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
+    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
 
-            let mutable pos = context.Span.Start - 1
+    interface IFSharpCodeFixProvider with
+        member _.GetCodeFixIfAppliesAsync context =
+            cancellableTask {
+                let! range = context.GetErrorRangeAsync()
 
-            // This won't ever actually happen, but eh why not
-            do! Option.guard (pos > 0)
+                let! parseResults = context.Document.GetFSharpParseResultsAsync(nameof AddMissingEqualsToTypeDefinitionCodeFixProvider)
 
-            let mutable ch = sourceText.[pos]
+                if parseResults.IsTypeName range then
+                    return None
 
-            while pos > 0 && Char.IsWhiteSpace(ch) do
-                pos <- pos - 1
-                ch <- sourceText.[pos]
-
-            do
-                context.RegisterFsharpFix(
-                    CodeFix.AddMissingEqualsToTypeDefinition,
-                    title,
-                    // 'pos + 1' is here because 'pos' is now the position of the first non-whitespace character.
-                    // Using just 'pos' will creat uncompilable code.
-                    [| TextChange(TextSpan(pos + 1, 0), " =") |]
-                )
-        }
-        |> Async.Ignore
-        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+                else
+                    return
+                        Some
+                            {
+                                Name = CodeFix.AddMissingEqualsToTypeDefinition
+                                Message = title
+                                Changes = [ TextChange(TextSpan(context.Span.Start, 0), "= ") ]
+                            }
+            }

--- a/vsintegration/src/FSharp.Editor/CodeFixes/ConvertToNotEqualsEqualityExpression.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/ConvertToNotEqualsEqualityExpression.fs
@@ -3,11 +3,12 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Threading.Tasks
 open System.Collections.Immutable
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
+
+open CancellableTasks
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.ConvertToNotEqualsEqualityExpression); Shared>]
 type internal ConvertToNotEqualsEqualityExpressionCodeFixProvider() =
@@ -15,17 +16,23 @@ type internal ConvertToNotEqualsEqualityExpressionCodeFixProvider() =
 
     static let title = SR.ConvertToNotEqualsEqualityExpression()
 
-    override _.FixableDiagnosticIds = ImmutableArray.Create("FS0043")
+    override _.FixableDiagnosticIds = ImmutableArray.Create "FS0043"
 
-    override this.RegisterCodeFixesAsync context : Task =
-        asyncMaybe {
-            let! sourceText = context.Document.GetTextAsync(context.CancellationToken)
-            let text = sourceText.GetSubText(context.Span).ToString()
+    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
 
-            // We're converting '!=' into '<>', a common new user mistake.
-            // If this is an FS00043 that is anything other than that, bail out
-            do! Option.guard (text = "!=")
-            do context.RegisterFsharpFix(CodeFix.ConvertToNotEqualsEqualityExpression, title, [| TextChange(context.Span, "<>") |])
-        }
-        |> Async.Ignore
-        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+    interface IFSharpCodeFixProvider with
+        member _.GetCodeFixIfAppliesAsync context =
+            cancellableTask {
+                let! text = context.GetSquigglyTextAsync()
+
+                if text <> "!=" then
+                    return None
+                else
+                    return
+                        Some
+                            {
+                                Name = CodeFix.ConvertToNotEqualsEqualityExpression
+                                Message = title
+                                Changes = [ TextChange(context.Span, "<>") ]
+                            }
+            }

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingEqualsToTypeDefinitionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingEqualsToTypeDefinitionTests.fs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.AddMissingEqualsToTypeDefinitionTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = AddMissingEqualsToTypeDefinitionCodeFixProvider()
+let private diagnostic = 3360 // Unexpected token in type def...
+
+[<Fact>]
+let ``Fixes FS0360 for missing equals in type def - simple types`` () =
+    let code =
+        """
+type Song { Artist : string; Title : int }
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Add missing '=' to type definition"
+                FixedCode =
+                    """
+type Song = { Artist : string; Title : int }
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Fixes FS0360 for missing equals in type def - records`` () =
+    let code =
+        """
+type Name Name of string
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Add missing '=' to type definition"
+                FixedCode =
+                    """
+type Name = Name of string
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+// apparently this throws the same error hah
+let ``Doesn't fix FS0360 for invalid interface defs`` () =
+    let code =
+        """
+type IA<'b> = 
+    abstract Foo : int -> int
+
+type IB<'b> = 
+    inherit IA<'b>
+    inherit IA<int>
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangePrefixNegationToInfixSubtractionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangePrefixNegationToInfixSubtractionTests.fs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ChangePrefixNegationToInfixNegationTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = ChangePrefixNegationToInfixSubtractionCodeFixProvider()
+let private diagnostic = 0003 // The value is not a function and cannot be applied
+
+[<Theory>]
+[<InlineData " ">]
+[<InlineData "   ">]
+let ``Fixes FS0003 for accidental negation`` spaces =
+    let code =
+        $"""
+let f (numbers: 'a array) = 
+    for x = 0 to numbers.Length{spaces}-1 do 
+        printfn "%%i" x
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use subtraction instead of negation"
+                FixedCode =
+                    $"""
+let f (numbers: 'a array) = 
+    for x = 0 to numbers.Length{spaces}- 1 do 
+        printfn "%%i" x
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0003 for random incorrect operator usage`` () =
+    let code =
+        """
+let x = 1 (+) 2
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeRefCellDerefToNotExpressionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeRefCellDerefToNotExpressionTests.fs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ChangeRefCellDerefToNotExpressionTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = ChangeRefCellDerefToNotExpressionCodeFixProvider()
+let private diagnostic = 0001 // Type mismatch...
+
+[<Fact>]
+let ``Fixes FS0001 for invalid negation syntax`` () =
+    let code =
+        """
+let myNot (value: bool) = !value
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use 'not' to negate expression"
+                FixedCode =
+                    """
+let myNot (value: bool) = not value
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0001 for random type mismatch`` () =
+    let code =
+        """
+let one, two = 1, 2, 3
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertToNotEqualsEqualityExpressionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertToNotEqualsEqualityExpressionTests.fs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ConvertToNotEqualsEqualityExpressionTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = ConvertToNotEqualsEqualityExpressionCodeFixProvider()
+let private diagnostic = 0043 // The type doesn't support the value...
+
+[<Fact>]
+let ``Fixes FS0043 for C# inequality operator`` () =
+    let code =
+        """
+let areNotEqual (x: int) (y: int) = x != y
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use '<>' for inequality check"
+                FixedCode =
+                    """
+let areNotEqual (x: int) (y: int) = x <> y
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0043 for random unsupported values`` () =
+    let code =
+        """
+type RecordType = { X : int }
+
+let x : RecordType = null
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertToSingleEqualsEqualityExpressionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ConvertToSingleEqualsEqualityExpressionTests.fs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.ConvertToSingleEqualsEqualityExpressionTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = ConvertToSingleEqualsEqualityExpressionCodeFixProvider()
+let private diagnostic = 0043 // The type doesn't support the value...
+
+[<Fact>]
+let ``Fixes FS0043 for C# equality operator`` () =
+    let code =
+        """
+let areEqual (x: int) (y: int) = x == y
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use '=' for equality check"
+                FixedCode =
+                    """
+let areEqual (x: int) (y: int) = x = y
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0043 for random unsupported values`` () =
+    let code =
+        """
+type RecordType = { X : int }
+
+let x : RecordType = null
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/UseTripleQuotedInterpolationTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/UseTripleQuotedInterpolationTests.fs
@@ -14,24 +14,19 @@ let private diagnostic = 3373 // ... invalid interpolated string ...
 let ``Fixes FS3373`` () =
     let code =
         """
-let answer = $"{"42"}"
+let pluralize n word = if n = 1 then word else $"{word}s"
+let createMsg x = $"Review in {x} {pluralize x "day"}"
 """
 
     let expected =
         Some
             {
                 Message = "Use triple quoted string interpolation."
-                // yeah... because I can't understand how to
-                // put a triple-quoted string inside a triple-quoted string
-                // but this is what we need
                 FixedCode =
-                    """
-let answer = $"""
-                    + "\"\"\""
-                    + """{"42"}"""
-                    + "\"\"\""
-                    + """
-"""
+                    "\r\n"
+                    + "let pluralize n word = if n = 1 then word else $\"{word}s\"\r\n"
+                    + "let createMsg x = $\"\"\"Review in {x} {pluralize x \"day\"}\"\"\""
+                    + "\r\n"
             }
 
     let actual = codeFix |> tryFix code diagnostic

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/UseTripleQuotedInterpolationTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/UseTripleQuotedInterpolationTests.fs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.UseTripleQuotedInterpolationTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = UseTripleQuotedInterpolationCodeFixProvider()
+let private diagnostic = 3373 // ... invalid interpolated string ...
+
+[<Fact>]
+let ``Fixes FS3373`` () =
+    let code =
+        """
+let answer = $"{"42"}"
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use triple quoted string interpolation."
+                // yeah... because I can't understand how to
+                // put a triple-quoted string inside a triple-quoted string
+                // but this is what we need
+                FixedCode =
+                    """
+let answer = $"""
+                    + "\"\"\""
+                    + """{"42"}"""
+                    + "\"\"\""
+                    + """
+"""
+            }
+
+    let actual = codeFix |> tryFix code diagnostic
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -43,6 +43,12 @@
     <Compile Include="CodeFixes\MakeOuterBindingRecursiveTests.fs" />
     <Compile Include="CodeFixes\AddMissingFunKeywordTests.fs" />
     <Compile Include="CodeFixes\ProposeUppercaseLabelTests.fs" />
+    <Compile Include="CodeFixes\UseTripleQuotedInterpolationTests.fs" />
+    <Compile Include="CodeFixes\ConvertToNotEqualsEqualityExpressionTests.fs" />
+    <Compile Include="CodeFixes\ConvertToSingleEqualsEqualityExpressionTests.fs" />
+    <Compile Include="CodeFixes\AddMissingEqualsToTypeDefinitionTests.fs" />
+    <Compile Include="CodeFixes\ChangeRefCellDerefToNotExpressionTests.fs" />
+    <Compile Include="CodeFixes\ChangePrefixNegationToInfixSubtractionTests.fs" />
     <Compile Include="Hints\HintTestFramework.fs" />
     <Compile Include="Hints\OptionParserTests.fs" />
     <Compile Include="Hints\InlineParameterNameHintTests.fs" />


### PR DESCRIPTION
This PR:
- Refactors and adds tests for a few code fixes:
  - AddMissingEqualsToTypeDefinition
  - ChangePrefixNegationToInfixSubtraction
  - ChangeRefCellDerefToNotExpression
  - ConvertToNotEqualsEqualityExpression
  - ConvertToSingleEqualsEqualityExpression
  - UseTripleQuotedInterpolation
- fixes #15547