### PR TITLE
voidptr passing the 'unmanaged' constraint

### DIFF
--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -1983,7 +1983,7 @@ let rec isUnmanagedTy g ty =
                     isEq g.int16_tcr || isEq g.uint16_tcr ||
                     isEq g.int32_tcr || isEq g.uint32_tcr ||
                     isEq g.int64_tcr || isEq g.uint64_tcr ||
-                    isEq g.char_tcr ||
+                    isEq g.char_tcr || isEq g.voidptr_tcr ||
                     isEq g.float32_tcr ||
                     isEq g.float_tcr ||
                     isEq g.decimal_tcr ||

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Constraints/Unmanaged.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Constraints/Unmanaged.fs
@@ -9,6 +9,32 @@ open FSharp.Test
 module Unmanaged =
 
     [<Fact>]
+    let ``voidptr is unmanaged`` () = 
+        Fsx """
+[<Struct>]
+type Test<'T when 'T: unmanaged> =
+    val element: 'T
+
+let test (x: 'T when 'T : unmanaged) = ()
+
+test (NativeInterop.NativePtr.nullPtr<voidptr>)
+test (NativeInterop.NativePtr.nullPtr<voidptr> |> NativeInterop.NativePtr.toVoidPtr)
+let _ = Test<voidptr voption>()
+        """
+        |> withNoWarn 9
+        |> typecheck
+        |> shouldSucceed
+    
+
+    [<Fact>]
+    let ``nativeptr of voidptr works`` () = 
+        Fsx """
+let myVal : nativeptr<voidptr> =  Unchecked.defaultof<_>
+        """
+        |> typecheck
+        |> shouldSucceed
+
+    [<Fact>]
     let ``Struct with private field can be unmanaged`` () = 
         Fsx """
 [<Struct>]


### PR DESCRIPTION
Implements suggestions https://github.com/fsharp/fslang-suggestions/issues/1160
Implements https://github.com/dotnet/fsharp/issues/15714

Makes `nativeptr<voidptr>` possible.

