### PR TITLE
Fixing code fixes, part 7

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
@@ -16,8 +16,16 @@ open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
 
 open CancellableTasks
+
+module internal MutableCodeFixHelper =
+    let getLineNumberAndText (sourceText: SourceText) position =
+        let textLine = sourceText.Lines.GetLineFromPosition position
+        let textLinePos = sourceText.Lines.GetLinePosition position
+        let fcsTextLineNumber = Line.fromZ textLinePos.Line
+        fcsTextLineNumber, textLine.ToString()
 
 module internal UnusedCodeFixHelper =
     let getUnusedSymbol textSpan (document: Document) (sourceText: SourceText) codeFixName =

--- a/vsintegration/src/FSharp.Editor/CodeFixes/MakeDeclarationMutable.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/MakeDeclarationMutable.fs
@@ -3,71 +3,80 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Threading.Tasks
-open System.Threading
 open System.Collections.Immutable
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 
 open FSharp.Compiler.EditorServices
-open FSharp.Compiler.Text
+
 open CancellableTasks
 
 [<ExportCodeFixProvider(FSharpConstants.FSharpLanguageName, Name = CodeFix.MakeDeclarationMutable); Shared>]
-type internal MakeDeclarationMutableFixProvider [<ImportingConstructor>] () =
+type internal MakeDeclarationMutableCodeFixProvider [<ImportingConstructor>] () =
     inherit CodeFixProvider()
 
     static let title = SR.MakeDeclarationMutable()
 
-    override _.FixableDiagnosticIds = ImmutableArray.Create("FS0027")
+    override _.FixableDiagnosticIds = ImmutableArray.Create "FS0027"
 
-    override _.RegisterCodeFixesAsync context : Task =
-        asyncMaybe {
+    override this.RegisterCodeFixesAsync context = context.RegisterFsharpFix this
 
-            let document = context.Document
-            do! Option.guard (not (isSignatureFile document.FilePath))
-            let position = context.Span.Start
+    interface IFSharpCodeFixProvider with
+        member _.GetCodeFixIfAppliesAsync context =
+            cancellableTask {
+                let document = context.Document
 
-            let! lexerSymbol =
-                document.TryFindFSharpLexerSymbolAsync(
-                    position,
-                    SymbolLookupKind.Greedy,
-                    false,
-                    false,
-                    nameof (MakeDeclarationMutableFixProvider)
-                )
+                if isSignatureFile document.FilePath then
+                    return ValueNone
+                else
+                    let position = context.Span.Start
 
-            let! sourceText = document.GetTextAsync() |> liftTaskAsync
-            let textLine = sourceText.Lines.GetLineFromPosition position
-            let textLinePos = sourceText.Lines.GetLinePosition position
-            let fcsTextLineNumber = Line.fromZ textLinePos.Line
+                    let! lexerSymbolOpt =
+                        document.TryFindFSharpLexerSymbolAsync(
+                            position,
+                            SymbolLookupKind.Greedy,
+                            false,
+                            false,
+                            nameof MakeDeclarationMutableCodeFixProvider
+                        )
 
-            let! parseFileResults, checkFileResults =
-                document.GetFSharpParseAndCheckResultsAsync(nameof (MakeDeclarationMutableFixProvider))
-                |> CancellableTask.start context.CancellationToken
-                |> Async.AwaitTask
-                |> liftAsync
+                    match lexerSymbolOpt with
+                    | None -> return ValueNone
+                    | Some lexerSymbol ->
+                        let! sourceText = context.GetSourceTextAsync()
 
-            let decl =
-                checkFileResults.GetDeclarationLocation(
-                    fcsTextLineNumber,
-                    lexerSymbol.Ident.idRange.EndColumn,
-                    textLine.ToString(),
-                    lexerSymbol.FullIsland,
-                    false
-                )
+                        let fcsTextLineNumber, textLine =
+                            MutableCodeFixHelper.getLineNumberAndText sourceText position
 
-            match decl with
-            // Only do this for symbols in the same file. That covers almost all cases anyways.
-            // We really shouldn't encourage making values mutable outside of local scopes anyways.
-            | FindDeclResult.DeclFound declRange when declRange.FileName = document.FilePath ->
-                let! span = RoslynHelpers.TryFSharpRangeToTextSpan(sourceText, declRange)
+                        let! parseFileResults, checkFileResults =
+                            document.GetFSharpParseAndCheckResultsAsync(nameof MakeDeclarationMutableCodeFixProvider)
 
-                // Bail if it's a parameter, because like, that ain't allowed
-                do! Option.guard (not (parseFileResults.IsPositionContainedInACurriedParameter declRange.Start))
-                do context.RegisterFsharpFix(CodeFix.MakeDeclarationMutable, title, [| TextChange(TextSpan(span.Start, 0), "mutable ") |])
-            | _ -> ()
-        }
-        |> Async.Ignore
-        |> RoslynHelpers.StartAsyncUnitAsTask(context.CancellationToken)
+                        let decl =
+                            checkFileResults.GetDeclarationLocation(
+                                fcsTextLineNumber,
+                                lexerSymbol.Ident.idRange.EndColumn,
+                                textLine,
+                                lexerSymbol.FullIsland,
+                                false
+                            )
+
+                        match decl with
+                        | FindDeclResult.DeclFound declRange when
+                            // Only do this for symbols in the same file. That covers almost all cases anyways.
+                            // We really shouldn't encourage making values mutable outside of local scopes anyways.
+                            declRange.FileName = document.FilePath
+                            // Bail if it's a parameter, because like, that ain't allowed
+                            && not <| parseFileResults.IsPositionContainedInACurriedParameter declRange.Start
+                            ->
+                            let span = RoslynHelpers.FSharpRangeToTextSpan(sourceText, declRange)
+
+                            return
+                                ValueSome
+                                    {
+                                        Name = CodeFix.MakeDeclarationMutable
+                                        Message = title
+                                        Changes = [ TextChange(TextSpan(span.Start, 0), "mutable ") ]
+                                    }
+                        | _ -> return ValueNone
+            }

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/MakeDeclarationMutableTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/MakeDeclarationMutableTests.fs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.MakeDeclarationMutableTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = MakeDeclarationMutableCodeFixProvider()
+
+[<Fact>]
+let ``Fixes FS0027 for let bindings`` () =
+    let code =
+        """
+let x = 42
+x <- 43
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Make declaration 'mutable'"
+                FixedCode =
+                    """
+let mutable x = 42
+x <- 43
+"""
+            }
+
+    let actual = codeFix |> tryFix code Auto
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0027 for parameters`` () =
+    let code =
+        """
+let f x =
+    x <- 42
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code Auto
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/UseMutationWhenValueIsMutableTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/UseMutationWhenValueIsMutableTests.fs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Editor.Tests.CodeFixes.UseMutationWhenValueIsMutableTests
+
+open Microsoft.VisualStudio.FSharp.Editor
+open Xunit
+
+open CodeFixTestFramework
+
+let private codeFix = UseMutationWhenValueIsMutableCodeFixProvider()
+
+[<Fact>]
+let ``Fixes FS0020 for let bindings`` () =
+    let code =
+        """
+let mutable x = 42
+x = 43
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Use '<-' to mutate value"
+                FixedCode =
+                    """
+let mutable x = 42
+x <- 43
+"""
+            }
+
+    let actual = codeFix |> tryFix code Auto
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix FS0020 for parameters`` () =
+    let code =
+        """
+let f x =
+    x = 42
+    ()
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code Auto
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Doesn't fix unrelated FS0020`` () =
+    let code =
+        """
+let square x = x * x
+square 32
+"""
+
+    let expected = None
+
+    let actual = codeFix |> tryFix code Auto
+
+    Assert.Equal(expected, actual)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -55,6 +55,8 @@
     <Compile Include="CodeFixes\FixIndexerAccessTests.fs" />
     <Compile Include="CodeFixes\DiscardUnusedValueTests.fs" />
     <Compile Include="CodeFixes\PrefixUnusedValueTests.fs" />
+    <Compile Include="CodeFixes\MakeDeclarationMutableTests.fs" />
+    <Compile Include="CodeFixes\UseMutationWhenValueIsMutableTests.fs" />
     <Compile Include="CodeFixes\ChangeEqualsInFieldTypeToColonTests.fs" />
     <Compile Include="CodeFixes\RemoveUnusedOpensTests.fs" />
     <Compile Include="CodeFixes\SimplifyNameTests.fs" />


### PR DESCRIPTION
This time two code fixes related to mutables. 

Those actually seem to work well hence I deliberately left the code mostly as-is, just added tests and cancellables.

Review without spaces.