### PR TITLE
Fix perl issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,6 +142,8 @@ stages:
                     /p:PublishToSymbolServer=true
                     /p:VisualStudioDropName=$(VisualStudioDropName)
                     /p:GenerateSbom=true
+            env:
+                NativeToolsOnMachine: true
           - script: .\tests\EndToEndBuildTests\EndToEndBuildTests.cmd -c $(_BuildConfig)
             displayName: End to end build tests
           - task: PublishTestResults@2
@@ -335,6 +337,8 @@ stages:
             clean: true
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration Release /p:FSharpLangVersion=preview
+            env:
+              NativeToolsOnMachine: true
             displayName: Build
 
           - task: PublishBuildArtifacts@1
@@ -361,6 +365,8 @@ stages:
             clean: true
 
           - script: eng\CIBuild.cmd -compressallmetadata -configuration Release /p:AdditionalFscCmdFlags=--strict-indentation+
+            env:
+              NativeToolsOnMachine: true
             displayName: Build
 
           - task: PublishBuildArtifacts@1
@@ -418,9 +424,13 @@ stages:
 
           # yes, this is miserable, but - https://github.com/dotnet/arcade/issues/13239
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
+            env:
+              NativeToolsOnMachine: true
             displayName: Build / Test
             condition: ne(variables['_testKind'], 'testIntegration')
           - script: eng\CIBuild.cmd -compressallmetadata -configuration $(_configuration) -$(_testKind)
+            env:
+              NativeToolsOnMachine: true
             displayName: Build / Integration Test
             continueOnError: true
             condition: eq(variables['_testKind'], 'testIntegration')
@@ -572,6 +582,7 @@ stages:
             clean: true
           - script: .\Build.cmd -c Release -pack
             env:
+              NativeToolsOnMachine: true
               FSHARP_EXPERIMENTAL_FEATURES: $(_experimental_flag)
           - script: .\tests\EndToEndBuildTests\EndToEndBuildTests.cmd -c Release
             env:
@@ -702,6 +713,8 @@ stages:
           - script: dotnet --list-sdks
             displayName: Report dotnet SDK versions
           - script: .\Build.cmd $(_kind) -pack -c $(_BuildConfig)
+            env:
+              NativeToolsOnMachine: true
             displayName: Initial build and prepare packages.
           - script: $(Build.SourcesDirectory)/tests/AheadOfTime/Trimming/check.cmd
             displayName: Build, trim, publish and check the state of the trimmed app.

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -514,6 +514,14 @@ try {
     TryDownloadDotnetFrameworkSdk
 
     $nativeTools = InitializeNativeTools
+
+    if (-not (Test-Path variable:NativeToolsOnMachine)) {
+        $env:PERL5Path = Join-Path $nativeTools "perl\5.38.0.1\perl\bin\perl.exe"
+        write-host "variable:NativeToolsOnMachine = unset or false"
+        $nativeTools
+        write-host "Path = $env:PERL5Path"
+    }
+
     $dotnetPath = InitializeDotNetCli
     $env:DOTNET_ROOT = "$dotnetPath"
     Get-Item -Path Env:
@@ -592,7 +600,15 @@ try {
         $env:FSCOREDLLPATH = "$ArtifactsDir\bin\fsc\$configuration\net472\FSharp.Core.dll"
         $env:LINK_EXE = "$RepoRoot\tests\fsharpqa\testenv\bin\link\link.exe"
         $env:OSARCH = $env:PROCESSOR_ARCHITECTURE
-        Exec-Console "perl.exe" """$RepoRoot\tests\fsharpqa\testenv\bin\runall.pl"" -resultsroot ""$resultsRoot"" -results $resultsLog -log $errorLog -fail $failLog -cleanup:no -procs:$env:NUMBER_OF_PROCESSORS"
+
+        if (-not (Test-Path variable:NativeToolsOnMachine)) {
+            Exec-Console $env:PERL5Path """$RepoRoot\tests\fsharpqa\testenv\bin\runall.pl"" -resultsroot ""$resultsRoot"" -results $resultsLog -log $errorLog -fail $failLog -cleanup:no -procs:$env:NUMBER_OF_PROCESSORS"
+        }
+        else
+        {
+            Exec-Console "perl.exe" """$RepoRoot\tests\fsharpqa\testenv\bin\runall.pl"" -resultsroot ""$resultsRoot"" -results $resultsLog -log $errorLog -fail $failLog -cleanup:no -procs:$env:NUMBER_OF_PROCESSORS"
+        }
+
         write-host "Exec-Console finished"
         Pop-Location
     }

--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "xcopy-msbuild": "17.6.0-2"
   },
   "native-tools": {
-    "perl": "latest"
+    "perl": "5.38.0.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23411.1",


### PR DESCRIPTION
Sets specific version in global.json and sets environment variable in azdo pipelines.

Idea is: if we run locally, we'll be downloading a specific version of the Perl, on CI it will use version, which is installed on CI, until we get rid of F#QA completely.