### PR TITLE
Enable completions in enum case value expression

### DIFF
--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -1522,7 +1522,7 @@ module ParsedInput =
 
                 member _.VisitEnumDefn(_, cases, _) =
                     cases
-                    |> List.tryPick (fun (SynEnumCase (ident = SynIdent (ident = id))) ->
+                    |> List.tryPick (fun (SynEnumCase(ident = SynIdent (ident = id))) ->
                         if rangeContainsPos id.idRange pos then
                             // No completions in an enum case identifier
                             Some CompletionContext.Invalid

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -1520,9 +1520,15 @@ module ParsedInput =
                                             None)
                             | _ -> None)
 
-                member _.VisitEnumDefn(_, _, _) =
-                    // No completions anywhere in an enum, except in attributes, which is established earlier in VisitAttributeApplication
-                    Some CompletionContext.Invalid
+                member _.VisitEnumDefn(_, cases, _) =
+                    cases
+                    |> List.tryPick (fun (SynEnumCase (ident = SynIdent (ident = id))) ->
+                        if rangeContainsPos id.idRange pos then
+                            // No completions in an enum case identifier
+                            Some CompletionContext.Invalid
+                        else
+                            // The value expression should still get completions
+                            None)
 
                 member _.VisitTypeAbbrev(_, _, range) =
                     if rangeContainsPos range pos then

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1281,11 +1281,15 @@ type A = l
     let ``No completion on enum case identifier at declaration site`` () =
         let fileContents =
             """
+let [<Literal>] lit = 1
+
 type A =
     | C = 0
+    | D = l
 """
 
         VerifyNoCompletionList(fileContents, "| C")
+        VerifyCompletionList(fileContents, "| D = l", [ "lit" ], [])
 
     [<Fact>]
     let ``Completion list in generic function body contains type parameter`` () =


### PR DESCRIPTION
Everything is shown for the time being. In the future I suggest we introduce a completion type for "literal expression" positions, which would only show namespaces, modules, classes, F# literals and IL constants in classes.