### PR TITLE
Checker: fix exception on wrong update syntax in anon records

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -1809,10 +1809,17 @@ let BuildFieldMap (cenv: cenv) env isPartial ty (flds: ((Ident list * Ident) * '
     let fldResolutions =
         let allFields = flds |> List.map (fun ((_, ident), _) -> ident)
         flds
-        |> List.map (fun (fld, fldExpr) ->
-            let (fldPath, fldId) = fld
-            let frefSet = ResolveField cenv.tcSink cenv.nameResolver env.eNameResEnv ad ty fldPath fldId allFields
-            fld, frefSet, fldExpr)
+        |> List.choose (fun (fld, fldExpr) ->
+            try
+                let fldPath, fldId = fld
+                let frefSet = ResolveField cenv.tcSink cenv.nameResolver env.eNameResEnv ad ty fldPath fldId allFields
+                Some(fld, frefSet, fldExpr)
+            with e ->
+                errorRecoveryNoRange e
+                None
+        )
+
+    if fldResolutions.IsEmpty then None else
 
     let relevantTypeSets =
         fldResolutions |> List.map (fun (_, frefSet, _) ->
@@ -1872,7 +1879,7 @@ let BuildFieldMap (cenv: cenv) env isPartial ty (flds: ((Ident list * Ident) * '
                         Map.add fref2.FieldName fldExpr fs, (fref2.FieldName, fldExpr) :: rfldsList
 
                 | _ -> error(Error(FSComp.SR.tcRecordFieldInconsistentTypes(), m)))
-    tinst, tcref, fldsmap, List.rev rfldsList
+    Some(tinst, tcref, fldsmap, List.rev rfldsList)
 
 let rec ApplyUnionCaseOrExn (makerForUnionCase, makerForExnTag) m (cenv: cenv) env overallTy item =
     let g = cenv.g
@@ -7370,7 +7377,10 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
         match flds with
         | [] -> []
         | _ ->
-            let tinst, tcref, _, fldsList = BuildFieldMap cenv env hasOrigExpr overallTy flds mWholeExpr
+            match BuildFieldMap cenv env hasOrigExpr overallTy flds mWholeExpr with
+            | None -> []
+            | Some(tinst, tcref, _, fldsList) ->
+
             let gtyp = mkAppTy tcref tinst
             UnifyTypes cenv env mWholeExpr overallTy gtyp
 
@@ -7401,7 +7411,7 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
             error(Error(errorInfo, mWholeExpr))
 
         if isFSharpObjModelTy g overallTy then errorR(Error(FSComp.SR.tcTypeIsNotARecordTypeNeedConstructor(), mWholeExpr))
-        elif not (isRecdTy g overallTy) then errorR(Error(FSComp.SR.tcTypeIsNotARecordType(), mWholeExpr))
+        elif not (isRecdTy g overallTy || fldsList.IsEmpty) then errorR(Error(FSComp.SR.tcTypeIsNotARecordType(), mWholeExpr))
 
     let superInitExprOpt , tpenv =
         match inherits, GetSuperTypeOfType g cenv.amap mWholeExpr overallTy with
@@ -7419,14 +7429,18 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
             errorR(InternalError("Unexpected failure in getting super type", mWholeExpr))
             None, tpenv
 
-    let expr, tpenv = TcRecordConstruction cenv overallTy env tpenv withExprInfoOpt overallTy fldsList mWholeExpr
+    if fldsList.IsEmpty && isTyparTy g overallTy then
+        SolveTypeAsError env.DisplayEnv cenv.css mWholeExpr overallTy
+        mkDefault (mWholeExpr, overallTy), tpenv
+    else
+        let expr, tpenv = TcRecordConstruction cenv overallTy env tpenv withExprInfoOpt overallTy fldsList mWholeExpr
 
-    let expr =
-        match superInitExprOpt  with
-        | _ when isStructTy g overallTy -> expr
-        | Some superInitExpr  -> mkCompGenSequential mWholeExpr superInitExpr  expr
-        | None -> expr
-    expr, tpenv
+        let expr =
+            match superInitExprOpt  with
+            | _ when isStructTy g overallTy -> expr
+            | Some superInitExpr  -> mkCompGenSequential mWholeExpr superInitExpr  expr
+            | None -> expr
+        expr, tpenv
 
 
 // Check '{| .... |}'

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -7396,7 +7396,7 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
             let withExprAddrVal, withExprAddrValExpr = mkCompGenLocal mWholeExpr "inputRecord" (if isStructTy g overallTy then mkByrefTy g overallTy else overallTy)
             Some(withExpr, withExprAddrVal, withExprAddrValExpr)
 
-    if hasOrigExpr && not (isRecdTy g overallTy) then
+    if hasOrigExpr && not (isRecdTy g overallTy || isAnonRecdTy g overallTy) then
         errorR(Error(FSComp.SR.tcExpressionFormRequiresRecordTypes(), mWholeExpr))
 
     if requiresCtor || haveCtor then
@@ -7429,7 +7429,7 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
             errorR(InternalError("Unexpected failure in getting super type", mWholeExpr))
             None, tpenv
 
-    if fldsList.IsEmpty && isTyparTy g overallTy then
+    if fldsList.IsEmpty && isTyparTy g overallTy || isAnonRecdTy g overallTy then
         SolveTypeAsError env.DisplayEnv cenv.css mWholeExpr overallTy
         mkDefault (mWholeExpr, overallTy), tpenv
     else

--- a/src/Compiler/Checking/CheckExpressions.fsi
+++ b/src/Compiler/Checking/CheckExpressions.fsi
@@ -895,7 +895,7 @@ val BuildFieldMap:
     ty: TType ->
     flds: ((Ident list * Ident) * 'T) list ->
     m: range ->
-        TypeInst * TyconRef * Map<string, 'T> * (string * 'T) list
+        (TypeInst * TyconRef * Map<string, 'T> * (string * 'T) list) option
 
 /// Check a long identifier 'Case' or 'Case argsR' that has been resolved to an active pattern case
 val TcPatLongIdentActivePatternCase:

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -441,7 +441,10 @@ and TcPatArrayOrList warnOnUpper cenv env vFlags patEnv ty isArray args m =
 
 and TcRecordPat warnOnUpper cenv env vFlags patEnv ty fieldPats m =
     let fieldPats = fieldPats |> List.map (fun (fieldId, _, fieldPat) -> fieldId, fieldPat)
-    let tinst, tcref, fldsmap, _fldsList = BuildFieldMap cenv env true ty fieldPats m
+    match BuildFieldMap cenv env true ty fieldPats m with
+    | None -> (fun _ -> TPat_error m), patEnv
+    | Some(tinst, tcref, fldsmap, _fldsList) ->
+
     let gtyp = mkAppTy tcref tinst
     let inst = List.zip (tcref.Typars m) tinst
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/RecordTypes/AnonymousRecords.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/RecordTypes/AnonymousRecords.fs
@@ -75,3 +75,16 @@ let x = {| abcd = {| ab = 4; cd = 1 |} |}
 """
         |> compile
         |> shouldSucceed
+
+    [<Fact>]
+    let ``Wrong update syntax`` () =
+        Fsx """
+let f (r: {| A: int |}) =
+    { r with A = 1 }
+"""
+        |> ignoreWarnings
+        |> compile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 39, Line 2, Col 36, Line 2, Col 37, "The record label 'A' is not defined.")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/RecordTypes/AnonymousRecords.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/RecordTypes/AnonymousRecords.fs
@@ -86,5 +86,5 @@ let f (r: {| A: int |}) =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 39, Line 2, Col 36, Line 2, Col 37, "The record label 'A' is not defined.")
+            (Error 39, Line 3, Col 14, Line 3, Col 15, "The record label 'A' is not defined.")
         ]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/NameResolutionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/NameResolutionTests.fs
@@ -21,8 +21,10 @@ let r:F = { Size=3; Height=4; Wall=1 }
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 1129, Line 9, Col 31, Line 9, Col 35,
-                                 ("The record type 'F' does not contain a label 'Wall'. Maybe you want one of the following:" + System.Environment.NewLine + "   Wallis"))
+        |> withDiagnostics [
+            (Error 1129, Line 9, Col 31, Line 9, Col 35, "The record type 'F' does not contain a label 'Wall'. Maybe you want one of the following:" + System.Environment.NewLine + "   Wallis")
+            (Error 764, Line 9, Col 11, Line 9, Col 39, "No assignment given for field 'Wallis' of type 'Test.F'")
+        ]
 
     [<Fact>]
     let RecordFieldProposal () =
@@ -38,5 +40,257 @@ let r = { Size=3; Height=4; Wall=1 }
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 39, Line 9, Col 29, Line 9, Col 33,
-                                 ("The record label 'Wall' is not defined. Maybe you want one of the following:" + System.Environment.NewLine + "   Walls" + System.Environment.NewLine + "   Wallis"))
+        |> withDiagnostics [
+            (Error 39, Line 9, Col 29, Line 9, Col 33, "The record label 'Wall' is not defined. Maybe you want one of the following:" + System.Environment.NewLine + "   Walls" + System.Environment.NewLine + "   Wallis")
+            (Error 764, Line 9, Col 9, Line 9, Col 37, "No assignment given for field 'Wallis' of type 'Test.F'")
+        ]
+
+    let multipleRecdTypeChoiceWarningWith1AlternativeSource = """
+namespace N
+
+module Module1 =
+
+    type OtherThing = 
+        { Name: string }
+
+module Module2 =
+
+    type Person = 
+        { Name: string
+          City: string }
+
+module Lib =
+
+    open Module2
+    open Module1
+
+    let F thing = 
+        let x = thing.Name
+        thing.City
+"""
+
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningWith1AlternativeLangPreview () =
+        FSharp multipleRecdTypeChoiceWarningWith1AlternativeSource
+        |> withLangVersionPreview
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 3566, Line 22, Col 9, Line 22, Col 19, "Multiple type matches were found:\n    N.Module1.OtherThing\n    N.Module2.Person\nThe type 'N.Module1.OtherThing' was used. Due to the overlapping field names\n    Name\nconsider using type annotations or change the order of open statements.")
+            (Error 39, Line 22, Col 15, Line 22, Col 19, "The type 'OtherThing' does not define the field, constructor or member 'City'.")
+        ]
+
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningWith1AlternativeLang7 () =
+        FSharp multipleRecdTypeChoiceWarningWith1AlternativeSource
+        |> withLangVersion70
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Information 3566, Line 22, Col 9, Line 22, Col 19, "Multiple type matches were found:\n    N.Module1.OtherThing\n    N.Module2.Person\nThe type 'N.Module1.OtherThing' was used. Due to the overlapping field names\n    Name\nconsider using type annotations or change the order of open statements.")
+            (Error 39, Line 22, Col 15, Line 22, Col 19, "The type 'OtherThing' does not define the field, constructor or member 'City'.")
+        ]
+
+    let multipleRecdTypeChoiceWarningWith2AlternativeSource = """
+namespace N
+
+module Module1 =
+
+    type OtherThing = 
+        { Name: string
+          Planet: string }
+
+module Module2 =
+
+    type Person = 
+        { Name: string
+          City: string
+          Planet: string }
+
+module Module3 =
+
+    type Cafe = 
+        { Name: string
+          City: string
+          Country: string
+          Planet: string }
+
+module Lib =
+
+    open Module3
+    open Module2
+    open Module1
+
+    let F thing = 
+        let x = thing.Name
+        thing.City
+"""
+
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningWith2AlternativeLangPreview () =
+        FSharp multipleRecdTypeChoiceWarningWith2AlternativeSource
+        |> withLangVersionPreview
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 3566, Line 33, Col 9, Line 33, Col 19, "Multiple type matches were found:\n    N.Module1.OtherThing\n    N.Module2.Person\n    N.Module3.Cafe\nThe type 'N.Module1.OtherThing' was used. Due to the overlapping field names\n    Name\n    Planet\nconsider using type annotations or change the order of open statements.")
+            (Error 39, Line 33, Col 15, Line 33, Col 19, "The type 'OtherThing' does not define the field, constructor or member 'City'.")
+        ]
+
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningWith2AlternativeLang7 () =
+        FSharp multipleRecdTypeChoiceWarningWith2AlternativeSource
+        |> withLangVersion70
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Information 3566, Line 33, Col 9, Line 33, Col 19, "Multiple type matches were found:\n    N.Module1.OtherThing\n    N.Module2.Person\n    N.Module3.Cafe\nThe type 'N.Module1.OtherThing' was used. Due to the overlapping field names\n    Name\n    Planet\nconsider using type annotations or change the order of open statements.")
+            (Error 39, Line 33, Col 15, Line 33, Col 19, "The type 'OtherThing' does not define the field, constructor or member 'City'.")
+        ]
+
+    let multipleRecdTypeChoiceWarningNotRaisedWithCorrectOpenStmtsOrderingSource = """
+namespace N
+
+module Module1 =
+
+   type OtherThing = 
+       { Name: string
+         Planet: string }
+
+module Module2 =
+
+   type Person = 
+       { Name: string
+         City: string
+         Planet: string }
+
+module Module3 =
+
+   type Cafe = 
+       { Name: string
+         City: string
+         Country: string
+         Planet: string }
+
+module Lib =
+
+   open Module3
+   open Module1
+   open Module2
+
+   let F thing = 
+       let x = thing.Name
+       thing.City
+"""
+
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningNotRaisedWithCorrectOpenStmtsOrderingLangPreview () =
+        FSharp multipleRecdTypeChoiceWarningNotRaisedWithCorrectOpenStmtsOrderingSource
+        |> withLangVersionPreview
+        |> typecheck
+        |> shouldSucceed
+
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningNotRaisedWithCorrectOpenStmtsOrderingLang7 () =
+        FSharp multipleRecdTypeChoiceWarningNotRaisedWithCorrectOpenStmtsOrderingSource
+        |> withLangVersion70
+        |> typecheck
+        |> shouldSucceed
+
+    let multipleRecdTypeChoiceWarningNotRaisedWithoutOverlapsSource = """
+namespace N
+
+module Module1 =
+
+    type OtherThing = 
+        { NameX: string
+          Planet: string }
+
+module Module2 =
+
+    type Person = 
+        { Name: string
+          City: string
+          Planet: string }
+
+module Module3 =
+
+    type Cafe = 
+        { NameX: string
+          City: string
+          Country: string
+          Planet: string }
+
+module Lib =
+
+    open Module3
+    open Module2
+    open Module1
+
+    let F thing = 
+        let x = thing.Name
+        thing.City
+"""
+    
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningNotRaisedWithoutOverlapsLangPreview () =
+        FSharp multipleRecdTypeChoiceWarningNotRaisedWithoutOverlapsSource
+        |> withLangVersionPreview
+        |> typecheck
+        |> shouldSucceed
+    
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningNotRaisedWithoutOverlapsLang7 () =
+        FSharp multipleRecdTypeChoiceWarningNotRaisedWithoutOverlapsSource
+        |> withLangVersion70
+        |> typecheck
+        |> shouldSucceed
+
+    let multipleRecdTypeChoiceWarningNotRaisedWithTypeAnnotationsSource = """
+        namespace N
+        
+        module Module1 =
+        
+            type OtherThing = 
+                { NameX: string
+                  Planet: string }
+        
+        module Module2 =
+        
+            type Person = 
+                { Name: string
+                  City: string
+                  Planet: string }
+        
+        module Module3 =
+        
+            type Cafe = 
+                { NameX: string
+                  City: string
+                  Country: string
+                  Planet: string }
+        
+        module Lib =
+        
+            open Module3
+            open Module2
+            open Module1
+        
+            let F (thing: Person) = 
+                let x = thing.Name
+                thing.City
+        """
+    
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningNotRaisedWithTypeAnnotationsLangPreview () =
+        FSharp multipleRecdTypeChoiceWarningNotRaisedWithTypeAnnotationsSource
+        |> withLangVersionPreview
+        |> typecheck
+        |> shouldSucceed
+    
+    [<Fact>]
+    let MultipleRecdTypeChoiceWarningNotRaisedWithTypeAnnotationsLang7 () =
+        FSharp multipleRecdTypeChoiceWarningNotRaisedWithTypeAnnotationsSource
+        |> withLangVersion70
+        |> typecheck
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/SuggestionsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/SuggestionsTests.fs
@@ -173,8 +173,10 @@ let r = { Field1 = "hallo"; Field2 = 1 }
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 39, Line 8, Col 11, Line 8, Col 17,
-                                 ("The record label 'Field1' is not defined. Maybe you want one of the following:" + Environment.NewLine + "   MyRecord.Field1"))
+        |> withDiagnostics [
+            (Error 39, Line 8, Col 11, Line 8, Col 17, "The record label 'Field1' is not defined. Maybe you want one of the following:" + Environment.NewLine + "   MyRecord.Field1")
+            (Error 39, Line 8, Col 29, Line 8, Col 35, "The record label 'Field2' is not defined. Maybe you want one of the following:" + Environment.NewLine + "   MyRecord.Field2")
+        ]
 
     [<Fact>]
     let ``Suggest Type Parameters`` () =

--- a/tests/fsharp/typecheck/sigs/neg07.bsl
+++ b/tests/fsharp/typecheck/sigs/neg07.bsl
@@ -24,8 +24,18 @@ neg07.fs(36,11,36,27): typecheck error FS0026: This rule will never be matched
 neg07.fs(46,15,46,27): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1
 
+neg07.fs(46,33,46,45): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
+   R.RecordLabel2
+
+neg07.fs(47,17,47,55): typecheck error FS0025: Incomplete pattern matches on this expression.
+neg07.fs(47,59,47,60): typecheck error FS0039: The value or constructor 'a' is not defined.
+neg07.fs(47,63,47,64): typecheck error FS0039: The value or constructor 'b' is not defined.
+
 neg07.fs(47,19,47,31): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1
+
+neg07.fs(47,37,47,49): typecheck error FS0039: The record label 'RecordLabel2' is not defined. Maybe you want one of the following:
+   R.RecordLabel2
 
 neg07.fs(57,10,57,17): typecheck error FS1196: The 'UseNullAsTrueValue' attribute flag may only be used with union types that have one nullary case and at least one non-nullary case
 

--- a/tests/fsharpqa/Source/Conformance/InferenceProcedures/NameResolution/RequireQualifiedAccess/E_OnRecord.fs
+++ b/tests/fsharpqa/Source/Conformance/InferenceProcedures/NameResolution/RequireQualifiedAccess/E_OnRecord.fs
@@ -3,7 +3,6 @@
 // has the RequireQualifiedAccess attribute.
 
 //<Expects id="FS0039" status="error">The record label 'Field1' is not defined\.</Expects>
-//<Expects id="FS0039" status="error">The record label 'Field1' is not defined\.</Expects>
 
 [<RequireQualifiedAccess>]
 type R = { Field1 : int; Field2 : string }

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -474,3 +474,207 @@ type Foo =
           (:? FSharpMemberOrFunctionOrValue as setMfv) ->
             Assert.AreNotEqual(getMfv.CurriedParameterGroups, setMfv.CurriedParameterGroups)
         | _ -> Assert.Fail "Expected symbols to be FSharpMemberOrFunctionOrValue"
+        
+    [<Test>]
+    let ``Multiple symbols are resolved for property`` () =
+        let source = """
+type X(y: string) =
+    member val Y = y with get, set
+"""
+
+        let _, checkResults = getParseAndCheckResults source
+        let symbolUses =
+            checkResults.GetSymbolUsesAtLocation(3, 16, "    member val Y = y with get, set", [ "Y" ])
+            |> List.map (fun su -> su.Symbol)
+
+        match symbolUses with
+        | [ :? FSharpMemberOrFunctionOrValue as setMfv
+            :? FSharpMemberOrFunctionOrValue as getMfv ] ->
+            Assert.AreEqual("set_Y", setMfv.CompiledName)
+            Assert.AreEqual("get_Y", getMfv.CompiledName)
+        | _ -> Assert.Fail "Expected symbols"
+
+    [<Test>]
+    let ``Multiple relevant symbols for type name`` () =
+        let _, checkResults = getParseAndCheckResults """
+// This is a generated file; the original input is 'FSInteractiveSettings.txt'
+namespace FSInteractiveSettings
+
+type internal SR () =
+
+    static let mutable swallowResourceText = false
+
+    /// If set to true, then all error messages will just return the filled 'holes' delimited by ',,,'s - this is for language-neutral testing (e.g. localization-invariant baselines).
+    static member SwallowResourceText with get () = swallowResourceText
+                                        and set (b) = swallowResourceText <- b
+    // END BOILERPLATE
+"""
+
+        let symbols =
+            checkResults.GetSymbolUsesAtLocation(5, 16, "type internal SR () =", [ "" ])
+            |> List.map (fun su -> su.Symbol)
+
+        match symbols with
+        | [ :? FSharpMemberOrFunctionOrValue as cctor
+            :? FSharpMemberOrFunctionOrValue as ctor
+            :? FSharpEntity as entity  ] ->
+            Assert.AreEqual(".cctor", cctor.CompiledName)
+            Assert.AreEqual(".ctor", ctor.CompiledName)
+            Assert.AreEqual("SR", entity.DisplayName)
+        | _ -> Assert.Fail "Expected symbols"
+
+module Expressions =
+    [<Test>]
+    let ``Unresolved record field 01`` () =
+        let _, checkResults = getParseAndCheckResults """
+type R =
+    { F1: int
+      F2: int }
+
+{ F = 1
+  F2 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 02`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+{ F1 = 1
+  R.F2 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 03`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+{ R.F2 = 1
+  F1 = 1 }
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 04`` () =
+        let _, checkResults = getParseAndCheckResults """
+type R =
+    { F1: int
+      F2: int }
+
+match Unchecked.defaultof<R> with
+{ F = 1
+  F2 = 1 } -> ()
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``Unresolved record field 05`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+match Unchecked.defaultof<R> with
+{ F = 1
+  R.F2 = 1 } -> ()
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+
+    [<Test>]
+    let ``Unresolved record field 06`` () =
+        let _, checkResults = getParseAndCheckResults """
+[<RequireQualifiedAccess>]
+type R =
+    { F1: int
+      F2: int }
+
+match Unchecked.defaultof<R> with
+{ R.F2 = 1
+  F = 1 } -> ()
+"""
+        getSymbolUses checkResults
+        |> Seq.exists (fun symbolUse -> symbolUse.IsFromUse && symbolUse.Symbol.DisplayName = "F2")
+        |> shouldEqual true
+
+module GetValSignatureText =
+    let private assertSignature (expected:string) source (lineNumber, column, line, identifier) =
+        let _, checkResults = getParseAndCheckResults source
+        let symbolUseOpt = checkResults.GetSymbolUseAtLocation(lineNumber, column, line, [ identifier ])
+        match symbolUseOpt with
+        | None -> Assert.Fail "Expected symbol"
+        | Some symbolUse ->
+            match symbolUse.Symbol with
+            | :? FSharpMemberOrFunctionOrValue as mfv ->
+                let expected = expected.Replace("\r", "")
+                let signature = mfv.GetValSignatureText(symbolUse.DisplayContext, symbolUse.Range)
+                Assert.AreEqual(expected, signature.Value)
+            | symbol -> Assert.Fail $"Expected FSharpMemberOrFunctionOrValue, got %A{symbol}"
+
+    [<Test>]
+    let ``Signature text for let binding`` () =
+        assertSignature
+            "val a: b: int -> c: int -> int"
+            "let a b c = b + c"
+            (1, 4, "let a b c = b + c", "a")
+
+    [<Test>]
+    let ``Signature text for member binding`` () =
+        assertSignature
+            "member Bar: a: int -> b: int -> int"
+            """
+type Foo() =
+    member this.Bar (a:int) (b:int) : int = 0
+"""
+            (3, 19, "    member this.Bar (a:int) (b:int) : int = 0", "Bar")
+
+#if NETCOREAPP
+    [<Test>]
+    let ``Signature text for type with generic parameter in path`` () =
+        assertSignature
+            "new: builder: ImmutableArray<'T>.Builder -> ImmutableArrayViaBuilder<'T>"
+            """
+module Telplin
+
+open System
+open System.Collections.Generic
+open System.Collections.Immutable
+
+type ImmutableArrayViaBuilder<'T>(builder: ImmutableArray<'T>.Builder) =
+    class end
+"""
+            (8, 29, "type ImmutableArrayViaBuilder<'T>(builder: ImmutableArray<'T>.Builder) =", ".ctor")
+#endif
+
+    [<Test>]
+    let ``Includes attribute for parameter`` () =
+        assertSignature
+            "val a: [<B>] c: int -> int"
+            """
+module Telplin
+
+type BAttribute() =
+    inherit System.Attribute()
+
+let a ([<B>] c: int) : int = 0
+"""
+            (7, 5, "let a ([<B>] c: int) : int = 0", "a")


### PR DESCRIPTION
Fixes exceptions introduced in https://github.com/dotnet/fsharp/pull/15214 when wrong syntax is used to update an anonymous record:

```fsharp
let f (r: {| A: int |}) =
    { r with A = 1 }
```