### PR TITLE
Improve completions for union field patterns

### DIFF
--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -1277,7 +1277,7 @@ module ParsedInput =
 
             // fun (Case (| )) ->
             | [ SynPat.Paren (SynPat.Const (SynConst.Unit, _), m) ] when rangeContainsPos m pos ->
-                Some (CompletionContext.Pattern (PatternContext.PositionalUnionCaseField (Some 0, id.Range)))
+                Some(CompletionContext.Pattern(PatternContext.PositionalUnionCaseField(Some 0, id.Range)))
 
             // fun (Case (a| , b)) ->
             | [ SynPat.Paren (SynPat.Tuple _ | SynPat.Named _ as pat, _) ] ->
@@ -1308,8 +1308,10 @@ module ParsedInput =
                 // Last resort - check for fun (Case (a, | )) ->
                 // That is, pos is after the last comma and before the end of the tuple
                 match previousContext, List.tryLast commas with
-                | Some (PatternContext.PositionalUnionCaseField (_, caseIdRange)), Some mComma when rangeBeforePos mComma pos && rangeContainsPos m pos ->
-                    Some (CompletionContext.Pattern (PatternContext.PositionalUnionCaseField(Some (pats.Length - 1), caseIdRange)))
+                | Some (PatternContext.PositionalUnionCaseField (_, caseIdRange)), Some mComma when
+                    rangeBeforePos mComma pos && rangeContainsPos m pos
+                    ->
+                    Some(CompletionContext.Pattern(PatternContext.PositionalUnionCaseField(Some(pats.Length - 1), caseIdRange)))
                 | _ -> None)
         | SynPat.Named (range = m) when rangeContainsPos m pos ->
             if suppressIdentifierCompletions then
@@ -1328,17 +1330,7 @@ module ParsedInput =
             TryGetCompletionContextInPattern suppressIdentifierCompletions pat1 None pos
             |> Option.orElseWith (fun () -> TryGetCompletionContextInPattern suppressIdentifierCompletions pat2 None pos)
         | SynPat.IsInst (_, m) when rangeContainsPos m pos -> Some CompletionContext.Type
-        | SynPat.Wild m ->
-            if rangeContainsPos m pos && m.StartColumn <> m.EndColumn then
-                // fun (Case (_| )) ->
-                Some CompletionContext.Invalid
-            //elif  then
-            //    // fun (Case (a, | )) ->
-            //    // A synthetic SynPat.Wild with a 0-length range is inserted after a comma like this.
-            //    // We return with the context from higher up, which should in this example be PositionalUnionCaseField (Some 1, ...).
-            //    previousContext |> Option.map CompletionContext.Pattern
-            else
-                None
+        | SynPat.Wild m when rangeContainsPos m pos && m.StartColumn <> m.EndColumn -> Some CompletionContext.Invalid
         | SynPat.Typed (pat = pat; targetType = synType) ->
             if rangeContainsPos pat.Range pos then
                 TryGetCompletionContextInPattern suppressIdentifierCompletions pat previousContext pos

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1675,6 +1675,21 @@ let x (du: Du list) =
         VerifyCompletionList(fileContents, "| [ C (first, rest); C (f, l", [ "list" ], [ "rest" ])
 
     [<Fact>]
+    let ``Completion list contains relevant items for the correct union case field pattern before its identifier has been typed`` () =
+        let fileContents =
+            """
+type Du =
+    | C of first: Du * second: Result<int, string>
+
+let x du =
+    match du with
+    | C () -> ()
+    | C  (first, ) -> ()
+"""
+        VerifyCompletionList(fileContents, "| C (", [ "first"; "du" ], [ "second"; "result" ])
+        VerifyCompletionList(fileContents, "| C  (first, ", [ "second"; "result" ], [ "first"; "du" ])
+
+    [<Fact>]
     let ``Completion list contains suggested names for union case field pattern in a let binding, lambda and member`` () =
         let fileContents =
             """

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1686,6 +1686,7 @@ let x du =
     | C () -> ()
     | C  (first, ) -> ()
 """
+
         VerifyCompletionList(fileContents, "| C (", [ "first"; "du" ], [ "second"; "result" ])
         VerifyCompletionList(fileContents, "| C  (first, ", [ "second"; "result" ], [ "first"; "du" ])
 


### PR DESCRIPTION
... when no identifier has been typed yet and the user presses Ctrl-space. In this case, the original ordering of completions from FCS is preserved, so we get suggested names at the top of the list (and the list itself is filtered). If you instead trigger completions by typing the first letter, VS will partially sort the list. That's not great when you don't necessarily know what you're looking for, and the suggested names would have been helpful.

Before

![devenv_gFrkZZaZFw](https://github.com/dotnet/fsharp/assets/5063478/d1733ed4-21b2-43f6-b5d3-cfcb7e3e8899)

Current, with the first letter, sorted by VS

![devenv_Kda9BH6crJ](https://github.com/dotnet/fsharp/assets/5063478/68b76593-410b-4a8d-8e6a-c144c0db4471)

After

![devenv_tz98OS9mh2](https://github.com/dotnet/fsharp/assets/5063478/0d49bb90-5375-4291-a5a7-3da7d8c62e96)
![devenv_wn27c9fRqx](https://github.com/dotnet/fsharp/assets/5063478/a4079940-4893-47bb-b554-6ab7bb317143)
