### PR TITLE
Only update typar name when TyparStaticReq matches.

### DIFF
--- a/member-contrains-type-extension.fsx
+++ b/member-contrains-type-extension.fsx
@@ -1,0 +1,23 @@
+module Extensions
+
+type DataItem<'data> =
+    { Identifier: string
+      Label: string
+      Data: 'data }
+
+    static member Create<'data>(identifier: string, label: string, data: 'data) =
+        { DataItem.Identifier = identifier
+          DataItem.Label = label
+          DataItem.Data = data }
+
+#nowarn "957"
+
+type DataItem< ^input> with
+
+    static member inline Create(item: ^input) =
+        let stringValue: string = (^input: (member get_StringValue: unit -> string) (item))
+
+        let friendlyStringValue: string =
+            (^input: (member get_FriendlyStringValue: unit -> string) (item))
+
+        DataItem.Create< ^input>(stringValue, friendlyStringValue, item)

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -4049,8 +4049,10 @@ module TcDeclarations =
                     if tcref.TyparsNoRange.Length = synTypars.Length then
                         (tcref.TyparsNoRange, synTypars)
                         ||> List.zip
-                        |> List.iter (fun (typar, SynTyparDecl.SynTyparDecl (typar = SynTypar (ident = untypedIdent))) ->
-                            typar.SetIdent(untypedIdent)
+                        |> List.iter (fun (typar, SynTyparDecl.SynTyparDecl (typar = tp)) ->
+                            let (SynTypar(ident = untypedIdent; staticReq = sr)) = tp
+                            if typar.StaticReq = sr then
+                                typar.SetIdent(untypedIdent)
                         )
 
                     res

--- a/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
@@ -46,3 +46,31 @@ else ()
         |> run
         |> shouldSucceed
         |> withExitCode 0
+
+    [<Fact>]
+    let ``Respect nowarn 957 for extension method`` () =
+        FSharp """        
+module Foo
+
+type DataItem<'data> =
+    { Identifier: string
+      Label: string
+      Data: 'data }
+
+    static member Create<'data>(identifier: string, label: string, data: 'data) =
+        { DataItem.Identifier = identifier
+          DataItem.Label = label
+          DataItem.Data = data }
+
+#nowarn "957"
+
+type DataItem< ^input> with
+
+    static member inline Create(item: ^input) =
+        let stringValue: string = (^input: (member get_StringValue: unit -> string) (item))
+        let friendlyStringValue: string = (^input: (member get_FriendlyStringValue: unit -> string) (item))
+
+        DataItem.Create< ^input>(stringValue, friendlyStringValue, item)
+"""
+        |> compile
+        |> shouldSucceed


### PR DESCRIPTION
As mentioned on Slack by Josua Jäger, there was a recent regression in the `7.0.400` SDK.
The fix for this is that we can't update the `ident` of the `syntypar` when `'` doesn't match with `^`. 