### PR TITLE
Fix nested copy-and-update

### DIFF
--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
@@ -37,12 +37,12 @@ let GroupUpdatesToNestedFields (fields: ((Ident list * Ident) * SynExpr option) 
                 let reducedRecd =
                     (lidwid, Some(SynExpr.Record(baseInfo, copyInfo, aFlds @ bFlds, m)))
 
-                groupIfNested (reducedRecd :: res) ys
+                groupIfNested res (reducedRecd :: ys)
             | (lidwid, Some (SynExpr.AnonRecd (isStruct, copyInfo, aFlds, m, trivia))), (_, Some (SynExpr.AnonRecd (recordFields = bFlds))) ->
                 let reducedRecd =
                     (lidwid, Some(SynExpr.AnonRecd(isStruct, copyInfo, aFlds @ bFlds, m, trivia)))
 
-                groupIfNested (reducedRecd :: res) ys
+                groupIfNested res (reducedRecd :: ys)
             | _ -> groupIfNested (x :: res) (y :: ys)
 
     fields

--- a/tests/FSharp.Compiler.ComponentTests/Language/CopyAndUpdateTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CopyAndUpdateTests.fs
@@ -168,18 +168,18 @@ module CopyAndUpdateTests
 [<Struct>]
 type AnotherNestedRecTy = { A: int }
 
-type NestdRecTy = { B: string; C: AnotherNestedRecTy }
+type NestdRecTy = { B: string; C: AnotherNestedRecTy; G: int }
 
 [<Struct>]
 type RecTy = { D: NestdRecTy; E: string option; F: int }
 
-let t1 = { D = { B = "t1"; C = { A = 1 } }; E = None; F = 42 }
+let t1 = { D = { B = "t1"; C = { A = 1 }; G = 0 }; E = None; F = 42 }
 
-let actual1 = { t1 with D.B = "t2" }
-let expected1 = { D = { B = "t2"; C = { A = 1 } }; E = None; F = 42 }
+let actual1 = { t1 with D.B = "t2"; D.G = 3 }
+let expected1 = { D = { B = "t2"; C = { A = 1 }; G = 3 }; E = None; F = 42 }
 
-let actual2 = { t1 with D.C.A = 3; E = Some "a" }
-let expected2 = { D = { B = "t1"; C = { A = 3 } }; E = Some "a"; F = 42 }
+let actual2 = { t1 with D.C.A = 3; E = Some "a"; D.G = 2 }
+let expected2 = { D = { B = "t1"; C = { A = 3 }; G = 2 }; E = Some "a"; F = 42 }
 
 if actual1 <> expected1 then
     failwith "actual1 does not equal expected1"
@@ -196,13 +196,13 @@ let ``Nested copy-and-update correctly updates fields in anonymous record``() =
     FSharp """
 module CopyAndUpdateTests
 
-let t1 = {| D = {| B = "t1"; C = struct {| A = 1 |} |}; E = Option<string>.None |}
+let t1 = {| D = {| B = "t1"; C = struct {| A = 1 |}; G = 0 |}; E = Option<string>.None |}
 
-let actual1 = {| t1 with D.B = "t2" |}
-let expected1 = {| D = {| B = "t2"; C = struct {| A = 1 |} |}; E = None |}
+let actual1 = {| t1 with D.B = "t2"; D.G = 3 |}
+let expected1 = {| D = {| B = "t2"; C = struct {| A = 1 |}; G = 3 |}; E = None |}
 
-let actual2 = {| t1 with D.C.A = 3; E = Some "a" |}
-let expected2 = {| D = {| B = "t1"; C = struct {| A = 3 |} |}; E = Some "a" |}
+let actual2 = {| t1 with D.C.A = 3; E = Some "a"; D.G = 2 |}
+let expected2 = {| D = {| B = "t1"; C = struct {| A = 3 |}; G = 2 |}; E = Some "a" |}
 
 if actual1 <> expected1 then
     failwith "actual1 does not equal expected1"

--- a/tests/FSharp.Compiler.ComponentTests/Language/CopyAndUpdateTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CopyAndUpdateTests.fs
@@ -168,18 +168,18 @@ module CopyAndUpdateTests
 [<Struct>]
 type AnotherNestedRecTy = { A: int }
 
-type NestdRecTy = { B: string; C: AnotherNestedRecTy; G: int }
+type NestdRecTy = { B: string; C: AnotherNestedRecTy; G: int; H: int }
 
 [<Struct>]
 type RecTy = { D: NestdRecTy; E: string option; F: int }
 
-let t1 = { D = { B = "t1"; C = { A = 1 }; G = 0 }; E = None; F = 42 }
+let t1 = { D = { B = "t1"; C = { A = 1 }; G = 0; H = 0 }; E = None; F = 42 }
 
-let actual1 = { t1 with D.B = "t2"; D.G = 3 }
-let expected1 = { D = { B = "t2"; C = { A = 1 }; G = 3 }; E = None; F = 42 }
+let actual1 = { t1 with D.B = "t2"; D.G = 3; D.H = 1 }
+let expected1 = { D = { B = "t2"; C = { A = 1 }; G = 3; H = 1 }; E = None; F = 42 }
 
-let actual2 = { t1 with D.C.A = 3; E = Some "a"; D.G = 2 }
-let expected2 = { D = { B = "t1"; C = { A = 3 }; G = 2 }; E = Some "a"; F = 42 }
+let actual2 = { t1 with D.C.A = 3; E = Some "a"; D.G = 2; D.H = 3 }
+let expected2 = { D = { B = "t1"; C = { A = 3 }; G = 2; H = 3 }; E = Some "a"; F = 42 }
 
 if actual1 <> expected1 then
     failwith "actual1 does not equal expected1"


### PR DESCRIPTION
Currently we're failing when there are more than 2 updates on the same level. The grouping code stopped processing reduced expressions too early.