### PR TITLE
Correct misleading doc in Async.Sleep

### DIFF
--- a/src/FSharp.Core/async.fsi
+++ b/src/FSharp.Core/async.fsi
@@ -807,7 +807,7 @@ namespace Microsoft.FSharp.Control
         ///
         /// printfn "C"
         /// </code>
-        /// Prints "C", then "A" quickly, and then "B" 1 second later
+        /// Prints "C" and "A" quickly in any order, and then "B" 1 second later
         /// </example>
         static member Sleep: millisecondsDueTime:int -> Async<unit>
 


### PR DESCRIPTION
Similar to L116, the behaviour should be A and C quickly in any order, and then B after 1 second.