### PR TITLE
Name resolution: report interfaces, report type arguments

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -1186,7 +1186,7 @@ module MutRecBindingChecking =
                             
                         // Phase2B: typecheck the argument to an 'inherits' call and build the new object expr for the inherit-call 
                         | Phase2AInherit (synBaseTy, arg, baseValOpt, m) ->
-                            let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Use WarnOnIWSAM.Yes envInstance tpenv synBaseTy
+                            let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes envInstance tpenv synBaseTy
                             let baseTy = baseTy |> convertToTypeWithMetadataIfPossible g
                             let inheritsExpr, tpenv =
                                 try 

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4924,7 +4924,7 @@ and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcr
 
     if not actualArgTys.IsEmpty then
         let item = Item.Types(tcref.DisplayNameCore, [ty])
-        CallNameResolutionSinkReplacing cenv.tcSink (function Item.Types _ -> true | _ -> false) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
+        CallNameResolutionSinkReplacing cenv.tcSink (function Item.CtorGroup _ -> false | _ -> true) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     ty, tpenv
 
@@ -8506,7 +8506,7 @@ and TcTypeItemThen (cenv: cenv) overallTy occ env nm ty tpenv mItem tinstEnclosi
 
     let reportTypeUsage ty =
         let item = Item.Types(nm, [ty])
-        CallNameResolutionSinkReplacing cenv.tcSink (function Item.Types _ -> true | _ -> false) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
+        CallNameResolutionSinkReplacing cenv.tcSink (function Item.CtorGroup _ -> false | _ -> true) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     match delayed with
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: DelayedDotLookup (longId, mLongId) :: otherDelayed ->

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4888,8 +4888,8 @@ and TcProvidedTypeApp (cenv: cenv) env tpenv tcref args m =
 /// the prefix of type arguments.
 and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcref pathTypeArgs (synArgTys: SynType list) =
     let g = cenv.g
-    CheckTyconAccessible cenv.amap mItem env.AccessRights tcref |> ignore
-    CheckEntityAttributes g tcref mItem |> CommitOperationResult
+    CheckTyconAccessible cenv.amap mWhole env.AccessRights tcref |> ignore
+    CheckEntityAttributes g tcref mWhole |> CommitOperationResult
 
 #if !NO_TYPEPROVIDERS
     // Provided types are (currently) always non-generic. Their names may include mangled

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -1694,7 +1694,7 @@ let MakeAndPublishSimpleValsForMergedScope (cenv: cenv) env m (names: NameMap<_>
                         member _.NotifyEnvWithScope(_, _, _) = () // ignore EnvWithScope reports
 
                         member _.NotifyNameResolution(pos, item, itemTyparInst, occurence, nenv, ad, m, replacing) =
-                            notifyNameResolution (pos, item, item, itemTyparInst, occurence, nenv, ad, m, replacing)
+                            notifyNameResolution (pos, item, item, itemTyparInst, occurence, nenv, ad, m, Option.isSome replacing)
 
                         member _.NotifyMethodGroupNameResolution(pos, item, itemGroup, itemTyparInst, occurence, nenv, ad, m, replacing) =
                             notifyNameResolution (pos, item, itemGroup, itemTyparInst, occurence, nenv, ad, m, replacing)
@@ -4911,7 +4911,7 @@ and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcr
         // Get the suffix of typars
         let tpsForArgs = List.skip (tps.Length - synArgTysLength) tps
         let kindsForArgs = tpsForArgs |> List.map (fun tp -> tp.Kind)
-        TcTypesOrMeasures (Some kindsForArgs) cenv newOk checkConstraints occ env tpenv synArgTys mWhole
+        TcTypesOrMeasures (Some kindsForArgs) cenv newOk checkConstraints ItemOccurence.UseInType env tpenv synArgTys mWhole
 
     // Add the types of the enclosing class for a nested type
     let actualArgTys = pathTypeArgs @ argTys
@@ -4924,7 +4924,7 @@ and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcr
 
     if not actualArgTys.IsEmpty then
         let item = Item.Types(tcref.DisplayNameCore, [ty])
-        CallNameResolutionSinkReplacing cenv.tcSink (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
+        CallNameResolutionSinkReplacing cenv.tcSink (function Item.Types _ -> true | _ -> false) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     ty, tpenv
 
@@ -5257,7 +5257,7 @@ and TcExprThen (cenv: cenv) overallTy env tpenv isArg synExpr delayed =
         | Some {contents = SynSimplePatAlternativeIdInfo.Decided altId} -> 
             TcExprThen cenv overallTy env tpenv isArg (SynExpr.LongIdent (isOpt, SynLongIdent([altId], [], [None]), None, mLongId)) delayed
         | _ ->
-            TcLongIdentThen cenv overallTy env tpenv longId delayed
+            TcLongIdentThen cenv overallTy ItemOccurence.Use env tpenv longId delayed
 
     // f?x<-v
     | SynExpr.Set(SynExpr.Dynamic(e1, _, e2, _) , rhsExpr, m) ->
@@ -5609,7 +5609,7 @@ and TcExprUndelayed (cenv: cenv) (overallTy: OverallTy) env tpenv (synExpr: SynE
         TcExprArrayOrList cenv overallTy env tpenv (isArray, args, m)
 
     | SynExpr.New (superInit, synObjTy, arg, mNewExpr) ->
-        let objTy, tpenv = TcType cenv NewTyparsOK CheckCxs ItemOccurence.Use WarnOnIWSAM.Yes env tpenv synObjTy
+        let objTy, tpenv = TcType cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv synObjTy
 
         TcNonControlFlowExpr env <| fun env ->
         TcPropagatingExprLeafThenConvert cenv overallTy objTy env (* true *) mNewExpr (fun () ->
@@ -6080,11 +6080,11 @@ and TcExprDotNamedIndexedPropertySet (cenv: cenv) overallTy env tpenv (synExpr1,
           MakeDelayedSet(expr3, mStmt)]
 
 and TcExprLongIdentSet (cenv: cenv) overallTy env tpenv (synLongId, synExpr2, m) =
-    TcLongIdentThen cenv overallTy env tpenv synLongId [ MakeDelayedSet(synExpr2, m) ]
+    TcLongIdentThen cenv overallTy ItemOccurence.Use env tpenv synLongId [ MakeDelayedSet(synExpr2, m) ]
 
 // Type.Items(synExpr1) <- synExpr2
 and TcExprNamedIndexPropertySet (cenv: cenv) overallTy env tpenv (synLongId, synExpr1, synExpr2, mStmt) =
-    TcLongIdentThen cenv overallTy env tpenv synLongId 
+    TcLongIdentThen cenv overallTy ItemOccurence.Use env tpenv synLongId 
         [ DelayedApp(ExprAtomicFlag.Atomic, false, None, synExpr1, mStmt)
           MakeDelayedSet(synExpr2, mStmt) ]
 
@@ -6229,8 +6229,9 @@ and TcTyparExprThen (cenv: cenv) overallTy env tpenv synTypar m delayed =
             match rest with
             | [] -> delayed2
             | _ -> DelayedDotLookup (rest, m2) :: delayed2
-        CallNameResolutionSink cenv.tcSink (ident.idRange, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.AccessRights)
-        TcItemThen cenv overallTy env tpenv ([], item, mExprAndLongId, [], AfterResolution.DoNothing) (Some ty) delayed3
+        let occ = ItemOccurence.Use
+        CallNameResolutionSink cenv.tcSink (ident.idRange, env.NameEnv, item, emptyTyparInst, occ, env.AccessRights)
+        TcItemThen cenv overallTy occ env tpenv ([], item, mExprAndLongId, [], AfterResolution.DoNothing) (Some ty) delayed3
         //TcLookupItemThen cenv overallTy env tpenv mObjExpr objExpr objExprTy delayed item mItem rest afterResolution
     | _ ->
         let (SynTypar(_, q, _)) = synTypar
@@ -8042,7 +8043,7 @@ and TcNameOfExpr (cenv: cenv) env tpenv (synArg: SynExpr) =
                           | Item.FakeInterfaceCtor _ -> false
                           | _ -> true) ->
                     let overallTy = match overallTyOpt with None -> MustEqual (NewInferenceType g) | Some t -> t
-                    let _, _ = TcItemThen cenv overallTy env tpenv res None delayed
+                    let _, _ = TcItemThen cenv overallTy ItemOccurence.Use env tpenv res None delayed
                     true
                 | _ ->
                     false
@@ -8243,21 +8244,21 @@ and GetLongIdentTypeNameInfo delayed =
     | _ ->
         TypeNameResolutionInfo.Default
 
-and TcLongIdentThen (cenv: cenv) (overallTy: OverallTy) env tpenv (SynLongIdent(longId, _, _)) delayed =
+and TcLongIdentThen (cenv: cenv) (overallTy: OverallTy) occ env tpenv (SynLongIdent(longId, _, _)) delayed =
 
     let ad = env.eAccessRights
     let typeNameResInfo = GetLongIdentTypeNameInfo delayed
     let nameResolutionResult =
         ResolveLongIdentAsExprAndComputeRange cenv.tcSink cenv.nameResolver (rangeOfLid longId) ad env.eNameResEnv typeNameResInfo longId
         |> ForceRaise
-    TcItemThen cenv overallTy env tpenv nameResolutionResult None delayed
+    TcItemThen cenv overallTy occ env tpenv nameResolutionResult None delayed
 
 //-------------------------------------------------------------------------
 // Typecheck "item+projections"
 //------------------------------------------------------------------------- *)
 
 // mItem is the textual range covered by the long identifiers that make up the item
-and TcItemThen (cenv: cenv) (overallTy: OverallTy) env tpenv (tinstEnclosing, item, mItem, rest, afterResolution) staticTyOpt delayed =
+and TcItemThen (cenv: cenv) (overallTy: OverallTy) occ env tpenv (tinstEnclosing, item, mItem, rest, afterResolution) staticTyOpt delayed =
     let delayed = delayRest rest mItem delayed
     match item with
     // x where x is a union case or active pattern result tag.
@@ -8265,7 +8266,7 @@ and TcItemThen (cenv: cenv) (overallTy: OverallTy) env tpenv (tinstEnclosing, it
         TcUnionCaseOrExnCaseOrActivePatternResultItemThen cenv overallTy env item tpenv mItem delayed
 
     | Item.Types(nm, ty :: _) ->
-        TcTypeItemThen cenv overallTy env nm ty tpenv mItem tinstEnclosing delayed
+        TcTypeItemThen cenv overallTy occ env nm ty tpenv mItem tinstEnclosing delayed
 
     | Item.MethodGroup (methodName, minfos, _) ->
         TcMethodItemThen cenv overallTy env item methodName minfos tpenv mItem afterResolution staticTyOpt delayed
@@ -8281,7 +8282,7 @@ and TcItemThen (cenv: cenv) (overallTy: OverallTy) env tpenv (tinstEnclosing, it
             match ty with
             | TType_app(tcref, _, _) -> tcref.DisplayNameCore
             | _ -> NicePrint.minimalStringOfType env.DisplayEnv ty
-        TcTypeItemThen cenv overallTy env nm ty tpenv mItem tinstEnclosing delayed
+        TcTypeItemThen cenv overallTy occ env nm ty tpenv mItem tinstEnclosing delayed
 
     | Item.ImplicitOp(id, sln) ->
         TcImplicitOpItemThen cenv overallTy env id sln tpenv mItem delayed
@@ -8490,7 +8491,7 @@ and TcUnionCaseOrExnCaseOrActivePatternResultItemThen (cenv: cenv) overallTy env
         let exprTy = tyOfExpr g expr
         PropagateThenTcDelayed cenv overallTy env tpenv mItem (MakeApplicableExprNoFlex cenv expr) exprTy ExprAtomicFlag.Atomic delayed
 
-and TcTypeItemThen (cenv: cenv) overallTy env nm ty tpenv mItem tinstEnclosing delayed =
+and TcTypeItemThen (cenv: cenv) overallTy occ env nm ty tpenv mItem tinstEnclosing delayed =
     let g = cenv.g
     let ad = env.eAccessRights
 
@@ -8505,23 +8506,23 @@ and TcTypeItemThen (cenv: cenv) overallTy env nm ty tpenv mItem tinstEnclosing d
 
     let reportTypeUsage ty =
         let item = Item.Types(nm, [ty])
-        CallNameResolutionSinkReplacing cenv.tcSink (mItem, env.NameEnv, item, getInst ty, ItemOccurence.Use, env.eAccessRights)
+        CallNameResolutionSinkReplacing cenv.tcSink (function Item.Types _ -> true | _ -> false) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     match delayed with
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: DelayedDotLookup (longId, mLongId) :: otherDelayed ->
         // If Item.Types is returned then the ty will be of the form TType_app(tcref, genericTyargs) where tyargs
         // is a fresh instantiation for tcref. TcNestedTypeApplication will chop off precisely #genericTyargs args
         // and replace them by 'tyargs'
-        let ty, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs ty tinstEnclosing tyargs
+        let ty, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs occ WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs ty tinstEnclosing tyargs
         let typeNameResInfo = GetLongIdentTypeNameInfo otherDelayed
         let item, mItem, rest, afterResolution = ResolveExprDotLongIdentAndComputeRange cenv.tcSink cenv.nameResolver (unionRanges mExprAndTypeArgs mLongId) ad env.eNameResEnv ty longId typeNameResInfo IgnoreOverrides true
-        TcItemThen cenv overallTy env tpenv ((argsOfAppTy g ty), item, mItem, rest, afterResolution) None otherDelayed
+        TcItemThen cenv overallTy occ env tpenv ((argsOfAppTy g ty), item, mItem, rest, afterResolution) None otherDelayed
 
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: _delayed' ->
         reportTypeUsage ty
 
         // A case where we have an incomplete name e.g. 'Foo<int>.' - we still want to report it to VS!
-        let ty, _ = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs ty tinstEnclosing tyargs
+        let ty, _ = TcNestedTypeApplication cenv NewTyparsOK CheckCxs occ WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs ty tinstEnclosing tyargs
         reportWrongTypeUsageError ty mItem mExprAndTypeArgs
 
     | _ ->
@@ -8544,7 +8545,7 @@ and TcMethodItemThen (cenv: cenv) overallTy env item methodName minfos tpenv mIt
 
             // Replace the resolution including the static parameters, plus the extra information about the original method info
             let item = Item.MethodGroup(methodName, [minfoAfterStaticArguments], Some minfos[0])
-            CallNameResolutionSinkReplacing cenv.tcSink (mItem, env.NameEnv, item, [], ItemOccurence.Use, env.eAccessRights)
+            CallNameResolutionSinkReplacing cenv.tcSink (fun _ -> true) (mItem, env.NameEnv, item, [], ItemOccurence.Use, env.eAccessRights)
 
             match otherDelayed with
             | DelayedApp(atomicFlag, _, _, arg, mExprAndArg) :: otherDelayed ->
@@ -9101,7 +9102,7 @@ and TcLookupItemThen cenv overallTy env tpenv mObjExpr objExpr objExprTy delayed
         | Some minfoAfterStaticArguments ->
             // Replace the resolution including the static parameters, plus the extra information about the original method info
             let item = Item.MethodGroup(methodName, [minfoAfterStaticArguments], Some minfos[0])
-            CallNameResolutionSinkReplacing cenv.tcSink (mExprAndItem, env.NameEnv, item, [], ItemOccurence.Use, env.eAccessRights)
+            CallNameResolutionSinkReplacing cenv.tcSink (fun _ -> true) (mExprAndItem, env.NameEnv, item, [], ItemOccurence.Use, env.eAccessRights)
 
             TcMethodApplicationThen cenv env overallTy None tpenv None objArgs mExprAndItem mItem methodName ad mutates false [(minfoAfterStaticArguments, None)] afterResolution NormalValUse args atomicFlag None delayed
         | None ->

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -484,7 +484,7 @@ type ITypecheckResultsSink =
 
     /// Record that a name resolution occurred at a specific location in the source
     abstract NotifyNameResolution:
-        pos * Item * TyparInstantiation * ItemOccurence * NameResolutionEnv * AccessorDomain * range * bool -> unit
+        pos * Item * TyparInstantiation * ItemOccurence * NameResolutionEnv * AccessorDomain * range * (Item -> bool) option -> unit
 
     /// Record that a method group name resolution occurred at a specific location in the source
     abstract NotifyMethodGroupNameResolution:
@@ -619,7 +619,7 @@ val internal CallMethodGroupNameResolutionSink:
 
 /// Report a specific name resolution at a source range, replacing any previous resolutions
 val internal CallNameResolutionSinkReplacing:
-    TcResultsSink -> range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain -> unit
+    TcResultsSink -> (Item -> bool) -> range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain -> unit
 
 /// Report a specific name resolution at a source range
 val internal CallExprHasTypeSink: TcResultsSink -> range * NameResolutionEnv * TType * AccessorDomain -> unit

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -484,7 +484,15 @@ type ITypecheckResultsSink =
 
     /// Record that a name resolution occurred at a specific location in the source
     abstract NotifyNameResolution:
-        pos * Item * TyparInstantiation * ItemOccurence * NameResolutionEnv * AccessorDomain * range * (Item -> bool) option -> unit
+        pos *
+        Item *
+        TyparInstantiation *
+        ItemOccurence *
+        NameResolutionEnv *
+        AccessorDomain *
+        range *
+        (Item -> bool) option ->
+            unit
 
     /// Record that a method group name resolution occurred at a specific location in the source
     abstract NotifyMethodGroupNameResolution:
@@ -619,7 +627,10 @@ val internal CallMethodGroupNameResolutionSink:
 
 /// Report a specific name resolution at a source range, replacing any previous resolutions
 val internal CallNameResolutionSinkReplacing:
-    TcResultsSink -> (Item -> bool) -> range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain -> unit
+    TcResultsSink ->
+    (Item -> bool) ->
+    range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain ->
+        unit
 
 /// Report a specific name resolution at a source range
 val internal CallExprHasTypeSink: TcResultsSink -> range * NameResolutionEnv * TType * AccessorDomain -> unit

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -102,6 +102,12 @@ type ValRemap = ValMap<ValRef>
 let emptyTyconRefRemap: TyconRefRemap = TyconRefMap<_>.Empty
 let emptyTyparInst = ([]: TyparInstantiation)
 
+let getInst (ty: TType) =
+    match stripTyparEqns ty with
+    | TType_app(tcref, typeArgs, _) ->
+        List.zip tcref.Deref.TyparsNoRange typeArgs
+    | _ -> []
+
 [<NoEquality; NoComparison>]
 type Remap =
     { tpinst: TyparInstantiation

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -567,6 +567,8 @@ val mkTyconRefInst: TyconRef -> TypeInst -> TyparInstantiation
 
 val emptyTyparInst: TyparInstantiation
 
+val getInst: TType -> TyparInstantiation
+
 val instType: TyparInstantiation -> TType -> TType
 
 val instTypes: TyparInstantiation -> TypeInst -> TypeInst

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
@@ -31,21 +31,23 @@ let createProject() = SyntheticProject.Create(impFile())
 [<Fact>]
 let ``Finding usage of type via GetUsesOfSymbolInFile should also find it's constructors`` () =
     createProject().Workflow
-        {        
+        {
             checkFile "First" (fun (typeCheckResult: FSharpCheckFileResults) ->
-             
+
                 let symbolUse = typeCheckResult.GetSymbolUseAtLocation(7, 11, "type MyType() =", ["MyType"]).Value
                 let references = 
-                    typeCheckResult.GetUsesOfSymbolInFile(symbolUse.Symbol) 
+                    typeCheckResult.GetUsesOfSymbolInFile(symbolUse.Symbol)
                     |> Array.sortBy (fun su -> su.Range.StartLine)
                     |> Array.map (fun su -> su.Range.StartLine, su.Range.StartColumn, su.Range.EndColumn, deriveOccurence su)
 
-                Assert.Equal<(int*int*int*Occurence)>(
-                    [| 7,5,11,Definition
-                       8,25,31,InType
-                       10,8,14,Use
-                       11,12,18,Use
-                    |],references)  )           
+                Assert.Equal<int * int * int * Occurence>(
+                    [| 7, 5, 11, Definition
+                       8, 25, 31, InType
+                       10, 8, 14, Use
+                       11, 12, 18, InType
+                       11, 12, 18, Use
+                    |], references)
+            )
         }
 
 

--- a/tests/service/CSharpProjectAnalysis.fs
+++ b/tests/service/CSharpProjectAnalysis.fs
@@ -142,8 +142,7 @@ let _ = CSharpGenericOuterClass<int>.InnerClass.StaticMember()
     |> shouldEqual 
         [|"FSharp"; "Compiler"; "Service"; "Tests"; "FSharp"; "member .ctor"; "int";
           "CSharpGenericOuterClass`1"; "CSharpGenericOuterClass`1"; "int";
-          "CSharpGenericOuterClass`1"; "InnerEnum"; "field Case1";
-          "CSharpGenericOuterClass`1"; "int"; "CSharpGenericOuterClass`1"; "InnerClass";
+          "InnerEnum"; "field Case1"; "CSharpGenericOuterClass`1"; "int"; "InnerClass";
           "member StaticMember"; "NestedEnumClass"|]
 
 [<Test>]

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -376,7 +376,7 @@ let inline dumpDiagnostics (results: FSharpCheckFileResults) =
     |> List.ofArray
 
 let getSymbolUses (results: FSharpCheckFileResults) =
-    results.GetAllUsesOfAllSymbolsInFile()
+    results.GetAllUsesOfAllSymbolsInFile() |> List.ofSeq
 
 let getSymbolUsesFromSource (source: string) =
     let _, typeCheckResults = getParseAndCheckResults source

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -3706,12 +3706,12 @@ let ``Test Project25 symbol uses of type-provided members`` () =
            ("Microsoft.FSharp.Data", "file1", ((3, 12), (3, 16)), ["namespace"]);
            ("FSharp.Data.XmlProvider", "file1", ((4, 15), (4, 26)),
             ["class"; "provided"; "erased"]);
+           ("FSharp.Data.XmlProvider<...>", "file1", ((4, 15), (4, 26)),
+            ["class"; "provided"; "staticinst"; "erased"]);
            ("FSharp.Data.XmlProvider", "file1", ((4, 15), (4, 26)),
             ["class"; "provided"; "erased"]);
-           ("FSharp.Data.XmlProvider", "file1", ((4, 15), (4, 26)),
-            ["class"; "provided"; "erased"]);
-           ("FSharp.Data.XmlProvider", "file1", ((4, 15), (4, 26)),
-            ["class"; "provided"; "erased"]);
+           ("FSharp.Data.XmlProvider<...>", "file1", ((4, 15), (4, 26)),
+            ["class"; "provided"; "staticinst"; "erased"]);
            ("TypeProviderTests.Project", "file1", ((4, 5), (4, 12)), ["abbrev"]);
            ("TypeProviderTests.Project", "file1", ((5, 8), (5, 15)), ["abbrev"]);
            ("FSharp.Data.XmlProvider<...>.GetSample", "file1", ((5, 8), (5, 25)),
@@ -3723,9 +3723,7 @@ let ``Test Project25 symbol uses of type-provided members`` () =
            ("TypeProviderTests.Record", "file1", ((8, 10), (8, 16)), ["record"]);
            ("TypeProviderTests.Record.Field", "file1", ((8, 17), (8, 22)), ["field"]);
            ("TypeProviderTests.r", "file1", ((8, 4), (8, 5)), ["val"]);
-           ("FSharp.Data.XmlProvider", "file1", ((10, 8), (10, 19)),
-            ["class"; "provided"; "erased"]);
-           ("FSharp.Data.XmlProvider<...>", "file1", ((10, 8), (10, 68)),
+           ("FSharp.Data.XmlProvider<...>", "file1", ((10, 8), (10, 19)),
             ["class"; "provided"; "staticinst"; "erased"]);
            ("FSharp.Data.XmlProvider<...>.GetSample", "file1", ((10, 8), (10, 78)),
             ["member"]); ("TypeProviderTests", "file1", ((2, 7), (2, 24)), ["module"])|]

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -762,7 +762,7 @@ let ``Test project2 all uses of all symbols`` () =
     let allUsesOfAllSymbols =
         [ for s in wholeProjectResults.GetAllUsesOfAllSymbols() ->
             s.Symbol.DisplayName, (if s.FileName = Project2.fileName1 then "file1" else "???"), tupsZ s.Range, attribsOfSymbol s.Symbol ]
-    let expected =
+    allUsesOfAllSymbols |> shouldEqual
           [("int", "file1", ((4, 13), (4, 16)), ["abbrev"]);
            ("int", "file1", ((4, 19), (4, 22)), ["abbrev"]);
            ("int", "file1", ((5, 13), (5, 16)), ["abbrev"]);
@@ -784,10 +784,10 @@ let ``Test project2 all uses of all symbols`` () =
            ("D", "file1", ((10, 8), (10, 9)), []);
            ("int", "file1", ((12, 35), (12, 38)), ["abbrev"]);
            ("int", "file1", ((12, 45), (12, 48)), ["abbrev"]);
-           ("int", "file1", ((12, 35), (12, 38)), ["abbrev"]);
            ("x", "file1", ((12, 31), (12, 32)), ["field"]);
-           ("int", "file1", ((12, 45), (12, 48)), ["abbrev"]);
+           ("int", "file1", ((12, 35), (12, 38)), ["abbrev"]);
            ("y", "file1", ((12, 41), (12, 42)), ["field"]);
+           ("int", "file1", ((12, 45), (12, 48)), ["abbrev"]);
            ("DU", "file1", ((12, 25), (12, 27)), []);
            ("DUWithNamedFields", "file1", ((12, 5), (12, 22)), ["union"]);
            ("DU", "file1", ((14, 8), (14, 10)), []);
@@ -806,11 +806,12 @@ let ``Test project2 all uses of all symbols`` () =
            ("u", "file1", ((17, 38), (17, 39)), []);
            ("t", "file1", ((17, 31), (17, 32)), []);
            ("GenericClass", "file1", ((19, 8), (19, 20)), ["member"; "ctor"]);
-           ("int", "file1", ((19, 21), (19, 24)), ["abbrev"]);
+           ("int", "file1", ((19, 21), (19, 24)), ["abbrev"])
+           ("GenericClass", "file1", ((19, 8), (19, 20)), ["class"]);
            ("c", "file1", ((19, 4), (19, 5)), ["val"]);
            ("c", "file1", ((20, 8), (20, 9)), ["val"]);
-           ("GenericMethod", "file1", ((20, 8), (20, 23)), ["member"]);
            ("int", "file1", ((20, 24), (20, 27)), ["abbrev"]);
+           ("GenericMethod", "file1", ((20, 8), (20, 23)), ["member"]);
            ("T", "file1", ((22, 23), (22, 25)), []);
            ("T", "file1", ((22, 30), (22, 32)), []);
            ("y", "file1", ((22, 27), (22, 28)), []);
@@ -822,9 +823,6 @@ let ``Test project2 all uses of all symbols`` () =
            ("GenericFunction", "file1", ((22, 4), (22, 19)), ["val"]);
            ("GenericFunction", "file1", ((24, 8), (24, 23)), ["val"]);
            ("M", "file1", ((1, 7), (1, 8)), ["module"])]
-    set allUsesOfAllSymbols - set expected |> shouldEqual Set.empty
-    set expected - set allUsesOfAllSymbols |> shouldEqual Set.empty
-    (set expected = set allUsesOfAllSymbols) |> shouldEqual true
 
 //-----------------------------------------------------------------------------------------
 
@@ -2055,24 +2053,22 @@ let ``Test Project11 all symbols`` () =
           [|("System", "System", "file1", ((4, 15), (4, 21)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((4, 22), (4, 33)), [], ["namespace"]);
             ("Generic", "Generic", "file1", ((4, 34), (4, 41)), [], ["namespace"]);
-            ("Dictionary`2", "Dictionary", "file1", ((4, 15), (4, 52)), ["type"],
-             ["class"]); ("int", "int", "file1", ((4, 53), (4, 56)), [], ["abbrev"]);
-            ("int", "int", "file1", ((4, 57), (4, 60)), [], ["abbrev"]);
-            ("Enumerator", "Enumerator", "file1", ((4, 62), (4, 72)), ["type"],
-             ["valuetype"]);
+            ("Dictionary`2", "Dictionary", "file1", ((4, 15), (4, 52)), ["type"], ["class"])
+            ("int", "int", "file1", ((4, 53), (4, 56)), ["type"], ["abbrev"]);
+            ("int", "int", "file1", ((4, 57), (4, 60)), ["type"], ["abbrev"]);
+            ("Enumerator", "Enumerator", "file1", ((4, 62), (4, 72)), ["type"], ["valuetype"]);
             ("member .ctor", "Enumerator", "file1", ((4, 15), (4, 72)), [], ["member"]);
             ("val enum", "enum", "file1", ((4, 4), (4, 8)), ["defn"], ["val"]);
             ("System", "System", "file1", ((5, 11), (5, 17)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((5, 18), (5, 29)), [], ["namespace"]);
             ("Generic", "Generic", "file1", ((5, 30), (5, 37)), [], ["namespace"]);
-            ("Dictionary`2", "Dictionary", "file1", ((5, 11), (5, 48)), ["type"],
-             ["class"]); ("int", "int", "file1", ((5, 49), (5, 52)), ["type"], ["abbrev"]);
+            ("Dictionary`2", "Dictionary", "file1", ((5, 11), (5, 48)), ["type"], ["class"])
+            ("int", "int", "file1", ((5, 49), (5, 52)), ["type"], ["abbrev"]);
             ("int", "int", "file1", ((5, 53), (5, 56)), ["type"], ["abbrev"]);
-            ("Enumerator", "Enumerator", "file1", ((5, 58), (5, 68)), ["type"],
-             ["valuetype"]); ("val x", "x", "file1", ((5, 9), (5, 10)), ["defn"], []);
+            ("Enumerator", "Enumerator", "file1", ((5, 58), (5, 68)), ["type"], ["valuetype"])
+            ("val x", "x", "file1", ((5, 9), (5, 10)), ["defn"], []);
             ("val fff", "fff", "file1", ((5, 4), (5, 7)), ["defn"], ["val"]);
-            ("NestedTypes", "NestedTypes", "file1", ((2, 7), (2, 18)), ["defn"],
-             ["module"])|]
+            ("NestedTypes", "NestedTypes", "file1", ((2, 7), (2, 18)), ["defn"], ["module"])|]
 
 //-----------------------------------------------------------------------------------------
 // see https://github.com/fsharp/FSharp.Compiler.Service/issues/92
@@ -2777,7 +2773,6 @@ let ``Test Project17 all symbols`` () =
             ("FSharp", "FSharp", "file1", ((4, 18), (4, 24)), [], ["namespace"]);
             ("FSharpList`1", "List", "file1", ((4, 8), (4, 41)), [], ["union"]);
             ("int", "int", "file1", ((4, 42), (4, 45)), ["type"], ["abbrev"]);
-            ("FSharpList`1", "List", "file1", ((4, 8), (4, 46)), [], ["union"]);
             ("property Empty", "Empty", "file1", ((4, 8), (4, 52)), [], ["member"; "prop"]);
             ("System", "System", "file1", ((6, 11), (6, 17)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((6, 18), (6, 29)), [], ["namespace"]);
@@ -2786,14 +2781,11 @@ let ``Test Project17 all symbols`` () =
             ("generic parameter T", "T", "file1", ((6, 44), (6, 46)), ["type"], []);
             ("val x", "x", "file1", ((6, 8), (6, 9)), ["defn"], []);
             ("val x", "x", "file1", ((6, 51), (6, 52)), [], []);
-            ("property Item", "Item", "file1", ((6, 51), (6, 57)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Item", "Item", "file1", ((6, 51), (6, 57)), [], ["slot"; "member"; "prop"]);
             ("val x", "x", "file1", ((6, 62), (6, 63)), [], []);
-            ("property Item", "Item", "file1", ((6, 62), (6, 67)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Item", "Item", "file1", ((6, 62), (6, 67)), [], ["slot"; "member"; "prop"]);
             ("val x", "x", "file1", ((6, 69), (6, 70)), [], []);
-            ("property Count", "Count", "file1", ((6, 69), (6, 76)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Count", "Count", "file1", ((6, 69), (6, 76)), [], ["slot"; "member"; "prop"]);
             ("val f1", "f1", "file1", ((6, 4), (6, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((8, 11), (8, 17)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((8, 18), (8, 29)), [], ["namespace"]);
@@ -2802,15 +2794,13 @@ let ``Test Project17 all symbols`` () =
             ("int", "int", "file1", ((8, 44), (8, 47)), ["type"], ["abbrev"]);
             ("val x", "x", "file1", ((8, 8), (8, 9)), ["defn"], []);
             ("val x", "x", "file1", ((8, 52), (8, 53)), [], []);
-            ("property Item", "Item", "file1", ((8, 52), (8, 57)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Item", "Item", "file1", ((8, 52), (8, 57)), [], ["slot"; "member"; "prop"]);
             ("val f2", "f2", "file1", ((8, 4), (8, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((10, 11), (10, 17)), [], ["namespace"]);
             ("Exception", "Exception", "file1", ((10, 11), (10, 27)), ["type"], ["class"]);
             ("val x", "x", "file1", ((10, 8), (10, 9)), ["defn"], []);
             ("val x", "x", "file1", ((10, 31), (10, 32)), [], []);
-            ("property HelpLink", "HelpLink", "file1", ((10, 31), (10, 41)), [],
-             ["slot"; "member"; "prop"]);
+            ("property HelpLink", "HelpLink", "file1", ((10, 31), (10, 41)), [], ["slot"; "member"; "prop"]);
             ("val f3", "f3", "file1", ((10, 4), (10, 6)), ["defn"], ["val"]);
             ("Impl", "Impl", "file1", ((2, 7), (2, 11)), ["defn"], ["module"])|]
 
@@ -2859,7 +2849,6 @@ let ``Test Project18 all symbols`` () =
 
     allUsesOfAllSymbols |> shouldEqual
       [|("list`1", "list", "file1", ((4, 8), (4, 12)), [], false);
-        ("list`1", "list", "file1", ((4, 8), (4, 15)), [], false);
         ("property Empty", "Empty", "file1", ((4, 8), (4, 21)), [], false);
         ("Impl", "Impl", "file1", ((2, 7), (2, 11)), ["defn"], false)|]
 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -355,7 +355,8 @@ let ``Test project1 all uses of all signature symbols`` () =
              yield s.ToString(),
                   [ for s in wholeProjectResults.GetUsesOfSymbol(s) ->
                          (Project1.cleanFileName s.FileName, tupsZ s.Range) ] ]
-    let expected =
+
+    allUsesOfAllSymbols |> shouldEqual
         [("N", [("file2", ((1, 7), (1, 8)))]);
          ("val y2", [("file2", ((12, 4), (12, 6)))]);
          ("val pair2", [("file2", ((23, 10), (23, 15)))]);
@@ -399,19 +400,16 @@ let ``Test project1 all uses of all signature symbols`` () =
          ("val fff", [("file1", ((7, 4), (7, 7))); ("file2", ((9, 28), (9, 33)))]);
          ("C",
           [("file1", ((3, 5), (3, 6))); ("file1", ((9, 15), (9, 16)));
-           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25)))]);
+           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25))); ("file2", ((38, 22), (38, 25)))]);
          ("member .ctor",
           [("file1", ((3, 5), (3, 6))); ("file1", ((9, 15), (9, 16)));
-           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25)))]);
+           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25))); ("file2", ((38, 22), (38, 25)))]);
          ("member get_P", [("file1", ((4, 13), (4, 14)))]);
          ("property P", [("file1", ((4, 13), (4, 14)))]);
          ("CAbbrev",
           [("file1", ((9, 5), (9, 12))); ("file2", ((39, 12), (39, 21)));
-           ("file2", ((39, 28), (39, 37)))]);
+           ("file2", ((39, 28), (39, 37))); ("file2", ((39, 28), (39, 37)))]);
          ("property P", [("file1", ((4, 13), (4, 14)))])]
-    set allUsesOfAllSymbols - set expected |> shouldEqual Set.empty
-    set expected - set allUsesOfAllSymbols |> shouldEqual Set.empty
-    (set expected = set allUsesOfAllSymbols) |> shouldEqual true
 
 [<Test>]
 let ``Test project1 all uses of all symbols`` () =
@@ -724,36 +722,32 @@ let ``Test project2 all uses of all signature symbols`` () =
         [ for s in allSymbols do
              let uses = [ for s in wholeProjectResults.GetUsesOfSymbol(s) -> (if s.FileName = Project2.fileName1 then "file1" else "??"), tupsZ s.Range ]
              yield s.ToString(), uses ]
-    let expected =
-              [("M", [("file1", ((1, 7), (1, 8)))]);
-               ("val c", [("file1", ((19, 4), (19, 5))); ("file1", ((20, 8), (20, 9)))]);
-               ("val GenericFunction",
-                [("file1", ((22, 4), (22, 19))); ("file1", ((24, 8), (24, 23)))]);
-               ("generic parameter T",
-                [("file1", ((22, 23), (22, 25))); ("file1", ((22, 30), (22, 32)));
-                 ("file1", ((22, 45), (22, 47))); ("file1", ((22, 50), (22, 52)))]);
-               ("DUWithNormalFields", [("file1", ((3, 5), (3, 23)))]);
-               ("DU1", [("file1", ((4, 6), (4, 9))); ("file1", ((8, 8), (8, 11)))]);
-               ("field Item1", []); ("field Item2", []);
-               ("DU2", [("file1", ((5, 6), (5, 9))); ("file1", ((9, 8), (9, 11)))]);
-               ("D", [("file1", ((6, 6), (6, 7))); ("file1", ((10, 8), (10, 9)))]);
-               ("DUWithNamedFields", [("file1", ((12, 5), (12, 22)))]);
-               ("DU", [("file1", ((12, 25), (12, 27))); ("file1", ((14, 8), (14, 10)))]);
-               ("field x", [("file1", ((12, 31), (12, 32))); ("file1", ((14, 11), (14, 12)))]);
-               ("field y", [("file1", ((12, 41), (12, 42))); ("file1", ((14, 16), (14, 17)))]);
-               ("GenericClass`1",
-                [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
-               ("generic parameter T",
-                [("file1", ((16, 18), (16, 20))); ("file1", ((17, 34), (17, 36)))]);
-               ("member .ctor",
-                [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
-               ("member GenericMethod",
-                [("file1", ((17, 13), (17, 26))); ("file1", ((20, 8), (20, 23)))]);
-               ("generic parameter U",
-                [("file1", ((17, 27), (17, 29))); ("file1", ((17, 41), (17, 43)))])]
-    set allUsesOfAllSymbols - set expected |> shouldEqual Set.empty
-    set expected - set allUsesOfAllSymbols |> shouldEqual Set.empty
-    (set expected = set allUsesOfAllSymbols) |> shouldEqual true
+    allUsesOfAllSymbols |> shouldEqual
+        [("M", [("file1", ((1, 7), (1, 8)))]);
+         ("val c", [("file1", ((19, 4), (19, 5))); ("file1", ((20, 8), (20, 9)))]);
+         ("val GenericFunction", [("file1", ((22, 4), (22, 19))); ("file1", ((24, 8), (24, 23)))]);
+         ("generic parameter T", [
+            ("file1", ((22, 23), (22, 25)))
+            ("file1", ((22, 30), (22, 32)))
+            ("file1", ((22, 45), (22, 47)))
+            ("file1", ((22, 50), (22, 52)))
+          ]);
+         ("DUWithNormalFields", [("file1", ((3, 5), (3, 23)))]);
+         ("DU1", [("file1", ((4, 6), (4, 9))); ("file1", ((8, 8), (8, 11)))]);
+         ("field Item1", []); ("field Item2", []);
+         ("DU2", [("file1", ((5, 6), (5, 9))); ("file1", ((9, 8), (9, 11)))]);
+         ("field Item1", []); ("field Item2", []);
+         ("D", [("file1", ((6, 6), (6, 7))); ("file1", ((10, 8), (10, 9)))])
+         ("field Item1", []); ("field Item2", []);
+         ("DUWithNamedFields", [("file1", ((12, 5), (12, 22)))]);
+         ("DU", [("file1", ((12, 25), (12, 27))); ("file1", ((14, 8), (14, 10)))]);
+         ("field x", [("file1", ((12, 31), (12, 32))); ("file1", ((14, 11), (14, 12)))]);
+         ("field y", [("file1", ((12, 41), (12, 42))); ("file1", ((14, 16), (14, 17)))]);
+         ("GenericClass`1", [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
+         ("generic parameter T", [("file1", ((16, 18), (16, 20))); ("file1", ((17, 34), (17, 36)))]);
+         ("member .ctor", [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
+         ("member GenericMethod", [("file1", ((17, 13), (17, 26))); ("file1", ((20, 8), (20, 23)))]);
+         ("generic parameter U", [("file1", ((17, 27), (17, 29))); ("file1", ((17, 41), (17, 43)))])]
 
 [<Test>]
 let ``Test project2 all uses of all symbols`` () =
@@ -807,7 +801,6 @@ let ``Test project2 all uses of all symbols`` () =
            ("t", "file1", ((17, 31), (17, 32)), []);
            ("GenericClass", "file1", ((19, 8), (19, 20)), ["member"; "ctor"]);
            ("int", "file1", ((19, 21), (19, 24)), ["abbrev"])
-           ("GenericClass", "file1", ((19, 8), (19, 20)), ["class"]);
            ("c", "file1", ((19, 4), (19, 5)), ["val"]);
            ("c", "file1", ((20, 8), (20, 9)), ["val"]);
            ("int", "file1", ((20, 24), (20, 27)), ["abbrev"]);
@@ -2185,15 +2178,15 @@ let ``Test Project13 all symbols`` () =
 
     allUsesOfAllSymbols |> shouldEqual
           [|("System", "System", "file1", ((4, 14), (4, 20)), [], ["namespace"]);
-            ("Object", "Object", "file1", ((4, 14), (4, 27)), [], ["class"]);
+            ("Object", "Object", "file1", ((4, 14), (4, 27)), ["type"], ["class"]);
             ("member .ctor", "Object", "file1", ((4, 14), (4, 27)), [], ["member"]);
             ("val x1", "x1", "file1", ((4, 4), (4, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((5, 14), (5, 20)), [], ["namespace"]);
-            ("DateTime", "DateTime", "file1", ((5, 14), (5, 29)), [], ["valuetype"]);
+            ("DateTime", "DateTime", "file1", ((5, 14), (5, 29)), ["type"], ["valuetype"]);
             ("member .ctor", "DateTime", "file1", ((5, 14), (5, 29)), [], ["member"]);
             ("val x2", "x2", "file1", ((5, 4), (5, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((6, 13), (6, 19)), [], ["namespace"]);
-            ("DateTime", "DateTime", "file1", ((6, 13), (6, 28)), [], ["valuetype"]);
+            ("DateTime", "DateTime", "file1", ((6, 13), (6, 28)), ["type"], ["valuetype"]);
             ("member .ctor", "DateTime", "file1", ((6, 13), (6, 28)), [], ["member"]);
             ("val x3", "x3", "file1", ((6, 4), (6, 6)), ["defn"], ["val"]);
             ("ExternalTypes", "ExternalTypes", "file1", ((2, 7), (2, 20)), ["defn"],


### PR DESCRIPTION
This is the second attempt of https://github.com/dotnet/fsharp/pull/14773.

The goals are:
* Report interface symbols when they are used in expressions (e.g. in unfinished code)
* Report type arguments inferred in these symbol usages

Reporting both symbols and type arguments may be useful for IDE features.

There're some issues, though. First, the name resolution and reporting of generic symbols is done earlier than type arguments are checked and available for reporting. If we report the types again later, when the needed info is ready, then we'll get duplicated symbol uses that will be different in the type arguments and range. If we remove the type arguments range (and that's what FCS clients often do in an ad-hoc ways), then we can use a special API to report the symbol usage and to replace the previously reported symbol at the range. This replacing API was previously only used in type providers analysis and it was implemented badly performance-wise: it went through all the reported items and tried to remove items at the range from the reported symbol and method group lists. Using that approach would be a no-go for type checking of all the type applications in a file. I've changed the implementation of the `CallNameResolutionSinkReplacing`, so it tries to find the last reported item at the range and replaces it in place. It will add a new item if no previously reported item is found.

What we can improve in the reporting in general?
- [ ] Strip qualifiers and type arguments from reported symbols (#3920, which was never fixed)
- [ ] Use a dictionary for a fast lookup/replace by `endPos`/`range`
  * For the rare cases where multiple symbols are actually expected on the same range, use a second dictionary with list values for the additional symbols
  * Clients relying on the order of reported things may need updating, but it seems doable overal.
- [ ] Revive https://github.com/dotnet/fsharp/pull/8828

What can be improved for making changes easier:
- [ ] Use the same approach to testing for symbols as in the parser tests, as that would allow:
    * easier automatic updates of baselines
    * no test project rebuild needed on test data/baseline update
    * more info captured without needing to specify parts of it manually in each test case
    * Less resolve conflicts when multiple people/PRs change Symbols.fs tests

We can extract the subsequent work notes to a separate issue.