### PR TITLE
Initial recovery for function types in union case field.

### DIFF
--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1724,3 +1724,4 @@ featureAccessorFunctionShorthand,"underscore dot shorthand for accessor only fun
 featureUnmanagedConstraintCsharpInterop,"Interop between C#'s and F#'s unmanaged generic constraint (emit additional modreq)"
 3578,chkCopyUpdateSyntaxInAnonRecords,"This expression is an anonymous record, use {{|...|}} instead of {{...}}."
 3579,alwaysUseTypedStringInterpolation,"Interpolated string contains untyped identifiers. Adding typed format specifiers is recommended."
+3580,tcUnexpectedFunTypeInUnionCaseField,"Unexpected function type in union case field definition"

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1724,4 +1724,4 @@ featureAccessorFunctionShorthand,"underscore dot shorthand for accessor only fun
 featureUnmanagedConstraintCsharpInterop,"Interop between C#'s and F#'s unmanaged generic constraint (emit additional modreq)"
 3578,chkCopyUpdateSyntaxInAnonRecords,"This expression is an anonymous record, use {{|...|}} instead of {{...}}."
 3579,alwaysUseTypedStringInterpolation,"Interpolated string contains untyped identifiers. Adding typed format specifiers is recommended."
-3580,tcUnexpectedFunTypeInUnionCaseField,"Unexpected function type in union case field definition"
+3580,tcUnexpectedFunTypeInUnionCaseField,"Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b)."

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2786,10 +2786,12 @@ unionCaseReprElement:
   | ident COLON invalidUseOfAppTypeFunction
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        let mWhole = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
+       reportParseErrorAt ($3 : SynType).Range (FSComp.SR.tcUnexpectedFunTypeInUnionCaseField())
        mkSynNamedField ($1, $3, xmlDoc, mWhole) }
 
   | invalidUseOfAppTypeFunction
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
+       reportParseErrorAt ($1 : SynType).Range (FSComp.SR.tcUnexpectedFunTypeInUnionCaseField())
        mkSynAnonField ($1, xmlDoc) }
 
 unionCaseRepr:
@@ -5809,7 +5811,6 @@ invalidUseOfAppTypeFunction:
   | appType RARROW appType
      { let mArrow = rhs parseState 2
        let m = rhs2 parseState 1 3
-       reportParseErrorAt m (FSComp.SR.tcUnexpectedFunTypeInUnionCaseField())
        SynType.Fun($1, $3, m, { ArrowRange = mArrow }) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2783,6 +2783,10 @@ unionCaseReprElement:
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        mkSynAnonField ($1, xmlDoc) }
 
+  | invalidUseOfAppTypeFunction
+     { let xmlDoc = grabXmlDoc(parseState, [], 1)
+       mkSynAnonField ($1, xmlDoc) }
+
 unionCaseRepr:
   | braceFieldDeclList
      { errorR(Deprecated(FSComp.SR.parsConsiderUsingSeparateRecordType(), lhs parseState))
@@ -5776,6 +5780,32 @@ topAppType:
 
   | appType
      { $1, SynArgInfo([], false, None) }
+
+/* Grammar rule meant for recovery scenarios */
+/* For example in unionCaseReprElement where function type is not allowed */
+invalidUseOfAppTypeFunction:
+  | appType RARROW invalidUseOfAppTypeFunction
+     { let mArrow = rhs parseState 2
+       let m = unionRanges (rhs2 parseState 1 2) $3.Range
+       SynType.Fun($1, $3, m, { ArrowRange = mArrow }) }
+  | appType RARROW recover
+     { let mArrow = rhs parseState 2
+       let ty = SynType.FromParseError(mArrow.EndRange)
+       let m = rhs2 parseState 1 2
+       SynType.Fun($1, ty, m, { ArrowRange = mArrow }) }
+  | appType RARROW RARROW invalidUseOfAppTypeFunction
+     { let mArrow1 = rhs parseState 2
+       let mArrow2 = rhs parseState 3
+       reportParseErrorAt mArrow2 (FSComp.SR.parsExpectingType ())
+       let ty = SynType.FromParseError(mArrow2.StartRange)
+       let m1 = unionRanges $1.Range $4.Range
+       let m2 = unionRanges mArrow2 $4.Range
+       SynType.Fun($1, SynType.Fun(ty, $4, m2, { ArrowRange = mArrow2 }), m1, { ArrowRange = mArrow1 }) }
+  | appType RARROW appType
+     { let mArrow = rhs parseState 2
+       let m = rhs2 parseState 1 3
+       reportParseErrorAt m (FSComp.SR.tcUnexpectedFunTypeInUnionCaseField())
+       SynType.Fun($1, $3, m, { ArrowRange = mArrow }) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
 /* See the F# specification "Lexical analysis of type applications and type parameter definitions" */

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2783,6 +2783,11 @@ unionCaseReprElement:
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        mkSynAnonField ($1, xmlDoc) }
 
+  | ident COLON invalidUseOfAppTypeFunction
+     { let xmlDoc = grabXmlDoc(parseState, [], 1)
+       let mWhole = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
+       mkSynNamedField ($1, $3, xmlDoc, mWhole) }
+
   | invalidUseOfAppTypeFunction
      { let xmlDoc = grabXmlDoc(parseState, [], 1)
        mkSynAnonField ($1, xmlDoc) }

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Neplatný interpolovaný řetězec. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' se obvykle používá jako omezení typu v obecném kódu, například \"T when ISomeInterface&lt;'T&gt;\" nebo \"let f (x: #ISomeInterface&lt;_&gt;)\". Pokyny najdete v https://aka.ms/fsharp-iwsams. Toto upozornění můžete zakázat pomocí #nowarn \"3536\" nebo '--nowarn:3536'.</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Ungültige interpolierte Zeichenfolge. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">„{0}“ wird normalerweise als Typeinschränkung im generischen Code verwendet, z. B. \"'T when ISomeInterface&lt;'T&gt;\" oder \"let f (x: #ISomeInterface&lt;_&gt;)\". Anleitungen finden Sie unter https://aka.ms/fsharp-iwsams. Sie können diese Warnung deaktivieren, indem Sie „#nowarn \"3536\"“ or „--nowarn:3536“ verwenden.</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Cadena interpolada no válida. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' se usa normalmente como restricción de tipo en código genérico; por ejemplo, \"'T when ISomeInterface&lt;'T&gt;\" o \"let f (x: #ISomeInterface&lt;_&gt;)\". Consulte https://aka.ms/fsharp-iwsams para obtener instrucciones. Puede deshabilitar esta advertencia con "#nowarn \"3536\"" o "--nowarn:3536".</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Chaîne interpolée non valide. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' est généralement utilisée comme contrainte de type dans le code générique, par exemple \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". Consultez https://aka.ms/fsharp-iwsams pour obtenir de l’aide. Vous pouvez désactiver cet avertissement à l’aide de '#nowarn \"3536\"' or '--nowarn:3536'.</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">La stringa interpolata non è valida. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' viene in genere usato come vincolo di tipo nel codice generico, ad esempio \"'T when ISomeInterface&lt;'T&gt;\" o \"let f (x: #ISomeInterface&lt;_&gt;)\". Per indicazioni, vedere https://aka.ms/fsharp-iwsams. È possibile disabilitare questo avviso usando '#nowarn \"3536\"' o '--nowarn:3536'.</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">補間された文字列が無効です。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' は通常、ジェネリック コードの型制約として使用されます (例: \"'T when ISomeInterface&lt;'T&gt;\" または \"let f (x: #ISomeInterface&lt;_&gt;)\")。ガイダンスについては https://aka.ms/fsharp-iwsams を参照してください。この警告は、'#nowarn \"3536\"' または '--nowarn:3536' を使用して無効にできます。</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">잘못된 보간 문자열. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}'은(는) 일반적으로 제네릭 코드에서 형식 제약 조건으로 사용됩니다(예: \"'T when ISomeInterface&lt;'T&gt;\" 또는 \"let f (x: #ISomeInterface&lt;_&gt;)\"). 지침은 https://aka.ms/fsharp-iwsams를 참조하세요. '#nowarn \"3536\"' 또는 '--nowarn:3536'을 사용하여 이 경고를 비활성화할 수 있습니다.</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Nieprawidłowy ciąg interpolowany. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">Element „{0}” jest zwykle używany jako ograniczenie typu w kodzie ogólnym, np. \"" T, gdy ISomeInterface&lt;' T&gt;\" lub \"let f (x: #ISomeInterface&lt;_&gt;)\". Aby uzyskać wskazówki, zobacz https://aka.ms/fsharp-iwsams. To ostrzeżenie można wyłączyć, używając polecenia „nowarn \"3536\"" lub "--nowarn:3536”.</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Cadeia de caracteres interpolada inválida. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' normalmente é usado como uma restrição de tipo em código genérico, por exemplo, \"'T when ISomeInterface&lt;'T&gt;\" ou \"let f (x: #ISomeInterface&lt;_&gt;)\". Confira https://aka.ms/fsharp-iwsams para obter as diretrizes. Você pode desabilitar este aviso usando '#nowarn \"3536\"' ou '--nowarn:3536'.</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Недопустимая интерполированная строка. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">"{0}" обычно используется в качестве ограничения типа в универсальном коде, например \"'T when ISomeInterface&lt;"T&gt;\" или \"let f (x: #ISomeInterface&lt;_&gt;)\". См. руководство на https://aka.ms/fsharp-iwsams. Это предупреждение можно отключить с помощью "#nowarn \"3536\"" или "--nowarn:3536".</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">Geçersiz düz metin arasına kod eklenmiş dize. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' normalde genel kodda tür kısıtlaması olarak kullanılır, ör. \"'T when ISomeInterface&lt;'T&gt;\" veya \"let f (x: #ISomeInterface&lt;_&gt;)\". Rehber için bkz. https://aka.ms/fsharp-iwsams. '#nowarn \"3536\"' veya '--nowarn:3536' kullanarak bu uyarıyı devre dışı bırakabilirsiniz.</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">内插字符串无效。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">"{0}" 通常用作泛型代码中的类型约束，例如 \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\"。有关指南，请参阅 https://aka.ms/fsharp-iwsams。可以使用 '#nowarn \"3536\"' 或 '--nowarn:3536' 禁用此警告。</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -1367,6 +1367,11 @@
         <target state="translated">插補字串無效。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
+        <source>Unexpected function type in union case field definition</source>
+        <target state="new">Unexpected function type in union case field definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">
         <source>'{0}' is normally used as a type constraint in generic code, e.g. \"'T when ISomeInterface&lt;'T&gt;\" or \"let f (x: #ISomeInterface&lt;_&gt;)\". See https://aka.ms/fsharp-iwsams for guidance. You can disable this warning by using '#nowarn \"3536\"' or '--nowarn:3536'.</source>
         <target state="translated">'{0}' 通常做為一般程式碼中的類型限制式，例如 \"'T when ISomeInterface&lt;'T&gt;\" 或 \"let f (x: #ISomeInterface&lt;_&gt;)\"。請參閱 https://aka.ms/fsharp-iwsams 以尋求指引。您可以使用 '#nowarn \"3536\"' 或 '--nowarn:3536' 來停用此警告。</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -1368,8 +1368,8 @@
         <note />
       </trans-unit>
       <trans-unit id="tcUnexpectedFunTypeInUnionCaseField">
-        <source>Unexpected function type in union case field definition</source>
-        <target state="new">Unexpected function type in union case field definition</target>
+        <source>Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</source>
+        <target state="new">Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -&gt; b into | Case of (a -&gt; b).</target>
         <note />
       </trans-unit>
       <trans-unit id="tcUsingInterfaceWithStaticAbstractMethodAsType">

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -233,6 +233,7 @@
     <Compile Include="TypeChecks\Graph\TypedTreeGraph.fs" />
     <Compile Include="TypeChecks\Graph\GraphProcessingTests.fs" />
     <Compile Include="TypeChecks\TyparNameTests.fs" />
+    <Compile Include="TypeChecks\CheckTypeTests.fs" />
     <Compile Include="CompilerOptions\fsc\checked\checked.fs" />
     <Compile Include="CompilerOptions\fsc\cliversion.fs" />
     <Compile Include="CompilerOptions\fsc\codepage\codepage.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
@@ -1,0 +1,15 @@
+﻿module TypeChecks.CheckTypeTests
+
+open Xunit
+open FSharp.Test.Compiler
+
+[<Fact>]
+let ``Recursive type with attribute`` () =
+    FSharp """
+namespace Foo
+
+type Bar = | Bar of int -> int
+type Other = int
+"""
+    |> typecheck
+    |> withSingleDiagnostic (Error 3578, Line 4, Col 21, Line 4, Col 31, "Unexpected function type in union case field definition")

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
@@ -4,7 +4,7 @@ open Xunit
 open FSharp.Test.Compiler
 
 [<Fact>]
-let ``Recursive type with attribute`` () =
+let ``Union case with function type`` () =
     FSharp """
 namespace Foo
 
@@ -12,4 +12,4 @@ type Bar = | Bar of int -> int
 type Other = int
 """
     |> typecheck
-    |> withSingleDiagnostic (Error 3578, Line 4, Col 21, Line 4, Col 31, "Unexpected function type in union case field definition")
+    |> withSingleDiagnostic (Error 3580, Line 4, Col 21, Line 4, Col 31, "Unexpected function type in union case field definition")

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
@@ -12,4 +12,4 @@ type Bar = | Bar of int -> int
 type Other = int
 """
     |> typecheck
-    |> withSingleDiagnostic (Error 3580, Line 4, Col 21, Line 4, Col 31, "Unexpected function type in union case field definition")
+    |> withSingleDiagnostic (Error 3580, Line 4, Col 21, Line 4, Col 31, "Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).")

--- a/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs
+++ b/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs
@@ -1,0 +1,4 @@
+namespace Foo
+
+exception Bar of int -> int
+exception Other of int

--- a/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs.bsl
@@ -43,4 +43,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,17)-(3,27) parse error Unexpected function type in union case field definition
+(3,17)-(3,27) parse error Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).

--- a/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Exception/Recover Function Type 01.fs", false,
+      QualifiedNameOfFile Recover Function Type 01, [], [],
+      [SynModuleOrNamespace
+         ([Foo], false, DeclaredNamespace,
+          [Exception
+             (SynExceptionDefn
+                (SynExceptionDefnRepr
+                   ([],
+                    SynUnionCase
+                      ([], SynIdent (Bar, None),
+                       Fields
+                         [SynField
+                            ([], false, None,
+                             Fun
+                               (LongIdent (SynLongIdent ([int], [], [None])),
+                                LongIdent (SynLongIdent ([int], [], [None])),
+                                (3,17--3,27), { ArrowRange = (3,21--3,23) }),
+                             false,
+                             PreXmlDoc ((3,17), FSharp.Compiler.Xml.XmlDocCollector),
+                             None, (3,17--3,27), { LeadingKeyword = None })],
+                       PreXmlDocEmpty, None, (3,10--3,27), { BarRange = None }),
+                    None, PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                    None, (3,0--3,27)), None, [], (3,0--3,27)), (3,0--3,27));
+           Exception
+             (SynExceptionDefn
+                (SynExceptionDefnRepr
+                   ([],
+                    SynUnionCase
+                      ([], SynIdent (Other, None),
+                       Fields
+                         [SynField
+                            ([], false, None,
+                             LongIdent (SynLongIdent ([int], [], [None])), false,
+                             PreXmlDoc ((4,19), FSharp.Compiler.Xml.XmlDocCollector),
+                             None, (4,19--4,22), { LeadingKeyword = None })],
+                       PreXmlDocEmpty, None, (4,10--4,22), { BarRange = None }),
+                    None, PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
+                    None, (4,0--4,22)), None, [], (4,0--4,22)), (4,0--4,22))],
+          PreXmlDocEmpty, [], None, (1,0--4,22),
+          { LeadingKeyword = Namespace (1,0--1,9) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,17)-(3,27) parse error Unexpected function type in union case field definition

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs
@@ -1,0 +1,4 @@
+namespace Foo
+
+type Bar = | Bar of int -> int
+type Other = int

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs.bsl
@@ -50,4 +50,4 @@ ImplFile
       (true, true), { ConditionalDirectives = []
                       CodeComments = [] }, set []))
 
-(3,20)-(3,30) parse error Unexpected function type in union case field definition
+(3,20)-(3,30) parse error Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs.bsl
@@ -1,0 +1,53 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Recover Function Type 01.fs", false,
+      QualifiedNameOfFile Recover Function Type 01, [], [],
+      [SynModuleOrNamespace
+         ([Foo], false, DeclaredNamespace,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [Bar],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,8)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (Bar, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  Fun
+                                    (LongIdent
+                                       (SynLongIdent ([int], [], [None])),
+                                     LongIdent
+                                       (SynLongIdent ([int], [], [None])),
+                                     (3,20--3,30), { ArrowRange = (3,24--3,26) }),
+                                  false,
+                                  PreXmlDoc ((3,20), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (3,20--3,30), { LeadingKeyword = None })],
+                            PreXmlDoc ((3,11), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (3,13--3,30), { BarRange = Some (3,11--3,12) })],
+                        (3,11--3,30)), (3,11--3,30)), [], None, (3,5--3,30),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (3,0--3,30));
+           Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [Other],
+                     PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (4,5--4,10)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (4,13--4,16)), (4,13--4,16)), [], None, (4,5--4,16),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,11--4,12)
+                    WithKeyword = None })], (4,0--4,16))], PreXmlDocEmpty, [],
+          None, (1,0--4,16), { LeadingKeyword = Namespace (1,0--1,9) })],
+      (true, true), { ConditionalDirectives = []
+                      CodeComments = [] }, set []))
+
+(3,20)-(3,30) parse error Unexpected function type in union case field definition

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs
@@ -1,0 +1,4 @@
+namespace Foo
+
+type B = | A of x: int -> int
+type Other = int

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs.bsl
@@ -1,0 +1,53 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Recover Function Type 02.fs", false,
+      QualifiedNameOfFile Recover Function Type 02, [], [],
+      [SynModuleOrNamespace
+         ([Foo], false, DeclaredNamespace,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [B],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, Some x,
+                                  Fun
+                                    (LongIdent
+                                       (SynLongIdent ([int], [], [None])),
+                                     LongIdent
+                                       (SynLongIdent ([int], [], [None])),
+                                     (3,19--3,29), { ArrowRange = (3,23--3,25) }),
+                                  false,
+                                  PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (3,16--3,29), { LeadingKeyword = None })],
+                            PreXmlDoc ((3,9), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (3,11--3,29), { BarRange = Some (3,9--3,10) })],
+                        (3,9--3,29)), (3,9--3,29)), [], None, (3,5--3,29),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--3,29));
+           Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [Other],
+                     PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (4,5--4,10)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (4,13--4,16)), (4,13--4,16)), [], None, (4,5--4,16),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,11--4,12)
+                    WithKeyword = None })], (4,0--4,16))], PreXmlDocEmpty, [],
+          None, (1,0--4,16), { LeadingKeyword = Namespace (1,0--1,9) })],
+      (true, true), { ConditionalDirectives = []
+                      CodeComments = [] }, set []))
+
+(3,19)-(3,29) parse error Unexpected function type in union case field definition

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs.bsl
@@ -50,4 +50,4 @@ ImplFile
       (true, true), { ConditionalDirectives = []
                       CodeComments = [] }, set []))
 
-(3,19)-(3,29) parse error Unexpected function type in union case field definition
+(3,19)-(3,29) parse error Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs
@@ -1,0 +1,4 @@
+namespace Foo
+
+type B = | A of int -> int -> int
+type Other = int

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs.bsl
@@ -55,4 +55,4 @@ ImplFile
       (true, true), { ConditionalDirectives = []
                       CodeComments = [] }, set []))
 
-(3,16)-(3,33) parse error Unexpected function type in union case field definition
+(3,16)-(3,33) parse error Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs.bsl
@@ -1,0 +1,58 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/UnionCase/Recover Function Type 03.fs", false,
+      QualifiedNameOfFile Recover Function Type 03, [], [],
+      [SynModuleOrNamespace
+         ([Foo], false, DeclaredNamespace,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [B],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  Fun
+                                    (LongIdent
+                                       (SynLongIdent ([int], [], [None])),
+                                     Fun
+                                       (LongIdent
+                                          (SynLongIdent ([int], [], [None])),
+                                        LongIdent
+                                          (SynLongIdent ([int], [], [None])),
+                                        (3,23--3,33),
+                                        { ArrowRange = (3,27--3,29) }),
+                                     (3,16--3,33), { ArrowRange = (3,20--3,22) }),
+                                  false,
+                                  PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (3,16--3,33), { LeadingKeyword = None })],
+                            PreXmlDoc ((3,9), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (3,11--3,33), { BarRange = Some (3,9--3,10) })],
+                        (3,9--3,33)), (3,9--3,33)), [], None, (3,5--3,33),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--3,33));
+           Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [Other],
+                     PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (4,5--4,10)),
+                  Simple
+                    (TypeAbbrev
+                       (Ok, LongIdent (SynLongIdent ([int], [], [None])),
+                        (4,13--4,16)), (4,13--4,16)), [], None, (4,5--4,16),
+                  { LeadingKeyword = Type (4,0--4,4)
+                    EqualsRange = Some (4,11--4,12)
+                    WithKeyword = None })], (4,0--4,16))], PreXmlDocEmpty, [],
+          None, (1,0--4,16), { LeadingKeyword = Namespace (1,0--1,9) })],
+      (true, true), { ConditionalDirectives = []
+                      CodeComments = [] }, set []))
+
+(3,16)-(3,33) parse error Unexpected function type in union case field definition


### PR DESCRIPTION
Right now, the following invalid code:

```fsharp
namespace Foo

type Bar = | Bar of int -> int
type Other = int
```

produces ([online tool](https://fsprojects.github.io/fantomas-tools/#/ast?data=N4KABGBEAmCmBmBLAdrAzpAXFSAacUiaAYmolmPAIYA2as%2BEkAxgPZwWTJUC26ADlWawwxVqwA6AJwnJpsgC4BPfiIBCVKWAC8YAD5gNW1vDAoFYALQA%2BM8gXz7KkQHkFAC1hbd5x3gKQsAAegsjQFNR0sCAAvkA)):
```fsharp
ImplFile
  (ParsedImplFileInput
     ("tmp.fsx", true, QualifiedNameOfFile Tmp$fsx, [], [],
      [SynModuleOrNamespace
         ([Tmp], false, AnonModule, [], PreXmlDocEmpty, [], None, (5,0--5,0),
          { LeadingKeyword = None })], (false, false),
      { ConditionalDirectives = []
        CodeComments = [] }, set []))

(3,24) (3, 26) error 10 parse
Unexpected symbol '->' in member definition
```

After this PR: see `Recover Function Type 01.fs.bsl`.

The `invalidUseOfAppTypeFunction` rule is a bit of an experiment.
We would allow more syntax to better tell the user what is not allowed.
