### PR TITLE
Filter completions when dotting into a type or module in a pattern

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -1530,6 +1530,9 @@ type internal TypeCheckInfo
                             |> List.filter (fun item ->
                                 match item.Item with
                                 | Item.Value v -> v.LiteralValue.IsSome
+                                | Item.ILField field -> field.LiteralValue.IsSome
+                                | Item.MethodGroup _
+                                | Item.Property _ -> false
                                 | _ -> true)
 
                         filtered, denv, range)

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -1268,6 +1268,7 @@ module ParsedInput =
                 TryGetCompletionContextInPattern false pat (Some(PatternContext.PositionalUnionCaseField(None, id.Range))) pos
             | [ SynPat.Paren (SynPat.Tuple _ | SynPat.Named _ as pat, _) ] ->
                 TryGetCompletionContextInPattern false pat (Some(PatternContext.PositionalUnionCaseField(Some 0, id.Range))) pos
+            | [] when rangeContainsPos id.Range pos -> Some(CompletionContext.Pattern PatternContext.Other)
             | _ ->
                 pats
                 |> List.tryPick (fun pat -> TryGetCompletionContextInPattern false pat None pos)

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1718,3 +1718,36 @@ match U1 (1, A) with
         VerifyCompletionList(fileContents, "| U2 s", [ "fff"; "string" ], [ "tab"; "xxx"; "yyy" ])
         VerifyCompletionList(fileContents, "| U1 (x", [ "xxx"; "num" ], [ "tab"; "yyy"; "fff" ])
         VerifyCompletionList(fileContents, "| U1 (x, y", [ "yyy"; "tab" ], [ "xxx"; "num"; "fff" ])
+
+    [<Fact>]
+    let ``Completion list does not contain methods and non-literals when dotting into a type or module in a pattern`` () =
+        let fileContents =
+            """
+module G =
+    let a = 1
+
+    [<Literal>]
+    let b = 1
+
+    let c () = ()
+
+type A =
+    | B of a: int
+    | C of float
+
+    static member Aug () = ()
+
+for G. in [] do
+
+let y x =
+    match x with
+    | [ B G. ] -> ()
+    | A.
+
+for Some ((0, C System.Double. ))
+"""
+
+        VerifyCompletionListExactly(fileContents, "for G.", [ "b" ])
+        VerifyCompletionListExactly(fileContents, "| [ B G.", [ "b" ])
+        VerifyCompletionListExactly(fileContents, "| A.", [ "B"; "C" ])
+        VerifyCompletionList(fileContents, "for Some ((0, C System.Double.", [ "Epsilon"; "MaxValue" ], [ "Abs" ])


### PR DESCRIPTION
Removing contents on a type, module or namespace when it's not usable in a pattern - methods, properties, values that are not literals and fields that are not constants.

Before

![devenv_Ytw2ETIA72](https://github.com/dotnet/fsharp/assets/5063478/b0606447-7a98-4f5f-ad23-7dc47bd065a5)

After

![devenv_dPKVHMzYvj](https://github.com/dotnet/fsharp/assets/5063478/880a6379-27a7-45d6-9a4c-67b5f5a79adf)