### PR TITLE
Fixing code fixes, part 6

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnusedOpens.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnusedOpens.fs
@@ -3,14 +3,14 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Threading
 open System.Threading.Tasks
 open System.Collections.Immutable
 
-open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics
+
+open CancellableTasks
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.RemoveUnusedOpens); Shared>]
 type internal RemoveUnusedOpensCodeFixProvider [<ImportingConstructor>] () =
@@ -21,30 +21,23 @@ type internal RemoveUnusedOpensCodeFixProvider [<ImportingConstructor>] () =
     override _.FixableDiagnosticIds =
         ImmutableArray.Create FSharpIDEDiagnosticIds.RemoveUnnecessaryImportsDiagnosticId
 
-    member this.GetChanges(document: Document, diagnostics: ImmutableArray<Diagnostic>, ct: CancellationToken) =
-        backgroundTask {
-            let! sourceText = document.GetTextAsync(ct)
+    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
 
-            let changes =
-                diagnostics
-                |> Seq.map (fun d ->
-                    sourceText
-                        .Lines
-                        .GetLineFromPosition(
-                            d.Location.SourceSpan.Start
-                        )
-                        .SpanIncludingLineBreak)
-                |> Seq.map (fun span -> TextChange(span, ""))
+    override this.GetFixAllProvider() = this.RegisterFsharpFixAll()
 
-            return changes
-        }
+    interface IFSharpCodeFixProvider with
+        member _.GetCodeFixIfAppliesAsync context =
+            cancellableTask {
+                let! sourceText = context.GetSourceTextAsync()
 
-    override this.RegisterCodeFixesAsync ctx : Task =
-        backgroundTask {
-            if ctx.Document.Project.IsFSharpCodeFixesUnusedOpensEnabled then
-                let! changes = this.GetChanges(ctx.Document, ctx.Diagnostics, ctx.CancellationToken)
-                ctx.RegisterFsharpFix(CodeFix.RemoveUnusedOpens, title, changes)
-        }
+                let span =
+                    sourceText.Lines.GetLineFromPosition(context.Span.Start).SpanIncludingLineBreak
 
-    override this.GetFixAllProvider() =
-        CodeFixHelpers.createFixAllProvider CodeFix.RemoveUnusedOpens this.GetChanges
+                return
+                    ValueSome
+                        {
+                            Name = CodeFix.RemoveUnusedOpens
+                            Message = title
+                            Changes = [ TextChange(span, "") ]
+                        }
+            }

--- a/vsintegration/src/FSharp.Editor/CodeFixes/SimplifyName.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/SimplifyName.fs
@@ -3,42 +3,41 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Threading
-open System.Threading.Tasks
 open System.Collections.Immutable
 
-open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics
+
+open CancellableTasks
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.SimplifyName); Shared>]
 type internal SimplifyNameCodeFixProvider() =
     inherit CodeFixProvider()
 
     override _.FixableDiagnosticIds =
-        ImmutableArray.Create(FSharpIDEDiagnosticIds.SimplifyNamesDiagnosticId)
+        ImmutableArray.Create FSharpIDEDiagnosticIds.SimplifyNamesDiagnosticId
 
-    member this.GetChanges(_document: Document, diagnostics: ImmutableArray<Diagnostic>, _ct: CancellationToken) =
-        backgroundTask {
-            let changes =
-                diagnostics |> Seq.map (fun d -> TextChange(d.Location.SourceSpan, ""))
+    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
 
-            return changes
-        }
+    override this.GetFixAllProvider() = this.RegisterFsharpFixAll()
 
-    override this.RegisterCodeFixesAsync ctx : Task =
-        backgroundTask {
-            let diag = ctx.Diagnostics |> Seq.head
+    interface IFSharpCodeFixProvider with
+        member _.GetCodeFixIfAppliesAsync context =
+            cancellableTask {
+                let propertyBag = context.Diagnostics[0].Properties
 
-            let title =
-                match diag.Properties.TryGetValue(SimplifyNameDiagnosticAnalyzer.LongIdentPropertyKey) with
-                | true, longIdent -> sprintf "%s '%s'" (SR.SimplifyName()) longIdent
-                | _ -> SR.SimplifyName()
+                let title =
+                    match propertyBag.TryGetValue SimplifyNameDiagnosticAnalyzer.LongIdentPropertyKey with
+                    | true, longIdent -> sprintf "%s '%s'" (SR.SimplifyName()) longIdent
+                    // TODO: figure out if this can happen in the real world
+                    | _ -> SR.SimplifyName()
 
-            let! changes = this.GetChanges(ctx.Document, ctx.Diagnostics, ctx.CancellationToken)
-            ctx.RegisterFsharpFix(CodeFix.SimplifyName, title, changes)
-        }
-
-    override this.GetFixAllProvider() =
-        CodeFixHelpers.createFixAllProvider CodeFix.SimplifyName this.GetChanges
+                return
+                    ValueSome
+                        {
+                            Name = CodeFix.SimplifyName
+                            Message = title
+                            Changes = [ TextChange(context.Span, "") ]
+                        }
+            }

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingRecToMutuallyRecFunctionsTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddMissingRecToMutuallyRecFunctionsTests.fs
@@ -44,6 +44,6 @@ and isOdd n =
 """
             }
 
-    let actual = codeFix |> tryFix code (Manual("let", 0576))
+    let actual = codeFix |> tryFix code (Manual("let", "FS0576"))
 
     Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeToUpcastTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ChangeToUpcastTests.fs
@@ -35,7 +35,7 @@ let Thing : IFoo = Foo() :> IFoo
 """
             }
 
-    let actual = codeFix |> tryFix code (Manual("Foo() :?> IFoo", 3198))
+    let actual = codeFix |> tryFix code (Manual("Foo() :?> IFoo", "FS3198"))
 
     Assert.Equal(expected, actual)
 
@@ -62,7 +62,7 @@ let Thing : IFoo = upcast Foo()
 """
             }
 
-    let actual = codeFix |> tryFix code (Manual("downcast Foo()", 3198))
+    let actual = codeFix |> tryFix code (Manual("downcast Foo()", "FS3198"))
 
     Assert.Equal(expected, actual)
 
@@ -79,6 +79,6 @@ let Thing : IdowncastFoo = Foo() :?> IdowncastFoo
 
     let expected = None
 
-    let actual = codeFix |> tryFix code (Manual("Foo() :?> IdowncastFoo", 3198))
+    let actual = codeFix |> tryFix code (Manual("Foo() :?> IdowncastFoo", "FS3198"))
 
     Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnusedBindingTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnusedBindingTests.fs
@@ -78,7 +78,7 @@ type C() = class end
 """
             }
 
-    let actual = codeFix |> tryFix code (Manual("this", 1182))
+    let actual = codeFix |> tryFix code (Manual("this", "FS1182"))
 
     Assert.Equal(expected, actual)
 
@@ -92,6 +92,6 @@ type T() =
 
     let expected = None
 
-    let actual = codeFix |> tryFix code (Manual("x", 1182))
+    let actual = codeFix |> tryFix code (Manual("x", "FS1182"))
 
     Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnusedOpensTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnusedOpensTests.fs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.RemoveUnusedOpensTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = RemoveUnusedOpensCodeFixProvider()
+
+[<Fact>]
+let ``Fixes IDE0005`` () =
+    let code =
+        """
+open System
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Remove unused open declarations"
+                FixedCode =
+                    """
+"""
+            }
+
+    let actual = codeFix |> tryFix code (Manual("open System", "IDE0005"))
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/SimplifyNameTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/SimplifyNameTests.fs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.SimplifyNameTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = SimplifyNameCodeFixProvider()
+
+[<Fact>]
+let ``Fixes IDE0002`` () =
+    let code =
+        """
+open System
+
+let now = System.DateTime.Now
+"""
+
+    let expected =
+        Some
+            {
+                // In reality, the message would be "Simplify name: 'System.DateTime.Now'".
+                // This diag is produced by an analyzer hence we have to create it manually.
+                // To simplify things, the test framework does not currently
+                // fill the property bag of the diag (which the code fix looks at).
+                // If we find more similar cases, this can be improved.
+                Message = "Simplify name"
+                FixedCode =
+                    """
+open System
+
+let now = DateTime.Now
+"""
+            }
+
+    let actual = codeFix |> tryFix code (Manual("System.", "IDE0002"))
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -56,6 +56,8 @@
     <Compile Include="CodeFixes\DiscardUnusedValueTests.fs" />
     <Compile Include="CodeFixes\PrefixUnusedValueTests.fs" />
     <Compile Include="CodeFixes\ChangeEqualsInFieldTypeToColonTests.fs" />
+    <Compile Include="CodeFixes\RemoveUnusedOpensTests.fs" />
+    <Compile Include="CodeFixes\SimplifyNameTests.fs" />
     <Compile Include="Hints\HintTestFramework.fs" />
     <Compile Include="Hints\OptionParserTests.fs" />
     <Compile Include="Hints\InlineParameterNameHintTests.fs" />


### PR DESCRIPTION
This PR addresses last remaining bulk code fixes - from analyzers.

As usual:
- adding tests
- moving to cancellables
- speeding things up

The test framework is extended to handle IDE diagnostics.