### PR TITLE
<WarningLevel>0 should work also for "Information" diagnostics, tests extended

### DIFF
--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -388,7 +388,7 @@ type PhasedDiagnostic with
             match x.Exception with
             | DiagnosticEnabledWithLanguageFeature (_, _, _, enabled) -> enabled
             | _ ->
-                (severity = FSharpDiagnosticSeverity.Info)
+                (severity = FSharpDiagnosticSeverity.Info && level > 0)
                 || (severity = FSharpDiagnosticSeverity.Warning && level >= x.WarningLevel)
 
     /// Indicates if a diagnostic should be reported as an informational

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn/warn.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn/warn.fs
@@ -11,10 +11,12 @@ module TestCompilerWarningLevel =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"warn_level0.fs"|])>]
     let ``warn_level0_fs --warn:0`` compilation =
         compilation
+        |> withLangVersionPreview
         |> asExe
         |> withOptions ["--warn:0"]
         |> compileAndRun
         |> shouldSucceed
+        |> withDiagnostics []
 
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"warn_level1.fs"|])>]
     let ``warn_level1_fs --warn:1 --warnaserror:52`` compilation =

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn/warn_level0.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn/warn_level0.fs
@@ -1,2 +1,16 @@
 // #NoMT #CompilerOptions 
+
+let x = 10
+// Normally a The result of this equality expression has type 'bool' and is implicitly discarded.
+x = 20
+
+let mul x y = x * y
+// Normally a warning
+[<TailCall>]
+let rec fact n acc =
+    if n = 0
+    then acc
+    else (fact (n - 1) (mul n acc)) + 23
+
+// Normally a 'Main module of program is empty: nothing will happen when it is run' warning
 ()

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn/warn_level0.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/warn/warn_level0.fs
@@ -1,5 +1,9 @@
 // #NoMT #CompilerOptions 
 
+[<NoComparison>]
+/// Meh - Informational diagnostics "XML comment is not placed on a valid language element."
+type A = int
+
 let x = 10
 // Normally a The result of this equality expression has type 'bool' and is implicitly discarded.
 x = 20


### PR DESCRIPTION
The issue https://github.com/dotnet/fsharp/issues/15375 mentioned that warn:0 did not work for Informational messages.

The setting can be enabled:
--warn:0  fsc.exe CLI flag
`<WarningLevel>0</WarningLevel>` in .fsproj properties


This does suppress the warnings for tests, full build as well as for VS diagnostics.