### PR TITLE
Fix loading legacy projects

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -401,6 +401,10 @@ type internal FSharpPackage() as this =
                 SingleFileWorkspaceMap(FSharpMiscellaneousFileService(workspace, miscFilesWorkspace, projectContextFactory), rdt)
                 |> ignore
 
+            do
+                LegacyProjectWorkspaceMap(solution, optionsManager, projectContextFactory)
+                |> ignore
+
         }
         |> CancellableTask.startAsTask cancellationToken
 


### PR DESCRIPTION
Fix for a bug with loading legacy projects, which I have introduced in 17.7, moving to tasks.
We might want to go through backporting