### PR TITLE
SImplify a small piece of code

### DIFF
--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -289,10 +289,7 @@ module rec CompilerAssertHelpers =
         member x.ExecuteTestCase assemblyPath (deps: string[]) =
             AppDomain.CurrentDomain.add_AssemblyResolve(ResolveEventHandler(fun _ args ->
                 deps
-                |> Array.tryFind (fun (x: string) -> Path.GetFileNameWithoutExtension x = args.Name)
-                |> Option.orElseWith (fun () -> 
-                    deps 
-                    |> Array.tryFind (fun (x: string) -> args.Name.StartsWith(Path.GetFileNameWithoutExtension(x) + ", Version")))
+                |> Array.tryFind (fun (x: string) -> Path.GetFileNameWithoutExtension x = AssemblyName(args.Name).Name)
                 |> Option.bind (fun x -> if FileSystem.FileExistsShim x then Some x else None)
                 |> Option.map Assembly.LoadFile
                 |> Option.defaultValue null))


### PR DESCRIPTION
Whilst resolving a merge conflict with one of my PR's, I came accross this piece of code that could be expressed a bit more clearly.

The code is intended to load an assembly given an assembly name string.  The change, uses the assembly name object to get the assembly name, then uses the name field to get the base file name.