### PR TITLE
Included get,set in range of AutoProperty.

### DIFF
--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1102,7 +1102,15 @@ let mkSynUnionCase attributes (access: SynAccess option) id kind mDecl (xmlDoc, 
 
 let mkAutoPropDefn mVal access ident typ mEquals (expr: SynExpr) accessors xmlDoc attribs flags rangeStart =
     let mWith, (getSet, getSetOpt) = accessors
-    let memberRange = unionRanges rangeStart expr.Range |> unionRangeWithXmlDoc xmlDoc
+
+    let memberRange =
+        match getSetOpt with
+        | None -> unionRanges rangeStart expr.Range |> unionRangeWithXmlDoc xmlDoc
+        | Some (getSet: GetSetKeywords) ->
+            unionRanges rangeStart expr.Range
+            |> unionRangeWithXmlDoc xmlDoc
+            |> unionRanges getSet.Range
+
     let flags, leadingKeyword = flags
     let leadingKeyword = appendValToLeadingKeyword mVal leadingKeyword
     let memberFlags: SynMemberFlags = flags SynMemberKind.Member

--- a/tests/fsharp/typecheck/sigs/neg62.bsl
+++ b/tests/fsharp/typecheck/sigs/neg62.bsl
@@ -23,7 +23,7 @@ neg62.fs(34,5,34,25): typecheck error FS3133: 'member val' definitions are only 
 
 neg62.fs(49,6,49,26): typecheck error FS0081: Implicit object constructors for structs must take at least one argument
 
-neg62.fs(50,5,50,21): typecheck error FS0901: Structs cannot contain value definitions because the default constructor for structs will not execute these bindings. Consider adding additional arguments to the primary constructor for the type.
+neg62.fs(50,5,50,34): typecheck error FS0901: Structs cannot contain value definitions because the default constructor for structs will not execute these bindings. Consider adding additional arguments to the primary constructor for the type.
 
 neg62.fs(54,31,54,34): typecheck error FS3135: To indicate that this property can be set, use 'member val PropertyName = expr with get,set'.
 

--- a/tests/service/ServiceUntypedParseTests.fs
+++ b/tests/service/ServiceUntypedParseTests.fs
@@ -291,7 +291,7 @@ type T =
 type T =
     member val Property1 = "" with get, set
 """
-        getTypeMemberRange source |> shouldEqual [ (3, 4), (3, 29) ]
+        getTypeMemberRange source |> shouldEqual [ (3, 4), (3, 43) ]
 
     
     [<Test>]

--- a/tests/service/XmlDocTests.fs
+++ b/tests/service/XmlDocTests.fs
@@ -923,7 +923,7 @@ type A() =
 
     match parseResults.ParseTree with
     | Members([_; SynMemberDefn.AutoProperty(range = range)]) ->
-        assertRange (3, 4) (7, 20) range
+        assertRange (3, 4) (7, 34) range
     | x ->
         failwith $"Unexpected ParsedInput %A{x}"
 

--- a/tests/service/data/SyntaxTree/Member/Auto property 07.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 07.fs
@@ -1,0 +1,4 @@
+module A
+
+type X() =
+    member val Y: int = 7 with get,set

--- a/tests/service/data/SyntaxTree/Member/Auto property 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 07.fs.bsl
@@ -1,0 +1,54 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 07.fs", false, QualifiedNameOfFile A, [], [],
+      [SynModuleOrNamespace
+         ([A], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [X],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ImplicitCtor
+                        (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                         PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                         (3,5--3,6), { AsKeyword = None });
+                      AutoProperty
+                        ([], false, Y,
+                         Some (LongIdent (SynLongIdent ([int], [], [None]))),
+                         PropertyGetSet,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 7, (4,24--4,25)), (4,4--4,38),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,26--4,30)
+                           EqualsRange = Some (4,22--4,23)
+                           GetSetKeywords =
+                            Some (GetSet ((4,31--4,34), (4,35--4,38))) })],
+                     (4,4--4,38)), [],
+                  Some
+                    (ImplicitCtor
+                       (None, [], SimplePats ([], [], (3,6--3,8)), None,
+                        PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
+                        (3,5--3,6), { AsKeyword = None })), (3,5--4,38),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,9--3,10)
+                    WithKeyword = None })], (3,0--4,38))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,38), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -46,14 +46,14 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, Ident name, (4,4--5,26),
+                         None, Ident name, (4,4--5,40),
                          { LeadingKeyword =
                             MemberVal ((5,4--5,10), (5,11--5,14))
                            WithKeyword = Some (5,27--5,31)
                            EqualsRange = Some (5,20--5,21)
                            GetSetKeywords =
                             Some (GetSet ((5,32--5,35), (5,37--5,40))) })],
-                     (4,4--5,26)), [],
+                     (4,4--5,40)), [],
                   Some
                     (ImplicitCtor
                        (None, [],
@@ -69,10 +69,10 @@ ImplFile
                                (3,27--3,36))], [(3,25--3,26)], (3,11--3,37)),
                         None,
                         PreXmlDoc ((3,11), FSharp.Compiler.Xml.XmlDocCollector),
-                        (3,5--3,11), { AsKeyword = None })), (2,0--5,26),
+                        (3,5--3,11), { AsKeyword = None })), (2,0--5,40),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,38--3,39)
-                    WithKeyword = None })], (2,0--5,26))], PreXmlDocEmpty, [],
+                    WithKeyword = None })], (2,0--5,40))], PreXmlDocEmpty, [],
           None, (3,0--6,0), { LeadingKeyword = None })], (true, true),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/SynTypeDefnWithAutoPropertyContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -34,7 +34,7 @@ ImplFile
                            GetterOrSetterIsCompilerGenerated = false
                            MemberKind = PropertySet },
                          PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
-                         None, Ident autoProp, (3,4--3,38),
+                         None, Ident autoProp, (3,4--3,52),
                          { LeadingKeyword =
                             MemberVal ((3,4--3,10), (3,11--3,14))
                            WithKeyword = Some (3,39--3,43)


### PR DESCRIPTION
The `with get,set` part should be included in the `SynMemberDefn.AutoProperty` range.