### PR TITLE
Optimize pattern compilation

### DIFF
--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -967,8 +967,8 @@ and erasePartials inps =
     List.map erasePartialPatterns inps
     
 let ReportUnusedTargets (clauses: MatchClause list) dtree =
-    match dtree with
-    | TDSuccess _ -> ()
+    match dtree, clauses with
+    | TDSuccess _, [ _ ] -> ()
     | _ ->
         let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
         clauses |> List.iteri (fun i c ->

--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -967,22 +967,26 @@ and erasePartials inps =
     List.map erasePartialPatterns inps
     
 let ReportUnusedTargets (clauses: MatchClause list) dtree =
-    let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
-    clauses |> List.iteri (fun i c ->
-        let m =
-            match c.BoundVals, c.GuardExpr with
-            | [], Some guard -> guard.Range
-            | [ bound ], None -> bound.Id.idRange
-            | [ _ ], Some guard -> guard.Range
-            | rest, None ->
-                match rest with
-                | [ head ] -> head.Id.idRange
-                | _ -> c.Pattern.Range
-            | _, Some guard -> guard.Range
-            
-        let m  = withStartEnd c.Range.Start m.End m
-            
-        if not (used.Contains i) then warning (RuleNeverMatched m))
+    match dtree with
+    | TDSuccess _ -> ()
+    | _ ->
+        let used = HashSet<_>(accTargetsOfDecisionTree dtree [], HashIdentity.Structural)
+        clauses |> List.iteri (fun i c ->
+            if not (used.Contains i) then
+                let m =
+                    match c.BoundVals, c.GuardExpr with
+                    | [], Some guard -> guard.Range
+                    | [ bound ], None -> bound.Id.idRange
+                    | [ _ ], Some guard -> guard.Range
+                    | rest, None ->
+                        match rest with
+                        | [ head ] -> head.Id.idRange
+                        | _ -> c.Pattern.Range
+                    | _, Some guard -> guard.Range
+                    
+                withStartEnd c.Range.Start m.End m
+                |> RuleNeverMatched
+                |> warning)
 
 let rec isPatternDisjunctive inpPat =
     match inpPat with


### PR DESCRIPTION
The improvement is twofold:

- Rule ranges are not computed until we know we're reporting an unused rule warning.
- Trivial pattern matches, typical in bindings - `let x = 0`, exit early and avoid some allocations.