### PR TITLE
disabling insert_final_newline in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ fsharp_max_array_or_list_number_of_items=5
 fsharp_max_dot_get_expression_width=80
 fsharp_multiline_block_brackets_on_same_column=true
 fsharp_keep_max_number_of_blank_lines=1
+insert_final_newline=false # reduces SIGH count
 
 [*.fsi]
 fsharp_newline_between_type_definition_and_members=true


### PR DESCRIPTION
Just a suggestion.

Also, wondering if we can tweak the output of the CI tasks that runs the fantomas check in this direction:
* prints the diff
* have github propose the diff to be applied in the PR, the same way it works in code review with suggested changes

I think this would be killer feature at intersection of fantomas and github.