### PR TITLE
Use trackErrors ce instead of ++ custom operator

### DIFF
--- a/src/Compiler/Checking/AttributeChecking.fs
+++ b/src/Compiler/Checking/AttributeChecking.fs
@@ -503,17 +503,19 @@ let PropInfoIsUnseen m pinfo =
 #endif
 
 /// Check the attributes on a union case, returning errors and warnings as data.
-let CheckUnionCaseAttributes g (x:UnionCaseRef) m = trackErrors {
-    do! CheckEntityAttributes g x.TyconRef m
-    do! CheckFSharpAttributes g x.Attribs m
-}
+let CheckUnionCaseAttributes g (x:UnionCaseRef) m =
+    trackErrors {
+        do! CheckEntityAttributes g x.TyconRef m
+        do! CheckFSharpAttributes g x.Attribs m
+    }
 
 /// Check the attributes on a record field, returning errors and warnings as data.
-let CheckRecdFieldAttributes g (x:RecdFieldRef) m = trackErrors {
-    do! CheckEntityAttributes g x.TyconRef m 
-    do! CheckFSharpAttributes g x.PropertyAttribs m
-    do! CheckFSharpAttributes g x.RecdField.FieldAttribs m
-}
+let CheckRecdFieldAttributes g (x:RecdFieldRef) m =
+    trackErrors {
+        do! CheckEntityAttributes g x.TyconRef m 
+        do! CheckFSharpAttributes g x.PropertyAttribs m
+        do! CheckFSharpAttributes g x.RecdField.FieldAttribs m
+    }
 
 /// Check the attributes on an F# value, returning errors and warnings as data.
 let CheckValAttributes g (x:ValRef) m =

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -3766,7 +3766,11 @@ let IsApplicableMethApprox g amap m (minfo: MethInfo) availObjTy =
         match minfo.GetObjArgTypes(amap, m, minst) with
         | [reqdObjTy] -> 
             let reqdObjTy = if isByrefTy g reqdObjTy then destByrefTy g reqdObjTy else reqdObjTy // This is to support byref extension methods.
-            TryD (fun () -> SolveTypeSubsumesType csenv 0 m NoTrace None reqdObjTy availObjTy ++ (fun () -> ResultD true))
+            TryD (fun () ->
+                    trackErrors {
+                        do! SolveTypeSubsumesType csenv 0 m NoTrace None reqdObjTy availObjTy
+                        return true
+                    })
                  (fun _err -> ResultD false)
             |> CommitOperationResult
         | _ -> true

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -1187,10 +1187,10 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
         if evalTupInfoIsStruct tupInfo1 <> evalTupInfoIsStruct tupInfo2 then ErrorD (ConstraintSolverError(FSComp.SR.tcTupleStructMismatch(), csenv.m, m2)) else
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2
 
-    | TType_anon (anonInfo1, l1),TType_anon (anonInfo2, l2) -> 
-        SolveAnonInfoEqualsAnonInfo csenv m2 anonInfo1 anonInfo2 ++ (fun () -> 
-        SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2)
-
+    | TType_anon (anonInfo1, l1),TType_anon (anonInfo2, l2) -> trackErrors {
+            do! SolveAnonInfoEqualsAnonInfo csenv m2 anonInfo1 anonInfo2
+            do! SolveTypeEqualsTypeEqns csenv ndeep m2 trace None l1 l2
+        } 
     | TType_fun (domainTy1, rangeTy1, _), TType_fun (domainTy2, rangeTy2, _) ->
         SolveFunTypeEqn csenv ndeep m2 trace None domainTy1 domainTy2 rangeTy1 rangeTy2
 
@@ -1274,9 +1274,10 @@ and SolveTypeSubsumesType (csenv: ConstraintSolverEnv) ndeep m2 (trace: Optional
         if evalTupInfoIsStruct tupInfo1 <> evalTupInfoIsStruct tupInfo2 then ErrorD (ConstraintSolverError(FSComp.SR.tcTupleStructMismatch(), csenv.m, m2)) else
         SolveTypeEqualsTypeEqns csenv ndeep m2 trace cxsln l1 l2 (* nb. can unify since no variance *)
 
-    | TType_anon (anonInfo1, l1), TType_anon (anonInfo2, l2)      -> 
-        SolveAnonInfoEqualsAnonInfo csenv m2 anonInfo1 anonInfo2 ++ (fun () -> 
-        SolveTypeEqualsTypeEqns csenv ndeep m2 trace cxsln l1 l2) (* nb. can unify since no variance *)
+    | TType_anon (anonInfo1, l1), TType_anon (anonInfo2, l2) -> trackErrors {
+            do! SolveAnonInfoEqualsAnonInfo csenv m2 anonInfo1 anonInfo2
+            do! SolveTypeEqualsTypeEqns csenv ndeep m2 trace cxsln l1 l2 (* nb. can unify since no variance *)
+        }
 
     | TType_fun (domainTy1, rangeTy1, _), TType_fun (domainTy2, rangeTy2, _) ->
         SolveFunTypeEqn csenv ndeep m2 trace cxsln domainTy1 domainTy2 rangeTy1 rangeTy2 (* nb. can unify since no variance *)

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -1233,8 +1233,11 @@ and SolveTypeEqualsTypeEqns csenv ndeep m2 trace cxsln origl1 origl2 =
        let rec loop l1 l2 = 
            match l1, l2 with 
            | [], [] -> CompleteD 
-           | h1 :: t1, h2 :: t2 when t1.Length = t2.Length -> 
-               SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln h1 h2 ++ (fun () -> loop t1 t2) 
+           | h1 :: t1, h2 :: t2 when t1.Length = t2.Length ->
+               trackErrors {
+                   do! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln h1 h2
+                   do! loop t1 t2
+               }
            | _ ->
                ErrorD(ConstraintSolverTupleDiffLengths(csenv.DisplayEnv, csenv.eContextInfo, origl1, origl2, csenv.m, m2)) 
        loop origl1 origl2


### PR DESCRIPTION
While contributing I always find confusing using custom operators.

In this PR my goal is to replace the usage of 
```fsharp
val (++): res: OperationResult<'T> -> f: ('T -> OperationResult<'b>) -> OperationResult<'b>`
```

with

```fsharp
trackErrors {
    ....
}

