### PR TITLE
Don't suppress inline keyword in GetValSignatureText.

### DIFF
--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -2357,7 +2357,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
     
     member x.GetValSignatureText (displayContext: FSharpDisplayContext, m: range) =
         checkIsResolved()
-        let displayEnv = { displayContext.Contents cenv.g with includeStaticParametersInTypeNames = true }
+        let displayEnv = { displayContext.Contents cenv.g with includeStaticParametersInTypeNames = true; suppressInlineKeyword = false }
 
         let stringValOfMethInfo (methInfo: MethInfo) =
             match methInfo with

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -752,7 +752,21 @@ type Foo() =
             and set (a: int) (b: float) = ()
 """
             (5, 14, "    member _.X", "X")
-            
+
+    [<Test>]
+    let ``Signature text for inline property`` () =
+        assertSignature
+            "member inline Item: i: int * j: char -> string with get\nmember inline Item: i: int * j: char -> string with set"
+            """
+module Meh
+
+type Foo =
+    member inline this.Item
+        with get (i:int,j: char) : string = ""
+        and set (i:int,j: char) (x:string) = printfn "%i %c" i j
+"""
+            (5, 27, "    member inline this.Item", "Item")
+
 module AnonymousRecord =
     [<Test>]
     let ``Anonymous record copy-and-update symbols usage`` () =


### PR DESCRIPTION
The `inline` keyword was missing for `GetValSignatureText`.