### PR TITLE
List.contains - change in order to inline + typespecialize

### DIFF
--- a/src/FSharp.Core/list.fs
+++ b/src/FSharp.Core/list.fs
@@ -453,10 +453,13 @@ module List =
 
     [<CompiledName("Contains")>]
     let inline contains value source =
+        let equalityCheck listElement =
+            value = listElement
+
         let rec contains e xs1 =
             match xs1 with
             | [] -> false
-            | h1 :: t1 -> e = h1 || contains e t1
+            | h1 :: t1 -> equalityCheck h1 || contains e t1
 
         contains value source
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Inlining.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Inlining.fs
@@ -33,3 +33,56 @@ module Inlining =
     let ``StructUnion01_fs`` compilation =
         compilation
         |> verifyCompilation
+
+
+    [<Fact>]
+    let ``List contains inlining`` () =
+        Fsx """module Test
+let data = [nanf |> float;5.0;infinity]
+let found = data |> List.contains nan
+        """
+        |> asExe
+        |> compile
+        (* This is the essential aspect of the IL we are interested in - doing a direct specialized 'ceq' on primitive values, and not going via a GenericEqualityIntrinsic call*)
+        |> verifyIL ["""
+      .method assembly static bool  contains@1<a>(!!a e,
+                                              class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64> xs1) cil managed
+  {
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64> V_1,
+             float64 V_2)
+    IL_0000:  ldarg.1
+    IL_0001:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::get_TailOrNull()
+    IL_0006:  brfalse.s  IL_000a
+
+    IL_0008:  br.s       IL_000c
+
+    IL_000a:  ldc.i4.0
+    IL_000b:  ret
+
+    IL_000c:  ldarg.1
+    IL_000d:  stloc.0
+    IL_000e:  ldloc.0
+    IL_000f:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::get_TailOrNull()
+    IL_0014:  stloc.1
+    IL_0015:  ldloc.0
+    IL_0016:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<float64>::get_HeadOrDefault()
+    IL_001b:  stloc.2
+    IL_001c:  call       float64 [FSharp.Core]Microsoft.FSharp.Core.Operators::get_NaN()
+    IL_0021:  ldloc.2
+    IL_0022:  ceq
+    IL_0024:  brfalse.s  IL_0028
+
+    IL_0026:  ldc.i4.1
+    IL_0027:  ret
+
+    IL_0028:  ldarg.0
+    IL_0029:  ldloc.1
+    IL_002a:  starg.s    xs1
+    IL_002c:  starg.s    e
+    IL_002e:  br.s       IL_0000
+  } """]
+

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ListModule.fs
@@ -1020,6 +1020,18 @@ type ListModule() =
         let resultStr = List.contains "....." strList
         Assert.False(resultStr)
 
+        // float List
+        let flList = [nan;infinity;5.0;-0.]     
+        Assert.False(List.contains nan flList)
+        Assert.False(List.contains 4.99 flList)
+        Assert.True(List.contains infinity flList)
+        Assert.True(List.contains 0. flList)
+
+        let flTupleList = [(nan,"text");(5.0,"wait")]
+        Assert.False(List.contains (nan,"text") flTupleList)
+        Assert.False(List.contains (5.0,"text") flTupleList)
+        Assert.True(List.contains (5.0,"wait") flTupleList)
+
         // empty List
         let emptyList:int list = [ ]
         let resultEpt = List.contains 4 emptyList


### PR DESCRIPTION
Credit to [@jindraiva](https://github.com/jindraivanek) , implements and tests https://github.com/dotnet/fsharp/issues/15720 .

Benchmarks showing original issue with current `List.contains` impl: https://github.com/jindraivanek/Benchmarks-list-contains/blob/master/Benchmarks/BenchmarkDotNet.Artifacts/results/ListBenchmarks.ListTests-report-github.md

Basic example of how the lifting of equality check `(=)` from the inner **rec** function to the outer one makes inlining possible.

https://sharplab.io/#v2:DYLgZgzgPsCmAuACAlgO2G2iD2BXesATgMLarwCGaEiAbhcLlhHoQMZYC8AsAFCIDEcJIkKw2KVKiKlyVVDSwAPCAEZEPfoO0BbCvDYALRCvUB3ZPEN9t2qIgDaAXUQBaAHyIwDCLBu2Be0N1EBBEeHUPRC5EYMQoezRpEjJKamjw1T5/ASSZVPkaekZmVg4cxD5hSQxpHHx8uWoAdUN9AEkwOgYmRBZcdi4K6rRarGQIAFl9I2i4HQ052AXObpLhhAExCTyUpoVWjq7lNQ0K3RnjU0QLK3PBe2c3T29gX3vA2JCwiOeUKcuX3iiSkjTSBza8E6GQi2S0uVBe3BEEOUK6xV6/UGFRxvGqYgguGASFWeAISMKiFQFFQjmpqAA3ABWAB0AAYGfSXFVNgSifBUdDSQ0KS1IdD6XSacz2ZyaS4gA