### PR TITLE
More pattern completion filtering

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -1574,9 +1574,9 @@ type internal TypeCheckInfo
                                 | Item.ILField field -> field.LiteralValue.IsSome
                                 | Item.ActivePatternCase _
                                 | Item.ModuleOrNamespaces _
-                                | Item.NewDef _
-                                | Item.Types _
                                 | Item.UnionCase _ -> true
+                                | Item.Types (_, ty :: _) ->
+                                    not (isInterfaceTy g ty || IsAttribute infoReader item.Item)
                                 | _ -> false)
 
                         filtered, denv, range)

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -1575,8 +1575,7 @@ type internal TypeCheckInfo
                                 | Item.ActivePatternCase _
                                 | Item.ModuleOrNamespaces _
                                 | Item.UnionCase _ -> true
-                                | Item.Types (_, ty :: _) ->
-                                    not (isInterfaceTy g ty || IsAttribute infoReader item.Item)
+                                | Item.Types (_, ty :: _) -> not (isInterfaceTy g ty || IsAttribute infoReader item.Item)
                                 | _ -> false)
 
                         filtered, denv, range)

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1619,7 +1619,9 @@ x[0].
         VerifyCompletionListExactly(fileContents, "x[0].", [ "Foo"; "Goo"; "Equals"; "GetHashCode"; "GetType"; "ToString" ])
 
     [<Fact>]
-    let ``Completion list contains suggested names for union case field pattern with one field, and no items that may not appear in a pattern`` () =
+    let ``Completion list contains suggested names for union case field pattern with one field, and no items that may not appear in a pattern``
+        ()
+        =
         let fileContents =
             """
 let logV = 1
@@ -1640,7 +1642,13 @@ match A 1 with
 
         // We don't want to see functions, non-literal values, keywords, attribute types, interface types
         // We want to see all other kinds of types, union cases, active patterns, modules, namespaces
-        VerifyCompletionList(fileContents, "| A", [ "A"; "DU"; "logLit"; "Even"; "Odd"; "System" ], [ "logV"; "failwith"; "false"; "Att"; "Inter" ])
+        VerifyCompletionList(
+            fileContents,
+            "| A",
+            [ "A"; "DU"; "logLit"; "Even"; "Odd"; "System" ],
+            [ "logV"; "failwith"; "false"; "Att"; "Inter" ]
+        )
+
         VerifyCompletionList(fileContents, "| A l", [ "logField"; "logLit"; "num" ], [ "logV"; "log" ])
 
     [<Fact>]

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -1619,7 +1619,7 @@ x[0].
         VerifyCompletionListExactly(fileContents, "x[0].", [ "Foo"; "Goo"; "Equals"; "GetHashCode"; "GetType"; "ToString" ])
 
     [<Fact>]
-    let ``Completion list contains suggested names for union case field pattern with one field, and no valrefs other than literals`` () =
+    let ``Completion list contains suggested names for union case field pattern with one field, and no items that may not appear in a pattern`` () =
         let fileContents =
             """
 let logV = 1
@@ -1629,11 +1629,18 @@ type DU = A of logField: int
 
 let (|Even|Odd|) input = Odd
 
+type Inter = interface end
+
+type Att =
+    inherit System.Attribute ()
+
 match A 1 with
 | A l -> ()
 """
 
-        VerifyCompletionList(fileContents, "| A", [ "A"; "DU"; "logLit"; "Even"; "Odd"; "System" ], [ "logV"; "failwith"; "false" ])
+        // We don't want to see functions, non-literal values, keywords, attribute types, interface types
+        // We want to see all other kinds of types, union cases, active patterns, modules, namespaces
+        VerifyCompletionList(fileContents, "| A", [ "A"; "DU"; "logLit"; "Even"; "Odd"; "System" ], [ "logV"; "failwith"; "false"; "Att"; "Inter" ])
         VerifyCompletionList(fileContents, "| A l", [ "logField"; "logLit"; "num" ], [ "logV"; "log" ])
 
     [<Fact>]


### PR DESCRIPTION
Removing interfaces as well as attributes. Attributes may *technically* appear in a pattern (other than to the right of `:?`, which gets a different completion context), but only to access a constant within (and this would have to come from C#). This scenario is so an outlandish and improbable that keeping attributes around is not warranted in my opinion. There's a surprising number of them in the prelude and `System`, so the number of completions for a pattern in a virtually empty file is whittled down to 185 from 234.