### PR TITLE
More accurate range for pattern matching error reporting

### DIFF
--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -1668,7 +1668,6 @@ let CompilePatternBasic
     if warnOnUnused then
         let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
 
-        // Account for bounds(as) and guards(when) used in clauses
         clauses |> List.iteri (fun i c ->
             let m =
                 match c.BoundVals, c.GuardExpr with
@@ -1677,7 +1676,8 @@ let CompilePatternBasic
                 | [ _ ], Some guard -> Some guard.Range
                 | rest, None ->
                     match rest with
-                    | head :: _ -> Some head.Id.idRange
+                    | [ head ] -> Some head.Id.idRange
+                    | _ :: _ -> Some c.Pattern.Range
                     | _ -> Some c.Pattern.Range
                 | _ -> None
                 

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -965,6 +965,30 @@ let rec erasePartialPatterns inpPat =
 
 and erasePartials inps =
     List.map erasePartialPatterns inps
+    
+let ReportUnusedTargets (clauses: MatchClause list) dtree =
+    let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
+    clauses |> List.iteri (fun i c ->
+        let m =
+            match c.BoundVals, c.GuardExpr with
+            | [], Some guard -> Some guard.Range
+            | [ bound ], None -> Some bound.Id.idRange
+            | [ _ ], Some guard -> Some guard.Range
+            | rest, None ->
+                match rest with
+                | [ head ] -> Some head.Id.idRange
+                | _ :: _ -> Some c.Pattern.Range
+                | _ -> Some c.Pattern.Range
+            | _, Some guard -> Some guard.Range
+            
+        let m =
+            match m with
+            | None -> c.Range
+            | Some m -> m
+            
+        let m  = withStartEnd c.Range.Start m.End m
+            
+        if not (used.Contains i) then warning (RuleNeverMatched m))
 
 let rec isPatternDisjunctive inpPat =
     match inpPat with
@@ -1656,41 +1680,13 @@ let CompilePatternBasic
           @
           mkFrontiers [([], ValMap<_>.Empty)] nClauses)
 
-    let dtree =
-      InvestigateFrontiers
-        []
-        frontiers
-
-    let targets = matchBuilder.CloseTargets()
-
+    let dtree = InvestigateFrontiers [] frontiers
 
     // Report unused targets
     if warnOnUnused then
-        let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
+        ReportUnusedTargets clauses dtree
 
-        clauses |> List.iteri (fun i c ->
-            let m =
-                match c.BoundVals, c.GuardExpr with
-                | [], Some guard -> Some guard.Range
-                | [ bound ], None -> Some bound.Id.idRange
-                | [ _ ], Some guard -> Some guard.Range
-                | rest, None ->
-                    match rest with
-                    | [ head ] -> Some head.Id.idRange
-                    | _ :: _ -> Some c.Pattern.Range
-                    | _ -> Some c.Pattern.Range
-                | _, Some guard -> Some guard.Range
-                
-            let m =
-                match m with
-                | None -> c.Range
-                | Some m -> m
-                
-            let m  = withStartEnd c.Range.Start m.End m
-                
-            if not (used.Contains i) then warning (RuleNeverMatched m))
-
-    dtree, targets
+    dtree, matchBuilder.CloseTargets()
 
 // Three pattern constructs can cause significant code expansion in various combinations
 //   - Partial active patterns

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -1669,7 +1669,7 @@ let CompilePatternBasic
         let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
 
         clauses |> List.iteri (fun i c ->
-            if not (used.Contains i) then warning (RuleNeverMatched c.Range))
+            if not (used.Contains i) then warning (RuleNeverMatched c.Pattern.Range))
 
     dtree, targets
 

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -1669,7 +1669,20 @@ let CompilePatternBasic
         let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
 
         clauses |> List.iteri (fun i c ->
-            if not (used.Contains i) then warning (RuleNeverMatched c.Pattern.Range))
+            let mBound =
+                match c.BoundVals, c.GuardExpr with
+                | [], Some guard -> guard.Range
+                | [ bounds ], None -> bounds.Id.idRange
+                | [ _ ], Some guard -> guard.Range
+                | rest, _ ->
+                    rest
+                    |> List.tryHead
+                    |> Option.map (fun b -> b.Id.idRange)
+                    |> Option.defaultValue c.Pattern.Range
+                
+            let m  = withStartEnd c.Range.Start mBound.End c.Pattern.Range
+                
+            if not (used.Contains i) then warning (RuleNeverMatched m))
 
     dtree, targets
 

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -1679,7 +1679,7 @@ let CompilePatternBasic
                     | [ head ] -> Some head.Id.idRange
                     | _ :: _ -> Some c.Pattern.Range
                     | _ -> Some c.Pattern.Range
-                | _ -> None
+                | _, Some guard -> Some guard.Range
                 
             let m =
                 match m with

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -971,20 +971,14 @@ let ReportUnusedTargets (clauses: MatchClause list) dtree =
     clauses |> List.iteri (fun i c ->
         let m =
             match c.BoundVals, c.GuardExpr with
-            | [], Some guard -> Some guard.Range
-            | [ bound ], None -> Some bound.Id.idRange
-            | [ _ ], Some guard -> Some guard.Range
+            | [], Some guard -> guard.Range
+            | [ bound ], None -> bound.Id.idRange
+            | [ _ ], Some guard -> guard.Range
             | rest, None ->
                 match rest with
-                | [ head ] -> Some head.Id.idRange
-                | _ :: _ -> Some c.Pattern.Range
-                | _ -> Some c.Pattern.Range
-            | _, Some guard -> Some guard.Range
-            
-        let m =
-            match m with
-            | None -> c.Range
-            | Some m -> m
+                | [ head ] -> head.Id.idRange
+                | _ -> c.Pattern.Range
+            | _, Some guard -> guard.Range
             
         let m  = withStartEnd c.Range.Start m.End m
             

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/DynamicTypeTest.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/DynamicTypeTest.fs
@@ -34,8 +34,8 @@ module DynamicTypeTest =
         |> typecheck
         |> shouldFail
         |> withDiagnostics [
-            (Warning 26, Line 31, Col 7, Line 31, Col 22, "This rule will never be matched")
-            (Warning 26, Line 32, Col 7, Line 32, Col 22, "This rule will never be matched")
+            (Warning 26, Line 31, Col 7, Line 31, Col 17, "This rule will never be matched")
+            (Warning 26, Line 32, Col 7, Line 32, Col 16, "This rule will never be matched")
         ]
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/DynamicTypeTest)
@@ -135,8 +135,8 @@ involves an indeterminate type based on information prior to this program point.
         |> typecheck
         |> shouldFail
         |> withDiagnostics [
-            (Warning 26, Line 12, Col 7, Line 12, Col 22, "This rule will never be matched")
-            (Warning 26, Line 18, Col 7, Line 18, Col 22, "This rule will never be matched")
+            (Warning 26, Line 12, Col 7, Line 12, Col 16, "This rule will never be matched")
+            (Warning 26, Line 18, Col 7, Line 18, Col 16, "This rule will never be matched")
         ]
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/DynamicTypeTest)
@@ -147,4 +147,38 @@ involves an indeterminate type based on information prior to this program point.
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Warning 67, Line 13, Col 7, Line 13, Col 13, "This type test or downcast will always hold")
+        |> withSingleDiagnostic (Warning 67, Line 13, Col 7, Line 13, Col 13, "This type test or downcast will always hold")// This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/DynamicTypeTest)
+    
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_DynamicTest01.fs"|])>]
+    let ``DynamicTypeTest - E_DynamicTest01_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 3, Col 3, Line 3, Col 54, "This rule will never be matched")
+        ]
+    
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_DynamicTest02.fs"|])>]
+    let ``DynamicTypeTest - E_DynamicTest02_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 4, Col 7, Line 4, Col 11, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_DynamicTest03.fs"|])>]
+    let ``DynamicTypeTest - E_DynamicTest03_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 8, Col 7, Line 8, Col 12, "This rule will never be matched")
+        ]
+        

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/E_DynamicTest01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/E_DynamicTest01.fs
@@ -1,0 +1,4 @@
+match Unchecked.defaultof<System.ValueType> with
+| :? System.Enum as (a & b) -> let c = a = b in ()
+| :? System.Enum as (:? System.ConsoleKey as (d & e)) -> let f = d + e + enum 1 in ()
+| g -> ()

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/E_DynamicTest02.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/E_DynamicTest02.fs
@@ -1,0 +1,5 @@
+let stuff(x: obj) =
+    match x with
+    | :? option<int> -> 0x200
+    | null -> 0x100
+    | _ -> 0x500

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/E_DynamicTest03.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/DynamicTypeTest/E_DynamicTest03.fs
@@ -1,0 +1,9 @@
+type A() = class end
+type B1() =
+    inherit A()
+    
+let stuff(x: obj) =
+    match x with
+    | :? A -> 1
+    | :? B1 -> 2
+    | _ -> 3

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Named/Named.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Named/Named.fs
@@ -360,8 +360,8 @@ but here has type
             (Error 72, Line 21, Col 20, Line 21, Col 31, "Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved.")
             (Warning 49, Line 22, Col 7, Line 22, Col 17, "Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.")
             (Error 39, Line 23, Col 7, Line 23, Col 18, "The pattern discriminator 'Punctuation' is not defined.")
-            (Warning 26, Line 23, Col 7, Line 23, Col 26, "This rule will never be matched")
-            (Warning 26, Line 24, Col 7, Line 24, Col 40, "This rule will never be matched")
+            (Warning 26, Line 23, Col 7, Line 23, Col 20, "This rule will never be matched")
+            (Warning 26, Line 24, Col 7, Line 24, Col 8, "This rule will never be matched")
         ]
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/Named)

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple/Simple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Simple/Simple.fs
@@ -31,8 +31,8 @@ module Simple =
         |> withDiagnostics [
             (Warning 25, Line 14, Col 15, Line 14, Col 16, "Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).")
             (Warning 25, Line 21, Col 31, Line 21, Col 39, "Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).")
-            (Warning 26, Line 31, Col 11, Line 31, Col 18, "This rule will never be matched")
-            (Warning 26, Line 32, Col 11, Line 32, Col 19, "This rule will never be matched")
+            (Warning 26, Line 31, Col 11, Line 31, Col 12, "This rule will never be matched")
+            (Warning 26, Line 32, Col 11, Line 32, Col 13, "This rule will never be matched")
         ]
 
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/Simple)
@@ -216,7 +216,7 @@ module Simple =
         |> withOptions ["--test:ErrorRanges"]
         |> compile
         |> shouldFail
-        |> withSingleDiagnostic (Warning 26, Line 10, Col 7, Line 10, Col 13, "This rule will never be matched")
+        |> withSingleDiagnostic (Warning 26, Line 10, Col 7, Line 10, Col 8, "This rule will never be matched")
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/Simple)
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"simplePatterns12.fs"|])>]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/SimpleConstant/SimpleConstant.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/SimpleConstant/SimpleConstant.fs
@@ -108,11 +108,11 @@ module SimpleConstant =
         |> shouldFail
         |> withDiagnostics [
             (Warning 3190, Line 13, Col 7, Line 13, Col 17, "Lowercase literal 'intLiteral' is being shadowed by a new pattern with the same name. Only uppercase and module-prefixed literals can be used as named patterns.")
-            (Warning 26, Line 14, Col 7, Line 14, Col 26, "This rule will never be matched")
+            (Warning 26, Line 14, Col 7, Line 14, Col 8, "This rule will never be matched")
             (Warning 3190, Line 20, Col 7, Line 20, Col 17, "Lowercase literal 'strLiteral' is being shadowed by a new pattern with the same name. Only uppercase and module-prefixed literals can be used as named patterns.")
-            (Warning 26, Line 21, Col 7, Line 21, Col 26, "This rule will never be matched")
+            (Warning 26, Line 21, Col 7, Line 21, Col 8, "This rule will never be matched")
             (Warning 3190, Line 27, Col 7, Line 27, Col 18, "Lowercase literal 'boolLiteral' is being shadowed by a new pattern with the same name. Only uppercase and module-prefixed literals can be used as named patterns.")
-            (Warning 26, Line 28, Col 7, Line 28, Col 27, "This rule will never be matched")
+            (Warning 26, Line 28, Col 7, Line 28, Col 11, "This rule will never be matched")
         ]
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/SimpleConstant)
@@ -125,8 +125,8 @@ module SimpleConstant =
         |> shouldFail
         |> withDiagnostics [
             (Warning 25, Line 8, Col 11, Line 8, Col 16, "Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).")
-            (Warning 26, Line 14, Col 7, Line 14, Col 57, "This rule will never be matched")
-            (Warning 26, Line 20, Col 7, Line 20, Col 57, "This rule will never be matched")
+            (Warning 26, Line 14, Col 7, Line 14, Col 24, "This rule will never be matched")
+            (Warning 26, Line 20, Col 7, Line 20, Col 24, "This rule will never be matched")
         ]
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/SimpleConstant)
@@ -146,7 +146,7 @@ module SimpleConstant =
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Warning 26, Line 10, Col 7, Line 10, Col 28, "This rule will never be matched")
+        |> withSingleDiagnostic (Warning 26, Line 10, Col 7, Line 10, Col 8, "This rule will never be matched")
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/SimpleConstant)
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"type_byte.fs"|])>]
@@ -246,7 +246,7 @@ module SimpleConstant =
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Warning 26, Line 10, Col 7, Line 10, Col 26, "This rule will never be matched")
+        |> withSingleDiagnostic (Warning 26, Line 10, Col 7, Line 10, Col 17, "This rule will never be matched")
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/SimpleConstant)
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"type_uint16.fs"|])>]
@@ -292,4 +292,4 @@ module SimpleConstant =
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Warning 26, Line 9, Col 7, Line 9, Col 17, "This rule will never be matched")
+        |> withSingleDiagnostic (Warning 26, Line 9, Col 7, Line 9, Col 8, "This rule will never be matched")

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Tuple/Tuple.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Tuple/Tuple.fs
@@ -43,7 +43,7 @@ module Tuple =
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Warning 26, Line 11, Col 7, Line 12, Col 16, "This rule will never be matched")
+        |> withSingleDiagnostic (Warning 26, Line 11, Col 7, Line 11, Col 14, "This rule will never be matched")
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/Tuple)
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"W_RedundantPattern02.fs"|])>]
@@ -53,5 +53,5 @@ module Tuple =
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Warning 26, Line 12, Col 28, Line 12, Col 50, "This rule will never be matched")
+        |> withSingleDiagnostic (Warning 26, Line 12, Col 28, Line 12, Col 29, "This rule will never be matched")
         

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern01.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A of string * int
+    | B of string * int
+    | C
+let x v = 
+  match v with
+  | A(a, b) -> ()
+  | B(a, b) -> ()
+  | A(a, b) | B(a, b) -> ()

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern02.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern02.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A of string * int
+    | B of string * int
+    | C
+let x v = 
+  match v with
+  | A(a, b) -> ()
+  | B(a, b) -> ()
+  | A(a, b) | B(a, b) as f -> ()

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern03.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern03.fs
@@ -1,0 +1,10 @@
+type Stuff =
+    | A
+    | B
+    | C
+    
+let x v = 
+    match v with
+    | A -> ""
+    | A -> false
+    | C -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern04.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern04.fs
@@ -1,0 +1,5 @@
+let v = 
+    match None with
+    | Some x -> ""
+    | Some _ -> ""
+    | None -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern05.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern05.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A
+    | B
+    | C
+let x v = 
+    match v with
+    | A -> ""
+    | A as foo as foo1 -> ""
+    | _ -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern06.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern06.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A
+    | B
+    | C
+let x v = 
+    match v with
+    | A -> ""
+    | A as foo -> ""
+    | C -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern07.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern07.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A
+    | B
+    | C
+let x v z = 
+    match v with
+    | A -> ""
+    | A as foo when z > 5 -> ""
+    | C -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern08.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern08.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A
+    | B
+    | C
+let x v = 
+    match v with
+    | A -> ""
+    | A -> ""
+    | C -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern09.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern09.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A
+    | B
+    | C
+let x v = 
+    match v with
+    | A -> ""
+    | A as foo as foo1 as foo3 as foo4 -> ""
+    | _ -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern10.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern10.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A
+    | B
+    | C
+let x v = 
+    match v with
+    | A -> ""
+    | A as foo as foo1 as foo3 as foo4 when foo = A -> ""
+    | _ -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern11.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/E_UnionPattern11.fs
@@ -1,0 +1,9 @@
+type Stuff =
+    | A of a: string * b: int
+    | B
+    | C
+let x v = 
+    match v with
+    | A(s, i) -> ""
+    | A(b=i) as foo as foo1 as foo3 as foo4 when i = 0 -> ""
+    | _ -> ""

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/Union.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/Union.fs
@@ -177,3 +177,36 @@ but here has type
             (Warning 25, Line 6, Col 11, Line 6, Col 12, "Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).")
             (Warning 26, Line 8, Col 7, Line 8, Col 8, "This rule will never be matched")
         ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern09.fs"|])>]
+    let ``Union - E_UnionPattern9_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 8, Col 7, Line 8, Col 39, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern10.fs"|])>]
+    let ``Union - E_UnionPattern10_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 8, Col 7, Line 8, Col 52, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern11.fs"|])>]
+    let ``Union - E_UnionPattern11_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 8, Col 7, Line 8, Col 55, "This rule will never be matched")
+        ]    

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/Union.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Union/Union.fs
@@ -70,8 +70,8 @@ but here has type
         |> typecheck
         |> shouldFail
         |> withDiagnostics [
-            (Warning 26, Line 12, Col 7, Line 12, Col 17, "This rule will never be matched")
-            (Warning 26, Line 21, Col 7, Line 21, Col 17, "This rule will never be matched")
+            (Warning 26, Line 12, Col 7, Line 12, Col 12, "This rule will never be matched")
+            (Warning 26, Line 21, Col 7, Line 21, Col 12, "This rule will never be matched")
         ]
         
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/Union)
@@ -82,3 +82,98 @@ but here has type
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldSucceed
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern01.fs"|])>]
+    let ``Union - E_UnionPattern1_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 25, Line 6, Col 9, Line 6, Col 10, "Incomplete pattern matches on this expression. For example, the value 'C' may indicate a case not covered by the pattern(s).")
+            (Warning 26, Line 9, Col 5, Line 9, Col 22, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern02.fs"|])>]
+    let ``Union - E_UnionPattern2_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 25, Line 6, Col 9, Line 6, Col 10, "Incomplete pattern matches on this expression. For example, the value 'C' may indicate a case not covered by the pattern(s).")
+            (Warning 26, Line 9, Col 5, Line 9, Col 27, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern03.fs"|])>]
+    let ``Union - E_UnionPattern3_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 1, Line 9, Col 12, Line 9, Col 17, "All branches of a pattern match expression must return values implicitly convertible to the type of the first branch, which here is 'string'. This branch returns a value of type 'bool'.")
+            (Warning 25, Line 7, Col 11, Line 7, Col 12, "Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).")
+            (Warning 26, Line 9, Col 7, Line 9, Col 8, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern04.fs"|])>]
+    let ``Union - E_UnionPattern4_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 4, Col 7, Line 4, Col 13, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern05.fs"|])>]
+    let ``Union - E_UnionPattern5_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 26, Line 8, Col 7, Line 8, Col 23, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern06.fs"|])>]
+    let ``Union - E_UnionPattern6_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 25, Line 6, Col 11, Line 6, Col 12, "Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).")
+            (Warning 26, Line 8, Col 7, Line 8, Col 15, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern07.fs"|])>]
+    let ``Union - E_UnionPattern7_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 25, Line 6, Col 11, Line 6, Col 12, "Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).")
+            (Warning 26, Line 8, Col 7, Line 8, Col 26, "This rule will never be matched")
+        ]
+        
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes = [|"E_UnionPattern08.fs"|])>]
+    let ``Union - E_UnionPattern8_fs - --test:ErrorRanges`` compilation =
+        compilation
+        |> asFs
+        |> withOptions ["--test:ErrorRanges"]
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 25, Line 6, Col 11, Line 6, Col 12, "Incomplete pattern matches on this expression. For example, the value 'B' may indicate a case not covered by the pattern(s).")
+            (Warning 26, Line 8, Col 7, Line 8, Col 8, "This rule will never be matched")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionTypes.fs
@@ -259,7 +259,7 @@ module UnionTypes =
         |> withDiagnostics [
             (Error 3174, Line 10, Col 18, Line 10, Col 20, "The union case 'Case1' does not have a field named 'V3'.")
             (Error 3174, Line 14, Col 9, Line 14, Col 11, "The union case 'Case1' does not have a field named 'V3'.")
-            (Warning 26, Line 15, Col 3, Line 15, Col 10, "This rule will never be matched")
+            (Warning 26, Line 15, Col 3, Line 15, Col 4, "This rule will never be matched")
             (Error 3174, Line 17, Col 12, Line 17, Col 14, "The union case 'Case1' does not have a field named 'V4'.")
             (Error 3174, Line 19, Col 25, Line 19, Col 26, "The union case 'Some' does not have a field named 'a'.")
         ]

--- a/tests/fsharp/typecheck/sigs/neg03.bsl
+++ b/tests/fsharp/typecheck/sigs/neg03.bsl
@@ -13,7 +13,7 @@ neg03.fs(14,5,14,8): typecheck error FS0025: Incomplete pattern matches on this 
 
 neg03.fs(16,8,16,11): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '[_;_]' may indicate a case not covered by the pattern(s).
 
-neg03.fs(22,39,22,47): typecheck error FS0026: This rule will never be matched
+neg03.fs(22,39,22,42): typecheck error FS0026: This rule will never be matched
 
 neg03.fs(25,9,25,13): typecheck error FS0001: The type 'bool' does not support the operator '<<<'
 
@@ -92,9 +92,9 @@ neg03.fs(86,9,86,13): typecheck error FS0025: Incomplete pattern matches on this
 
 neg03.fs(87,19,87,26): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).
 
-neg03.fs(91,11,91,26): typecheck error FS0026: This rule will never be matched
+neg03.fs(91,11,91,20): typecheck error FS0026: This rule will never be matched
 
-neg03.fs(97,11,97,26): typecheck error FS0026: This rule will never be matched
+neg03.fs(97,11,97,20): typecheck error FS0026: This rule will never be matched
 
 neg03.fs(100,9,100,12): typecheck error FS0025: Incomplete pattern matches on this expression. For example, the value '[_]' may indicate a case not covered by the pattern(s).
 

--- a/tests/fsharp/typecheck/sigs/neg07.bsl
+++ b/tests/fsharp/typecheck/sigs/neg07.bsl
@@ -10,7 +10,7 @@ neg07.fs(27,11,27,21): typecheck error FS0049: Uppercase variable identifiers sh
 
 neg07.fs(28,11,28,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
-neg07.fs(28,11,28,26): typecheck error FS0026: This rule will never be matched
+neg07.fs(28,11,28,21): typecheck error FS0026: This rule will never be matched
 
 neg07.fs(31,18,31,28): typecheck error FS0039: The value or constructor 'UnionCase1' is not defined. Maybe you want one of the following:
    X.UnionCase1
@@ -19,7 +19,7 @@ neg07.fs(35,11,35,21): typecheck error FS0049: Uppercase variable identifiers sh
 
 neg07.fs(36,11,36,21): typecheck error FS0049: Uppercase variable identifiers should not generally be used in patterns, and may indicate a missing open declaration or a misspelt pattern name.
 
-neg07.fs(36,11,36,27): typecheck error FS0026: This rule will never be matched
+neg07.fs(36,11,36,21): typecheck error FS0026: This rule will never be matched
 
 neg07.fs(46,15,46,27): typecheck error FS0039: The record label 'RecordLabel1' is not defined. Maybe you want one of the following:
    R.RecordLabel1

--- a/tests/fsharp/typecheck/sigs/neg133.bsl
+++ b/tests/fsharp/typecheck/sigs/neg133.bsl
@@ -19,6 +19,4 @@ neg133.fs(63,7,63,14): typecheck error FS0026: This rule will never be matched
 
 neg133.fs(69,7,69,16): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(76,10,76,19): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'
-
 neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'

--- a/tests/fsharp/typecheck/sigs/neg133.bsl
+++ b/tests/fsharp/typecheck/sigs/neg133.bsl
@@ -3,22 +3,22 @@ neg133.fs(4,19,4,22): typecheck error FS3521: Invalid member declaration. The na
 
 neg133.fs(7,19,7,27): typecheck error FS3521: Invalid member declaration. The name of the member is missing or has parentheses.
 
-neg133.fs(28,7,28,17): typecheck error FS0026: This rule will never be matched
+neg133.fs(28,7,28,12): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(34,7,34,17): typecheck error FS0026: This rule will never be matched
+neg133.fs(34,7,34,12): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(40,7,40,17): typecheck error FS0026: This rule will never be matched
+neg133.fs(40,7,40,12): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(46,7,46,20): typecheck error FS0026: This rule will never be matched
+neg133.fs(46,7,46,11): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(52,7,52,37): typecheck error FS0026: This rule will never be matched
+neg133.fs(52,7,52,32): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(57,7,57,19): typecheck error FS0026: This rule will never be matched
+neg133.fs(57,7,57,14): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(63,7,63,19): typecheck error FS0026: This rule will never be matched
+neg133.fs(63,7,63,14): typecheck error FS0026: This rule will never be matched
 
 neg133.fs(69,7,69,21): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'
+neg133.fs(76,10,76,19): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'
 
 neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'

--- a/tests/fsharp/typecheck/sigs/neg133.bsl
+++ b/tests/fsharp/typecheck/sigs/neg133.bsl
@@ -17,7 +17,7 @@ neg133.fs(57,7,57,14): typecheck error FS0026: This rule will never be matched
 
 neg133.fs(63,7,63,14): typecheck error FS0026: This rule will never be matched
 
-neg133.fs(69,7,69,21): typecheck error FS0026: This rule will never be matched
+neg133.fs(69,7,69,16): typecheck error FS0026: This rule will never be matched
 
 neg133.fs(76,10,76,19): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'
 

--- a/tests/fsharp/typecheck/sigs/neg133.bsl
+++ b/tests/fsharp/typecheck/sigs/neg133.bsl
@@ -20,3 +20,5 @@ neg133.fs(63,7,63,14): typecheck error FS0026: This rule will never be matched
 neg133.fs(69,7,69,16): typecheck error FS0026: This rule will never be matched
 
 neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'
+
+neg133.fs(76,10,76,11): typecheck error FS0957: One or more of the declared type parameters for this type extension have a missing or wrong type constraint not matching the original type constraints on 'A<_,_,_>'

--- a/tests/fsharpqa/Source/Diagnostics/General/W_LowercaseLiteralNotIgnored.fs
+++ b/tests/fsharpqa/Source/Diagnostics/General/W_LowercaseLiteralNotIgnored.fs
@@ -1,5 +1,5 @@
 // #Regression #Diagnostics 
-//<Expects status="warning" span="(13,7-13,24)" id="FS0026">This rule will never be matched$</Expects>
+//<Expects status="warning" span="(13,7-13,8)" id="FS0026">This rule will never be matched$</Expects>
 module M0
 
 module m1 =

--- a/tests/service/PatternMatchCompilationTests.fs
+++ b/tests/service/PatternMatchCompilationTests.fs
@@ -377,7 +377,7 @@ match Unchecked.defaultof<System.ValueType> with
 """
     assertHasSymbolUsages ["a"; "b"; "c"; "d"; "e"; "f"; "g"] checkResults
     dumpDiagnostics checkResults |> shouldEqual [
-        "(4,2--4,85): This rule will never be matched"
+        "(4,2--4,53): This rule will never be matched"
     ]
 
 [<Test>]


### PR DESCRIPTION
Currently want to investigate using the `Pattern` range

- Single error:
    -  Range should only include only `A` range

<img width="437" alt="image" src="https://github.com/dotnet/fsharp/assets/31915729/be2c5ad2-a42f-42c5-b7ad-d4844fad79a4">


- Multiple errors
    - First error should include `A` range
    - Second error should only include `false` range

<img width="574" alt="image" src="https://github.com/dotnet/fsharp/assets/31915729/99112bd7-f230-41fc-8185-b2edfd760d42">
