### PR TITLE
Improving FS0010 code fixes

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingEqualsToTypeDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingEqualsToTypeDefinition.fs
@@ -19,13 +19,13 @@ type internal AddMissingEqualsToTypeDefinitionCodeFixProvider() =
 
     override _.FixableDiagnosticIds = ImmutableArray.Create "FS0010"
 
-    override this.RegisterCodeFixesAsync context = 
+    override this.RegisterCodeFixesAsync context =
         // This is a performance shortcut.
         // Since FS0010 fires all too often, we're just stopping any processing if it's a different error message.
         // The code fix logic itself still has this logic and implements it more reliably.
-        if 
+        if
             context.Diagnostics
-            |> Seq.exists (fun d -> d.Descriptor.MessageFormat.ToString().Contains "=") 
+            |> Seq.exists (fun d -> d.Descriptor.MessageFormat.ToString().Contains "=")
         then
             context.RegisterFsharpFix this
         else

--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingEqualsToTypeDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingEqualsToTypeDefinition.fs
@@ -4,6 +4,7 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
 open System.Collections.Immutable
+open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
@@ -18,33 +19,33 @@ type internal AddMissingEqualsToTypeDefinitionCodeFixProvider() =
 
     override _.FixableDiagnosticIds = ImmutableArray.Create "FS0010"
 
-    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
+    override this.RegisterCodeFixesAsync context = 
+        // This is a performance shortcut.
+        // Since FS0010 fires all too often, we're just stopping any processing if it's a different error message.
+        // The code fix logic itself still has this logic and implements it more reliably.
+        if 
+            context.Diagnostics
+            |> Seq.exists (fun d -> d.Descriptor.MessageFormat.ToString().Contains "=") 
+        then
+            context.RegisterFsharpFix this
+        else
+            Task.CompletedTask
 
     interface IFSharpCodeFixProvider with
         member _.GetCodeFixIfAppliesAsync context =
             cancellableTask {
-                let message =
-                    context.Diagnostics
-                    |> Seq.exactlyOne
-                    |> fun d -> d.Descriptor.MessageFormat.ToString()
+                let! range = context.GetErrorRangeAsync()
+                let! parseResults = context.Document.GetFSharpParseResultsAsync(nameof AddMissingEqualsToTypeDefinitionCodeFixProvider)
 
-                // this should eliminate 99.9% of germs
-                if not <| message.Contains "=" then
+                if not <| parseResults.IsPositionWithinTypeDefinition range.Start then
                     return ValueNone
+
                 else
-
-                    let! range = context.GetErrorRangeAsync()
-                    let! parseResults = context.Document.GetFSharpParseResultsAsync(nameof AddMissingEqualsToTypeDefinitionCodeFixProvider)
-
-                    if not <| parseResults.IsPositionWithinTypeDefinition range.Start then
-                        return ValueNone
-
-                    else
-                        return
-                            ValueSome
-                                {
-                                    Name = CodeFix.AddMissingEqualsToTypeDefinition
-                                    Message = title
-                                    Changes = [ TextChange(TextSpan(context.Span.Start, 0), "= ") ]
-                                }
+                    return
+                        ValueSome
+                            {
+                                Name = CodeFix.AddMissingEqualsToTypeDefinition
+                                Message = title
+                                Changes = [ TextChange(TextSpan(context.Span.Start, 0), "= ") ]
+                            }
             }

--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingFunKeyword.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingFunKeyword.fs
@@ -29,13 +29,13 @@ type internal AddMissingFunKeywordCodeFixProvider [<ImportingConstructor>] () =
 
     override _.FixableDiagnosticIds = ImmutableArray.Create "FS0010"
 
-    override this.RegisterCodeFixesAsync context = 
+    override this.RegisterCodeFixesAsync context =
         // This is a performance shortcut.
         // Since FS0010 fires all too often, we're just stopping any processing if it's a different error message.
         // The code fix logic itself still has this logic and implements it more reliably.
-        if 
+        if
             context.Diagnostics
-            |> Seq.exists (fun d -> d.Descriptor.MessageFormat.ToString().Contains "->") 
+            |> Seq.exists (fun d -> d.Descriptor.MessageFormat.ToString().Contains "->")
         then
             context.RegisterFsharpFix this
         else

--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingFunKeyword.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddMissingFunKeyword.fs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 open System
 open System.Composition
 open System.Collections.Immutable
+open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
@@ -28,7 +29,17 @@ type internal AddMissingFunKeywordCodeFixProvider [<ImportingConstructor>] () =
 
     override _.FixableDiagnosticIds = ImmutableArray.Create "FS0010"
 
-    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
+    override this.RegisterCodeFixesAsync context = 
+        // This is a performance shortcut.
+        // Since FS0010 fires all too often, we're just stopping any processing if it's a different error message.
+        // The code fix logic itself still has this logic and implements it more reliably.
+        if 
+            context.Diagnostics
+            |> Seq.exists (fun d -> d.Descriptor.MessageFormat.ToString().Contains "->") 
+        then
+            context.RegisterFsharpFix this
+        else
+            Task.CompletedTask
 
     interface IFSharpCodeFixProvider with
         member _.GetCodeFixIfAppliesAsync context =

--- a/vsintegration/src/FSharp.Editor/CodeFixes/ChangeEqualsInFieldTypeToColon.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/ChangeEqualsInFieldTypeToColon.fs
@@ -32,10 +32,7 @@ type internal ChangeEqualsInFieldTypeToColonCodeFixProvider() =
         // This is a performance shortcut.
         // Since FS0010 fires all too often, we're just stopping any processing if it's a different error message.
         // The code fix logic itself still has this logic and implements it more reliably.
-        if 
-            context.Diagnostics
-            |> Seq.exists (fun d -> d.GetMessage() = errorMessage) 
-        then
+        if context.Diagnostics |> Seq.exists (fun d -> d.GetMessage() = errorMessage) then
             context.RegisterFsharpFix this
         else
             Task.CompletedTask

--- a/vsintegration/src/FSharp.Editor/CodeFixes/ChangeEqualsInFieldTypeToColon.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/ChangeEqualsInFieldTypeToColon.fs
@@ -32,7 +32,10 @@ type internal ChangeEqualsInFieldTypeToColonCodeFixProvider() =
         // This is a performance shortcut.
         // Since FS0010 fires all too often, we're just stopping any processing if it's a different error message.
         // The code fix logic itself still has this logic and implements it more reliably.
-        if context.Diagnostics[ 0 ].GetMessage() = errorMessage then
+        if 
+            context.Diagnostics
+            |> Seq.exists (fun d -> d.GetMessage() = errorMessage) 
+        then
             context.RegisterFsharpFix this
         else
             Task.CompletedTask

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingEqualsToTypeDefinitionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingEqualsToTypeDefinitionTests.fs
@@ -54,6 +54,13 @@ type Name = Name of string
 [<Theory>]
 [<InlineData "type X = open">]
 [<InlineData "=">]
+[<InlineData "let f x = 
+    match x with
+    | _ ->
+        let _ = [
+            x with
+        ]
+">]
 let ``Doesn't fix FS0010 for random unexpected symbols`` code =
     let expected = None
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingFunKeywordTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingFunKeywordTests.fs
@@ -34,13 +34,18 @@ let gettingEven numbers =
 
     Assert.Equal(expected, actual)
 
-[<Fact>]
-let ``Doesn't fix FS0010 for random unexpected symbols`` () =
-    let code =
-        """
+[<Theory>]
+[<InlineData("""
 =
-"""
-
+""")>]
+[<InlineData "let f x = 
+    match x with
+    | _ ->
+        let _ = [
+            x with
+        ]
+">]
+let ``Doesn't fix FS0010 for random unexpected symbols`` code =
     let expected = None
 
     let actual = codeFix |> tryFix code Auto

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeEqualsInFieldTypeToColonTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeEqualsInFieldTypeToColonTests.fs
@@ -58,6 +58,13 @@ type Band = { Name open string }
 [<InlineData("""
 type Band = {| Name open string |}
 """)>]
+[<InlineData "let f x = 
+    match x with
+    | _ ->
+        let _ = [
+            x with
+        ]
+">]
 let ``Doesn't fix FS0010 for random unexpected symbols`` code =
     let expected = None
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
@@ -36,43 +36,53 @@ let getDocument code mode =
     | WithOption option -> RoslynTestHelpers.GetFsDocument(code, option)
     | Manual _ -> RoslynTestHelpers.GetFsDocument code
 
-let getRelevantDiagnostic (document: Document) =
+let getRelevantDiagnostics (document: Document) =
     cancellableTask {
         let! _, checkFileResults = document.GetFSharpParseAndCheckResultsAsync "test"
 
-        return checkFileResults.Diagnostics |> Seq.head
+        return checkFileResults.Diagnostics
     }
+    |> CancellableTask.startWithoutCancellation
+    |> fun task -> task.Result
 
-let createTestCodeFixContext (code: string) document (mode: Mode) =
+let createTestCodeFixContext (code: string) document (mode: Mode) diagnosticIds =
     cancellableTask {
         let! cancellationToken = CancellableTask.getCancellationToken ()
 
         let sourceText = SourceText.From code
 
-        let! diagnostic =
+        let diagnostics =
             match mode with
-            | Auto -> getRelevantDiagnostic document
-            | WithOption _ -> getRelevantDiagnostic document
+            | Auto -> 
+                getRelevantDiagnostics document
+                |> Array.filter (fun d -> diagnosticIds |> Seq.contains d.ErrorNumberText)
+            | WithOption _ -> 
+                getRelevantDiagnostics document   
             | Manual (squiggly, number) ->
                 let spanStart = code.IndexOf squiggly
                 let span = TextSpan(spanStart, squiggly.Length)
                 let range = RoslynHelpers.TextSpanToFSharpRange(document.FilePath, span, sourceText)
-                CancellableTask.singleton (FSharpDiagnostic.Create(FSharpDiagnosticSeverity.Warning, "test", number, range))
+                [| FSharpDiagnostic.Create(FSharpDiagnosticSeverity.Warning, "test", number, range) |]
 
+        let range = diagnostics[0].Range
         let location =
-            RoslynHelpers.RangeToLocation(diagnostic.Range, sourceText, document.FilePath)
+            RoslynHelpers.RangeToLocation(range, sourceText, document.FilePath)
+        let textSpan = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
 
-        let roslynDiagnostic = RoslynHelpers.ConvertError(diagnostic, location)
+        let roslynDiagnostics = 
+            diagnostics
+            |> Array.map (fun diagnostic -> RoslynHelpers.ConvertError(diagnostic, location)) 
+            |> ImmutableArray.ToImmutableArray
 
-        return CodeFixContext(document, roslynDiagnostic, mockAction, cancellationToken)
+        return CodeFixContext(document, textSpan, roslynDiagnostics, mockAction, cancellationToken)
     }
 
-let tryFix (code: string) mode (fixProvider: IFSharpCodeFixProvider) =
+let tryFix (code: string) mode (fixProvider : 'T when 'T :> IFSharpCodeFixProvider and 'T :> CodeFixProvider) =
     cancellableTask {
         let sourceText = SourceText.From code
         let document = getDocument code mode
 
-        let! context = createTestCodeFixContext code document mode
+        let! context = createTestCodeFixContext code document mode fixProvider.FixableDiagnosticIds
 
         let! result = fixProvider.GetCodeFixIfAppliesAsync context
 
@@ -85,5 +95,5 @@ let tryFix (code: string) mode (fixProvider: IFSharpCodeFixProvider) =
                      FixedCode = (sourceText.WithChanges codeFix.Changes).ToString()
                  }))
     }
-    |> CancellableTask.start CancellationToken.None
+    |> CancellableTask.startWithoutCancellation
     |> fun task -> task.Result


### PR DESCRIPTION
FS0010 ("unexpected symbol...") fires very often for various reasons so deserves special treatment in code fixes.

This:
- fixes #15685
- protects ChangeEqualsInFieldTypeToColon code fix from misfunctioning in similar cases
- saves some function calls
- adds some tests
- adjust the testing framework a bit

Review without whitespaces.
Thanks @0101 for finding the original bug, that brought a valuable insight about possible code fix cases.