### PR TITLE
Name resolution: report record symbols resolved as expressions

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -1109,7 +1109,7 @@ module MutRecBindingChecking =
                             
                         // Phase2B: typecheck the argument to an 'inherits' call and build the new object expr for the inherit-call 
                         | Phase2AInherit (synBaseTy, arg, baseValOpt, m) ->
-                            let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Use WarnOnIWSAM.Yes envInstance tpenv synBaseTy
+                            let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes envInstance tpenv synBaseTy
                             let baseTy = baseTy |> convertToTypeWithMetadataIfPossible g
                             let inheritsExpr, tpenv =
                                 try 

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4885,8 +4885,8 @@ and TcProvidedTypeApp (cenv: cenv) env tpenv tcref args m =
 /// the prefix of type arguments.
 and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcref pathTypeArgs (synArgTys: SynType list) =
     let g = cenv.g
-    CheckTyconAccessible cenv.amap mItem env.AccessRights tcref |> ignore
-    CheckEntityAttributes g tcref mItem |> CommitOperationResult
+    CheckTyconAccessible cenv.amap mWhole env.AccessRights tcref |> ignore
+    CheckEntityAttributes g tcref mWhole |> CommitOperationResult
 
 #if !NO_TYPEPROVIDERS
     // Provided types are (currently) always non-generic. Their names may include mangled

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4921,7 +4921,7 @@ and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcr
 
     if not actualArgTys.IsEmpty then
         let item = Item.Types(tcref.DisplayNameCore, [ty])
-        CallNameResolutionSinkReplacing cenv.tcSink (function Item.Types _ -> true | _ -> false) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
+        CallNameResolutionSinkReplacing cenv.tcSink (function Item.CtorGroup _ -> false | _ -> true) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     ty, tpenv
 
@@ -8495,7 +8495,7 @@ and TcTypeItemThen (cenv: cenv) overallTy occ env nm ty tpenv mItem tinstEnclosi
 
     let reportTypeUsage ty =
         let item = Item.Types(nm, [ty])
-        CallNameResolutionSinkReplacing cenv.tcSink (function Item.Types _ -> true | _ -> false) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
+        CallNameResolutionSinkReplacing cenv.tcSink (function Item.CtorGroup _ -> false | _ -> true) (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     match delayed with
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: DelayedDotLookup (longId, mLongId) :: otherDelayed ->

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -4437,7 +4437,7 @@ and TcLongIdentType kindOpt (cenv: cenv) newOk checkConstraints occ iwsam env tp
     | _, TyparKind.Measure ->
         TType_measure (Measure.Const tcref), tpenv
     | _, TyparKind.Type ->
-        TcTypeApp cenv newOk checkConstraints occ env tpenv m tcref tinstEnclosing []
+        TcTypeApp cenv newOk checkConstraints occ env tpenv m m tcref tinstEnclosing []
 
 /// Some.Long.TypeName<ty1, ty2>
 /// ty1 SomeLongTypeName
@@ -4464,7 +4464,7 @@ and TcLongIdentAppType kindOpt (cenv: cenv) newOk checkConstraints occ iwsam env
     | _, TyparKind.Type ->
         if postfix && tcref.Typars m |> List.exists (fun tp -> match tp.Kind with TyparKind.Measure -> true | _ -> false) then
             error(Error(FSComp.SR.tcInvalidUnitsOfMeasurePrefix(), m))
-        TcTypeApp cenv newOk checkConstraints occ env tpenv m tcref tinstEnclosing args
+        TcTypeApp cenv newOk checkConstraints occ env tpenv longId.Range m tcref tinstEnclosing args
 
     | _, TyparKind.Measure ->
         match args, postfix with
@@ -4484,7 +4484,7 @@ and TcNestedAppType (cenv: cenv) newOk checkConstraints occ iwsam env tpenv synL
     match leftTy with
     | AppTy g (tcref, tinst) ->
         let tcref = ResolveTypeLongIdentInTyconRef cenv.tcSink cenv.nameResolver env.eNameResEnv (TypeNameResolutionInfo.ResolveToTypeRefs (TypeNameResolutionStaticArgsInfo.FromTyArgs args.Length)) ad m tcref longId
-        TcTypeApp cenv newOk checkConstraints occ env tpenv m tcref tinst args
+        TcTypeApp cenv newOk checkConstraints occ env tpenv synLongId.Range m tcref tinst args
     | _ ->
         error(Error(FSComp.SR.tcTypeHasNoNestedTypes(), m))
 
@@ -4883,18 +4883,18 @@ and TcProvidedTypeApp (cenv: cenv) env tpenv tcref args m =
 /// Note that the generic type may be a nested generic type List<T>.ListEnumerator<U>.
 /// In this case, 'argsR is only the instantiation of the suffix type arguments, and pathTypeArgs gives
 /// the prefix of type arguments.
-and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv m tcref pathTypeArgs (synArgTys: SynType list) =
+and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv mItem mWhole tcref pathTypeArgs (synArgTys: SynType list) =
     let g = cenv.g
-    CheckTyconAccessible cenv.amap m env.AccessRights tcref |> ignore
-    CheckEntityAttributes g tcref m |> CommitOperationResult
+    CheckTyconAccessible cenv.amap mItem env.AccessRights tcref |> ignore
+    CheckEntityAttributes g tcref mItem |> CommitOperationResult
 
 #if !NO_TYPEPROVIDERS
     // Provided types are (currently) always non-generic. Their names may include mangled
     // static parameters, which are passed by the provider.
-    if tcref.Deref.IsProvided then TcProvidedTypeApp cenv env tpenv tcref synArgTys m else
+    if tcref.Deref.IsProvided then TcProvidedTypeApp cenv env tpenv tcref synArgTys mWhole else
 #endif
 
-    let tps, _, tinst, _ = FreshenTyconRef2 g m tcref
+    let tps, _, tinst, _ = FreshenTyconRef2 g mItem tcref
 
     // If we're not checking constraints, i.e. when we first assert the super/interfaces of a type definition, then just
     // clear the constraint lists of the freshly generated type variables. A little ugly but fairly localized.
@@ -4902,22 +4902,26 @@ and TcTypeApp (cenv: cenv) newOk checkConstraints occ env tpenv m tcref pathType
     let synArgTysLength = synArgTys.Length
     let pathTypeArgsLength = pathTypeArgs.Length
     if tinst.Length <> pathTypeArgsLength + synArgTysLength then
-        error (TyconBadArgs(env.DisplayEnv, tcref, pathTypeArgsLength + synArgTysLength, m))
+        error (TyconBadArgs(env.DisplayEnv, tcref, pathTypeArgsLength + synArgTysLength, mWhole))
 
     let argTys, tpenv =
         // Get the suffix of typars
         let tpsForArgs = List.skip (tps.Length - synArgTysLength) tps
         let kindsForArgs = tpsForArgs |> List.map (fun tp -> tp.Kind)
-        TcTypesOrMeasures (Some kindsForArgs) cenv newOk checkConstraints occ env tpenv synArgTys m
+        TcTypesOrMeasures (Some kindsForArgs) cenv newOk checkConstraints occ env tpenv synArgTys mWhole
 
     // Add the types of the enclosing class for a nested type
     let actualArgTys = pathTypeArgs @ argTys
 
     if checkConstraints = CheckCxs then
-        List.iter2 (UnifyTypes cenv env m) tinst actualArgTys
+        List.iter2 (UnifyTypes cenv env mWhole) tinst actualArgTys
 
     // Try to decode System.Tuple --> F# tuple types etc.
     let ty = g.decompileType tcref actualArgTys
+
+    if not actualArgTys.IsEmpty then
+        let item = Item.Types(tcref.DisplayNameCore, [ty])
+        CallNameResolutionSinkReplacing cenv.tcSink (mItem, env.NameEnv, item, getInst ty, occ, env.eAccessRights)
 
     ty, tpenv
 
@@ -4940,7 +4944,7 @@ and TcTypeOrMeasureAndRecover kindOpt (cenv: cenv) newOk checkConstraints occ iw
 and TcTypeAndRecover (cenv: cenv) newOk checkConstraints occ iwsam env tpenv ty =
     TcTypeOrMeasureAndRecover (Some TyparKind.Type) cenv newOk checkConstraints occ iwsam env tpenv ty
 
-and TcNestedTypeApplication (cenv: cenv) newOk checkConstraints occ iwsam env tpenv mWholeTypeApp ty pathTypeArgs tyargs =
+and TcNestedTypeApplication (cenv: cenv) newOk checkConstraints occ iwsam env tpenv mItem mWholeTypeApp ty pathTypeArgs tyargs =
     let g = cenv.g
 
     let ty = convertToTypeWithMetadataIfPossible g ty
@@ -4951,7 +4955,7 @@ and TcNestedTypeApplication (cenv: cenv) newOk checkConstraints occ iwsam env tp
     match ty with
     | TType_app(tcref, _, _) ->
         CheckIWSAM cenv env checkConstraints iwsam mWholeTypeApp tcref
-        TcTypeApp cenv newOk checkConstraints occ env tpenv mWholeTypeApp tcref pathTypeArgs tyargs
+        TcTypeApp cenv newOk checkConstraints occ env tpenv mItem mWholeTypeApp tcref pathTypeArgs tyargs
     | _ ->
         error(InternalError("TcNestedTypeApplication: expected type application", mWholeTypeApp))
 
@@ -8041,7 +8045,7 @@ and TcNameOfExpr (cenv: cenv) env tpenv (synArg: SynExpr) =
                     | Result (tinstEnclosing, tcref) when IsEntityAccessible cenv.amap m ad tcref ->
                         match delayed with
                         | [DelayedTypeApp (tyargs, _, mExprAndTypeArgs)] ->
-                            TcTypeApp cenv NewTyparsOK CheckCxs ItemOccurence.UseInType env tpenv mExprAndTypeArgs tcref tinstEnclosing tyargs |> ignore
+                            TcTypeApp cenv NewTyparsOK CheckCxs ItemOccurence.UseInType env tpenv mExprAndTypeArgs mExprAndTypeArgs tcref tinstEnclosing tyargs |> ignore
                         | _ -> ()
                         true // resolved to a type name, done with checks
                     | _ ->
@@ -8261,8 +8265,12 @@ and TcItemThen (cenv: cenv) (overallTy: OverallTy) env tpenv (tinstEnclosing, it
     | Item.CtorGroup(nm, minfos) ->
         TcCtorItemThen cenv overallTy env item nm minfos tinstEnclosing tpenv mItem afterResolution delayed
 
-    | Item.FakeInterfaceCtor _ ->
-        error(Error(FSComp.SR.tcInvalidUseOfInterfaceType(), mItem))
+    | Item.FakeInterfaceCtor ty ->
+        let nm =
+            match ty with
+            | TType_app(tcref, _, _) -> tcref.DisplayNameCore
+            | _ -> NicePrint.minimalStringOfType env.DisplayEnv ty
+        TcTypeItemThen cenv overallTy env nm ty tpenv mItem tinstEnclosing delayed
 
     | Item.ImplicitOp(id, sln) ->
         TcImplicitOpItemThen cenv overallTy env id sln tpenv mItem delayed
@@ -8474,34 +8482,40 @@ and TcUnionCaseOrExnCaseOrActivePatternResultItemThen (cenv: cenv) overallTy env
 and TcTypeItemThen (cenv: cenv) overallTy env nm ty tpenv mItem tinstEnclosing delayed =
     let g = cenv.g
     let ad = env.eAccessRights
+
+    // In this case the type is not generic, and indeed we should never have returned Item.Types.
+    // That's because ResolveTypeNamesToCtors should have been set at the original
+    // call to ResolveLongIdentAsExprAndComputeRange
+    let reportWrongTypeUsageError ty m _mWithArgs =
+        if isInterfaceTy g ty then
+            error(Error(FSComp.SR.tcInvalidUseOfInterfaceType(), m))
+        else
+            error(Error(FSComp.SR.tcInvalidUseOfTypeName(), m))
+
+    let reportTypeUsage ty =
+        let item = Item.Types(nm, [ty])
+        CallNameResolutionSinkReplacing cenv.tcSink (mItem, env.NameEnv, item, getInst ty, ItemOccurence.Use, env.eAccessRights)
+
     match delayed with
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: DelayedDotLookup (longId, mLongId) :: otherDelayed ->
         // If Item.Types is returned then the ty will be of the form TType_app(tcref, genericTyargs) where tyargs
         // is a fresh instantiation for tcref. TcNestedTypeApplication will chop off precisely #genericTyargs args
         // and replace them by 'tyargs'
-        let ty, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mExprAndTypeArgs ty tinstEnclosing tyargs
-
-        // Report information about the whole expression including type arguments to VS
-        let item = Item.Types(nm, [ty])
-        CallNameResolutionSink cenv.tcSink (mExprAndTypeArgs, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)
+        let ty, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs ty tinstEnclosing tyargs
         let typeNameResInfo = GetLongIdentTypeNameInfo otherDelayed
         let item, mItem, rest, afterResolution = ResolveExprDotLongIdentAndComputeRange cenv.tcSink cenv.nameResolver (unionRanges mExprAndTypeArgs mLongId) ad env.eNameResEnv ty longId typeNameResInfo IgnoreOverrides true
         TcItemThen cenv overallTy env tpenv ((argsOfAppTy g ty), item, mItem, rest, afterResolution) None otherDelayed
 
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: _delayed' ->
-        // A case where we have an incomplete name e.g. 'Foo<int>.' - we still want to report it to VS!
-        let ty, _ = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mExprAndTypeArgs ty tinstEnclosing tyargs
-        let item = Item.Types(nm, [ty])
-        CallNameResolutionSink cenv.tcSink (mExprAndTypeArgs, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)
+        reportTypeUsage ty
 
-        // Same error as in the following case
-        error(Error(FSComp.SR.tcInvalidUseOfTypeName(), mItem))
+        // A case where we have an incomplete name e.g. 'Foo<int>.' - we still want to report it to VS!
+        let ty, _ = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs ty tinstEnclosing tyargs
+        reportWrongTypeUsageError ty mItem mExprAndTypeArgs
 
     | _ ->
-        // In this case the type is not generic, and indeed we should never have returned Item.Types.
-        // That's because ResolveTypeNamesToCtors should have been set at the original
-        // call to ResolveLongIdentAsExprAndComputeRange
-        error(Error(FSComp.SR.tcInvalidUseOfTypeName(), mItem))
+        reportTypeUsage ty
+        reportWrongTypeUsageError ty mItem mItem
 
 and TcMethodItemThen (cenv: cenv) overallTy env item methodName minfos tpenv mItem afterResolution staticTyOpt delayed =
     let ad = env.eAccessRights
@@ -8567,7 +8581,7 @@ and TcCtorItemThen (cenv: cenv) overallTy env item nm minfos tinstEnclosing tpen
 
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: DelayedApp(_, _, _, arg, mExprAndArg) :: otherDelayed ->
 
-        let objTyAfterTyArgs, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mExprAndTypeArgs objTy tinstEnclosing tyargs
+        let objTyAfterTyArgs, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs objTy tinstEnclosing tyargs
         CallExprHasTypeSink cenv.tcSink (mExprAndArg, env.NameEnv, objTyAfterTyArgs, env.eAccessRights)
         let itemAfterTyArgs, minfosAfterTyArgs =
 #if !NO_TYPEPROVIDERS
@@ -8588,7 +8602,7 @@ and TcCtorItemThen (cenv: cenv) overallTy env item nm minfos tinstEnclosing tpen
 
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: otherDelayed ->
 
-        let objTy, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mExprAndTypeArgs objTy tinstEnclosing tyargs
+        let objTy, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mExprAndTypeArgs objTy tinstEnclosing tyargs
 
         // A case where we have an incomplete name e.g. 'Foo<int>.' - we still want to report it to VS!
         let resolvedItem = Item.Types(nm, [objTy])
@@ -8797,7 +8811,7 @@ and TcDelegateCtorItemThen cenv overallTy env ty tinstEnclosing tpenv mItem dela
     | DelayedApp (atomicFlag, _, _, arg, mItemAndArg) :: otherDelayed ->
         TcNewDelegateThen cenv overallTy env tpenv mItem mItemAndArg ty arg atomicFlag otherDelayed
     | DelayedTypeApp(tyargs, _mTypeArgs, mItemAndTypeArgs) :: DelayedApp (atomicFlag, _, _, arg, mItemAndArg) :: otherDelayed ->
-        let ty, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItemAndTypeArgs ty tinstEnclosing tyargs
+        let ty, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurence.UseInType WarnOnIWSAM.Yes env tpenv mItem mItemAndTypeArgs ty tinstEnclosing tyargs
 
         // Report information about the whole expression including type arguments to VS
         let item = Item.DelegateCtor ty

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -8030,6 +8030,7 @@ and TcNameOfExpr (cenv: cenv) env tpenv (synArg: SynExpr) =
                           | Item.DelegateCtor _
                           | Item.CtorGroup _
                           | Item.FakeInterfaceCtor _ -> false
+                          | Item.Types _ -> false
                           | _ -> true) ->
                     let overallTy = match overallTyOpt with None -> MustEqual (NewInferenceType g) | Some t -> t
                     let _, _ = TcItemThen cenv overallTy ItemOccurence.Use env tpenv res None delayed

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -8030,7 +8030,7 @@ and TcNameOfExpr (cenv: cenv) env tpenv (synArg: SynExpr) =
                           | Item.DelegateCtor _
                           | Item.CtorGroup _
                           | Item.FakeInterfaceCtor _ -> false
-                          | Item.Types _ -> false
+                          | Item.Types _ when delayed.IsEmpty -> false
                           | _ -> true) ->
                     let overallTy = match overallTyOpt with None -> MustEqual (NewInferenceType g) | Some t -> t
                     let _, _ = TcItemThen cenv overallTy ItemOccurence.Use env tpenv res None delayed

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -484,7 +484,7 @@ type ITypecheckResultsSink =
 
     /// Record that a name resolution occurred at a specific location in the source
     abstract NotifyNameResolution:
-        pos * Item * TyparInstantiation * ItemOccurence * NameResolutionEnv * AccessorDomain * range * bool -> unit
+        pos * Item * TyparInstantiation * ItemOccurence * NameResolutionEnv * AccessorDomain * range * (Item -> bool) option -> unit
 
     /// Record that a method group name resolution occurred at a specific location in the source
     abstract NotifyMethodGroupNameResolution:
@@ -619,7 +619,7 @@ val internal CallMethodGroupNameResolutionSink:
 
 /// Report a specific name resolution at a source range, replacing any previous resolutions
 val internal CallNameResolutionSinkReplacing:
-    TcResultsSink -> range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain -> unit
+    TcResultsSink -> (Item -> bool) -> range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain -> unit
 
 /// Report a specific name resolution at a source range
 val internal CallExprHasTypeSink: TcResultsSink -> range * NameResolutionEnv * TType * AccessorDomain -> unit

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -484,7 +484,15 @@ type ITypecheckResultsSink =
 
     /// Record that a name resolution occurred at a specific location in the source
     abstract NotifyNameResolution:
-        pos * Item * TyparInstantiation * ItemOccurence * NameResolutionEnv * AccessorDomain * range * (Item -> bool) option -> unit
+        pos *
+        Item *
+        TyparInstantiation *
+        ItemOccurence *
+        NameResolutionEnv *
+        AccessorDomain *
+        range *
+        (Item -> bool) option ->
+            unit
 
     /// Record that a method group name resolution occurred at a specific location in the source
     abstract NotifyMethodGroupNameResolution:
@@ -619,7 +627,10 @@ val internal CallMethodGroupNameResolutionSink:
 
 /// Report a specific name resolution at a source range, replacing any previous resolutions
 val internal CallNameResolutionSinkReplacing:
-    TcResultsSink -> (Item -> bool) -> range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain -> unit
+    TcResultsSink ->
+    (Item -> bool) ->
+    range * NameResolutionEnv * Item * TyparInstantiation * ItemOccurence * AccessorDomain ->
+        unit
 
 /// Report a specific name resolution at a source range
 val internal CallExprHasTypeSink: TcResultsSink -> range * NameResolutionEnv * TType * AccessorDomain -> unit

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -102,6 +102,12 @@ type ValRemap = ValMap<ValRef>
 let emptyTyconRefRemap: TyconRefRemap = TyconRefMap<_>.Empty
 let emptyTyparInst = ([]: TyparInstantiation)
 
+let getInst (ty: TType) =
+    match stripTyparEqns ty with
+    | TType_app(tcref, typeArgs, _) ->
+        List.zip tcref.Deref.TyparsNoRange typeArgs
+    | _ -> []
+
 [<NoEquality; NoComparison>]
 type Remap =
     { tpinst: TyparInstantiation

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -567,6 +567,8 @@ val mkTyconRefInst: TyconRef -> TypeInst -> TyparInstantiation
 
 val emptyTyparInst: TyparInstantiation
 
+val getInst: TType -> TyparInstantiation
+
 val instType: TyparInstantiation -> TType -> TType
 
 val instTypes: TyparInstantiation -> TypeInst -> TypeInst

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
@@ -31,21 +31,23 @@ let createProject() = SyntheticProject.Create(impFile())
 [<Fact>]
 let ``Finding usage of type via GetUsesOfSymbolInFile should also find it's constructors`` () =
     createProject().Workflow
-        {        
+        {
             checkFile "First" (fun (typeCheckResult: FSharpCheckFileResults) ->
-             
+
                 let symbolUse = typeCheckResult.GetSymbolUseAtLocation(7, 11, "type MyType() =", ["MyType"]).Value
                 let references = 
-                    typeCheckResult.GetUsesOfSymbolInFile(symbolUse.Symbol) 
+                    typeCheckResult.GetUsesOfSymbolInFile(symbolUse.Symbol)
                     |> Array.sortBy (fun su -> su.Range.StartLine)
                     |> Array.map (fun su -> su.Range.StartLine, su.Range.StartColumn, su.Range.EndColumn, deriveOccurence su)
 
-                Assert.Equal<(int*int*int*Occurence)>(
-                    [| 7,5,11,Definition
-                       8,25,31,InType
-                       10,8,14,Use
-                       11,12,18,Use
-                    |],references)  )           
+                Assert.Equal<int * int * int * Occurence>(
+                    [| 7, 5, 11, Definition
+                       8, 25, 31, InType
+                       10, 8, 14, Use
+                       11, 12, 18, InType
+                       11, 12, 18, Use
+                    |], references)
+            )
         }
 
 

--- a/tests/fsharp/typecheck/sigs/neg06.bsl
+++ b/tests/fsharp/typecheck/sigs/neg06.bsl
@@ -94,27 +94,27 @@ neg06.fs(128,53,128,61): typecheck error FS0043: A type parameter is missing a c
 
 neg06.fs(141,10,141,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(148,13,148,21): typecheck error FS0039: The value or constructor 'BadType1' is not defined.
+neg06.fs(148,13,148,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(150,10,150,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(157,13,157,21): typecheck error FS0039: The value or constructor 'BadType2' is not defined.
+neg06.fs(157,13,157,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(159,10,159,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(166,13,166,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined.
+neg06.fs(166,13,166,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(195,10,195,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(203,13,203,21): typecheck error FS0039: The value or constructor 'BadType1' is not defined.
+neg06.fs(203,13,203,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(205,10,205,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(213,13,213,21): typecheck error FS0039: The value or constructor 'BadType2' is not defined.
+neg06.fs(213,13,213,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(215,10,215,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(223,13,223,21): typecheck error FS0039: The value or constructor 'BadType3' is not defined.
+neg06.fs(223,13,223,21):typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(300,10,300,12): typecheck error FS0009: Uses of this construct may result in the generation of unverifiable .NET IL code. This warning can be disabled using '--nowarn:9' or '#nowarn "9"'.
 
@@ -130,11 +130,11 @@ neg06.fs(320,10,320,12): typecheck error FS0937: Only structs and classes withou
 
 neg06.fs(326,10,326,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(335,13,335,21): typecheck error FS0039: The value or constructor 'BadType4' is not defined.
+neg06.fs(335,13,335,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(340,10,340,18): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 
-neg06.fs(350,13,350,21): typecheck error FS0039: The value or constructor 'BadType4' is not defined.
+neg06.fs(350,13,350,21): typecheck error FS0800: Invalid use of a type name
 
 neg06.fs(375,9,375,10): typecheck error FS1197: The parameter 'x' was inferred to have byref type. Parameters of byref type must be given an explicit type annotation, e.g. 'x1: byref<int>'. When used, a byref parameter is implicitly dereferenced.
 

--- a/tests/service/Common.fs
+++ b/tests/service/Common.fs
@@ -376,7 +376,7 @@ let inline dumpDiagnostics (results: FSharpCheckFileResults) =
     |> List.ofArray
 
 let getSymbolUses (results: FSharpCheckFileResults) =
-    results.GetAllUsesOfAllSymbolsInFile()
+    results.GetAllUsesOfAllSymbolsInFile() |> List.ofSeq
 
 let getSymbolUsesFromSource (source: string) =
     let _, typeCheckResults = getParseAndCheckResults source

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -762,7 +762,7 @@ let ``Test project2 all uses of all symbols`` () =
     let allUsesOfAllSymbols =
         [ for s in wholeProjectResults.GetAllUsesOfAllSymbols() ->
             s.Symbol.DisplayName, (if s.FileName = Project2.fileName1 then "file1" else "???"), tupsZ s.Range, attribsOfSymbol s.Symbol ]
-    let expected =
+    allUsesOfAllSymbols |> shouldEqual
           [("int", "file1", ((4, 13), (4, 16)), ["abbrev"]);
            ("int", "file1", ((4, 19), (4, 22)), ["abbrev"]);
            ("int", "file1", ((5, 13), (5, 16)), ["abbrev"]);
@@ -784,10 +784,10 @@ let ``Test project2 all uses of all symbols`` () =
            ("D", "file1", ((10, 8), (10, 9)), []);
            ("int", "file1", ((12, 35), (12, 38)), ["abbrev"]);
            ("int", "file1", ((12, 45), (12, 48)), ["abbrev"]);
-           ("int", "file1", ((12, 35), (12, 38)), ["abbrev"]);
            ("x", "file1", ((12, 31), (12, 32)), ["field"]);
-           ("int", "file1", ((12, 45), (12, 48)), ["abbrev"]);
+           ("int", "file1", ((12, 35), (12, 38)), ["abbrev"]);
            ("y", "file1", ((12, 41), (12, 42)), ["field"]);
+           ("int", "file1", ((12, 45), (12, 48)), ["abbrev"]);
            ("DU", "file1", ((12, 25), (12, 27)), []);
            ("DUWithNamedFields", "file1", ((12, 5), (12, 22)), ["union"]);
            ("DU", "file1", ((14, 8), (14, 10)), []);
@@ -806,11 +806,12 @@ let ``Test project2 all uses of all symbols`` () =
            ("u", "file1", ((17, 38), (17, 39)), []);
            ("t", "file1", ((17, 31), (17, 32)), []);
            ("GenericClass", "file1", ((19, 8), (19, 20)), ["member"; "ctor"]);
-           ("int", "file1", ((19, 21), (19, 24)), ["abbrev"]);
+           ("int", "file1", ((19, 21), (19, 24)), ["abbrev"])
+           ("GenericClass", "file1", ((19, 8), (19, 20)), ["class"]);
            ("c", "file1", ((19, 4), (19, 5)), ["val"]);
            ("c", "file1", ((20, 8), (20, 9)), ["val"]);
-           ("GenericMethod", "file1", ((20, 8), (20, 23)), ["member"]);
            ("int", "file1", ((20, 24), (20, 27)), ["abbrev"]);
+           ("GenericMethod", "file1", ((20, 8), (20, 23)), ["member"]);
            ("T", "file1", ((22, 23), (22, 25)), []);
            ("T", "file1", ((22, 30), (22, 32)), []);
            ("y", "file1", ((22, 27), (22, 28)), []);
@@ -822,9 +823,6 @@ let ``Test project2 all uses of all symbols`` () =
            ("GenericFunction", "file1", ((22, 4), (22, 19)), ["val"]);
            ("GenericFunction", "file1", ((24, 8), (24, 23)), ["val"]);
            ("M", "file1", ((1, 7), (1, 8)), ["module"])]
-    set allUsesOfAllSymbols - set expected |> shouldEqual Set.empty
-    set expected - set allUsesOfAllSymbols |> shouldEqual Set.empty
-    (set expected = set allUsesOfAllSymbols) |> shouldEqual true
 
 //-----------------------------------------------------------------------------------------
 
@@ -2055,24 +2053,22 @@ let ``Test Project11 all symbols`` () =
           [|("System", "System", "file1", ((4, 15), (4, 21)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((4, 22), (4, 33)), [], ["namespace"]);
             ("Generic", "Generic", "file1", ((4, 34), (4, 41)), [], ["namespace"]);
-            ("Dictionary`2", "Dictionary", "file1", ((4, 15), (4, 52)), ["type"],
-             ["class"]); ("int", "int", "file1", ((4, 53), (4, 56)), [], ["abbrev"]);
-            ("int", "int", "file1", ((4, 57), (4, 60)), [], ["abbrev"]);
-            ("Enumerator", "Enumerator", "file1", ((4, 62), (4, 72)), ["type"],
-             ["valuetype"]);
+            ("Dictionary`2", "Dictionary", "file1", ((4, 15), (4, 52)), ["type"], ["class"])
+            ("int", "int", "file1", ((4, 53), (4, 56)), ["type"], ["abbrev"]);
+            ("int", "int", "file1", ((4, 57), (4, 60)), ["type"], ["abbrev"]);
+            ("Enumerator", "Enumerator", "file1", ((4, 62), (4, 72)), ["type"], ["valuetype"]);
             ("member .ctor", "Enumerator", "file1", ((4, 15), (4, 72)), [], ["member"]);
             ("val enum", "enum", "file1", ((4, 4), (4, 8)), ["defn"], ["val"]);
             ("System", "System", "file1", ((5, 11), (5, 17)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((5, 18), (5, 29)), [], ["namespace"]);
             ("Generic", "Generic", "file1", ((5, 30), (5, 37)), [], ["namespace"]);
-            ("Dictionary`2", "Dictionary", "file1", ((5, 11), (5, 48)), ["type"],
-             ["class"]); ("int", "int", "file1", ((5, 49), (5, 52)), ["type"], ["abbrev"]);
+            ("Dictionary`2", "Dictionary", "file1", ((5, 11), (5, 48)), ["type"], ["class"])
+            ("int", "int", "file1", ((5, 49), (5, 52)), ["type"], ["abbrev"]);
             ("int", "int", "file1", ((5, 53), (5, 56)), ["type"], ["abbrev"]);
-            ("Enumerator", "Enumerator", "file1", ((5, 58), (5, 68)), ["type"],
-             ["valuetype"]); ("val x", "x", "file1", ((5, 9), (5, 10)), ["defn"], []);
+            ("Enumerator", "Enumerator", "file1", ((5, 58), (5, 68)), ["type"], ["valuetype"])
+            ("val x", "x", "file1", ((5, 9), (5, 10)), ["defn"], []);
             ("val fff", "fff", "file1", ((5, 4), (5, 7)), ["defn"], ["val"]);
-            ("NestedTypes", "NestedTypes", "file1", ((2, 7), (2, 18)), ["defn"],
-             ["module"])|]
+            ("NestedTypes", "NestedTypes", "file1", ((2, 7), (2, 18)), ["defn"], ["module"])|]
 
 //-----------------------------------------------------------------------------------------
 // see https://github.com/fsharp/FSharp.Compiler.Service/issues/92
@@ -2777,7 +2773,6 @@ let ``Test Project17 all symbols`` () =
             ("FSharp", "FSharp", "file1", ((4, 18), (4, 24)), [], ["namespace"]);
             ("FSharpList`1", "List", "file1", ((4, 8), (4, 41)), [], ["union"]);
             ("int", "int", "file1", ((4, 42), (4, 45)), ["type"], ["abbrev"]);
-            ("FSharpList`1", "List", "file1", ((4, 8), (4, 46)), [], ["union"]);
             ("property Empty", "Empty", "file1", ((4, 8), (4, 52)), [], ["member"; "prop"]);
             ("System", "System", "file1", ((6, 11), (6, 17)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((6, 18), (6, 29)), [], ["namespace"]);
@@ -2786,14 +2781,11 @@ let ``Test Project17 all symbols`` () =
             ("generic parameter T", "T", "file1", ((6, 44), (6, 46)), ["type"], []);
             ("val x", "x", "file1", ((6, 8), (6, 9)), ["defn"], []);
             ("val x", "x", "file1", ((6, 51), (6, 52)), [], []);
-            ("property Item", "Item", "file1", ((6, 51), (6, 57)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Item", "Item", "file1", ((6, 51), (6, 57)), [], ["slot"; "member"; "prop"]);
             ("val x", "x", "file1", ((6, 62), (6, 63)), [], []);
-            ("property Item", "Item", "file1", ((6, 62), (6, 67)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Item", "Item", "file1", ((6, 62), (6, 67)), [], ["slot"; "member"; "prop"]);
             ("val x", "x", "file1", ((6, 69), (6, 70)), [], []);
-            ("property Count", "Count", "file1", ((6, 69), (6, 76)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Count", "Count", "file1", ((6, 69), (6, 76)), [], ["slot"; "member"; "prop"]);
             ("val f1", "f1", "file1", ((6, 4), (6, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((8, 11), (8, 17)), [], ["namespace"]);
             ("Collections", "Collections", "file1", ((8, 18), (8, 29)), [], ["namespace"]);
@@ -2802,15 +2794,13 @@ let ``Test Project17 all symbols`` () =
             ("int", "int", "file1", ((8, 44), (8, 47)), ["type"], ["abbrev"]);
             ("val x", "x", "file1", ((8, 8), (8, 9)), ["defn"], []);
             ("val x", "x", "file1", ((8, 52), (8, 53)), [], []);
-            ("property Item", "Item", "file1", ((8, 52), (8, 57)), [],
-             ["slot"; "member"; "prop"]);
+            ("property Item", "Item", "file1", ((8, 52), (8, 57)), [], ["slot"; "member"; "prop"]);
             ("val f2", "f2", "file1", ((8, 4), (8, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((10, 11), (10, 17)), [], ["namespace"]);
             ("Exception", "Exception", "file1", ((10, 11), (10, 27)), ["type"], ["class"]);
             ("val x", "x", "file1", ((10, 8), (10, 9)), ["defn"], []);
             ("val x", "x", "file1", ((10, 31), (10, 32)), [], []);
-            ("property HelpLink", "HelpLink", "file1", ((10, 31), (10, 41)), [],
-             ["slot"; "member"; "prop"]);
+            ("property HelpLink", "HelpLink", "file1", ((10, 31), (10, 41)), [], ["slot"; "member"; "prop"]);
             ("val f3", "f3", "file1", ((10, 4), (10, 6)), ["defn"], ["val"]);
             ("Impl", "Impl", "file1", ((2, 7), (2, 11)), ["defn"], ["module"])|]
 
@@ -2859,7 +2849,6 @@ let ``Test Project18 all symbols`` () =
 
     allUsesOfAllSymbols |> shouldEqual
       [|("list`1", "list", "file1", ((4, 8), (4, 12)), [], false);
-        ("list`1", "list", "file1", ((4, 8), (4, 15)), [], false);
         ("property Empty", "Empty", "file1", ((4, 8), (4, 21)), [], false);
         ("Impl", "Impl", "file1", ((2, 7), (2, 11)), ["defn"], false)|]
 

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -355,7 +355,8 @@ let ``Test project1 all uses of all signature symbols`` () =
              yield s.ToString(),
                   [ for s in wholeProjectResults.GetUsesOfSymbol(s) ->
                          (Project1.cleanFileName s.FileName, tupsZ s.Range) ] ]
-    let expected =
+
+    allUsesOfAllSymbols |> shouldEqual
         [("N", [("file2", ((1, 7), (1, 8)))]);
          ("val y2", [("file2", ((12, 4), (12, 6)))]);
          ("val pair2", [("file2", ((23, 10), (23, 15)))]);
@@ -399,19 +400,16 @@ let ``Test project1 all uses of all signature symbols`` () =
          ("val fff", [("file1", ((7, 4), (7, 7))); ("file2", ((9, 28), (9, 33)))]);
          ("C",
           [("file1", ((3, 5), (3, 6))); ("file1", ((9, 15), (9, 16)));
-           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25)))]);
+           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25))); ("file2", ((38, 22), (38, 25)))]);
          ("member .ctor",
           [("file1", ((3, 5), (3, 6))); ("file1", ((9, 15), (9, 16)));
-           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25)))]);
+           ("file2", ((38, 12), (38, 15))); ("file2", ((38, 22), (38, 25))); ("file2", ((38, 22), (38, 25)))]);
          ("member get_P", [("file1", ((4, 13), (4, 14)))]);
          ("property P", [("file1", ((4, 13), (4, 14)))]);
          ("CAbbrev",
           [("file1", ((9, 5), (9, 12))); ("file2", ((39, 12), (39, 21)));
-           ("file2", ((39, 28), (39, 37)))]);
+           ("file2", ((39, 28), (39, 37))); ("file2", ((39, 28), (39, 37)))]);
          ("property P", [("file1", ((4, 13), (4, 14)))])]
-    set allUsesOfAllSymbols - set expected |> shouldEqual Set.empty
-    set expected - set allUsesOfAllSymbols |> shouldEqual Set.empty
-    (set expected = set allUsesOfAllSymbols) |> shouldEqual true
 
 [<Test>]
 let ``Test project1 all uses of all symbols`` () =
@@ -724,36 +722,32 @@ let ``Test project2 all uses of all signature symbols`` () =
         [ for s in allSymbols do
              let uses = [ for s in wholeProjectResults.GetUsesOfSymbol(s) -> (if s.FileName = Project2.fileName1 then "file1" else "??"), tupsZ s.Range ]
              yield s.ToString(), uses ]
-    let expected =
-              [("M", [("file1", ((1, 7), (1, 8)))]);
-               ("val c", [("file1", ((19, 4), (19, 5))); ("file1", ((20, 8), (20, 9)))]);
-               ("val GenericFunction",
-                [("file1", ((22, 4), (22, 19))); ("file1", ((24, 8), (24, 23)))]);
-               ("generic parameter T",
-                [("file1", ((22, 23), (22, 25))); ("file1", ((22, 30), (22, 32)));
-                 ("file1", ((22, 45), (22, 47))); ("file1", ((22, 50), (22, 52)))]);
-               ("DUWithNormalFields", [("file1", ((3, 5), (3, 23)))]);
-               ("DU1", [("file1", ((4, 6), (4, 9))); ("file1", ((8, 8), (8, 11)))]);
-               ("field Item1", []); ("field Item2", []);
-               ("DU2", [("file1", ((5, 6), (5, 9))); ("file1", ((9, 8), (9, 11)))]);
-               ("D", [("file1", ((6, 6), (6, 7))); ("file1", ((10, 8), (10, 9)))]);
-               ("DUWithNamedFields", [("file1", ((12, 5), (12, 22)))]);
-               ("DU", [("file1", ((12, 25), (12, 27))); ("file1", ((14, 8), (14, 10)))]);
-               ("field x", [("file1", ((12, 31), (12, 32))); ("file1", ((14, 11), (14, 12)))]);
-               ("field y", [("file1", ((12, 41), (12, 42))); ("file1", ((14, 16), (14, 17)))]);
-               ("GenericClass`1",
-                [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
-               ("generic parameter T",
-                [("file1", ((16, 18), (16, 20))); ("file1", ((17, 34), (17, 36)))]);
-               ("member .ctor",
-                [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
-               ("member GenericMethod",
-                [("file1", ((17, 13), (17, 26))); ("file1", ((20, 8), (20, 23)))]);
-               ("generic parameter U",
-                [("file1", ((17, 27), (17, 29))); ("file1", ((17, 41), (17, 43)))])]
-    set allUsesOfAllSymbols - set expected |> shouldEqual Set.empty
-    set expected - set allUsesOfAllSymbols |> shouldEqual Set.empty
-    (set expected = set allUsesOfAllSymbols) |> shouldEqual true
+    allUsesOfAllSymbols |> shouldEqual
+        [("M", [("file1", ((1, 7), (1, 8)))]);
+         ("val c", [("file1", ((19, 4), (19, 5))); ("file1", ((20, 8), (20, 9)))]);
+         ("val GenericFunction", [("file1", ((22, 4), (22, 19))); ("file1", ((24, 8), (24, 23)))]);
+         ("generic parameter T", [
+            ("file1", ((22, 23), (22, 25)))
+            ("file1", ((22, 30), (22, 32)))
+            ("file1", ((22, 45), (22, 47)))
+            ("file1", ((22, 50), (22, 52)))
+          ]);
+         ("DUWithNormalFields", [("file1", ((3, 5), (3, 23)))]);
+         ("DU1", [("file1", ((4, 6), (4, 9))); ("file1", ((8, 8), (8, 11)))]);
+         ("field Item1", []); ("field Item2", []);
+         ("DU2", [("file1", ((5, 6), (5, 9))); ("file1", ((9, 8), (9, 11)))]);
+         ("field Item1", []); ("field Item2", []);
+         ("D", [("file1", ((6, 6), (6, 7))); ("file1", ((10, 8), (10, 9)))])
+         ("field Item1", []); ("field Item2", []);
+         ("DUWithNamedFields", [("file1", ((12, 5), (12, 22)))]);
+         ("DU", [("file1", ((12, 25), (12, 27))); ("file1", ((14, 8), (14, 10)))]);
+         ("field x", [("file1", ((12, 31), (12, 32))); ("file1", ((14, 11), (14, 12)))]);
+         ("field y", [("file1", ((12, 41), (12, 42))); ("file1", ((14, 16), (14, 17)))]);
+         ("GenericClass`1", [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
+         ("generic parameter T", [("file1", ((16, 18), (16, 20))); ("file1", ((17, 34), (17, 36)))]);
+         ("member .ctor", [("file1", ((16, 5), (16, 17))); ("file1", ((19, 8), (19, 20)))]);
+         ("member GenericMethod", [("file1", ((17, 13), (17, 26))); ("file1", ((20, 8), (20, 23)))]);
+         ("generic parameter U", [("file1", ((17, 27), (17, 29))); ("file1", ((17, 41), (17, 43)))])]
 
 [<Test>]
 let ``Test project2 all uses of all symbols`` () =
@@ -807,7 +801,6 @@ let ``Test project2 all uses of all symbols`` () =
            ("t", "file1", ((17, 31), (17, 32)), []);
            ("GenericClass", "file1", ((19, 8), (19, 20)), ["member"; "ctor"]);
            ("int", "file1", ((19, 21), (19, 24)), ["abbrev"])
-           ("GenericClass", "file1", ((19, 8), (19, 20)), ["class"]);
            ("c", "file1", ((19, 4), (19, 5)), ["val"]);
            ("c", "file1", ((20, 8), (20, 9)), ["val"]);
            ("int", "file1", ((20, 24), (20, 27)), ["abbrev"]);
@@ -2185,15 +2178,15 @@ let ``Test Project13 all symbols`` () =
 
     allUsesOfAllSymbols |> shouldEqual
           [|("System", "System", "file1", ((4, 14), (4, 20)), [], ["namespace"]);
-            ("Object", "Object", "file1", ((4, 14), (4, 27)), [], ["class"]);
+            ("Object", "Object", "file1", ((4, 14), (4, 27)), ["type"], ["class"]);
             ("member .ctor", "Object", "file1", ((4, 14), (4, 27)), [], ["member"]);
             ("val x1", "x1", "file1", ((4, 4), (4, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((5, 14), (5, 20)), [], ["namespace"]);
-            ("DateTime", "DateTime", "file1", ((5, 14), (5, 29)), [], ["valuetype"]);
+            ("DateTime", "DateTime", "file1", ((5, 14), (5, 29)), ["type"], ["valuetype"]);
             ("member .ctor", "DateTime", "file1", ((5, 14), (5, 29)), [], ["member"]);
             ("val x2", "x2", "file1", ((5, 4), (5, 6)), ["defn"], ["val"]);
             ("System", "System", "file1", ((6, 13), (6, 19)), [], ["namespace"]);
-            ("DateTime", "DateTime", "file1", ((6, 13), (6, 28)), [], ["valuetype"]);
+            ("DateTime", "DateTime", "file1", ((6, 13), (6, 28)), ["type"], ["valuetype"]);
             ("member .ctor", "DateTime", "file1", ((6, 13), (6, 28)), [], ["member"]);
             ("val x3", "x3", "file1", ((6, 4), (6, 6)), ["defn"], ["val"]);
             ("ExternalTypes", "ExternalTypes", "file1", ((2, 7), (2, 20)), ["defn"],

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -692,6 +692,9 @@ module TypeSymbols =
     let isClass (entity: FSharpEntity) =
         entity.IsClass
 
+    let isRecord (entity: FSharpEntity) =
+        entity.IsFSharpRecord
+
     [<Test>]
     let ``Interface 01`` () =
         let _, checkResults = getParseAndCheckResults """
@@ -772,4 +775,95 @@ let l: List<_> = List [|1|]
         |> getSymbols isClass
         |> shouldEqual [
             "List", ["int"]
+        ]
+
+    [<Test>]
+    let ``Record 01`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+type R = { Field: int }
+
+R
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isRecord
+        |> shouldEqual [
+            "R", []
+            "R", []
+        ]
+
+    [<Test>]
+    let ``Record 02`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+type R = { Field: int }
+
+R.
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isRecord
+        |> shouldEqual [
+            "R", []
+            "R", []
+        ]
+
+    [<Test>]
+    let ``Record 03`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+type R =
+    { Field: int }
+    static member P = 1
+
+R.P
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isRecord
+        |> shouldEqual [
+            "R", []
+            "R", []
+        ]
+
+    [<Test>]
+    let ``Record 04 - Generic`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+type R<'T> =
+    { Field: int }
+    static member P = 1
+
+R<int>
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isRecord
+        |> shouldEqual [
+            "R", []
+            "R", ["int"]
+        ]
+
+    [<Test>]
+    let ``Record 05 - Generic`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+type R<'T> =
+    { Field: int }
+    static member P = 1
+
+R<int>.P
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isRecord
+        |> shouldEqual [
+            "R", []
+            "R", ["int"]
         ]

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -7,7 +7,7 @@
 module Tests.Service.Symbols
 #endif
 
-open System
+open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
@@ -678,3 +678,98 @@ type BAttribute() =
 let a ([<B>] c: int) : int = 0
 """
             (7, 5, "let a ([<B>] c: int) : int = 0", "a")
+
+
+module TypeSymbols =
+    let getSymbols f (symbolUses: FSharpSymbolUse list) =
+        symbolUses
+        |> List.choose (fun symbolUse -> match symbolUse.Symbol with :? FSharpEntity as e when f e -> Some(e, symbolUse) | _ -> None)
+        |> List.map (fun (e, symbolUse) -> e.DisplayNameCore, symbolUse.GenericArguments |> List.map (fun (_, t) -> t.Format(symbolUse.DisplayContext)))
+
+    let isInterface (entity: FSharpEntity) =
+        entity.IsInterface
+
+    let isClass (entity: FSharpEntity) =
+        entity.IsClass
+
+    [<Test>]
+    let ``Interface 01`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+open System
+
+IDisposable
+"""
+        let symbolUses: FSharpSymbolUse list = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isInterface
+        |> shouldEqual [
+            "IDisposable", []
+        ]
+
+    [<Test>]
+    let ``Interface 02`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+System.IDisposable
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isInterface
+        |> shouldEqual [
+            "IDisposable", []
+        ]
+
+    [<Test>]
+    let ``Interface 03 - Application`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+open System.Collections.Generic
+
+IList<int>
+IList<foo>
+IList<_>
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isInterface
+        |> shouldEqual [
+            "IList", ["int"]
+            "IList", ["'a"]
+            "IList", ["'a"]
+        ]
+
+    [<Test>]
+    let ``Interface 04 - Application`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+open System.Collections.Generic
+
+let l: IList<_> = [|1|]
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isInterface
+        |> shouldEqual [
+            "IList", ["int"]
+        ]
+
+    [<Test>]
+    let ``Class 01 - Application`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+open System.Collections.Generic
+
+let l: List<_> = List [|1|]
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isClass
+        |> shouldEqual [
+            "List", ["int"]
+        ]

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -867,3 +867,22 @@ R<int>.P
             "R", []
             "R", ["int"]
         ]
+
+    [<Test>]
+    let ``Record 06 - Nameof`` () =
+        let _, checkResults = getParseAndCheckResults """
+module Module
+
+type R =
+    { Field: int }
+
+nameof R
+"""
+        let symbolUses = getSymbolUses checkResults
+        symbolUses
+        |> getSymbols isRecord
+        |> shouldEqual [
+            "R", []
+            "R", []
+            "R", []
+        ]


### PR DESCRIPTION
This is an experiment for reporting record symbols, as previously attempted in https://github.com/dotnet/fsharp/pull/14773. This currently builds on top of changes from https://github.com/dotnet/fsharp/pull/15628.