### PR TITLE
Fantomas update

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.0.3",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ fsharp_max_array_or_list_width=80
 fsharp_max_array_or_list_number_of_items=5
 fsharp_max_dot_get_expression_width=80
 fsharp_multiline_block_brackets_on_same_column=true
+fsharp_multiline_bracket_style=aligned
 fsharp_keep_max_number_of_blank_lines=1
 
 [*.fsi]

--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -201,13 +201,13 @@ or
 Some of the code in this repository is formatted automatically by [Fantomas](https://github.com/fsprojects/fantomas). To format all files use:
 
 ```cmd
-dotnet fantomas . -r
+dotnet fantomas .
 ```
 
 The formatting is checked automatically by CI:
 
 ```cmd
-dotnet fantomas . -r --check
+dotnet fantomas . --check
 ```
 
 At the time of writing only a subset of signature files (`*.fsi`) are formatted. See the settings in `.fantomasignore` and `.editorconfig`.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -274,10 +274,10 @@ stages:
             env:
               DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
             displayName: Check error code sorting in src/Compiler/FSComp.txt
-          - script: dotnet fantomas . -r --check
+          - script: dotnet fantomas . --check
             env:
               DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1
-            displayName: Check code formatting (run 'dotnet fantomas . -r' to fix)
+            displayName: Check code formatting (run 'dotnet fantomas .' to fix)
 
         # Check whether package with current version has been published to nuget.org
         # We will try to restore both FSharp.Core and FCS and if restore is _successful_, package version needs to be bumped.

--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -432,8 +432,8 @@ let AssemblyRefUniqueStampGenerator = UniqueStampGenerator<AssemblyRefData>()
 type ILAssemblyRef(data) =
     let pkToken key =
         match key with
-        | Some (PublicKey bytes) -> Some(PublicKey(SHA1.sha1HashBytes bytes))
-        | Some (PublicKeyToken token) -> Some(PublicKey token)
+        | Some(PublicKey bytes) -> Some(PublicKey(SHA1.sha1HashBytes bytes))
+        | Some(PublicKeyToken token) -> Some(PublicKey token)
         | None -> None
 
     let uniqueStamp =
@@ -649,9 +649,9 @@ type ILCallingConv =
 
     | Callconv of ILThisConvention * ILArgConvention
 
-    member x.ThisConv = let (Callconv (a, _b)) = x in a
+    member x.ThisConv = let (Callconv(a, _b)) = x in a
 
-    member x.BasicConv = let (Callconv (_a, b)) = x in b
+    member x.BasicConv = let (Callconv(_a, b)) = x in b
 
     member x.IsInstance =
         match x.ThisConv with
@@ -885,8 +885,8 @@ and [<RequireQualifiedAccess; StructuralEquality; StructuralComparison; Structur
     member x.BasicQualifiedName =
         match x with
         | ILType.TypeVar n -> "!" + string n
-        | ILType.Modified (_, _ty1, ty2) -> ty2.BasicQualifiedName
-        | ILType.Array (ILArrayShape s, ty) -> ty.BasicQualifiedName + "[" + String(',', s.Length - 1) + "]"
+        | ILType.Modified(_, _ty1, ty2) -> ty2.BasicQualifiedName
+        | ILType.Array(ILArrayShape s, ty) -> ty.BasicQualifiedName + "[" + String(',', s.Length - 1) + "]"
         | ILType.Value tr
         | ILType.Boxed tr -> tr.BasicQualifiedName
         | ILType.Void -> "void"
@@ -897,8 +897,8 @@ and [<RequireQualifiedAccess; StructuralEquality; StructuralComparison; Structur
     member x.AddQualifiedNameExtension basic =
         match x with
         | ILType.TypeVar _n -> basic
-        | ILType.Modified (_, _ty1, ty2) -> ty2.AddQualifiedNameExtension basic
-        | ILType.Array (ILArrayShape (_s), ty) -> ty.AddQualifiedNameExtension basic
+        | ILType.Modified(_, _ty1, ty2) -> ty2.AddQualifiedNameExtension basic
+        | ILType.Array(ILArrayShape(_s), ty) -> ty.AddQualifiedNameExtension basic
         | ILType.Value tr
         | ILType.Boxed tr -> tr.AddQualifiedNameExtension basic
         | ILType.Void -> failwith "void"
@@ -1190,18 +1190,18 @@ type ILAttribute =
 
     member x.Method =
         match x with
-        | Encoded (method, _, _)
-        | Decoded (method, _, _) -> method
+        | Encoded(method, _, _)
+        | Decoded(method, _, _) -> method
 
     member x.Elements =
         match x with
-        | Encoded (_, _, elements) -> elements
-        | Decoded (_, fixedArgs, namedArgs) -> fixedArgs @ (namedArgs |> List.map (fun (_, _, _, e) -> e))
+        | Encoded(_, _, elements) -> elements
+        | Decoded(_, fixedArgs, namedArgs) -> fixedArgs @ (namedArgs |> List.map (fun (_, _, _, e) -> e))
 
     member x.WithMethod(method: ILMethodSpec) =
         match x with
-        | Encoded (_, data, elements) -> Encoded(method, data, elements)
-        | Decoded (_, fixedArgs, namedArgs) -> Decoded(method, fixedArgs, namedArgs)
+        | Encoded(_, data, elements) -> Encoded(method, data, elements)
+        | Decoded(_, fixedArgs, namedArgs) -> Decoded(method, fixedArgs, namedArgs)
 
     /// For debugging
     [<DebuggerBrowsable(DebuggerBrowsableState.Never)>]
@@ -1804,9 +1804,9 @@ type ILReturn =
 type ILOverridesSpec =
     | OverridesSpec of ILMethodRef * ILType
 
-    member x.MethodRef = let (OverridesSpec (mr, _ty)) = x in mr
+    member x.MethodRef = let (OverridesSpec(mr, _ty)) = x in mr
 
-    member x.DeclaringType = let (OverridesSpec (_mr, ty)) = x in ty
+    member x.DeclaringType = let (OverridesSpec(_mr, ty)) = x in ty
 
     override x.ToString() =
         "overrides " + x.DeclaringType.ToString() + "::" + x.MethodRef.ToString()
@@ -3337,7 +3337,7 @@ let isILArrTy ty =
 
 let destILArrTy ty =
     match ty with
-    | ILType.Array (shape, ty) -> (shape, ty)
+    | ILType.Array(shape, ty) -> (shape, ty)
     | _ -> failwith "destILArrTy"
 
 // --------------------------------------------------------------------
@@ -3547,7 +3547,7 @@ let isILValueTy =
 
 let rec stripILModifiedFromTy (ty: ILType) =
     match ty with
-    | ILType.Modified (_, _, ty) -> stripILModifiedFromTy ty
+    | ILType.Modified(_, _, ty) -> stripILModifiedFromTy ty
     | _ -> ty
 
 let isBuiltInTySpec (ilg: ILGlobals) (tspec: ILTypeSpec) n =
@@ -3655,7 +3655,7 @@ and rescopeILType scoref ty =
         let cr2 = rescopeILTypeSpec scoref cr1
 
         if cr1 === cr2 then ty else mkILBoxedType cr2
-    | ILType.Array (s, ety1) ->
+    | ILType.Array(s, ety1) ->
         let ety2 = rescopeILType scoref ety1
 
         if ety1 === ety2 then ty else ILType.Array(s, ety2)
@@ -3663,7 +3663,7 @@ and rescopeILType scoref ty =
         let cr2 = rescopeILTypeSpec scoref cr1
 
         if cr1 === cr2 then ty else ILType.Value cr2
-    | ILType.Modified (b, tref, ty) -> ILType.Modified(b, rescopeILTypeRef scoref tref, rescopeILType scoref ty)
+    | ILType.Modified(b, tref, ty) -> ILType.Modified(b, rescopeILTypeRef scoref tref, rescopeILType scoref ty)
     | x -> x
 
 and rescopeILTypes scoref i =
@@ -3700,7 +3700,7 @@ and instILTypeAux numFree (inst: ILGenericArgs) ty =
     match ty with
     | ILType.Ptr t -> ILType.Ptr(instILTypeAux numFree inst t)
     | ILType.FunctionPointer t -> ILType.FunctionPointer(instILCallSigAux numFree inst t)
-    | ILType.Array (a, t) -> ILType.Array(a, instILTypeAux numFree inst t)
+    | ILType.Array(a, t) -> ILType.Array(a, instILTypeAux numFree inst t)
     | ILType.Byref t -> ILType.Byref(instILTypeAux numFree inst t)
     | ILType.Boxed cr -> mkILBoxedType (instILTypeSpecAux numFree inst cr)
     | ILType.Value cr -> ILType.Value(instILTypeSpecAux numFree inst cr)
@@ -3822,7 +3822,7 @@ let mkILCtor (access, args, impl) =
 let mkCallBaseConstructor (ty, args: ILType list) =
     [ mkLdarg0 ]
     @ List.mapi (fun i _ -> mkLdarg (uint16 (i + 1))) args
-      @ [ mkNormalCall (mkILCtorMethSpecForTy (ty, [])) ]
+    @ [ mkNormalCall (mkILCtorMethSpecForTy (ty, [])) ]
 
 let mkNormalStfld fspec = I_stfld(Aligned, Nonvolatile, fspec)
 
@@ -4643,7 +4643,7 @@ let rec encodeCustomAttrElemType x =
     | ILType.Boxed tspec when tspec.Name = tname_Object -> [| 0x51uy |]
     | ILType.Boxed tspec when tspec.Name = tname_Type -> [| 0x50uy |]
     | ILType.Value tspec -> Array.append [| 0x55uy |] (encodeCustomAttrString tspec.TypeRef.QualifiedName)
-    | ILType.Array (shape, elemType) when shape = ILArrayShape.SingleDimensional ->
+    | ILType.Array(shape, elemType) when shape = ILArrayShape.SingleDimensional ->
         Array.append [| et_SZARRAY |] (encodeCustomAttrElemType elemType)
     | _ -> failwith "encodeCustomAttrElemType: unrecognized custom element type"
 
@@ -4666,7 +4666,7 @@ let rec encodeCustomAttrElemTypeForObject x =
     | ILAttribElem.Null -> [| et_STRING |] // yes, the 0xe prefix is used when passing a "null" to a property or argument of type "object" here
     | ILAttribElem.Single _ -> [| et_R4 |]
     | ILAttribElem.Double _ -> [| et_R8 |]
-    | ILAttribElem.Array (elemTy, _) -> [| yield et_SZARRAY; yield! encodeCustomAttrElemType elemTy |]
+    | ILAttribElem.Array(elemTy, _) -> [| yield et_SZARRAY; yield! encodeCustomAttrElemType elemTy |]
 
 let tspan = TimeSpan(DateTime.UtcNow.Ticks - DateTime(2000, 1, 1).Ticks)
 
@@ -4774,7 +4774,7 @@ let rec encodeCustomAttrPrimValue c =
     | ILAttribElem.Type None
     | ILAttribElem.TypeRef None
     | ILAttribElem.Null -> [| 0xFFuy |]
-    | ILAttribElem.String (Some s) -> encodeCustomAttrString s
+    | ILAttribElem.String(Some s) -> encodeCustomAttrString s
     | ILAttribElem.Char x -> u16AsBytes (uint16 x)
     | ILAttribElem.SByte x -> i8AsBytes x
     | ILAttribElem.Int16 x -> i16AsBytes x
@@ -4786,9 +4786,9 @@ let rec encodeCustomAttrPrimValue c =
     | ILAttribElem.UInt64 x -> u64AsBytes x
     | ILAttribElem.Single x -> ieee32AsBytes x
     | ILAttribElem.Double x -> ieee64AsBytes x
-    | ILAttribElem.Type (Some ty) -> encodeCustomAttrString ty.QualifiedName
-    | ILAttribElem.TypeRef (Some tref) -> encodeCustomAttrString tref.QualifiedName
-    | ILAttribElem.Array (_, elems) ->
+    | ILAttribElem.Type(Some ty) -> encodeCustomAttrString ty.QualifiedName
+    | ILAttribElem.TypeRef(Some tref) -> encodeCustomAttrString tref.QualifiedName
+    | ILAttribElem.Array(_, elems) ->
         [|
             yield! i32AsBytes elems.Length
             for elem in elems do
@@ -4802,8 +4802,8 @@ and encodeCustomAttrValue ty c =
             yield! encodeCustomAttrElemTypeForObject c
             yield! encodeCustomAttrPrimValue c
         |]
-    | ILType.Array (shape, _), ILAttribElem.Null when shape = ILArrayShape.SingleDimensional -> [| yield! i32AsBytes 0xFFFFFFFF |]
-    | ILType.Array (shape, elemType), ILAttribElem.Array (_, elems) when shape = ILArrayShape.SingleDimensional ->
+    | ILType.Array(shape, _), ILAttribElem.Null when shape = ILArrayShape.SingleDimensional -> [| yield! i32AsBytes 0xFFFFFFFF |]
+    | ILType.Array(shape, elemType), ILAttribElem.Array(_, elems) when shape = ILArrayShape.SingleDimensional ->
         [|
             yield! i32AsBytes elems.Length
             for elem in elems do
@@ -4843,8 +4843,8 @@ let mkILCustomAttribute (tref, argTys, argvs, propvs) =
 
 let getCustomAttrData cattr =
     match cattr with
-    | ILAttribute.Encoded (_, data, _) -> data
-    | ILAttribute.Decoded (mspec, fixedArgs, namedArgs) -> encodeCustomAttrArgs mspec fixedArgs namedArgs
+    | ILAttribute.Encoded(_, data, _) -> data
+    | ILAttribute.Decoded(mspec, fixedArgs, namedArgs) -> encodeCustomAttrArgs mspec fixedArgs namedArgs
 
 // ILSecurityDecl is a 'blob' having the following format:
 // - A byte containing a period (.).
@@ -5071,8 +5071,8 @@ type ILTypeSigParser(tstring: string) =
 
 let decodeILAttribData (ca: ILAttribute) =
     match ca with
-    | ILAttribute.Decoded (_, fixedArgs, namedArgs) -> fixedArgs, namedArgs
-    | ILAttribute.Encoded (_, bytes, _) ->
+    | ILAttribute.Decoded(_, fixedArgs, namedArgs) -> fixedArgs, namedArgs
+    | ILAttribute.Encoded(_, bytes, _) ->
 
         let sigptr = 0
         let bb0, sigptr = sigptr_get_byte bytes sigptr
@@ -5141,7 +5141,7 @@ let decodeILAttribData (ca: ILAttribute) =
                 else
                     let ty, sigptr = decodeCustomAttrElemType bytes sigptr et
                     parseVal ty sigptr
-            | ILType.Array (shape, elemTy) when shape = ILArrayShape.SingleDimensional ->
+            | ILType.Array(shape, elemTy) when shape = ILArrayShape.SingleDimensional ->
                 let n, sigptr = sigptr_get_i32 bytes sigptr
 
                 if n = 0xFFFFFFFF then
@@ -5261,10 +5261,10 @@ let rec refsOfILType s x =
     match x with
     | ILType.Void
     | ILType.TypeVar _ -> ()
-    | ILType.Modified (_, ty1, ty2) ->
+    | ILType.Modified(_, ty1, ty2) ->
         refsOfILTypeRef s ty1
         refsOfILType s ty2
-    | ILType.Array (_, ty)
+    | ILType.Array(_, ty)
     | ILType.Ptr ty
     | ILType.Byref ty -> refsOfILType s ty
     | ILType.Value tr
@@ -5294,7 +5294,7 @@ and refsOfILFieldRef s x =
     refsOfILType s x.Type
     s.refsFs.Add x |> ignore
 
-and refsOfILOverridesSpec s (OverridesSpec (mref, ty)) =
+and refsOfILOverridesSpec s (OverridesSpec(mref, ty)) =
     refsOfILMethodRef s mref
     refsOfILType s ty
 
@@ -5317,9 +5317,9 @@ and refsOfILToken s x =
 
 and refsOfILCustomAttrElem s (elem: ILAttribElem) =
     match elem with
-    | Type (Some ty) -> refsOfILType s ty
-    | TypeRef (Some tref) -> refsOfILTypeRef s tref
-    | Array (ty, els) ->
+    | Type(Some ty) -> refsOfILType s ty
+    | TypeRef(Some tref) -> refsOfILTypeRef s tref
+    | Array(ty, els) ->
         refsOfILType s ty
         refsOfILCustomAttrElems s els
     | _ -> ()
@@ -5338,41 +5338,41 @@ and refsOfILVarArgs s tyso = Option.iter (refsOfILTypes s) tyso
 
 and refsOfILInstr s x =
     match x with
-    | I_call (_, mr, varargs)
-    | I_newobj (mr, varargs)
-    | I_callvirt (_, mr, varargs) ->
+    | I_call(_, mr, varargs)
+    | I_newobj(mr, varargs)
+    | I_callvirt(_, mr, varargs) ->
         refsOfILMethodSpec s mr
         refsOfILVarArgs s varargs
-    | I_callconstraint (_, _, tr, mr, varargs) ->
+    | I_callconstraint(_, _, tr, mr, varargs) ->
         refsOfILType s tr
         refsOfILMethodSpec s mr
         refsOfILVarArgs s varargs
-    | I_calli (_, callsig, varargs) ->
+    | I_calli(_, callsig, varargs) ->
         refsOfILCallsig s callsig
         refsOfILVarArgs s varargs
     | I_jmp mr
     | I_ldftn mr
     | I_ldvirtftn mr -> refsOfILMethodSpec s mr
-    | I_ldsfld (_, fr)
-    | I_ldfld (_, _, fr)
+    | I_ldsfld(_, fr)
+    | I_ldfld(_, _, fr)
     | I_ldsflda fr
     | I_ldflda fr
-    | I_stsfld (_, fr)
-    | I_stfld (_, _, fr) -> refsOfILFieldSpec s fr
+    | I_stsfld(_, fr)
+    | I_stfld(_, _, fr) -> refsOfILFieldSpec s fr
     | I_isinst ty
     | I_castclass ty
     | I_cpobj ty
     | I_initobj ty
-    | I_ldobj (_, _, ty)
-    | I_stobj (_, _, ty)
+    | I_ldobj(_, _, ty)
+    | I_stobj(_, _, ty)
     | I_box ty
     | I_unbox ty
     | I_unbox_any ty
     | I_sizeof ty
-    | I_ldelem_any (_, ty)
-    | I_ldelema (_, _, _, ty)
-    | I_stelem_any (_, ty)
-    | I_newarr (_, ty)
+    | I_ldelem_any(_, ty)
+    | I_ldelema(_, _, _, ty)
+    | I_stelem_any(_, ty)
+    | I_newarr(_, ty)
     | I_mkrefany ty
     | I_refanyval ty
     | EI_ilzero ty -> refsOfILType s ty
@@ -5448,7 +5448,7 @@ and refsOfILCode s (c: ILCode) =
 
     for exnClause in c.Exceptions do
         match exnClause.Clause with
-        | ILExceptionClause.TypeCatch (ilTy, _) -> refsOfILType s ilTy
+        | ILExceptionClause.TypeCatch(ilTy, _) -> refsOfILType s ilTy
         | _ -> ()
 
 and refsOfILMethodBody s (il: ILMethodBody) =
@@ -5531,7 +5531,7 @@ and refsOfILExportedTypes s (tab: ILExportedTypesAndForwarders) =
 and refsOfILResourceLocation s x =
     match x with
     | ILResourceLocation.Local _ -> ()
-    | ILResourceLocation.File (mref, _) -> refsOfILModuleRef s mref
+    | ILResourceLocation.File(mref, _) -> refsOfILModuleRef s mref
     | ILResourceLocation.Assembly aref -> refsOfILAssemblyRef s aref
 
 and refsOfILResource s x =
@@ -5587,9 +5587,9 @@ and unscopeILType ty =
     | ILType.FunctionPointer t -> ILType.FunctionPointer(unscopeILCallSig t)
     | ILType.Byref t -> ILType.Byref(unscopeILType t)
     | ILType.Boxed cr -> mkILBoxedType (unscopeILTypeSpec cr)
-    | ILType.Array (s, ty) -> ILType.Array(s, unscopeILType ty)
+    | ILType.Array(s, ty) -> ILType.Array(s, unscopeILType ty)
     | ILType.Value cr -> ILType.Value(unscopeILTypeSpec cr)
-    | ILType.Modified (b, tref, ty) -> ILType.Modified(b, unscopeILTypeRef tref, unscopeILType ty)
+    | ILType.Modified(b, tref, ty) -> ILType.Modified(b, unscopeILTypeRef tref, unscopeILType ty)
     | x -> x
 
 and unscopeILTypes i =

--- a/src/Compiler/AbstractIL/il.fsi
+++ b/src/Compiler/AbstractIL/il.fsi
@@ -41,6 +41,7 @@ type ILPlatform =
 type ILSourceDocument =
     static member Create:
         language: ILGuid option * vendor: ILGuid option * documentType: ILGuid option * file: string -> ILSourceDocument
+
     member Language: ILGuid option
     member Vendor: ILGuid option
     member DocumentType: ILGuid option
@@ -50,6 +51,7 @@ type ILSourceDocument =
 type internal ILDebugPoint =
     static member Create:
         document: ILSourceDocument * line: int * column: int * endLine: int * endColumn: int -> ILDebugPoint
+
     member Document: ILSourceDocument
     member Line: int
     member Column: int

--- a/src/Compiler/AbstractIL/ilbinary.fs
+++ b/src/Compiler/AbstractIL/ilbinary.fs
@@ -689,7 +689,7 @@ let noArgInstrs =
 
 let isNoArgInstr i =
     match i with
-    | AI_ldc (DT_I4, ILConst.I4 n) when -1 <= n && n <= 8 -> true
+    | AI_ldc(DT_I4, ILConst.I4 n) when -1 <= n && n <= 8 -> true
     | I_stloc n
     | I_ldloc n
     | I_ldarg n when n <= 3us -> true

--- a/src/Compiler/AbstractIL/ilmorph.fs
+++ b/src/Compiler/AbstractIL/ilmorph.fs
@@ -57,7 +57,7 @@ let code_instr2instr_ty2ty (finstr, fTy) (code: ILCode) =
             for exnSpec in codeR.Exceptions do
                 let clause =
                     match exnSpec.Clause with
-                    | ILExceptionClause.TypeCatch (ilTy, b) -> ILExceptionClause.TypeCatch(fTy ilTy, b)
+                    | ILExceptionClause.TypeCatch(ilTy, b) -> ILExceptionClause.TypeCatch(fTy ilTy, b)
                     | cl -> cl
 
                 { exnSpec with Clause = clause }
@@ -81,9 +81,9 @@ let rec morphILTypeRefsInILType f x =
     | ILType.Byref t -> ILType.Byref(morphILTypeRefsInILType f t)
     | ILType.Boxed cr -> mkILBoxedType (tspec_tref2tref f cr)
     | ILType.Value ir -> ILType.Value(tspec_tref2tref f ir)
-    | ILType.Array (s, ty) -> ILType.Array(s, morphILTypeRefsInILType f ty)
+    | ILType.Array(s, ty) -> ILType.Array(s, morphILTypeRefsInILType f ty)
     | ILType.TypeVar v -> ILType.TypeVar v
-    | ILType.Modified (req, tref, ty) -> ILType.Modified(req, f tref, morphILTypeRefsInILType f ty)
+    | ILType.Modified(req, tref, ty) -> ILType.Modified(req, f tref, morphILTypeRefsInILType f ty)
     | ILType.Void -> ILType.Void
 
 and tspec_tref2tref f (tspec: ILTypeSpec) =
@@ -96,7 +96,7 @@ let rec ty_scoref2scoref_tyvar2ty ((_fscope, fTyvar) as fs) ty =
     | ILType.Byref elemTy -> ILType.Byref(ty_scoref2scoref_tyvar2ty fs elemTy)
     | ILType.Boxed tspec -> mkILBoxedType (tspec_scoref2scoref_tyvar2ty fs tspec)
     | ILType.Value tspec -> ILType.Value(tspec_scoref2scoref_tyvar2ty fs tspec)
-    | ILType.Array (shape, elemTy) -> ILType.Array(shape, ty_scoref2scoref_tyvar2ty fs elemTy)
+    | ILType.Array(shape, elemTy) -> ILType.Array(shape, ty_scoref2scoref_tyvar2ty fs elemTy)
     | ILType.TypeVar idx -> fTyvar idx
     | x -> x
 
@@ -163,9 +163,9 @@ let fspec_ty2ty ((factualTy, fformalTy: formal_scopeCtxt -> ILType -> ILType)) f
 
 let rec celem_ty2ty f celem =
     match celem with
-    | ILAttribElem.Type (Some ty) -> ILAttribElem.Type(Some(f ty))
-    | ILAttribElem.TypeRef (Some tref) -> ILAttribElem.TypeRef(Some (f (mkILBoxedType (mkILNonGenericTySpec tref))).TypeRef)
-    | ILAttribElem.Array (elemTy, elems) -> ILAttribElem.Array(f elemTy, List.map (celem_ty2ty f) elems)
+    | ILAttribElem.Type(Some ty) -> ILAttribElem.Type(Some(f ty))
+    | ILAttribElem.TypeRef(Some tref) -> ILAttribElem.TypeRef(Some (f (mkILBoxedType (mkILNonGenericTySpec tref))).TypeRef)
+    | ILAttribElem.Array(elemTy, elems) -> ILAttribElem.Array(f elemTy, List.map (celem_ty2ty f) elems)
     | _ -> celem
 
 let cnamedarg_ty2ty f ((nm, ty, isProp, elem): ILAttributeNamedArg) = (nm, f ty, isProp, celem_ty2ty f elem)
@@ -204,33 +204,33 @@ let morphILTypesInILInstr ((factualTy, fformalTy)) i =
         mspec_ty2ty (factualTy, fformalTy (Some i)) mr
 
     match i with
-    | I_calli (a, mref, varargs) -> I_calli(a, callsig_ty2ty factualTy mref, morphILVarArgs factualTy varargs)
-    | I_call (a, mr, varargs) -> I_call(a, conv_mspec mr, morphILVarArgs factualTy varargs)
-    | I_callvirt (a, mr, varargs) -> I_callvirt(a, conv_mspec mr, morphILVarArgs factualTy varargs)
-    | I_callconstraint (callvirt, a, ty, mr, varargs) ->
+    | I_calli(a, mref, varargs) -> I_calli(a, callsig_ty2ty factualTy mref, morphILVarArgs factualTy varargs)
+    | I_call(a, mr, varargs) -> I_call(a, conv_mspec mr, morphILVarArgs factualTy varargs)
+    | I_callvirt(a, mr, varargs) -> I_callvirt(a, conv_mspec mr, morphILVarArgs factualTy varargs)
+    | I_callconstraint(callvirt, a, ty, mr, varargs) ->
         I_callconstraint(callvirt, a, factualTy ty, conv_mspec mr, morphILVarArgs factualTy varargs)
-    | I_newobj (mr, varargs) -> I_newobj(conv_mspec mr, morphILVarArgs factualTy varargs)
+    | I_newobj(mr, varargs) -> I_newobj(conv_mspec mr, morphILVarArgs factualTy varargs)
     | I_ldftn mr -> I_ldftn(conv_mspec mr)
     | I_ldvirtftn mr -> I_ldvirtftn(conv_mspec mr)
-    | I_ldfld (a, b, fr) -> I_ldfld(a, b, conv_fspec fr)
-    | I_ldsfld (a, fr) -> I_ldsfld(a, conv_fspec fr)
+    | I_ldfld(a, b, fr) -> I_ldfld(a, b, conv_fspec fr)
+    | I_ldsfld(a, fr) -> I_ldsfld(a, conv_fspec fr)
     | I_ldsflda fr -> I_ldsflda(conv_fspec fr)
     | I_ldflda fr -> I_ldflda(conv_fspec fr)
-    | I_stfld (a, b, fr) -> I_stfld(a, b, conv_fspec fr)
-    | I_stsfld (a, fr) -> I_stsfld(a, conv_fspec fr)
+    | I_stfld(a, b, fr) -> I_stfld(a, b, conv_fspec fr)
+    | I_stsfld(a, fr) -> I_stsfld(a, conv_fspec fr)
     | I_castclass ty -> I_castclass(factualTy ty)
     | I_isinst ty -> I_isinst(factualTy ty)
     | I_initobj ty -> I_initobj(factualTy ty)
     | I_cpobj ty -> I_cpobj(factualTy ty)
-    | I_stobj (al, vol, ty) -> I_stobj(al, vol, factualTy ty)
-    | I_ldobj (al, vol, ty) -> I_ldobj(al, vol, factualTy ty)
+    | I_stobj(al, vol, ty) -> I_stobj(al, vol, factualTy ty)
+    | I_ldobj(al, vol, ty) -> I_ldobj(al, vol, factualTy ty)
     | I_box ty -> I_box(factualTy ty)
     | I_unbox ty -> I_unbox(factualTy ty)
     | I_unbox_any ty -> I_unbox_any(factualTy ty)
-    | I_ldelem_any (shape, ty) -> I_ldelem_any(shape, factualTy ty)
-    | I_stelem_any (shape, ty) -> I_stelem_any(shape, factualTy ty)
-    | I_newarr (shape, ty) -> I_newarr(shape, factualTy ty)
-    | I_ldelema (ro, isNativePtr, shape, ty) -> I_ldelema(ro, isNativePtr, shape, factualTy ty)
+    | I_ldelem_any(shape, ty) -> I_ldelem_any(shape, factualTy ty)
+    | I_stelem_any(shape, ty) -> I_stelem_any(shape, factualTy ty)
+    | I_newarr(shape, ty) -> I_newarr(shape, factualTy ty)
+    | I_ldelema(ro, isNativePtr, shape, ty) -> I_ldelema(ro, isNativePtr, shape, factualTy ty)
     | I_sizeof ty -> I_sizeof(factualTy ty)
     | I_ldtoken tok ->
         match tok with
@@ -308,7 +308,7 @@ let morphILMethodBody fMethBody (x: MethodBody) =
         MethodBody.IL(InterruptibleLazy.FromValue ilCode)
     | x -> x
 
-let ospec_ty2ty f (OverridesSpec (mref, ty)) = OverridesSpec(mref_ty2ty f mref, f ty)
+let ospec_ty2ty f (OverridesSpec(mref, ty)) = OverridesSpec(mref_ty2ty f mref, f ty)
 
 let mdef_ty2ty_ilmbody2ilmbody fs (md: ILMethodDef) =
     let fTyInCtxt, fMethBody = fs

--- a/src/Compiler/AbstractIL/ilnativeres.fs
+++ b/src/Compiler/AbstractIL/ilnativeres.fs
@@ -437,7 +437,7 @@ type VersionHelper() =
                                             if not (Char.IsDigit elements[i].[idx]) then
                                                 invalidFormat <- true
 
-                                                VersionHelper.TryGetValue((elements[ i ].Substring(0, idx)), ref values[i])
+                                                VersionHelper.TryGetValue((elements[i].Substring(0, idx)), ref values[i])
                                                 |> ignore<bool>
 
                                                 breakLoop <- true
@@ -697,7 +697,8 @@ type VersionResourceSerializer() =
             Array.zeroCreate (
                 VersionResourceSerializer.KEYBYTES VersionResourceSerializer.vsVersionInfoKey
                 - VersionResourceSerializer.vsVersionInfoKey.Length * 2
-            ): byte[]
+            )
+            : byte[]
         )
 
         Debug.Assert(writer.BaseStream.Position &&& 3L = 0L)
@@ -720,7 +721,8 @@ type VersionResourceSerializer() =
             Array.zeroCreate (
                 VersionResourceSerializer.KEYBYTES VersionResourceSerializer.varFileInfoKey
                 - VersionResourceSerializer.varFileInfoKey.Length * 2
-            ): byte[]
+            )
+            : byte[]
         )
 
         Debug.Assert(writer.BaseStream.Position &&& 3L = 0L)
@@ -741,7 +743,8 @@ type VersionResourceSerializer() =
             Array.zeroCreate (
                 VersionResourceSerializer.KEYBYTES VersionResourceSerializer.translationKey
                 - VersionResourceSerializer.translationKey.Length * 2
-            ): byte[]
+            )
+            : byte[]
         )
 
         Debug.Assert(writer.BaseStream.Position &&& 3L = 0L)
@@ -766,7 +769,8 @@ type VersionResourceSerializer() =
             Array.zeroCreate (
                 VersionResourceSerializer.KEYBYTES VersionResourceSerializer.stringFileInfoKey
                 - VersionResourceSerializer.stringFileInfoKey.Length * 2
-            ): byte[]
+            )
+            : byte[]
         )
 
         Debug.Assert(writer.BaseStream.Position &&& 3L = 0L)
@@ -787,7 +791,8 @@ type VersionResourceSerializer() =
             Array.zeroCreate (
                 VersionResourceSerializer.KEYBYTES this._langIdAndCodePageKey
                 - this._langIdAndCodePageKey.Length * 2
-            ): byte[]
+            )
+            : byte[]
         )
 
         Debug.Assert(writer.BaseStream.Position &&& 3L = 0L)
@@ -1019,7 +1024,7 @@ type NativeResourceWriter() =
             String.Compare(xString, yString, StringComparison.OrdinalIgnoreCase)
 
     static member SortResources(resources: IEnumerable<Win32Resource>) =
-        resources.OrderBy((fun d -> d), Comparer<_>.Create (Comparison<_> NativeResourceWriter.CompareResources))
+        resources.OrderBy((fun d -> d), Comparer<_>.Create(Comparison<_> NativeResourceWriter.CompareResources))
         :> IEnumerable<Win32Resource>
 
     static member SerializeWin32Resources(builder: BlobBuilder, theResources: IEnumerable<Win32Resource>, resourcesRva: int) =

--- a/src/Compiler/AbstractIL/ilnativeres.fsi
+++ b/src/Compiler/AbstractIL/ilnativeres.fsi
@@ -32,6 +32,7 @@ type Win32Resource =
     new:
         data: byte[] * codePage: DWORD * languageId: DWORD * id: int * name: string * typeId: int * typeName: string ->
             Win32Resource
+
     member CodePage: DWORD
     member Data: byte[]
     member Id: int
@@ -47,6 +48,7 @@ type CvtResFile =
 [<Class>]
 type Win32ResourceConversions =
     static member AppendIconToResourceStream: resStream: Stream * iconStream: Stream -> unit
+
     static member AppendVersionToResourceStream:
         resStream: Stream *
         isDll: Boolean *
@@ -62,12 +64,14 @@ type Win32ResourceConversions =
         ?comments: string *
         ?companyName: string ->
             unit
+
     static member AppendManifestToResourceStream: resStream: Stream * manifestStream: Stream * isDll: Boolean -> unit
 
 // Write native resources
 [<Class>]
 type NativeResourceWriter =
     static member SortResources: resources: IEnumerable<Win32Resource> -> IEnumerable<Win32Resource>
+
     static member SerializeWin32Resources:
         builder: BlobBuilder * theResources: IEnumerable<Win32Resource> * resourcesRva: int -> unit
 (*

--- a/src/Compiler/AbstractIL/ilprint.fs
+++ b/src/Compiler/AbstractIL/ilprint.fs
@@ -253,7 +253,7 @@ and goutput_typ env os ty =
         output_string os " "
         goutput_gactuals env os tspec.GenericArgs
     | ILType.Void -> output_string os "void"
-    | ILType.Array (bounds, ty) ->
+    | ILType.Array(bounds, ty) ->
         goutput_typ env os ty
         output_string os "["
         output_arr_bounds os bounds
@@ -334,7 +334,7 @@ and goutput_permission _env os p =
              | ILSecurityAction.DemandChoice -> "demandchoice")
 
     match p with
-    | ILSecurityDecl (sa, b) ->
+    | ILSecurityDecl(sa, b) ->
         output_string os " .permissionset "
         output_security_action os sa
         output_string os " = ("
@@ -366,7 +366,7 @@ and output_bcc os bcc =
          | ILArgConvention.Default -> " "
          | ILArgConvention.VarArg -> "vararg ")
 
-and output_callconv os (Callconv (hasthis, cc)) =
+and output_callconv os (Callconv(hasthis, cc)) =
     output_string
         os
         (match hasthis with
@@ -562,13 +562,13 @@ let goutput_fdef _tref env os (fd: ILFieldDef) =
 
 let rec goutput_apps env os =
     function
-    | Apps_tyapp (actual, cs) ->
+    | Apps_tyapp(actual, cs) ->
         output_angled (goutput_gactual env) os actual
         output_string os " "
         output_angled (goutput_gparam env) os (mkILSimpleTypar "T")
         output_string os " "
         goutput_apps env os cs
-    | Apps_app (ty, cs) ->
+    | Apps_app(ty, cs) ->
         output_parens (goutput_typ env) os ty
         output_string os " "
         goutput_apps env os cs
@@ -856,11 +856,11 @@ and output_init_semantics os f =
 
 and goutput_lambdas env os lambdas =
     match lambdas with
-    | Lambdas_forall (gf, l) ->
+    | Lambdas_forall(gf, l) ->
         output_angled (goutput_gparam env) os gf
         output_string os " "
         (goutput_lambdas env) os l
-    | Lambdas_lambda (ps, l) ->
+    | Lambdas_lambda(ps, l) ->
         output_parens (goutput_param env) os ps
         output_string os " "
         (goutput_lambdas env) os l
@@ -905,7 +905,7 @@ let goutput_resource env os r =
 
     match r.Location with
     | ILResourceLocation.Local _ -> output_string os " /* loc nyi */ "
-    | ILResourceLocation.File (mref, off) ->
+    | ILResourceLocation.File(mref, off) ->
         output_string os " .file "
         output_sqstring os mref.Name
         output_string os "  at "

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -248,7 +248,7 @@ type WeakByteFile(fileName: string, chunk: (int * int) option) =
 
                         match chunk with
                         | None -> stream.ReadAllBytes()
-                        | Some (start, length) -> stream.ReadBytes(start, length)
+                        | Some(start, length) -> stream.ReadBytes(start, length)
 
                     tg <- bytes
 
@@ -849,37 +849,37 @@ let kindIllegal = RowKind []
 // kind of element in that column.
 //---------------------------------------------------------------------
 
-let hcCompare (TaggedIndex (t1: HasConstantTag, idx1: int)) (TaggedIndex (t2: HasConstantTag, idx2)) =
+let hcCompare (TaggedIndex(t1: HasConstantTag, idx1: int)) (TaggedIndex(t2: HasConstantTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
 
-let hsCompare (TaggedIndex (t1: HasSemanticsTag, idx1: int)) (TaggedIndex (t2: HasSemanticsTag, idx2)) =
+let hsCompare (TaggedIndex(t1: HasSemanticsTag, idx1: int)) (TaggedIndex(t2: HasSemanticsTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
 
-let hcaCompare (TaggedIndex (t1: HasCustomAttributeTag, idx1: int)) (TaggedIndex (t2: HasCustomAttributeTag, idx2)) =
+let hcaCompare (TaggedIndex(t1: HasCustomAttributeTag, idx1: int)) (TaggedIndex(t2: HasCustomAttributeTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
 
-let mfCompare (TaggedIndex (t1: MemberForwardedTag, idx1: int)) (TaggedIndex (t2: MemberForwardedTag, idx2)) =
+let mfCompare (TaggedIndex(t1: MemberForwardedTag, idx1: int)) (TaggedIndex(t2: MemberForwardedTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
 
-let hdsCompare (TaggedIndex (t1: HasDeclSecurityTag, idx1: int)) (TaggedIndex (t2: HasDeclSecurityTag, idx2)) =
+let hdsCompare (TaggedIndex(t1: HasDeclSecurityTag, idx1: int)) (TaggedIndex(t2: HasDeclSecurityTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
 
-let hfmCompare (TaggedIndex (t1: HasFieldMarshalTag, idx1)) (TaggedIndex (t2: HasFieldMarshalTag, idx2)) =
+let hfmCompare (TaggedIndex(t1: HasFieldMarshalTag, idx1)) (TaggedIndex(t2: HasFieldMarshalTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
 
-let tomdCompare (TaggedIndex (t1: TypeOrMethodDefTag, idx1)) (TaggedIndex (t2: TypeOrMethodDefTag, idx2)) =
+let tomdCompare (TaggedIndex(t1: TypeOrMethodDefTag, idx1)) (TaggedIndex(t2: TypeOrMethodDefTag, idx2)) =
     if idx1 < idx2 then -1
     elif idx1 > idx2 then 1
     else compare t1.Tag t2.Tag
@@ -1804,7 +1804,7 @@ let getDataEndPointsDelayed (pectxt: PEReader) ctxtH =
                     let rva, _fidx = seekReadFieldRVARow ctxt mdv i
                     ("field", rva)
                 for i = 1 to ctxt.getNumRows TableNames.ManifestResource do
-                    let offset, _, _, TaggedIndex (_tag, idx) = seekReadManifestResourceRow ctxt mdv i
+                    let offset, _, _, TaggedIndex(_tag, idx) = seekReadManifestResourceRow ctxt mdv i
 
                     if idx = 0 then
                         let rva = pectxt.resourcesAddr + offset
@@ -1834,25 +1834,25 @@ let getDataEndPointsDelayed (pectxt: PEReader) ctxtH =
                   @ [
                       for virtAddr, _virtSize, _physLoc in pectxt.sectionHeaders do
                           yield ("section start", virtAddr)
-                    ]
-                    @ [ ("md", pectxt.metadataAddr) ]
-                      @ (if pectxt.nativeResourcesAddr = 0x0 then
-                             []
-                         else
-                             [ ("native resources", pectxt.nativeResourcesAddr) ])
-                        @ (if pectxt.resourcesAddr = 0x0 then
-                               []
-                           else
-                               [ ("managed resources", pectxt.resourcesAddr) ])
-                          @ (if pectxt.strongnameAddr = 0x0 then
-                                 []
-                             else
-                                 [ ("managed strongname", pectxt.strongnameAddr) ])
-                            @ (if pectxt.vtableFixupsAddr = 0x0 then
-                                   []
-                               else
-                                   [ ("managed vtable_fixups", pectxt.vtableFixupsAddr) ])
-                              @ methodRVAs)))
+                  ]
+                  @ [ ("md", pectxt.metadataAddr) ]
+                  @ (if pectxt.nativeResourcesAddr = 0x0 then
+                         []
+                     else
+                         [ ("native resources", pectxt.nativeResourcesAddr) ])
+                  @ (if pectxt.resourcesAddr = 0x0 then
+                         []
+                     else
+                         [ ("managed resources", pectxt.resourcesAddr) ])
+                  @ (if pectxt.strongnameAddr = 0x0 then
+                         []
+                     else
+                         [ ("managed strongname", pectxt.strongnameAddr) ])
+                  @ (if pectxt.vtableFixupsAddr = 0x0 then
+                         []
+                     else
+                         [ ("managed vtable_fixups", pectxt.vtableFixupsAddr) ])
+                  @ methodRVAs)))
             |> List.distinct
             |> List.sort)
 
@@ -2038,7 +2038,7 @@ and seekReadClassLayout (ctxt: ILMetadataReader) mdv idx =
 
     match res with
     | None -> { Size = None; Pack = None }
-    | Some (pack, size) -> { Size = Some size; Pack = Some pack }
+    | Some(pack, size) -> { Size = Some size; Pack = Some pack }
 
 and typeAccessOfFlags flags =
     let f = (flags &&& 0x00000007)
@@ -2197,7 +2197,7 @@ and seekReadInterfaceImpls (ctxt: ILMetadataReader) mdv numTypars tidx =
 and seekReadGenericParams ctxt numTypars (a, b) : ILGenericParameterDefs =
     ctxt.seekReadGenericParams (GenericParamsIdx(numTypars, a, b))
 
-and seekReadGenericParamsUncached ctxtH (GenericParamsIdx (numTypars, a, b)) =
+and seekReadGenericParamsUncached ctxtH (GenericParamsIdx(numTypars, a, b)) =
     let (ctxt: ILMetadataReader) = getHole ctxtH
     let mdv = ctxt.mdfile.GetView()
 
@@ -2248,7 +2248,7 @@ and seekReadGenericParamConstraints (ctxt: ILMetadataReader) mdv numTypars gpidx
 and seekReadTypeDefAsType (ctxt: ILMetadataReader) boxity (ginst: ILTypes) idx =
     ctxt.seekReadTypeDefAsType (TypeDefAsTypIdx(boxity, ginst, idx))
 
-and seekReadTypeDefAsTypeUncached ctxtH (TypeDefAsTypIdx (boxity, ginst, idx)) =
+and seekReadTypeDefAsTypeUncached ctxtH (TypeDefAsTypIdx(boxity, ginst, idx)) =
     let ctxt = getHole ctxtH
     mkILTy boxity (ILTypeSpec.Create(seekReadTypeDefAsTypeRef ctxt idx, ginst))
 
@@ -2287,11 +2287,11 @@ and seekReadTypeRefUncached ctxtH idx =
 and seekReadTypeRefAsType (ctxt: ILMetadataReader) boxity ginst idx =
     ctxt.seekReadTypeRefAsType (TypeRefAsTypIdx(boxity, ginst, idx))
 
-and seekReadTypeRefAsTypeUncached ctxtH (TypeRefAsTypIdx (boxity, ginst, idx)) =
+and seekReadTypeRefAsTypeUncached ctxtH (TypeRefAsTypIdx(boxity, ginst, idx)) =
     let ctxt = getHole ctxtH
     mkILTy boxity (ILTypeSpec.Create(seekReadTypeRef ctxt idx, ginst))
 
-and seekReadTypeDefOrRef (ctxt: ILMetadataReader) numTypars boxity (ginst: ILTypes) (TaggedIndex (tag, idx)) =
+and seekReadTypeDefOrRef (ctxt: ILMetadataReader) numTypars boxity (ginst: ILTypes) (TaggedIndex(tag, idx)) =
     let mdv = ctxt.mdfile.GetView()
 
     match tag with
@@ -2304,7 +2304,7 @@ and seekReadTypeDefOrRef (ctxt: ILMetadataReader) numTypars boxity (ginst: ILTyp
         readBlobHeapAsType ctxt numTypars (seekReadTypeSpecRow ctxt mdv idx)
     | _ -> failwith "seekReadTypeDefOrRef ctxt"
 
-and seekReadTypeDefOrRefAsTypeRef (ctxt: ILMetadataReader) (TaggedIndex (tag, idx)) =
+and seekReadTypeDefOrRefAsTypeRef (ctxt: ILMetadataReader) (TaggedIndex(tag, idx)) =
     match tag with
     | tag when tag = tdor_TypeDef -> seekReadTypeDefAsTypeRef ctxt idx
     | tag when tag = tdor_TypeRef -> seekReadTypeRef ctxt idx
@@ -2313,13 +2313,13 @@ and seekReadTypeDefOrRefAsTypeRef (ctxt: ILMetadataReader) (TaggedIndex (tag, id
         PrimaryAssemblyILGlobals.typ_Object.TypeRef
     | _ -> failwith "seekReadTypeDefOrRefAsTypeRef_readTypeDefOrRefOrSpec"
 
-and seekReadMethodRefParent (ctxt: ILMetadataReader) mdv numTypars (TaggedIndex (tag, idx)) =
+and seekReadMethodRefParent (ctxt: ILMetadataReader) mdv numTypars (TaggedIndex(tag, idx)) =
     match tag with
     | tag when tag = mrp_TypeRef ->
         seekReadTypeRefAsType ctxt AsObject (* not ok - no way to tell if a member ref parent is a value type or not *) List.empty idx
     | tag when tag = mrp_ModuleRef -> mkILTypeForGlobalFunctions (ILScopeRef.Module(seekReadModuleRef ctxt mdv idx))
     | tag when tag = mrp_MethodDef ->
-        let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
             seekReadMethodDefAsMethodData ctxt idx
 
         let mspec = mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
@@ -2327,10 +2327,10 @@ and seekReadMethodRefParent (ctxt: ILMetadataReader) mdv numTypars (TaggedIndex 
     | tag when tag = mrp_TypeSpec -> readBlobHeapAsType ctxt numTypars (seekReadTypeSpecRow ctxt mdv idx)
     | _ -> failwith "seekReadMethodRefParent"
 
-and seekReadMethodDefOrRef (ctxt: ILMetadataReader) numTypars (TaggedIndex (tag, idx)) =
+and seekReadMethodDefOrRef (ctxt: ILMetadataReader) numTypars (TaggedIndex(tag, idx)) =
     match tag with
     | tag when tag = mdor_MethodDef ->
-        let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
             seekReadMethodDefAsMethodData ctxt idx
 
         VarArgMethodData(enclTy, cc, nm, argTys, None, retTy, methInst)
@@ -2338,7 +2338,7 @@ and seekReadMethodDefOrRef (ctxt: ILMetadataReader) numTypars (TaggedIndex (tag,
     | _ -> failwith "seekReadMethodDefOrRef"
 
 and seekReadMethodDefOrRefNoVarargs (ctxt: ILMetadataReader) numTypars x =
-    let (VarArgMethodData (enclTy, cc, nm, argTys, varargs, retTy, methInst)) =
+    let (VarArgMethodData(enclTy, cc, nm, argTys, varargs, retTy, methInst)) =
         seekReadMethodDefOrRef ctxt numTypars x
 
     if varargs <> None then
@@ -2346,21 +2346,21 @@ and seekReadMethodDefOrRefNoVarargs (ctxt: ILMetadataReader) numTypars x =
 
     MethodData(enclTy, cc, nm, argTys, retTy, methInst)
 
-and seekReadCustomAttrType (ctxt: ILMetadataReader) (TaggedIndex (tag, idx)) =
+and seekReadCustomAttrType (ctxt: ILMetadataReader) (TaggedIndex(tag, idx)) =
     match tag with
     | tag when tag = cat_MethodDef ->
-        let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
             seekReadMethodDefAsMethodData ctxt idx
 
         mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
     | tag when tag = cat_MemberRef ->
-        let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
             seekReadMemberRefAsMethDataNoVarArgs ctxt 0 idx
 
         mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
     | _ -> failwith "seekReadCustomAttrType ctxt"
 
-and seekReadImplAsScopeRef (ctxt: ILMetadataReader) mdv (TaggedIndex (tag, idx)) =
+and seekReadImplAsScopeRef (ctxt: ILMetadataReader) mdv (TaggedIndex(tag, idx)) =
     if idx = 0 then
         ILScopeRef.Local
     else
@@ -2370,7 +2370,7 @@ and seekReadImplAsScopeRef (ctxt: ILMetadataReader) mdv (TaggedIndex (tag, idx))
         | tag when tag = i_ExportedType -> failwith "seekReadImplAsScopeRef"
         | _ -> failwith "seekReadImplAsScopeRef"
 
-and seekReadTypeRefScope (ctxt: ILMetadataReader) mdv (TaggedIndex (tag, idx)) =
+and seekReadTypeRefScope (ctxt: ILMetadataReader) mdv (TaggedIndex(tag, idx)) =
     match tag with
     | tag when tag = rs_Module -> ILScopeRef.Local, []
     | tag when tag = rs_ModuleRef -> ILScopeRef.Module(seekReadModuleRef ctxt mdv idx), []
@@ -2635,7 +2635,7 @@ and sigptrGetLocal (ctxt: ILMetadataReader) numTypars bytes sigptr =
 and readBlobHeapAsMethodSig (ctxt: ILMetadataReader) numTypars blobIdx =
     ctxt.readBlobHeapAsMethodSig (BlobAsMethodSigIdx(numTypars, blobIdx))
 
-and readBlobHeapAsMethodSigUncached ctxtH (BlobAsMethodSigIdx (numTypars, blobIdx)) =
+and readBlobHeapAsMethodSigUncached ctxtH (BlobAsMethodSigIdx(numTypars, blobIdx)) =
     let (ctxt: ILMetadataReader) = getHole ctxtH
     let bytes = readBlobHeap ctxt blobIdx
     let sigptr = 0
@@ -2664,7 +2664,7 @@ and readBlobHeapAsType ctxt numTypars blobIdx =
 and readBlobHeapAsFieldSig ctxt numTypars blobIdx =
     ctxt.readBlobHeapAsFieldSig (BlobAsFieldSigIdx(numTypars, blobIdx))
 
-and readBlobHeapAsFieldSigUncached ctxtH (BlobAsFieldSigIdx (numTypars, blobIdx)) =
+and readBlobHeapAsFieldSigUncached ctxtH (BlobAsFieldSigIdx(numTypars, blobIdx)) =
     let ctxt = getHole ctxtH
     let bytes = readBlobHeap ctxt blobIdx
     let sigptr = 0
@@ -2679,7 +2679,7 @@ and readBlobHeapAsFieldSigUncached ctxtH (BlobAsFieldSigIdx (numTypars, blobIdx)
 and readBlobHeapAsPropertySig (ctxt: ILMetadataReader) numTypars blobIdx =
     ctxt.readBlobHeapAsPropertySig (BlobAsPropSigIdx(numTypars, blobIdx))
 
-and readBlobHeapAsPropertySigUncached ctxtH (BlobAsPropSigIdx (numTypars, blobIdx)) =
+and readBlobHeapAsPropertySigUncached ctxtH (BlobAsPropSigIdx(numTypars, blobIdx)) =
     let ctxt = getHole ctxtH
     let bytes = readBlobHeap ctxt blobIdx
     let sigptr = 0
@@ -2698,7 +2698,7 @@ and readBlobHeapAsPropertySigUncached ctxtH (BlobAsPropSigIdx (numTypars, blobId
 and readBlobHeapAsLocalsSig (ctxt: ILMetadataReader) numTypars blobIdx =
     ctxt.readBlobHeapAsLocalsSig (BlobAsLocalSigIdx(numTypars, blobIdx))
 
-and readBlobHeapAsLocalsSigUncached ctxtH (BlobAsLocalSigIdx (numTypars, blobIdx)) =
+and readBlobHeapAsLocalsSigUncached ctxtH (BlobAsLocalSigIdx(numTypars, blobIdx)) =
     let ctxt = getHole ctxtH
     let bytes = readBlobHeap ctxt blobIdx
     let sigptr = 0
@@ -2747,7 +2747,7 @@ and byteAsCallConv b =
 and seekReadMemberRefAsMethodData ctxt numTypars idx : VarArgMethodData =
     ctxt.seekReadMemberRefAsMethodData (MemberRefAsMspecIdx(numTypars, idx))
 
-and seekReadMemberRefAsMethodDataUncached ctxtH (MemberRefAsMspecIdx (numTypars, idx)) =
+and seekReadMemberRefAsMethodDataUncached ctxtH (MemberRefAsMspecIdx(numTypars, idx)) =
     let (ctxt: ILMetadataReader) = getHole ctxtH
     let mdv = ctxt.mdfile.GetView()
     let mrpIdx, nameIdx, typeIdx = seekReadMemberRefRow ctxt mdv idx
@@ -2761,7 +2761,7 @@ and seekReadMemberRefAsMethodDataUncached ctxtH (MemberRefAsMspecIdx (numTypars,
     (VarArgMethodData(enclTy, cc, nm, argTys, varargs, retTy, methInst))
 
 and seekReadMemberRefAsMethDataNoVarArgs ctxt numTypars idx : MethodData =
-    let (VarArgMethodData (enclTy, cc, nm, argTys, varargs, retTy, methInst)) =
+    let (VarArgMethodData(enclTy, cc, nm, argTys, varargs, retTy, methInst)) =
         seekReadMemberRefAsMethodData ctxt numTypars idx
 
     if Option.isSome varargs then
@@ -2772,12 +2772,12 @@ and seekReadMemberRefAsMethDataNoVarArgs ctxt numTypars idx : MethodData =
 and seekReadMethodSpecAsMethodData (ctxt: ILMetadataReader) numTypars idx =
     ctxt.seekReadMethodSpecAsMethodData (MethodSpecAsMspecIdx(numTypars, idx))
 
-and seekReadMethodSpecAsMethodDataUncached ctxtH (MethodSpecAsMspecIdx (numTypars, idx)) =
+and seekReadMethodSpecAsMethodDataUncached ctxtH (MethodSpecAsMspecIdx(numTypars, idx)) =
     let (ctxt: ILMetadataReader) = getHole ctxtH
     let mdv = ctxt.mdfile.GetView()
     let mdorIdx, instIdx = seekReadMethodSpecRow ctxt mdv idx
 
-    let (VarArgMethodData (enclTy, cc, nm, argTys, varargs, retTy, _)) =
+    let (VarArgMethodData(enclTy, cc, nm, argTys, varargs, retTy, _)) =
         seekReadMethodDefOrRef ctxt numTypars mdorIdx
 
     let methInst =
@@ -2801,7 +2801,7 @@ and seekReadMethodSpecAsMethodDataUncached ctxtH (MethodSpecAsMspecIdx (numTypar
 and seekReadMemberRefAsFieldSpec (ctxt: ILMetadataReader) numTypars idx =
     ctxt.seekReadMemberRefAsFieldSpec (MemberRefAsFspecIdx(numTypars, idx))
 
-and seekReadMemberRefAsFieldSpecUncached ctxtH (MemberRefAsFspecIdx (numTypars, idx)) =
+and seekReadMemberRefAsFieldSpecUncached ctxtH (MemberRefAsFspecIdx(numTypars, idx)) =
     let (ctxt: ILMetadataReader) = getHole ctxtH
     let mdv = ctxt.mdfile.GetView()
     let mrpIdx, nameIdx, typeIdx = seekReadMemberRefRow ctxt mdv idx
@@ -3032,12 +3032,12 @@ and seekReadMethodImpls (ctxt: ILMetadataReader) numTypars tidx =
             |> List.map (fun (b, c) ->
                 {
                     OverrideBy =
-                        let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+                        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
                             seekReadMethodDefOrRefNoVarargs ctxt numTypars b
 
                         mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
                     Overrides =
-                        let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+                        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
                             seekReadMethodDefOrRefNoVarargs ctxt numTypars c
 
                         let mspec = mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
@@ -3053,7 +3053,7 @@ and seekReadMultipleMethodSemantics (ctxt: ILMetadataReader) (flags, id) =
         hsCompare id,
         isSorted ctxt TableNames.MethodSemantics,
         (fun (a, b, _c) ->
-            let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+            let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
                 seekReadMethodDefAsMethodData ctxt b
 
             a, (mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)).MethodRef)
@@ -3106,7 +3106,7 @@ and seekReadEvents (ctxt: ILMetadataReader) numTypars tidx =
                 )
             with
             | None -> []
-            | Some (rowNum, beginEventIdx) ->
+            | Some(rowNum, beginEventIdx) ->
                 let endEventIdx =
                     if rowNum >= ctxt.getNumRows TableNames.EventMap then
                         ctxt.getNumRows TableNames.Event + 1
@@ -3173,7 +3173,7 @@ and seekReadProperties (ctxt: ILMetadataReader) numTypars tidx =
                 )
             with
             | None -> []
-            | Some (rowNum, beginPropIdx) ->
+            | Some(rowNum, beginPropIdx) ->
                 let endPropIdx =
                     if rowNum >= ctxt.getNumRows TableNames.PropertyMap then
                         ctxt.getNumRows TableNames.Property + 1
@@ -3208,10 +3208,10 @@ and customAttrsReader ctxtH tag : ILAttributesStored =
 
         seekReadIndexedRowsByInterface (ctxt.getNumRows TableNames.CustomAttribute) (isSorted ctxt TableNames.CustomAttribute) reader)
 
-and seekReadCustomAttr ctxt (TaggedIndex (cat, idx), b) =
+and seekReadCustomAttr ctxt (TaggedIndex(cat, idx), b) =
     ctxt.seekReadCustomAttr (CustomAttrIdx(cat, idx, b))
 
-and seekReadCustomAttrUncached ctxtH (CustomAttrIdx (cat, idx, valIdx)) =
+and seekReadCustomAttrUncached ctxtH (CustomAttrIdx(cat, idx, valIdx)) =
     let ctxt = getHole ctxtH
     let method = seekReadCustomAttrType ctxt (TaggedIndex(cat, idx))
 
@@ -3533,7 +3533,7 @@ and seekReadTopCode (ctxt: ILMetadataReader) pev mdv numTypars (sz: int) start =
                     let tab, idx = seekReadUncodedToken pev (start + curr)
                     curr <- curr + 4
 
-                    let (VarArgMethodData (enclTy, cc, nm, argTys, varargs, retTy, methInst)) =
+                    let (VarArgMethodData(enclTy, cc, nm, argTys, varargs, retTy, methInst)) =
                         if tab = TableNames.Method then
                             seekReadMethodDefOrRef ctxt numTypars (TaggedIndex(mdor_MethodDef, idx))
                         elif tab = TableNames.MemberRef then
@@ -3544,7 +3544,7 @@ and seekReadTopCode (ctxt: ILMetadataReader) pev mdv numTypars (sz: int) start =
                             failwith "bad table in MethodDefOrRefOrSpec"
 
                     match enclTy with
-                    | ILType.Array (shape, ty) ->
+                    | ILType.Array(shape, ty) ->
                         match nm with
                         | "Get" -> I_ldelem_any(shape, ty)
                         | "Set" -> I_stelem_any(shape, ty)
@@ -3608,7 +3608,7 @@ and seekReadTopCode (ctxt: ILMetadataReader) pev mdv numTypars (sz: int) start =
                             tab = TableNames.Method
                             || tab = TableNames.MemberRef (* REVIEW: generics or tab = TableNames.MethodSpec *)
                         then
-                            let (MethodData (enclTy, cc, nm, argTys, retTy, methInst)) =
+                            let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
                                 seekReadMethodDefOrRefNoVarargs ctxt numTypars (uncodedTokenToMethodDefOrRef (tab, idx))
 
                             ILToken.ILMethod(mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst))
@@ -3831,7 +3831,7 @@ and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (nm, noinline,
                                     | _ -> sehMap[key] <- [ clause ]
 
                                 ([], sehMap)
-                                ||> Seq.fold (fun acc (KeyValue (key, bs)) ->
+                                ||> Seq.fold (fun acc (KeyValue(key, bs)) ->
                                     [ for b in bs -> { Range = key; Clause = b }: ILExceptionSpec ] @ acc)
 
                             seh <- sehClauses
@@ -4031,7 +4031,7 @@ and seekReadTopExportedTypes (ctxt: ILMetadataReader) =
                     (let nested = [| for _i in 1..numRows -> [] |]
 
                      for i = 1 to numRows do
-                         let flags, _, _, _, TaggedIndex (tag, idx) = exported[i - 1]
+                         let flags, _, _, _, TaggedIndex(tag, idx) = exported[i - 1]
 
                          if not (isTopTypeDef flags) && (tag = i_ExportedType) then
                              nested[idx - 1] <- i :: nested[idx - 1]
@@ -4042,7 +4042,7 @@ and seekReadTopExportedTypes (ctxt: ILMetadataReader) =
             [
                 for i = 1 to numRows do
                     let flags, _tok, nameIdx, namespaceIdx, implIdx = exported[i - 1]
-                    let (TaggedIndex (tag, _idx)) = implIdx
+                    let (TaggedIndex(tag, _idx)) = implIdx
 
                     // if not a nested type
                     if (isTopTypeDef flags) && (tag <> i_ExportedType) then
@@ -4933,7 +4933,7 @@ let createByteFileChunk opts fileName chunk =
 
             match chunk with
             | None -> stream.ReadAllBytes()
-            | Some (start, length) -> stream.ReadBytes(start, length)
+            | Some(start, length) -> stream.ReadBytes(start, length)
 
         ByteFile(fileName, bytes) :> BinaryFile
 
@@ -4982,7 +4982,7 @@ let ClearAllILModuleReaderCache () =
 
 let OpenILModuleReader fileName opts =
     // Pseudo-normalize the paths.
-    let ILModuleReaderCacheKey (fullPath, writeStamp, _, _, _) as key, keyOk =
+    let ILModuleReaderCacheKey(fullPath, writeStamp, _, _, _) as key, keyOk =
         try
             let fullPath = FileSystem.GetFullPathShim fileName
             let writeTime = FileSystem.GetLastWriteTimeShim fileName
@@ -5043,7 +5043,7 @@ let OpenILModuleReader fileName opts =
                         // See if tryGetMetadata gives us a BinaryFile for the metadata section alone.
                         let mdfileOpt =
                             match opts.tryGetMetadataSnapshot (fullPath, writeStamp) with
-                            | Some (obj, start, len) -> Some(RawMemoryFile(fullPath, obj, start, len) :> BinaryFile)
+                            | Some(obj, start, len) -> Some(RawMemoryFile(fullPath, obj, start, len) :> BinaryFile)
                             | None -> None
 
                         // For metadata-only, always use a temporary, short-lived PE file reader, preferably over a memory mapped file.

--- a/src/Compiler/AbstractIL/ilreflect.fs
+++ b/src/Compiler/AbstractIL/ilreflect.fs
@@ -445,8 +445,8 @@ let convAssemblyRef (aref: ILAssemblyRef) =
 
     (match aref.PublicKey with
      | None -> ()
-     | Some (PublicKey bytes) -> asmName.SetPublicKey bytes
-     | Some (PublicKeyToken bytes) -> asmName.SetPublicKeyToken bytes)
+     | Some(PublicKey bytes) -> asmName.SetPublicKey bytes
+     | Some(PublicKeyToken bytes) -> asmName.SetPublicKeyToken bytes)
 
     let setVersion (version: ILVersionInfo) =
         asmName.Version <- Version(int32 version.Major, int32 version.Minor, int32 version.Build, int32 version.Revision)
@@ -472,12 +472,12 @@ type cenv =
 let convResolveAssemblyRef (cenv: cenv) (asmref: ILAssemblyRef) qualifiedName =
     let assembly =
         match cenv.resolveAssemblyRef asmref with
-        | Some (Choice1Of2 path) ->
+        | Some(Choice1Of2 path) ->
             // asmRef is a path but the runtime is smarter with assembly names so make one
             let asmName = AssemblyName.GetAssemblyName(path)
             asmName.CodeBase <- path
             FileSystem.AssemblyLoader.AssemblyLoad asmName
-        | Some (Choice2Of2 assembly) -> assembly
+        | Some(Choice2Of2 assembly) -> assembly
         | None ->
             let asmName = convAssemblyRef asmref
             FileSystem.AssemblyLoader.AssemblyLoad asmName
@@ -575,8 +575,8 @@ let envUpdateCreatedTypeRef emEnv (tref: ILTypeRef) =
 
 let convTypeRef cenv emEnv preferCreated (tref: ILTypeRef) =
     match Zmap.tryFind tref emEnv.emTypMap with
-    | Some (_typT, _typB, _typeDef, Some createdTy) when preferCreated -> createdTy
-    | Some (typT, _typB, _typeDef, _) -> typT
+    | Some(_typT, _typB, _typeDef, Some createdTy) when preferCreated -> createdTy
+    | Some(typT, _typB, _typeDef, _) -> typT
     | None -> convTypeRefAux cenv tref
 
 let envBindConsRef emEnv (mref: ILMethodRef) consB =
@@ -667,7 +667,7 @@ let envPopEntryPts emEnv =
 // convCallConv
 //----------------------------------------------------------------------------
 
-let convCallConv (Callconv (hasThis, basic)) =
+let convCallConv (Callconv(hasThis, basic)) =
     let ccA =
         match hasThis with
         | ILThisConvention.Static -> CallingConventions.Standard
@@ -707,7 +707,7 @@ let rec convTypeSpec cenv emEnv preferCreated (tspec: ILTypeSpec) =
 and convTypeAux cenv emEnv preferCreated ty =
     match ty with
     | ILType.Void -> Type.GetType("System.Void")
-    | ILType.Array (shape, eltType) ->
+    | ILType.Array(shape, eltType) ->
         let baseT = convTypeAux cenv emEnv preferCreated eltType
         let nDims = shape.Rank
         // MakeArrayType() returns "eltType[]"
@@ -728,7 +728,7 @@ and convTypeAux cenv emEnv preferCreated ty =
         let baseT = convTypeAux cenv emEnv preferCreated eltType
         baseT.MakeByRefType()
     | ILType.TypeVar tv -> envGetTyvar emEnv tv
-    | ILType.Modified (_, _, modifiedTy) ->
+    | ILType.Modified(_, _, modifiedTy) ->
 
         convTypeAux cenv emEnv preferCreated modifiedTy
 
@@ -772,7 +772,7 @@ let convCreatedTypeRef cenv emEnv ty = convTypeRef cenv emEnv true ty
 let rec convParamModifiersOfType cenv emEnv (paramTy: ILType) =
     [|
         match paramTy with
-        | ILType.Modified (modreq, ty, modifiedTy) ->
+        | ILType.Modified(modreq, ty, modifiedTy) ->
             yield (modreq, convTypeRef cenv emEnv false ty)
             yield! convParamModifiersOfType cenv emEnv modifiedTy
         | _ -> ()
@@ -874,9 +874,8 @@ let convFieldSpec cenv emEnv fspec =
         // NOTE: if "convType becomes convCreatedType", then handle queryable types here too. [bug 4063] (necessary? what repro?)
         let fieldB = envGetFieldB emEnv fref
         nonQueryableTypeGetField parentTI fieldB
-    else
-    // Prior type.
-    if
+    else if
+        // Prior type.
         typeIsNotQueryable parentTI
     then
         let parentT = getTypeConstructor parentTI
@@ -1049,9 +1048,8 @@ let convMethodRef cenv emEnv (parentTI: Type) (mref: ILMethodRef) =
             // Emitted type, can get fully generic MethodBuilder from env.
             let methB = envGetMethB emEnv mref
             nonQueryableTypeGetMethod parentTI methB
-        else
-        // Prior type.
-        if
+        else if
+            // Prior type.
             typeIsNotQueryable parentTI
         then
             let parentT = getTypeConstructor parentTI
@@ -1126,9 +1124,8 @@ let convConstructorSpec cenv emEnv (mspec: ILMethodSpec) =
         if isEmittedTypeRef emEnv mref.DeclaringTypeRef then
             let consB = envGetConsB emEnv mref
             nonQueryableTypeGetConstructor parentTI consB
-        else
-        // Prior type.
-        if
+        else if
+            // Prior type.
             typeIsNotQueryable parentTI
         then
             let parentT = getTypeConstructor parentTI
@@ -1298,14 +1295,14 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
     | AI_pop -> ilG.EmitAndLog OpCodes.Pop
     | AI_ckfinite -> ilG.EmitAndLog OpCodes.Ckfinite
     | AI_nop -> ilG.EmitAndLog OpCodes.Nop
-    | AI_ldc (DT_I4, ILConst.I4 i32) -> ilG.EmitAndLog(OpCodes.Ldc_I4, i32)
-    | AI_ldc (DT_I8, ILConst.I8 i64) -> ilG.Emit(OpCodes.Ldc_I8, i64)
-    | AI_ldc (DT_R4, ILConst.R4 r32) -> ilG.Emit(OpCodes.Ldc_R4, r32)
-    | AI_ldc (DT_R8, ILConst.R8 r64) -> ilG.Emit(OpCodes.Ldc_R8, r64)
+    | AI_ldc(DT_I4, ILConst.I4 i32) -> ilG.EmitAndLog(OpCodes.Ldc_I4, i32)
+    | AI_ldc(DT_I8, ILConst.I8 i64) -> ilG.Emit(OpCodes.Ldc_I8, i64)
+    | AI_ldc(DT_R4, ILConst.R4 r32) -> ilG.Emit(OpCodes.Ldc_R4, r32)
+    | AI_ldc(DT_R8, ILConst.R8 r64) -> ilG.Emit(OpCodes.Ldc_R8, r64)
     | AI_ldc _ -> failwith "emitInstrI_arith (AI_ldc (ty, const)) iltyped"
     | I_ldarg u16 -> ilG.EmitAndLog(OpCodes.Ldarg, int16 u16)
     | I_ldarga u16 -> ilG.EmitAndLog(OpCodes.Ldarga, int16 u16)
-    | I_ldind (align, vol, dt) ->
+    | I_ldind(align, vol, dt) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
 
@@ -1327,7 +1324,7 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
     | I_ldloc u16 -> ilG.EmitAndLog(OpCodes.Ldloc, int16 u16)
     | I_ldloca u16 -> ilG.EmitAndLog(OpCodes.Ldloca, int16 u16)
     | I_starg u16 -> ilG.EmitAndLog(OpCodes.Starg, int16 u16)
-    | I_stind (align, vol, dt) ->
+    | I_stind(align, vol, dt) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
 
@@ -1349,24 +1346,24 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
     | I_stloc u16 -> ilG.EmitAndLog(OpCodes.Stloc, int16 u16)
     | I_br targ -> ilG.EmitAndLog(OpCodes.Br, envGetLabel emEnv targ)
     | I_jmp mspec -> ilG.EmitAndLog(OpCodes.Jmp, convMethodSpec cenv emEnv mspec)
-    | I_brcmp (comp, targ) -> emitInstrCompare emEnv ilG comp targ
+    | I_brcmp(comp, targ) -> emitInstrCompare emEnv ilG comp targ
     | I_switch labels -> ilG.Emit(OpCodes.Switch, Array.ofList (List.map (envGetLabel emEnv) labels))
     | I_ret -> ilG.EmitAndLog OpCodes.Ret
 
-    | I_call (tail, mspec, varargs) ->
+    | I_call(tail, mspec, varargs) ->
         emitSilverlightCheck ilG
         emitInstrCall cenv emEnv ilG OpCodes.Call tail mspec varargs
 
-    | I_callvirt (tail, mspec, varargs) ->
+    | I_callvirt(tail, mspec, varargs) ->
         emitSilverlightCheck ilG
         emitInstrCall cenv emEnv ilG OpCodes.Callvirt tail mspec varargs
 
-    | I_callconstraint (callvirt, tail, ty, mspec, varargs) ->
+    | I_callconstraint(callvirt, tail, ty, mspec, varargs) ->
         ilG.Emit(OpCodes.Constrained, convType cenv emEnv ty)
         let instr = if callvirt then OpCodes.Callvirt else OpCodes.Call
         emitInstrCall cenv emEnv ilG instr tail mspec varargs
 
-    | I_calli (tail, callsig, None) ->
+    | I_calli(tail, callsig, None) ->
         emitInstrTail cenv ilG tail (fun () ->
             ilG.EmitCalli(
                 OpCodes.Calli,
@@ -1376,7 +1373,7 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
                 Unchecked.defaultof<Type[]>
             ))
 
-    | I_calli (tail, callsig, Some varargTys) ->
+    | I_calli(tail, callsig, Some varargTys) ->
         emitInstrTail cenv ilG tail (fun () ->
             ilG.EmitCalli(
                 OpCodes.Calli,
@@ -1388,27 +1385,27 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
 
     | I_ldftn mspec -> ilG.EmitAndLog(OpCodes.Ldftn, convMethodSpec cenv emEnv mspec)
 
-    | I_newobj (mspec, varargs) -> emitInstrNewobj cenv emEnv ilG mspec varargs
+    | I_newobj(mspec, varargs) -> emitInstrNewobj cenv emEnv ilG mspec varargs
 
     | I_throw -> ilG.EmitAndLog OpCodes.Throw
     | I_endfinally -> ilG.EmitAndLog OpCodes.Endfinally
     | I_endfilter -> ilG.EmitAndLog OpCodes.Endfilter
     | I_leave label -> ilG.EmitAndLog(OpCodes.Leave, envGetLabel emEnv label)
-    | I_ldsfld (vol, fspec) ->
+    | I_ldsfld(vol, fspec) ->
         emitInstrVolatile ilG vol
         ilG.EmitAndLog(OpCodes.Ldsfld, convFieldSpec cenv emEnv fspec)
-    | I_ldfld (align, vol, fspec) ->
+    | I_ldfld(align, vol, fspec) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
         ilG.EmitAndLog(OpCodes.Ldfld, convFieldSpec cenv emEnv fspec)
     | I_ldsflda fspec -> ilG.EmitAndLog(OpCodes.Ldsflda, convFieldSpec cenv emEnv fspec)
     | I_ldflda fspec -> ilG.EmitAndLog(OpCodes.Ldflda, convFieldSpec cenv emEnv fspec)
 
-    | I_stsfld (vol, fspec) ->
+    | I_stsfld(vol, fspec) ->
         emitInstrVolatile ilG vol
         ilG.EmitAndLog(OpCodes.Stsfld, convFieldSpec cenv emEnv fspec)
 
-    | I_stfld (align, vol, fspec) ->
+    | I_stfld(align, vol, fspec) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
         ilG.EmitAndLog(OpCodes.Stfld, convFieldSpec cenv emEnv fspec)
@@ -1416,20 +1413,20 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
     | I_ldstr s -> ilG.EmitAndLog(OpCodes.Ldstr, s)
     | I_isinst ty -> ilG.EmitAndLog(OpCodes.Isinst, convType cenv emEnv ty)
     | I_castclass ty -> ilG.EmitAndLog(OpCodes.Castclass, convType cenv emEnv ty)
-    | I_ldtoken (ILToken.ILType ty) -> ilG.EmitAndLog(OpCodes.Ldtoken, convTypeOrTypeDef cenv emEnv ty)
-    | I_ldtoken (ILToken.ILMethod mspec) -> ilG.EmitAndLog(OpCodes.Ldtoken, convMethodSpec cenv emEnv mspec)
-    | I_ldtoken (ILToken.ILField fspec) -> ilG.EmitAndLog(OpCodes.Ldtoken, convFieldSpec cenv emEnv fspec)
+    | I_ldtoken(ILToken.ILType ty) -> ilG.EmitAndLog(OpCodes.Ldtoken, convTypeOrTypeDef cenv emEnv ty)
+    | I_ldtoken(ILToken.ILMethod mspec) -> ilG.EmitAndLog(OpCodes.Ldtoken, convMethodSpec cenv emEnv mspec)
+    | I_ldtoken(ILToken.ILField fspec) -> ilG.EmitAndLog(OpCodes.Ldtoken, convFieldSpec cenv emEnv fspec)
     | I_ldvirtftn mspec -> ilG.EmitAndLog(OpCodes.Ldvirtftn, convMethodSpec cenv emEnv mspec)
     // Value type instructions
     | I_cpobj ty -> ilG.EmitAndLog(OpCodes.Cpobj, convType cenv emEnv ty)
     | I_initobj ty -> ilG.EmitAndLog(OpCodes.Initobj, convType cenv emEnv ty)
 
-    | I_ldobj (align, vol, ty) ->
+    | I_ldobj(align, vol, ty) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
         ilG.EmitAndLog(OpCodes.Ldobj, convType cenv emEnv ty)
 
-    | I_stobj (align, vol, ty) ->
+    | I_stobj(align, vol, ty) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
         ilG.EmitAndLog(OpCodes.Stobj, convType cenv emEnv ty)
@@ -1485,7 +1482,7 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
         | DT_U8 -> failwith "emitInstr cenv: stelem U8"
         | DT_REF -> ilG.EmitAndLog OpCodes.Stelem_Ref
 
-    | I_ldelema (ro, _isNativePtr, shape, ty) ->
+    | I_ldelema(ro, _isNativePtr, shape, ty) ->
         if (ro = ReadonlyAddress) then
             ilG.EmitAndLog OpCodes.Readonly
 
@@ -1502,7 +1499,7 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
 
             ilG.EmitAndLog(OpCodes.Call, meth)
 
-    | I_ldelem_any (shape, ty) ->
+    | I_ldelem_any(shape, ty) ->
         if shape = ILArrayShape.SingleDimensional then
             ilG.EmitAndLog(OpCodes.Ldelem, convType cenv emEnv ty)
         else
@@ -1514,7 +1511,7 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
 
             ilG.EmitAndLog(OpCodes.Call, meth)
 
-    | I_stelem_any (shape, ty) ->
+    | I_stelem_any(shape, ty) ->
         if shape = ILArrayShape.SingleDimensional then
             ilG.EmitAndLog(OpCodes.Stelem, convType cenv emEnv ty)
         else
@@ -1532,7 +1529,7 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
 
             ilG.EmitAndLog(OpCodes.Call, meth)
 
-    | I_newarr (shape, ty) ->
+    | I_newarr(shape, ty) ->
         if shape = ILArrayShape.SingleDimensional then
             ilG.EmitAndLog(OpCodes.Newarr, convType cenv emEnv ty)
         else
@@ -1553,17 +1550,17 @@ let rec emitInstr cenv (modB: ModuleBuilder) emEnv (ilG: ILGenerator) instr =
     | I_arglist -> ilG.EmitAndLog OpCodes.Arglist
     | I_localloc -> ilG.EmitAndLog OpCodes.Localloc
 
-    | I_cpblk (align, vol) ->
+    | I_cpblk(align, vol) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
         ilG.EmitAndLog OpCodes.Cpblk
 
-    | I_initblk (align, vol) ->
+    | I_initblk(align, vol) ->
         emitInstrAlign ilG align
         emitInstrVolatile ilG vol
         ilG.EmitAndLog OpCodes.Initblk
 
-    | EI_ldlen_multi (_, m) ->
+    | EI_ldlen_multi(_, m) ->
         emitInstr cenv modB emEnv ilG (mkLdcInt32 m)
 
         emitInstr
@@ -1589,7 +1586,7 @@ let emitCode cenv modB emEnv (ilG: ILGenerator) (code: ILCode) =
 
     let emEnv =
         (emEnv, code.Labels)
-        ||> Seq.fold (fun emEnv (KeyValue (label, pc)) ->
+        ||> Seq.fold (fun emEnv (KeyValue(label, pc)) ->
             let lab = ilG.DefineLabelAndLog()
 
             pc2lab[pc] <-
@@ -1617,20 +1614,20 @@ let emitCode cenv modB emEnv (ilG: ILGenerator) (code: ILCode) =
         add startTry (fun () -> ilG.BeginExceptionBlockAndLog() |> ignore)
 
         match exnSpec.Clause with
-        | ILExceptionClause.Finally (startHandler, endHandler) ->
+        | ILExceptionClause.Finally(startHandler, endHandler) ->
             add startHandler ilG.BeginFinallyBlockAndLog
             add endHandler ilG.EndExceptionBlockAndLog
 
-        | ILExceptionClause.Fault (startHandler, endHandler) ->
+        | ILExceptionClause.Fault(startHandler, endHandler) ->
             add startHandler ilG.BeginFaultBlockAndLog
             add endHandler ilG.EndExceptionBlockAndLog
 
-        | ILExceptionClause.FilterCatch ((startFilter, _), (startHandler, endHandler)) ->
+        | ILExceptionClause.FilterCatch((startFilter, _), (startHandler, endHandler)) ->
             add startFilter ilG.BeginExceptFilterBlockAndLog
             add startHandler (fun () -> ilG.BeginCatchBlockAndLog null)
             add endHandler ilG.EndExceptionBlockAndLog
 
-        | ILExceptionClause.TypeCatch (ty, (startHandler, endHandler)) ->
+        | ILExceptionClause.TypeCatch(ty, (startHandler, endHandler)) ->
             add startHandler (fun () -> ilG.BeginCatchBlockAndLog(convType cenv emEnv ty))
             add endHandler ilG.EndExceptionBlockAndLog
 
@@ -1770,23 +1767,25 @@ let emitParameter cenv emEnv (defineParameter: int * ParameterAttributes * strin
 
 // Use reflection to invoke the api when we are executing on a platform that doesn't directly have this API.
 let definePInvokeMethod =
-    typeof<TypeBuilder>.GetMethod
-        ("DefinePInvokeMethod",
-         [|
-             typeof<string>
-             typeof<string>
-             typeof<string>
-             typeof<MethodAttributes>
-             typeof<CallingConventions>
-             typeof<Type>
-             typeof<Type[]>
-             typeof<Type[]>
-             typeof<Type[]>
-             typeof<Type[][]>
-             typeof<Type[][]>
-             typeof<CallingConvention>
-             typeof<CharSet>
-         |])
+    typeof<TypeBuilder>
+        .GetMethod(
+            "DefinePInvokeMethod",
+            [|
+                typeof<string>
+                typeof<string>
+                typeof<string>
+                typeof<MethodAttributes>
+                typeof<CallingConventions>
+                typeof<Type>
+                typeof<Type[]>
+                typeof<Type[]>
+                typeof<Type[]>
+                typeof<Type[][]>
+                typeof<Type[][]>
+                typeof<CallingConvention>
+                typeof<CharSet>
+            |]
+        )
 
 let enablePInvoke = definePInvokeMethod <> null
 
@@ -2063,7 +2062,7 @@ let buildEventPass3 cenv (typB: TypeBuilder) emEnv (eventDef: ILEventDef) =
 let buildMethodImplsPass3 cenv _tref (typB: TypeBuilder) emEnv (mimpl: ILMethodImplDef) =
     let bodyMethInfo = convMethodRef cenv emEnv typB mimpl.OverrideBy.MethodRef // doc: must be MethodBuilder
 
-    let (OverridesSpec (mref, dtyp)) = mimpl.Overrides
+    let (OverridesSpec(mref, dtyp)) = mimpl.Overrides
     let declMethTI = convType cenv emEnv dtyp
     let declMethInfo = convMethodRef cenv emEnv declMethTI mref
     typB.DefineMethodOverride(bodyMethInfo, declMethInfo)
@@ -2279,7 +2278,7 @@ let rec getTypeRefsInType (allTypes: CollectTypes) ty acc =
     | ILType.TypeVar _ -> acc
     | ILType.Ptr eltType
     | ILType.Byref eltType -> getTypeRefsInType allTypes eltType acc
-    | ILType.Array (_, eltType) ->
+    | ILType.Array(_, eltType) ->
         match allTypes with
         | CollectTypes.ValueTypesOnly -> acc
         | CollectTypes.All -> getTypeRefsInType allTypes eltType acc
@@ -2375,7 +2374,7 @@ let createTypeRef (visited: Dictionary<_, _>, created: Dictionary<_, _>) emEnv t
                     let typeRef = ILTypeRef.Create(ILScopeRef.Local, nestingToProbe, typeName)
 
                     match emEnv.emTypMap.TryFind typeRef with
-                    | Some (_, tb, _, _) ->
+                    | Some(_, tb, _, _) ->
                         if not (tb.IsCreated()) then
                             tb.CreateTypeAndLog() |> ignore
 

--- a/src/Compiler/AbstractIL/ilwritepdb.fs
+++ b/src/Compiler/AbstractIL/ilwritepdb.fs
@@ -340,14 +340,7 @@ let scopeSorter (scope1: PdbMethodScope) (scope2: PdbMethodScope) =
         0
 
 type PortablePdbGenerator
-    (
-        embedAllSource: bool,
-        embedSourceList: string list,
-        sourceLink: string,
-        checksumAlgorithm,
-        info: PdbData,
-        pathMap: PathMap
-    ) =
+    (embedAllSource: bool, embedSourceList: string list, sourceLink: string, checksumAlgorithm, info: PdbData, pathMap: PathMap) =
 
     let docs =
         match info.Documents with
@@ -438,7 +431,7 @@ type PortablePdbGenerator
             // For F# Interactive, file name 'stdin' gets generated for interactive inputs
             let handle =
                 match checkSum doc.File checksumAlgorithm with
-                | Some (hashAlg, checkSum) ->
+                | Some(hashAlg, checkSum) ->
                     let dbgInfo =
                         (serializeDocumentName doc.File,
                          metadata.GetOrAddGuid hashAlg,

--- a/src/Compiler/AbstractIL/ilx.fs
+++ b/src/Compiler/AbstractIL/ilx.fs
@@ -57,21 +57,20 @@ type IlxUnionSpec =
     | IlxUnionSpec of IlxUnionRef * ILGenericArgs
 
     member x.DeclaringType =
-        let (IlxUnionSpec (IlxUnionRef (bx, tref, _, _, _), inst)) = x in mkILNamedTy bx tref inst
+        let (IlxUnionSpec(IlxUnionRef(bx, tref, _, _, _), inst)) = x in mkILNamedTy bx tref inst
 
-    member x.Boxity = let (IlxUnionSpec (IlxUnionRef (bx, _, _, _, _), _)) = x in bx
+    member x.Boxity = let (IlxUnionSpec(IlxUnionRef(bx, _, _, _, _), _)) = x in bx
 
-    member x.TypeRef = let (IlxUnionSpec (IlxUnionRef (_, tref, _, _, _), _)) = x in tref
+    member x.TypeRef = let (IlxUnionSpec(IlxUnionRef(_, tref, _, _, _), _)) = x in tref
 
-    member x.GenericArgs = let (IlxUnionSpec (_, inst)) = x in inst
+    member x.GenericArgs = let (IlxUnionSpec(_, inst)) = x in inst
 
     member x.AlternativesArray =
-        let (IlxUnionSpec (IlxUnionRef (_, _, alts, _, _), _)) = x in alts
+        let (IlxUnionSpec(IlxUnionRef(_, _, alts, _, _), _)) = x in alts
 
-    member x.IsNullPermitted =
-        let (IlxUnionSpec (IlxUnionRef (_, _, _, np, _), _)) = x in np
+    member x.IsNullPermitted = let (IlxUnionSpec(IlxUnionRef(_, _, _, np, _), _)) = x in np
 
-    member x.HasHelpers = let (IlxUnionSpec (IlxUnionRef (_, _, _, _, b), _)) = x in b
+    member x.HasHelpers = let (IlxUnionSpec(IlxUnionRef(_, _, _, _, b), _)) = x in b
 
     member x.Alternatives = Array.toList x.AlternativesArray
 
@@ -93,14 +92,14 @@ type IlxClosureApps =
 
 let rec instAppsAux n inst apps =
     match apps with
-    | Apps_tyapp (ty, rest) -> Apps_tyapp(instILTypeAux n inst ty, instAppsAux n inst rest)
-    | Apps_app (domainTy, rest) -> Apps_app(instILTypeAux n inst domainTy, instAppsAux n inst rest)
+    | Apps_tyapp(ty, rest) -> Apps_tyapp(instILTypeAux n inst ty, instAppsAux n inst rest)
+    | Apps_app(domainTy, rest) -> Apps_app(instILTypeAux n inst domainTy, instAppsAux n inst rest)
     | Apps_done retTy -> Apps_done(instILTypeAux n inst retTy)
 
 let rec instLambdasAux n inst lambdas =
     match lambdas with
-    | Lambdas_forall (gpdef, bodyTy) -> Lambdas_forall(gpdef, instLambdasAux n inst bodyTy)
-    | Lambdas_lambda (pdef, bodyTy) ->
+    | Lambdas_forall(gpdef, bodyTy) -> Lambdas_forall(gpdef, instLambdasAux n inst bodyTy)
+    | Lambdas_lambda(pdef, bodyTy) ->
         Lambdas_lambda(
             { pdef with
                 Type = instILTypeAux n inst pdef.Type
@@ -130,20 +129,20 @@ type IlxClosureRef = IlxClosureRef of ILTypeRef * IlxClosureLambdas * IlxClosure
 type IlxClosureSpec =
     | IlxClosureSpec of IlxClosureRef * ILGenericArgs * ILType * useStaticField: bool
 
-    member x.TypeRef = let (IlxClosureRef (tref, _, _)) = x.ClosureRef in tref
+    member x.TypeRef = let (IlxClosureRef(tref, _, _)) = x.ClosureRef in tref
 
-    member x.ILType = let (IlxClosureSpec (_, _, ty, _)) = x in ty
+    member x.ILType = let (IlxClosureSpec(_, _, ty, _)) = x in ty
 
-    member x.ClosureRef = let (IlxClosureSpec (cloref, _, _, _)) = x in cloref
+    member x.ClosureRef = let (IlxClosureSpec(cloref, _, _, _)) = x in cloref
 
-    member x.FormalFreeVars = let (IlxClosureRef (_, _, fvs)) = x.ClosureRef in fvs
+    member x.FormalFreeVars = let (IlxClosureRef(_, _, fvs)) = x.ClosureRef in fvs
 
-    member x.FormalLambdas = let (IlxClosureRef (_, lambdas, _)) = x.ClosureRef in lambdas
+    member x.FormalLambdas = let (IlxClosureRef(_, lambdas, _)) = x.ClosureRef in lambdas
 
-    member x.GenericArgs = let (IlxClosureSpec (_, inst, _, _)) = x in inst
+    member x.GenericArgs = let (IlxClosureSpec(_, inst, _, _)) = x in inst
 
     static member Create(cloref, inst, useStaticField) =
-        let (IlxClosureRef (tref, _, _)) = cloref
+        let (IlxClosureRef(tref, _, _)) = cloref
         IlxClosureSpec(cloref, inst, mkILBoxedType (mkILTySpec (tref, inst)), useStaticField)
 
     member x.Constructor =
@@ -152,7 +151,7 @@ type IlxClosureSpec =
         mkILCtorMethSpecForTy (cloTy, fields |> Array.map (fun fv -> fv.fvType) |> Array.toList)
 
     member x.UseStaticField =
-        let (IlxClosureSpec (_, _, _, useStaticField)) = x
+        let (IlxClosureSpec(_, _, _, useStaticField)) = x
         useStaticField
 
     member x.GetStaticFieldSpec() =
@@ -200,7 +199,7 @@ type IlxUnionInfo =
 
 let destTyFuncApp input =
     match input with
-    | Apps_tyapp (b, c) -> b, c
+    | Apps_tyapp(b, c) -> b, c
     | _ -> failwith "destTyFuncApp"
 
 let mkILFormalCloRef gparams csig useStaticField =

--- a/src/Compiler/Checking/CheckBasics.fsi
+++ b/src/Compiler/Checking/CheckBasics.fsi
@@ -270,51 +270,44 @@ type TcFileState =
         argInfoCache: ConcurrentDictionary<(string * range), ArgReprInfo>
 
         // forward call
-        TcPat: WarnOnUpperFlag
-            -> TcFileState
-            -> TcEnv
-            -> PrelimValReprInfo option
-            -> TcPatValFlags
-            -> TcPatLinearEnv
-            -> TType
-            -> SynPat
-            -> (TcPatPhase2Input -> Pattern) * TcPatLinearEnv
+        TcPat:
+            WarnOnUpperFlag
+                -> TcFileState
+                -> TcEnv
+                -> PrelimValReprInfo option
+                -> TcPatValFlags
+                -> TcPatLinearEnv
+                -> TType
+                -> SynPat
+                -> (TcPatPhase2Input -> Pattern) * TcPatLinearEnv
 
         // forward call
-        TcSimplePats: TcFileState
-            -> bool
-            -> CheckConstraints
-            -> TType
-            -> TcEnv
-            -> TcPatLinearEnv
-            -> SynSimplePats
-            -> string list * TcPatLinearEnv
+        TcSimplePats:
+            TcFileState
+                -> bool
+                -> CheckConstraints
+                -> TType
+                -> TcEnv
+                -> TcPatLinearEnv
+                -> SynSimplePats
+                -> string list * TcPatLinearEnv
 
         // forward call
-        TcSequenceExpressionEntry: TcFileState
-            -> TcEnv
-            -> OverallTy
-            -> UnscopedTyparEnv
-            -> bool * SynExpr
-            -> range
-            -> Expr * UnscopedTyparEnv
+        TcSequenceExpressionEntry:
+            TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv
 
         // forward call
-        TcArrayOrListComputedExpression: TcFileState
-            -> TcEnv
-            -> OverallTy
-            -> UnscopedTyparEnv
-            -> bool * SynExpr
-            -> range
-            -> Expr * UnscopedTyparEnv
+        TcArrayOrListComputedExpression:
+            TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv
 
         // forward call
-        TcComputationExpression: TcFileState
-            -> TcEnv
-            -> OverallTy
-            -> UnscopedTyparEnv
-            -> range * Expr * TType * SynExpr
-            -> Expr * UnscopedTyparEnv
+        TcComputationExpression:
+            TcFileState
+                -> TcEnv
+                -> OverallTy
+                -> UnscopedTyparEnv
+                -> range * Expr * TType * SynExpr
+                -> Expr * UnscopedTyparEnv
     }
 
     static member Create:
@@ -329,9 +322,34 @@ type TcFileState =
         tcVal: TcValF *
         isInternalTestSpanStackReferring: bool *
         diagnosticOptions: FSharpDiagnosticOptions *
-        tcPat: (WarnOnUpperFlag -> TcFileState -> TcEnv -> PrelimValReprInfo option -> TcPatValFlags -> TcPatLinearEnv -> TType -> SynPat -> (TcPatPhase2Input -> Pattern) * TcPatLinearEnv) *
-        tcSimplePats: (TcFileState -> bool -> CheckConstraints -> TType -> TcEnv -> TcPatLinearEnv -> SynSimplePats -> string list * TcPatLinearEnv) *
-        tcSequenceExpressionEntry: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *
-        tcArrayOrListSequenceExpression: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *
-        tcComputationExpression: (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> range * Expr * TType * SynExpr -> Expr * UnscopedTyparEnv) ->
+        tcPat:
+            (WarnOnUpperFlag
+                -> TcFileState
+                -> TcEnv
+                -> PrelimValReprInfo option
+                -> TcPatValFlags
+                -> TcPatLinearEnv
+                -> TType
+                -> SynPat
+                -> (TcPatPhase2Input -> Pattern) * TcPatLinearEnv) *
+        tcSimplePats:
+            (TcFileState
+                -> bool
+                -> CheckConstraints
+                -> TType
+                -> TcEnv
+                -> TcPatLinearEnv
+                -> SynSimplePats
+                -> string list * TcPatLinearEnv) *
+        tcSequenceExpressionEntry:
+            (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *
+        tcArrayOrListSequenceExpression:
+            (TcFileState -> TcEnv -> OverallTy -> UnscopedTyparEnv -> bool * SynExpr -> range -> Expr * UnscopedTyparEnv) *
+        tcComputationExpression:
+            (TcFileState
+                -> TcEnv
+                -> OverallTy
+                -> UnscopedTyparEnv
+                -> range * Expr * TType * SynExpr
+                -> Expr * UnscopedTyparEnv) ->
             TcFileState

--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
@@ -36,13 +36,12 @@ let GroupUpdatesToNestedFields (fields: ((Ident list * Ident) * SynExpr option) 
         | x :: [] -> x :: res
         | x :: y :: ys ->
             match x, y with
-            | (lidwid, Some (SynExpr.Record (baseInfo, copyInfo, fields1, m))), (_, Some (SynExpr.Record (recordFields = fields2))) ->
+            | (lidwid, Some(SynExpr.Record(baseInfo, copyInfo, fields1, m))), (_, Some(SynExpr.Record(recordFields = fields2))) ->
                 let reducedRecd =
                     (lidwid, Some(SynExpr.Record(baseInfo, copyInfo, fields1 @ fields2, m)))
 
                 groupIfNested res (reducedRecd :: ys)
-            | (lidwid, Some (SynExpr.AnonRecd (isStruct, copyInfo, fields1, m, trivia))),
-              (_, Some (SynExpr.AnonRecd (recordFields = fields2))) ->
+            | (lidwid, Some(SynExpr.AnonRecd(isStruct, copyInfo, fields1, m, trivia))), (_, Some(SynExpr.AnonRecd(recordFields = fields2))) ->
                 let reducedRecd =
                     (lidwid, Some(SynExpr.AnonRecd(isStruct, copyInfo, fields1 @ fields2, m, trivia)))
 
@@ -121,9 +120,10 @@ let TransformAstForNestedUpdates (cenv: TcFileState) (env: TcEnv) overallTy (lid
                     synExprRecd copyInfo fieldId rest exprBeingAssigned
 
             match item with
-            | Item.AnonRecdField(anonInfo = {
-                                                AnonRecdTypeInfo.TupInfo = TupInfo.Const isStruct
-                                            }) ->
+            | Item.AnonRecdField(
+                anonInfo = {
+                               AnonRecdTypeInfo.TupInfo = TupInfo.Const isStruct
+                           }) ->
                 let fields = [ LongIdentWithDots([ fieldId ], []), None, nestedField ]
                 SynExpr.AnonRecd(isStruct, copyInfo outerFieldId, fields, outerFieldId.idRange, { OpeningBraceRange = range0 })
             | _ ->

--- a/src/Compiler/Checking/InfoReader.fsi
+++ b/src/Compiler/Checking/InfoReader.fsi
@@ -41,6 +41,7 @@ type PropertyCollector =
     new:
         g: TcGlobals * amap: ImportMap * m: range * ty: TType * optFilter: string option * ad: AccessorDomain ->
             PropertyCollector
+
     member Close: unit -> PropInfo list
     member Collect: membInfo: ValMemberInfo * vref: ValRef -> unit
 
@@ -109,6 +110,7 @@ type InfoReader =
     /// Read the IL fields of a type, including inherited ones. Cache the result for monomorphic types.
     member GetILFieldInfosOfType:
         optFilter: string option * ad: AccessorDomain * m: range * ty: TType -> ILFieldInfo list
+
     member GetImmediateIntrinsicEventsOfType:
         optFilter: string option * ad: AccessorDomain * m: range * ty: TType -> EventInfo list
 

--- a/src/Compiler/Checking/QuotationTranslator.fsi
+++ b/src/Compiler/Checking/QuotationTranslator.fsi
@@ -32,6 +32,7 @@ type QuotationSerializationFormat =
 type QuotationGenerationScope =
     static member Create:
         TcGlobals * ImportMap * CcuThunk * ConstraintSolver.TcValF * IsReflectedDefinition -> QuotationGenerationScope
+
     member Close: unit -> ILTypeRef list * (TType * range) list * (Expr * range) list
     static member ComputeQuotationFormat: TcGlobals -> QuotationSerializationFormat
 

--- a/src/Compiler/Checking/SignatureHash.fs
+++ b/src/Compiler/Checking/SignatureHash.fs
@@ -95,14 +95,14 @@ module HashIL =
     let rec hashILType (ty: ILType) : Hash =
         match ty with
         | ILType.Void -> hash ILType.Void
-        | ILType.Array (sh, t) -> hashILType t @@ hashILArrayShape sh
+        | ILType.Array(sh, t) -> hashILType t @@ hashILArrayShape sh
         | ILType.Value t
         | ILType.Boxed t -> hashILTypeRef t.TypeRef @@ (t.GenericArgs |> hashListOrderMatters (hashILType))
         | ILType.Ptr t
         | ILType.Byref t -> hashILType t
         | ILType.FunctionPointer t -> hashILCallingSignature t
         | ILType.TypeVar n -> hash n
-        | ILType.Modified (_, _, t) -> hashILType t
+        | ILType.Modified(_, _, t) -> hashILType t
 
     and hashILCallingSignature (signature: ILCallingSignature) =
         let res = signature.ReturnType |> hashILType
@@ -113,7 +113,7 @@ module HashAccessibility =
     let isHiddenToObserver (TAccess access) (observer: ObserverVisibility) =
         let isInternalCompPath x =
             match x with
-            | CompPath (ILScopeRef.Local, []) -> true
+            | CompPath(ILScopeRef.Local, []) -> true
             | _ -> false
 
         match access with
@@ -134,7 +134,7 @@ module rec HashTypes =
     let hashMemberFlags (memFlags: SynMemberFlags) = hash memFlags
 
     /// Hash an attribute 'Type(arg1, ..., argN)'
-    let private hashAttrib (Attrib (tyconRef = tcref)) = hashTyconRefImpl tcref
+    let private hashAttrib (Attrib(tyconRef = tcref)) = hashTyconRefImpl tcref
 
     let hashAttributeList attrs =
         attrs |> hashListOrderIndependent hashAttrib
@@ -151,18 +151,18 @@ module rec HashTypes =
         let tpHash = hashTyparRefWithInfo tp
 
         match tpc with
-        | TyparConstraint.CoercesTo (tgtTy, _) -> tpHash @@ 1 @@ hashTType g tgtTy
-        | TyparConstraint.MayResolveMember (traitInfo, _) -> tpHash @@ 2 @@ hashTraitWithInfo (* denv *) g traitInfo
-        | TyparConstraint.DefaultsTo (_, ty, _) -> tpHash @@ 3 @@ hashTType g ty
-        | TyparConstraint.IsEnum (ty, _) -> tpHash @@ 4 @@ hashTType g ty
+        | TyparConstraint.CoercesTo(tgtTy, _) -> tpHash @@ 1 @@ hashTType g tgtTy
+        | TyparConstraint.MayResolveMember(traitInfo, _) -> tpHash @@ 2 @@ hashTraitWithInfo (* denv *) g traitInfo
+        | TyparConstraint.DefaultsTo(_, ty, _) -> tpHash @@ 3 @@ hashTType g ty
+        | TyparConstraint.IsEnum(ty, _) -> tpHash @@ 4 @@ hashTType g ty
         | TyparConstraint.SupportsComparison _ -> tpHash @@ 5
         | TyparConstraint.SupportsEquality _ -> tpHash @@ 6
-        | TyparConstraint.IsDelegate (aty, bty, _) -> tpHash @@ 7 @@ hashTType g aty @@ hashTType g bty
+        | TyparConstraint.IsDelegate(aty, bty, _) -> tpHash @@ 7 @@ hashTType g aty @@ hashTType g bty
         | TyparConstraint.SupportsNull _ -> tpHash @@ 8
         | TyparConstraint.IsNonNullableStruct _ -> tpHash @@ 9
         | TyparConstraint.IsUnmanaged _ -> tpHash @@ 10
         | TyparConstraint.IsReferenceType _ -> tpHash @@ 11
-        | TyparConstraint.SimpleChoice (tys, _) -> tpHash @@ 12 @@ (tys |> hashListOrderIndependent (hashTType g))
+        | TyparConstraint.SimpleChoice(tys, _) -> tpHash @@ 12 @@ (tys |> hashListOrderIndependent (hashTType g))
         | TyparConstraint.RequiresDefaultConstructor _ -> tpHash @@ 13
 
     /// Hash type parameter constraints
@@ -197,23 +197,23 @@ module rec HashTypes =
     let hashTType (g: TcGlobals) ty =
 
         match stripTyparEqns ty |> (stripTyEqns g) with
-        | TType_ucase (UnionCaseRef (tc, _), args)
-        | TType_app (tc, args, _) -> args |> hashListOrderMatters (hashTType g) |> pipeToHash (hashTyconRef tc)
-        | TType_anon (anonInfo, tys) ->
+        | TType_ucase(UnionCaseRef(tc, _), args)
+        | TType_app(tc, args, _) -> args |> hashListOrderMatters (hashTType g) |> pipeToHash (hashTyconRef tc)
+        | TType_anon(anonInfo, tys) ->
             tys
             |> hashListOrderMatters (hashTType g)
             |> pipeToHash (anonInfo.SortedNames |> hashListOrderMatters hashText)
             |> addFullStructuralHash (evalAnonInfoIsStruct anonInfo)
-        | TType_tuple (tupInfo, t) ->
+        | TType_tuple(tupInfo, t) ->
             t
             |> hashListOrderMatters (hashTType g)
             |> addFullStructuralHash (evalTupInfoIsStruct tupInfo)
         // Hash a first-class generic type.
-        | TType_forall (tps, tau) -> tps |> hashListOrderMatters (hashTyparRef) |> pipeToHash (hashTType g tau)
+        | TType_forall(tps, tau) -> tps |> hashListOrderMatters (hashTyparRef) |> pipeToHash (hashTType g tau)
         | TType_fun _ ->
             let argTys, retTy = stripFunTy g ty
             argTys |> hashListOrderMatters (hashTType g) |> pipeToHash (hashTType g retTy)
-        | TType_var (r, _) -> hashTyparRefWithInfo r
+        | TType_var(r, _) -> hashTyparRefWithInfo r
         | TType_measure unt -> hashMeasure unt
 
     // Hash a single argument, including its name and type
@@ -268,7 +268,7 @@ module rec HashTypes =
 
     let hashMemberType (g: TcGlobals) vref typarInst argInfos retTy =
         match PartitionValRefTypars g vref with
-        | Some (_, _, memberMethodTypars, memberToParentInst, _) ->
+        | Some(_, _, memberMethodTypars, memberToParentInst, _) ->
             hashMemberSigCore g memberToParentInst (typarInst, memberMethodTypars, argInfos, retTy)
         | None -> hashUncurriedSig g typarInst argInfos retTy
 
@@ -293,7 +293,11 @@ module HashTastMemberOrVals =
 
             let combinedHash =
                 memberFlagsHash
-                @@ parentTypeHash @@ memberTypeHash @@ flagsHash @@ nameHash @@ attribsHash
+                @@ parentTypeHash
+                @@ memberTypeHash
+                @@ flagsHash
+                @@ nameHash
+                @@ attribsHash
 
             combinedHash
 
@@ -344,7 +348,10 @@ module TyconDefinitionHash =
             let combined =
                 nameHash
                 @@ attribHash
-                   @@ typeHash @@ (hash fld.IsStatic) @@ (hash fld.IsVolatile) @@ (hash fld.IsMutable)
+                @@ typeHash
+                @@ (hash fld.IsStatic)
+                @@ (hash fld.IsVolatile)
+                @@ (hash fld.IsMutable)
 
             combined
 
@@ -368,7 +375,7 @@ module TyconDefinitionHash =
         |> hashListOrderMatters (hashUnionCase (g, obs))
 
     let private hashFsharpDelegate g slotSig =
-        let (TSlotSig (_, _, _, _, paraml, retTy)) = slotSig
+        let (TSlotSig(_, _, _, _, paraml, retTy)) = slotSig
 
         (paraml
          |> hashListOrderMatters (fun pl -> pl |> hashListOrderMatters (fun sp -> hashTType g sp.Type)))
@@ -471,11 +478,11 @@ let calculateHashOfImpliedSignature g observer (expr: ModuleOrNamespaceContents)
         match monb with
         | ModuleOrNamespaceBinding.Binding b when b.Var.LogicalName.StartsWith("doval@") -> 0
         | ModuleOrNamespaceBinding.Binding b -> HashTastMemberOrVals.hashValOrMemberNoInst (g, observer) (mkLocalValRef b.Var)
-        | ModuleOrNamespaceBinding.Module (moduleInfo, contents) -> hashSingleModuleOrNameSpaceIncludingName (moduleInfo, contents)
+        | ModuleOrNamespaceBinding.Module(moduleInfo, contents) -> hashSingleModuleOrNameSpaceIncludingName (moduleInfo, contents)
 
     and hashSingleModuleOrNamespaceContents x =
         match x with
-        | TMDefRec (_, _opens, tycons, mbinds, _) ->
+        | TMDefRec(_, _opens, tycons, mbinds, _) ->
             let mbindsHash = mbinds |> hashListOrderIndependent (hashModuleOrNameSpaceBinding)
 
             let tyconsHash = TyconDefinitionHash.hashTyconDefns (g, observer) tycons
@@ -485,7 +492,7 @@ let calculateHashOfImpliedSignature g observer (expr: ModuleOrNamespaceContents)
             else
                 0
 
-        | TMDefLet (bind, _) -> HashTastMemberOrVals.hashValOrMemberNoInst (g, observer) (mkLocalValRef bind.Var)
+        | TMDefLet(bind, _) -> HashTastMemberOrVals.hashValOrMemberNoInst (g, observer) (mkLocalValRef bind.Var)
         | TMDefOpens _ -> 0 (* empty hash *)
         | TMDefs defs -> defs |> hashListOrderIndependent hashSingleModuleOrNamespaceContents
         | TMDefDo _ -> 0 (* empty hash *)
@@ -525,4 +532,5 @@ let calculateHashOfAssemblyTopAttributes (attrs: TopAttribs) (platform: ILPlatfo
 
     HashTypes.hashAttributeList attrs.assemblyAttrs
     @@ HashTypes.hashAttributeList attrs.mainMethodAttrs
-       @@ HashTypes.hashAttributeList attrs.netModuleAttrs @@ platformHash
+    @@ HashTypes.hashAttributeList attrs.netModuleAttrs
+    @@ platformHash

--- a/src/Compiler/Checking/TailCallChecks.fs
+++ b/src/Compiler/Checking/TailCallChecks.fs
@@ -20,9 +20,8 @@ let PostInferenceChecksStackGuardDepth = GetEnvInteger "FSHARP_TailCallChecks" 5
 
 let (|ValUseAtApp|_|) e =
     match e with
-    | InnerExprPat (Expr.App(funcExpr = InnerExprPat (Expr.Val (valRef = vref; flags = valUseFlags))) | Expr.Val (valRef = vref
-                                                                                                                  flags = valUseFlags)) ->
-        Some(vref, valUseFlags)
+    | InnerExprPat(Expr.App(funcExpr = InnerExprPat(Expr.Val(valRef = vref; flags = valUseFlags))) | Expr.Val(
+        valRef = vref; flags = valUseFlags)) -> Some(vref, valUseFlags)
     | _ -> None
 
 type TailCallReturnType =
@@ -51,7 +50,7 @@ type TailCall =
 
     static member YesFromExpr (g: TcGlobals) (expr: Expr) =
         match expr with
-        | ValUseAtApp (valRef, _) -> TailCall.Yes(TailCall.IsVoidRet g valRef.Deref)
+        | ValUseAtApp(valRef, _) -> TailCall.Yes(TailCall.IsVoidRet g valRef.Deref)
         | _ -> TailCall.Yes TailCallReturnType.NonVoid
 
     member x.AtExprLambda =
@@ -136,11 +135,11 @@ let mkArgsForAppliedVal isBaseCall (vref: ValRef) argsl =
 let rec mkArgsForAppliedExpr isBaseCall argsl x =
     match stripDebugPoints (stripExpr x) with
     // recognise val
-    | Expr.Val (vref, _, _) -> mkArgsForAppliedVal isBaseCall vref argsl
+    | Expr.Val(vref, _, _) -> mkArgsForAppliedVal isBaseCall vref argsl
     // step through instantiations
-    | Expr.App (f, _fty, _tyargs, [], _) -> mkArgsForAppliedExpr isBaseCall argsl f
+    | Expr.App(f, _fty, _tyargs, [], _) -> mkArgsForAppliedExpr isBaseCall argsl f
     // step through subsumption coercions
-    | Expr.Op (TOp.Coerce, _, [ f ], _) -> mkArgsForAppliedExpr isBaseCall argsl f
+    | Expr.Op(TOp.Coerce, _, [ f ], _) -> mkArgsForAppliedExpr isBaseCall argsl f
     | _ -> []
 
 /// Check an expression, where the expression is in a position where byrefs can be generated
@@ -154,12 +153,12 @@ and CheckForNonTailRecCall (cenv: cenv) expr (tailCall: TailCall) =
     let expr = stripDebugPoints expr
 
     match expr with
-    | Expr.App (f, _fty, _tyargs, argsl, m) ->
+    | Expr.App(f, _fty, _tyargs, argsl, m) ->
 
         if cenv.reportErrors then
             if cenv.g.langVersion.SupportsFeature LanguageFeature.WarningWhenTailRecAttributeButNonTailRecUsage then
                 match f with
-                | ValUseAtApp (vref, valUseFlags) when cenv.mustTailCall.Contains vref.Deref ->
+                | ValUseAtApp(vref, valUseFlags) when cenv.mustTailCall.Contains vref.Deref ->
 
                     let canTailCall =
                         match tailCall with
@@ -220,8 +219,8 @@ and CheckCall cenv args ctxts (tailCall: TailCall) =
     // detect CPS-like expressions
     let rec (|IsAppInLambdaBody|_|) e =
         match stripDebugPoints e with
-        | Expr.TyLambda (bodyExpr = bodyExpr)
-        | Expr.Lambda (bodyExpr = bodyExpr) ->
+        | Expr.TyLambda(bodyExpr = bodyExpr)
+        | Expr.Lambda(bodyExpr = bodyExpr) ->
             match (stripDebugPoints bodyExpr) with
             | Expr.App _ -> Some(TailCall.YesFromExpr cenv.g e)
             | IsAppInLambdaBody t -> Some t
@@ -258,12 +257,12 @@ and CheckCallWithReceiver cenv args ctxts =
 
 and CheckExprLinear (cenv: cenv) expr (ctxt: PermitByRefExpr) (tailCall: TailCall) : unit =
     match expr with
-    | Expr.Sequential (e1, e2, NormalSeq, _) ->
+    | Expr.Sequential(e1, e2, NormalSeq, _) ->
         CheckExprNoByrefs cenv TailCall.No e1
         // tailcall
         CheckExprLinear cenv e2 ctxt tailCall
 
-    | Expr.Let (TBind (v, _bindRhs, _) as bind, body, _, _) ->
+    | Expr.Let(TBind(v, _bindRhs, _) as bind, body, _, _) ->
         let isByRef = isByrefTy cenv.g v.Type
 
         let bindingContext =
@@ -276,18 +275,18 @@ and CheckExprLinear (cenv: cenv) expr (ctxt: PermitByRefExpr) (tailCall: TailCal
         // tailcall
         CheckExprLinear cenv body ctxt tailCall
 
-    | LinearOpExpr (_op, _tyargs, argsHead, argLast, _m) ->
+    | LinearOpExpr(_op, _tyargs, argsHead, argLast, _m) ->
         argsHead |> List.iter (CheckExprNoByrefs cenv tailCall)
         // tailcall
         CheckExprLinear cenv argLast PermitByRefExpr.No tailCall
 
-    | LinearMatchExpr (_spMatch, _exprm, dtree, tg1, e2, _m, _ty) ->
+    | LinearMatchExpr(_spMatch, _exprm, dtree, tg1, e2, _m, _ty) ->
         CheckDecisionTree cenv dtree
         CheckDecisionTreeTarget cenv tailCall ctxt tg1
         // tailcall
         CheckExprLinear cenv e2 ctxt tailCall
 
-    | Expr.DebugPoint (_, innerExpr) -> CheckExprLinear cenv innerExpr ctxt tailCall
+    | Expr.DebugPoint(_, innerExpr) -> CheckExprLinear cenv innerExpr ctxt tailCall
 
     | _ ->
         // not a linear expression
@@ -313,10 +312,10 @@ and CheckExpr (cenv: cenv) origExpr (ctxt: PermitByRefExpr) (tailCall: TailCall)
         | LinearOpExpr _
         | LinearMatchExpr _
         | Expr.Let _
-        | Expr.Sequential (_, _, NormalSeq, _)
+        | Expr.Sequential(_, _, NormalSeq, _)
         | Expr.DebugPoint _ -> CheckExprLinear cenv expr ctxt tailCall
 
-        | Expr.Sequential (e1, e2, ThenDoSeq, _) ->
+        | Expr.Sequential(e1, e2, ThenDoSeq, _) ->
             CheckExprNoByrefs cenv TailCall.No e1
             CheckExprNoByrefs cenv TailCall.No e2
 
@@ -326,10 +325,10 @@ and CheckExpr (cenv: cenv) origExpr (ctxt: PermitByRefExpr) (tailCall: TailCall)
 
         | StructStateMachineExpr g info -> CheckStructStateMachineExpr cenv info
 
-        | Expr.Obj (_, ty, _basev, superInitCall, overrides, iimpls, _) -> CheckObjectExpr cenv (ty, superInitCall, overrides, iimpls)
+        | Expr.Obj(_, ty, _basev, superInitCall, overrides, iimpls, _) -> CheckObjectExpr cenv (ty, superInitCall, overrides, iimpls)
 
         // Allow base calls to F# methods
-        | Expr.App (InnerExprPat (ExprValWithPossibleTypeInst (v, vFlags, _, _) as f), _fty, _tyargs, Expr.Val (baseVal, _, _) :: rest, _m) when
+        | Expr.App(InnerExprPat(ExprValWithPossibleTypeInst(v, vFlags, _, _) as f), _fty, _tyargs, Expr.Val(baseVal, _, _) :: rest, _m) when
             ((match vFlags with
               | VSlotDirectCall -> true
               | _ -> false)
@@ -338,14 +337,14 @@ and CheckExpr (cenv: cenv) origExpr (ctxt: PermitByRefExpr) (tailCall: TailCall)
             CheckFSharpBaseCall cenv (v, f, rest)
 
         // Allow base calls to IL methods
-        | Expr.Op (TOp.ILCall (isVirtual, _, _, _, _, _, _, _ilMethRef, _enclTypeInst, _methInst, _retTypes),
-                   _tyargs,
-                   Expr.Val (baseVal, _, _) :: rest,
-                   _m) when not isVirtual && baseVal.IsBaseVal ->
+        | Expr.Op(TOp.ILCall(isVirtual, _, _, _, _, _, _, _ilMethRef, _enclTypeInst, _methInst, _retTypes),
+                  _tyargs,
+                  Expr.Val(baseVal, _, _) :: rest,
+                  _m) when not isVirtual && baseVal.IsBaseVal ->
 
             CheckILBaseCall cenv rest
 
-        | Expr.Op (op, tyargs, args, m) -> CheckExprOp cenv (op, tyargs, args, m) ctxt
+        | Expr.Op(op, tyargs, args, m) -> CheckExprOp cenv (op, tyargs, args, m) ctxt
 
         // Allow 'typeof<System.Void>' calls as a special case, the only accepted use of System.Void!
         | TypeOfExpr g ty when isVoidTy g ty -> ()
@@ -354,14 +353,14 @@ and CheckExpr (cenv: cenv) origExpr (ctxt: PermitByRefExpr) (tailCall: TailCall)
         | TypeDefOfExpr g ty when isVoidTy g ty -> ()
 
         // Check an application
-        | Expr.App (f, _fty, _tyargs, argsl, _m) ->
+        | Expr.App(f, _fty, _tyargs, argsl, _m) ->
             // detect expressions like List.collect
             let checkArgForLambdaWithAppOfMustTailCall e =
                 match stripDebugPoints e with
-                | Expr.TyLambda (bodyExpr = bodyExpr)
-                | Expr.Lambda (bodyExpr = bodyExpr) ->
+                | Expr.TyLambda(bodyExpr = bodyExpr)
+                | Expr.Lambda(bodyExpr = bodyExpr) ->
                     match bodyExpr with
-                    | Expr.App (ValUseAtApp (vref, _valUseFlags), _formalType, _typeArgs, _exprs, _range) ->
+                    | Expr.App(ValUseAtApp(vref, _valUseFlags), _formalType, _typeArgs, _exprs, _range) ->
                         cenv.mustTailCall.Contains vref.Deref
                     | _ -> false
                 | _ -> false
@@ -374,17 +373,17 @@ and CheckExpr (cenv: cenv) origExpr (ctxt: PermitByRefExpr) (tailCall: TailCall)
 
             CheckApplication cenv (f, argsl) tailCall
 
-        | Expr.Lambda (_, _, _, argvs, _, m, bodyTy) -> CheckLambda cenv expr (argvs, m, bodyTy) tailCall
+        | Expr.Lambda(_, _, _, argvs, _, m, bodyTy) -> CheckLambda cenv expr (argvs, m, bodyTy) tailCall
 
-        | Expr.TyLambda (_, tps, _, m, bodyTy) -> CheckTyLambda cenv expr (tps, m, bodyTy) tailCall
+        | Expr.TyLambda(_, tps, _, m, bodyTy) -> CheckTyLambda cenv expr (tps, m, bodyTy) tailCall
 
-        | Expr.TyChoose (_tps, e1, _) -> CheckExprNoByrefs cenv tailCall e1
+        | Expr.TyChoose(_tps, e1, _) -> CheckExprNoByrefs cenv tailCall e1
 
-        | Expr.Match (_, _, dtree, targets, _m, _ty) -> CheckMatch cenv ctxt (dtree, targets) tailCall
+        | Expr.Match(_, _, dtree, targets, _m, _ty) -> CheckMatch cenv ctxt (dtree, targets) tailCall
 
-        | Expr.LetRec (binds, bodyExpr, _, _) -> CheckLetRec cenv (binds, bodyExpr) tailCall
+        | Expr.LetRec(binds, bodyExpr, _, _) -> CheckLetRec cenv (binds, bodyExpr) tailCall
 
-        | Expr.StaticOptimization (_constraints, e2, e3, _m) -> CheckStaticOptimization cenv (e2, e3)
+        | Expr.StaticOptimization(_constraints, e2, e3, _m) -> CheckStaticOptimization cenv (e2, e3)
 
         | Expr.WitnessArg _ -> ()
 
@@ -422,7 +421,7 @@ and CheckApplication cenv (f, argsl) (tailCall: TailCall) : unit =
 
     let hasReceiver =
         match f with
-        | Expr.Val (vref, _, _) when vref.IsInstanceMember && not argsl.IsEmpty -> true
+        | Expr.Val(vref, _, _) when vref.IsInstanceMember && not argsl.IsEmpty -> true
         | _ -> false
 
     let ctxts = mkArgsForAppliedExpr false argsl f
@@ -461,7 +460,7 @@ and CheckStaticOptimization cenv (e2, e3) =
 and CheckMethods cenv (ty, methods) =
     methods |> List.iter (CheckMethod cenv ty)
 
-and CheckMethod cenv _ty (TObjExprMethod (_, _, _tps, _vs, body, _m)) =
+and CheckMethod cenv _ty (TObjExprMethod(_, _, _tps, _vs, body, _m)) =
     let tailCall =
         match stripDebugPoints body with
         | Expr.App _ as a -> TailCall.YesFromExpr cenv.g a
@@ -480,26 +479,26 @@ and CheckExprOp cenv (op, tyargs, args, m) ctxt : unit =
     // Special cases
     match op, tyargs, args with
     // Handle these as special cases since mutables are allowed inside their bodies
-    | TOp.While _, _, [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _) ] ->
+    | TOp.While _, _, [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], e2, _, _) ] ->
         CheckExprsNoByRefLike cenv [ e1; e2 ]
 
-    | TOp.TryFinally _, [ _ ], [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _) ] ->
+    | TOp.TryFinally _, [ _ ], [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], e2, _, _) ] ->
         CheckExpr cenv e1 ctxt TailCall.No // result of a try/finally can be a byref if in a position where the overall expression is can be a byref
         CheckExprNoByrefs cenv TailCall.No e2
 
     | TOp.IntegerForLoop _,
       _,
-      [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _); Expr.Lambda (_, _, _, [ _ ], e3, _, _) ] ->
+      [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], e2, _, _); Expr.Lambda(_, _, _, [ _ ], e3, _, _) ] ->
         CheckExprsNoByRefLike cenv [ e1; e2; e3 ]
 
     | TOp.TryWith _,
       [ _ ],
-      [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], _e2, _, _); Expr.Lambda (_, _, _, [ _ ], e3, _, _) ] ->
+      [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], _e2, _, _); Expr.Lambda(_, _, _, [ _ ], e3, _, _) ] ->
         CheckExpr cenv e1 ctxt TailCall.No // result of a try/catch can be a byref if in a position where the overall expression is can be a byref
         // [(* e2; -- don't check filter body - duplicates logic in 'catch' body *) e3]
         CheckExpr cenv e3 ctxt TailCall.No // result of a try/catch can be a byref if in a position where the overall expression is can be a byref
 
-    | TOp.ILCall (_, _, _, _, _, _, _, ilMethRef, _enclTypeInst, _methInst, retTypes), _, _ ->
+    | TOp.ILCall(_, _, _, _, _, _, _, ilMethRef, _enclTypeInst, _methInst, retTypes), _, _ ->
 
         let hasReceiver =
             (ilMethRef.CallingConv.IsInstance || ilMethRef.CallingConv.IsInstanceExplicit)
@@ -527,13 +526,13 @@ and CheckExprOp cenv (op, tyargs, args, m) ctxt : unit =
             CheckExprsPermitByRefLike cenv args
         | _ -> CheckExprsNoByRefLike cenv args
 
-    | TOp.LValueOp (LAddrOf _, _vref), _, _ -> CheckExprsNoByRefLike cenv args
+    | TOp.LValueOp(LAddrOf _, _vref), _, _ -> CheckExprsNoByRefLike cenv args
 
-    | TOp.LValueOp (LByrefSet, _vref), _, [ _arg ] -> ()
+    | TOp.LValueOp(LByrefSet, _vref), _, [ _arg ] -> ()
 
-    | TOp.LValueOp (LByrefGet, _vref), _, [] -> ()
+    | TOp.LValueOp(LByrefGet, _vref), _, [] -> ()
 
-    | TOp.LValueOp (LSet, _vref), _, [ _arg ] -> ()
+    | TOp.LValueOp(LSet, _vref), _, [ _arg ] -> ()
 
     | TOp.AnonRecdGet _, _, [ arg1 ]
     | TOp.TupleFieldGet _, _, [ arg1 ] -> CheckExprsPermitByRefLike cenv [ arg1 ]
@@ -553,10 +552,10 @@ and CheckExprOp cenv (op, tyargs, args, m) ctxt : unit =
     | TOp.Reraise, [ _ty1 ], [] -> ()
 
     // Check get of static field
-    | TOp.ValFieldGetAddr (_rfref, _readonly), _tyargs, [] -> ()
+    | TOp.ValFieldGetAddr(_rfref, _readonly), _tyargs, [] -> ()
 
     // Check get of instance field
-    | TOp.ValFieldGetAddr (_rfref, _readonly), _tyargs, [ obj ] ->
+    | TOp.ValFieldGetAddr(_rfref, _readonly), _tyargs, [ obj ] ->
         // Recursively check in same ctxt, e.g. if at PermitOnlyReturnable the obj arg must also be returnable
         CheckExpr cenv obj ctxt TailCall.No
 
@@ -564,14 +563,14 @@ and CheckExprOp cenv (op, tyargs, args, m) ctxt : unit =
 
     | TOp.UnionCaseTagGet _, _, [ arg1 ] -> CheckExprPermitByRefLike cenv arg1 // allow byref - it may be address-of-struct
 
-    | TOp.UnionCaseFieldGetAddr (_uref, _idx, _readonly), _tyargs, [ obj ] ->
+    | TOp.UnionCaseFieldGetAddr(_uref, _idx, _readonly), _tyargs, [ obj ] ->
         // Recursively check in same ctxt, e.g. if at PermitOnlyReturnable the obj arg must also be returnable
         CheckExpr cenv obj ctxt TailCall.No
 
-    | TOp.ILAsm (instrs, _retTypes), _, _ ->
+    | TOp.ILAsm(instrs, _retTypes), _, _ ->
         match instrs, args with
         // Write a .NET instance field
-        | [ I_stfld (_alignment, _vol, _fspec) ], _ ->
+        | [ I_stfld(_alignment, _vol, _fspec) ], _ ->
             match args with
             | [ _; rhs ] -> CheckExprNoByrefs cenv TailCall.No rhs
             | _ -> ()
@@ -581,12 +580,12 @@ and CheckExprOp cenv (op, tyargs, args, m) ctxt : unit =
             CheckExprsPermitByRefLike cenv args
 
         // Read a .NET instance field
-        | [ I_ldfld (_alignment, _vol, _fspec) ], _ ->
+        | [ I_ldfld(_alignment, _vol, _fspec) ], _ ->
             // permit byref for lhs lvalue
             CheckExprsPermitByRefLike cenv args
 
         // Read a .NET instance field
-        | [ I_ldfld (_alignment, _vol, _fspec); AI_nop ], _ ->
+        | [ I_ldfld(_alignment, _vol, _fspec); AI_nop ], _ ->
             // permit byref for lhs lvalue of readonly value
             CheckExprsPermitByRefLike cenv args
 
@@ -597,7 +596,7 @@ and CheckExprOp cenv (op, tyargs, args, m) ctxt : unit =
             // Recursively check in same ctxt, e.g. if at PermitOnlyReturnable the obj arg must also be returnable
             CheckExpr cenv obj ctxt TailCall.No
 
-        | [ I_ldelema (_, _isNativePtr, _, _) ], lhsArray :: indices ->
+        | [ I_ldelema(_, _isNativePtr, _, _) ], lhsArray :: indices ->
             // permit byref for lhs lvalue
             CheckExprPermitByRefLike cenv lhsArray
             CheckExprsNoByRefLike cenv indices
@@ -634,10 +633,10 @@ and CheckLambdas
     // The valReprInfo here says we are _guaranteeing_ to compile a function value
     // as a .NET method with precisely the corresponding argument counts.
     match stripDebugPoints expr with
-    | Expr.TyChoose (_tps, e1, m) -> CheckLambdas isTop memberVal cenv inlined valReprInfo tailCall alwaysCheckNoReraise e1 m ety ctxt
+    | Expr.TyChoose(_tps, e1, m) -> CheckLambdas isTop memberVal cenv inlined valReprInfo tailCall alwaysCheckNoReraise e1 m ety ctxt
 
-    | Expr.Lambda (_, _, _, _, _, m, _)
-    | Expr.TyLambda (_, _, _, m, _) ->
+    | Expr.Lambda(_, _, _, _, _, m, _)
+    | Expr.TyLambda(_, _, _, m, _) ->
         let _tps, _ctorThisValOpt, _baseValOpt, _vsl, body, bodyTy =
             destLambdaWithValReprInfo g cenv.amap valReprInfo (expr, ety)
 
@@ -687,20 +686,20 @@ and CheckDecisionTreeTargets cenv targets ctxt (tailCall: TailCall) =
     |> List.ofArray
     |> ignore
 
-and CheckDecisionTreeTarget cenv (tailCall: TailCall) ctxt (TTarget (_vs, targetExpr, _)) : unit = CheckExpr cenv targetExpr ctxt tailCall
+and CheckDecisionTreeTarget cenv (tailCall: TailCall) ctxt (TTarget(_vs, targetExpr, _)) : unit = CheckExpr cenv targetExpr ctxt tailCall
 
 and CheckDecisionTree cenv dtree =
     match dtree with
-    | TDSuccess (resultExprs, _) -> CheckExprsNoByRefLike cenv resultExprs
-    | TDBind (bind, rest) ->
+    | TDSuccess(resultExprs, _) -> CheckExprsNoByRefLike cenv resultExprs
+    | TDBind(bind, rest) ->
         CheckBinding cenv false PermitByRefExpr.Yes bind
         CheckDecisionTree cenv rest
-    | TDSwitch (inpExpr, cases, dflt, _m) -> CheckDecisionTreeSwitch cenv (inpExpr, cases, dflt)
+    | TDSwitch(inpExpr, cases, dflt, _m) -> CheckDecisionTreeSwitch cenv (inpExpr, cases, dflt)
 
 and CheckDecisionTreeSwitch cenv (inpExpr, cases, dflt) =
     CheckExprPermitByRefLike cenv inpExpr // can be byref for struct union switch
 
-    for TCase (discrim, dtree) in cases do
+    for TCase(discrim, dtree) in cases do
         CheckDecisionTreeTest cenv discrim
         CheckDecisionTree cenv dtree
 
@@ -708,10 +707,10 @@ and CheckDecisionTreeSwitch cenv (inpExpr, cases, dflt) =
 
 and CheckDecisionTreeTest cenv discrim =
     match discrim with
-    | DecisionTreeTest.ActivePatternCase (exp, _, _, _, _, _) -> CheckExprNoByrefs cenv TailCall.No exp
+    | DecisionTreeTest.ActivePatternCase(exp, _, _, _, _, _) -> CheckExprNoByrefs cenv TailCall.No exp
     | _ -> ()
 
-and CheckBinding cenv alwaysCheckNoReraise ctxt (TBind (v, bindRhs, _) as bind) : unit =
+and CheckBinding cenv alwaysCheckNoReraise ctxt (TBind(v, bindRhs, _) as bind) : unit =
     let g = cenv.g
     let isTop = Option.isSome bind.Var.ValReprInfo
     let tailCall = TailCall.YesFromVal g bind.Var
@@ -733,20 +732,20 @@ let CheckModuleBinding cenv (isRec: bool) (TBind _ as bind) =
     // see test ``Warn successfully for rec call in binding`` for an example
     if cenv.g.langVersion.SupportsFeature LanguageFeature.WarningWhenTailRecAttributeButNonTailRecUsage then
         match bind.Expr with
-        | Expr.TyLambda (bodyExpr = bodyExpr)
-        | Expr.Lambda (bodyExpr = bodyExpr) ->
+        | Expr.TyLambda(bodyExpr = bodyExpr)
+        | Expr.Lambda(bodyExpr = bodyExpr) ->
             let rec checkTailCall (insideSubBinding: bool) expr =
                 match expr with
-                | Expr.Val (valRef = valRef; range = m) ->
+                | Expr.Val(valRef = valRef; range = m) ->
                     if isRec && insideSubBinding && cenv.mustTailCall.Contains valRef.Deref then
                         warning (Error(FSComp.SR.chkNotTailRecursive valRef.DisplayName, m))
-                | Expr.App (funcExpr = funcExpr; args = argExprs) ->
+                | Expr.App(funcExpr = funcExpr; args = argExprs) ->
                     checkTailCall insideSubBinding funcExpr
                     argExprs |> List.iter (checkTailCall insideSubBinding)
                 | Expr.Link exprRef -> checkTailCall insideSubBinding exprRef.Value
-                | Expr.Lambda (bodyExpr = bodyExpr) -> checkTailCall insideSubBinding bodyExpr
-                | Expr.DebugPoint (_debugPointAtLeafExpr, expr) -> checkTailCall insideSubBinding expr
-                | Expr.Let (binding = binding; bodyExpr = bodyExpr) ->
+                | Expr.Lambda(bodyExpr = bodyExpr) -> checkTailCall insideSubBinding bodyExpr
+                | Expr.DebugPoint(_debugPointAtLeafExpr, expr) -> checkTailCall insideSubBinding expr
+                | Expr.Let(binding = binding; bodyExpr = bodyExpr) ->
                     checkTailCall true binding.Expr
 
                     let warnForBodyExpr =
@@ -755,10 +754,10 @@ let CheckModuleBinding cenv (isRec: bool) (TBind _ as bind) =
                         | _ -> false
 
                     checkTailCall warnForBodyExpr bodyExpr
-                | Expr.Match (targets = decisionTreeTargets) ->
+                | Expr.Match(targets = decisionTreeTargets) ->
                     decisionTreeTargets
                     |> Array.iter (fun target -> checkTailCall insideSubBinding target.TargetExpression)
-                | Expr.Op (args = exprs) -> exprs |> Seq.iter (checkTailCall insideSubBinding)
+                | Expr.Op(args = exprs) -> exprs |> Seq.iter (checkTailCall insideSubBinding)
                 | _ -> ()
 
             checkTailCall false bodyExpr
@@ -776,7 +775,7 @@ let rec CheckDefnsInModule cenv mdefs =
 
 and CheckDefnInModule cenv mdef =
     match mdef with
-    | TMDefRec (isRec, _opens, _tycons, mspecs, _m) ->
+    | TMDefRec(isRec, _opens, _tycons, mspecs, _m) ->
         let cenv =
             if isRec then
                 let vals = allValsOfModDef mdef
@@ -799,14 +798,14 @@ and CheckDefnInModule cenv mdef =
                 cenv
 
         List.iter (CheckModuleSpec cenv isRec) mspecs
-    | TMDefLet (bind, _m) -> CheckModuleBinding cenv false bind
+    | TMDefLet(bind, _m) -> CheckModuleBinding cenv false bind
     | TMDefOpens _ -> ()
-    | TMDefDo (e, _m) ->
+    | TMDefDo(e, _m) ->
         let tailCall =
             match stripDebugPoints e with
-            | Expr.App (funcExpr = funcExpr) ->
+            | Expr.App(funcExpr = funcExpr) ->
                 match funcExpr with
-                | ValUseAtApp (vref, _valUseFlags) -> TailCall.YesFromVal cenv.g vref.Deref
+                | ValUseAtApp(vref, _valUseFlags) -> TailCall.YesFromVal cenv.g vref.Deref
                 | _ -> TailCall.No
             | _ -> TailCall.No
 
@@ -819,7 +818,7 @@ and CheckModuleSpec cenv isRec mbind =
         if cenv.mustTailCall.Contains bind.Var then
             CheckModuleBinding cenv isRec bind
 
-    | ModuleOrNamespaceBinding.Module (_mspec, rhs) -> CheckDefnInModule cenv rhs
+    | ModuleOrNamespaceBinding.Module(_mspec, rhs) -> CheckDefnInModule cenv rhs
 
 let CheckImplFile (g, amap, reportErrors, implFileContents) =
     let cenv =

--- a/src/Compiler/CodeGen/EraseClosures.fs
+++ b/src/Compiler/CodeGen/EraseClosures.fs
@@ -35,7 +35,7 @@ let rec stripUpTo n test dest x =
 
 let destTyLambda =
     function
-    | Lambdas_forall (l, r) -> (l, r)
+    | Lambdas_forall(l, r) -> (l, r)
     | _ -> failwith "no"
 
 let isTyLambda =
@@ -66,11 +66,11 @@ let stripTyLambdasUpTo n lambdas =
 // and type applications are never mixed in a single step.
 let stripSupportedIndirectCall apps =
     match apps with
-    | Apps_app (x, Apps_app (y, Apps_app (z, Apps_app (w, Apps_app (v, rest))))) -> [], [ x; y; z; w; v ], rest
-    | Apps_app (x, Apps_app (y, Apps_app (z, Apps_app (w, rest)))) -> [], [ x; y; z; w ], rest
-    | Apps_app (x, Apps_app (y, Apps_app (z, rest))) -> [], [ x; y; z ], rest
-    | Apps_app (x, Apps_app (y, rest)) -> [], [ x; y ], rest
-    | Apps_app (x, rest) -> [], [ x ], rest
+    | Apps_app(x, Apps_app(y, Apps_app(z, Apps_app(w, Apps_app(v, rest))))) -> [], [ x; y; z; w; v ], rest
+    | Apps_app(x, Apps_app(y, Apps_app(z, Apps_app(w, rest)))) -> [], [ x; y; z; w ], rest
+    | Apps_app(x, Apps_app(y, Apps_app(z, rest))) -> [], [ x; y; z ], rest
+    | Apps_app(x, Apps_app(y, rest)) -> [], [ x; y ], rest
+    | Apps_app(x, rest) -> [], [ x ], rest
     | Apps_tyapp _ ->
         let maxTyApps = 1
         let tys, rest = stripUpTo maxTyApps isTyApp destTyFuncApp apps
@@ -89,12 +89,11 @@ let stripSupportedIndirectCall apps =
 // and type applications are never mixed in a single step.
 let stripSupportedAbstraction lambdas =
     match lambdas with
-    | Lambdas_lambda (x, Lambdas_lambda (y, Lambdas_lambda (z, Lambdas_lambda (w, Lambdas_lambda (v, rest))))) ->
-        [], [ x; y; z; w; v ], rest
-    | Lambdas_lambda (x, Lambdas_lambda (y, Lambdas_lambda (z, Lambdas_lambda (w, rest)))) -> [], [ x; y; z; w ], rest
-    | Lambdas_lambda (x, Lambdas_lambda (y, Lambdas_lambda (z, rest))) -> [], [ x; y; z ], rest
-    | Lambdas_lambda (x, Lambdas_lambda (y, rest)) -> [], [ x; y ], rest
-    | Lambdas_lambda (x, rest) -> [], [ x ], rest
+    | Lambdas_lambda(x, Lambdas_lambda(y, Lambdas_lambda(z, Lambdas_lambda(w, Lambdas_lambda(v, rest))))) -> [], [ x; y; z; w; v ], rest
+    | Lambdas_lambda(x, Lambdas_lambda(y, Lambdas_lambda(z, Lambdas_lambda(w, rest)))) -> [], [ x; y; z; w ], rest
+    | Lambdas_lambda(x, Lambdas_lambda(y, Lambdas_lambda(z, rest))) -> [], [ x; y; z ], rest
+    | Lambdas_lambda(x, Lambdas_lambda(y, rest)) -> [], [ x; y ], rest
+    | Lambdas_lambda(x, rest) -> [], [ x ], rest
     | Lambdas_forall _ ->
         let maxTyApps = 1
         let tys, rest = stripTyLambdasUpTo maxTyApps lambdas
@@ -173,13 +172,13 @@ let typ_Func cenv (dtys: ILType list) rty =
 let rec mkTyOfApps cenv apps =
     match apps with
     | Apps_tyapp _ -> cenv.mkILTyFuncTy
-    | Apps_app (dty, rest) -> mkILFuncTy cenv dty (mkTyOfApps cenv rest)
+    | Apps_app(dty, rest) -> mkILFuncTy cenv dty (mkTyOfApps cenv rest)
     | Apps_done rty -> rty
 
 let rec mkTyOfLambdas cenv lam =
     match lam with
     | Lambdas_return rty -> rty
-    | Lambdas_lambda (d, r) -> mkILFuncTy cenv d.Type (mkTyOfLambdas cenv r)
+    | Lambdas_lambda(d, r) -> mkILFuncTy cenv d.Type (mkTyOfLambdas cenv r)
     | Lambdas_forall _ -> cenv.mkILTyFuncTy
 
 // --------------------------------------------------------------------
@@ -239,11 +238,11 @@ let mkCallFunc cenv allocLocal numThisGenParams tailness apps =
     // the apps, and the loaders are used to load them back on.
     let rec unwind apps =
         match apps with
-        | Apps_tyapp (actual, rest) ->
+        | Apps_tyapp(actual, rest) ->
             let rest = instAppsAux varCount [ actual ] rest
             let storers, loaders = unwind rest
             [] :: storers, [] :: loaders
-        | Apps_app (arg, rest) ->
+        | Apps_app(arg, rest) ->
             let storers, loaders = unwind rest
 
             let argStorers, argLoaders =
@@ -341,10 +340,10 @@ let mkCallFunc cenv allocLocal numThisGenParams tailness apps =
 let convReturnInstr ty instr =
     match instr with
     | I_ret -> [ I_box ty; I_ret ]
-    | I_call (_, mspec, varargs) -> [ I_call(Normalcall, mspec, varargs) ]
-    | I_callvirt (_, mspec, varargs) -> [ I_callvirt(Normalcall, mspec, varargs) ]
-    | I_callconstraint (callvirt, _, ty, mspec, varargs) -> [ I_callconstraint(callvirt, Normalcall, ty, mspec, varargs) ]
-    | I_calli (_, csig, varargs) -> [ I_calli(Normalcall, csig, varargs) ]
+    | I_call(_, mspec, varargs) -> [ I_call(Normalcall, mspec, varargs) ]
+    | I_callvirt(_, mspec, varargs) -> [ I_callvirt(Normalcall, mspec, varargs) ]
+    | I_callconstraint(callvirt, _, ty, mspec, varargs) -> [ I_callconstraint(callvirt, Normalcall, ty, mspec, varargs) ]
+    | I_calli(_, csig, varargs) -> [ I_calli(Normalcall, csig, varargs) ]
     | _ -> [ instr ]
 
 let convILMethodBody (thisClo, boxReturnTy) (il: ILMethodBody) =

--- a/src/Compiler/CodeGen/EraseUnions.fs
+++ b/src/Compiler/CodeGen/EraseUnions.fs
@@ -271,8 +271,8 @@ let mkRuntimeTypeDiscriminateThen ilg avoidHelpers cuspec alt altName altTy afte
     let useHelper = doesRuntimeTypeDiscriminateUseHelper avoidHelpers cuspec alt
 
     match after with
-    | I_brcmp (BI_brfalse, _)
-    | I_brcmp (BI_brtrue, _) when not useHelper -> [ I_isinst altTy; after ]
+    | I_brcmp(BI_brfalse, _)
+    | I_brcmp(BI_brtrue, _) when not useHelper -> [ I_isinst altTy; after ]
     | _ -> mkRuntimeTypeDiscriminate ilg avoidHelpers cuspec alt altName altTy @ [ after ]
 
 let mkGetTagFromField ilg cuspec baseTy =
@@ -327,8 +327,8 @@ let mkGetTag ilg (cuspec: IlxUnionSpec) =
 
 let mkCeqThen after =
     match after with
-    | I_brcmp (BI_brfalse, a) -> [ I_brcmp(BI_bne_un, a) ]
-    | I_brcmp (BI_brtrue, a) -> [ I_brcmp(BI_beq, a) ]
+    | I_brcmp(BI_brfalse, a) -> [ I_brcmp(BI_bne_un, a) ]
+    | I_brcmp(BI_brtrue, a) -> [ I_brcmp(BI_beq, a) ]
     | _ -> [ AI_ceq; after ]
 
 let mkTagDiscriminate ilg cuspec _baseTy cidx =
@@ -1009,8 +1009,9 @@ let convAlternativeDef
                                     let instrs =
                                         [
                                             mkLdarg0
-                                            (if td.IsStruct then mkNormalLdflda else mkNormalLdfld)
-                                                (mkILFieldSpecInTy (debugProxyTy, debugProxyFieldName, altTy))
+                                            (if td.IsStruct then mkNormalLdflda else mkNormalLdfld) (
+                                                mkILFieldSpecInTy (debugProxyTy, debugProxyFieldName, altTy)
+                                            )
                                             mkNormalLdfld (mkILFieldSpecInTy (altTy, fldName, fldTy))
                                         ]
                                         |> nonBranchingInstrsToCode
@@ -1450,7 +1451,9 @@ let mkClassUnionDef
                 nestedTypes =
                     mkILTypeDefs (
                         Option.toList enumTypeDef
-                        @ altTypeDefs @ altDebugTypeDefs @ td.NestedTypes.AsList()
+                        @ altTypeDefs
+                        @ altDebugTypeDefs
+                        @ td.NestedTypes.AsList()
                     ),
                 extends =
                     (match td.Extends with
@@ -1459,13 +1462,17 @@ let mkClassUnionDef
                 methods =
                     mkILMethods (
                         ctorMeths
-                        @ baseMethsFromAlt @ selfMeths @ tagMeths @ altUniqObjMeths @ existingMeths
+                        @ baseMethsFromAlt
+                        @ selfMeths
+                        @ tagMeths
+                        @ altUniqObjMeths
+                        @ existingMeths
                     ),
                 fields =
                     mkILFields (
                         selfAndTagFields
                         @ List.map (fun (_, _, _, _, fdef, _) -> fdef) altNullaryFields
-                          @ td.Fields.AsList()
+                        @ td.Fields.AsList()
                     ),
                 properties = mkILProperties (tagProps @ basePropsFromAlt @ selfProps @ existingProps)
             )

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -132,7 +132,7 @@ let ChooseFreeVarNames takenNames ts =
 let rec IsILTypeByref inp =
     match inp with
     | ILType.Byref _ -> true
-    | ILType.Modified (_, _, nestedTy) -> IsILTypeByref nestedTy
+    | ILType.Modified(_, _, nestedTy) -> IsILTypeByref nestedTy
     | _ -> false
 
 let mainMethName = CompilerGeneratedName "main"
@@ -142,37 +142,37 @@ type AttributeDecoder(namedArgs) =
 
     let nameMap =
         namedArgs
-        |> List.map (fun (AttribNamedArg (s, _, _, c)) -> s, c)
+        |> List.map (fun (AttribNamedArg(s, _, _, c)) -> s, c)
         |> NameMap.ofList
 
     let findConst x =
         match NameMap.tryFind x nameMap with
-        | Some (AttribExpr (_, Expr.Const (c, _, _))) -> Some c
+        | Some(AttribExpr(_, Expr.Const(c, _, _))) -> Some c
         | _ -> None
 
     let findTyconRef x =
         match NameMap.tryFind x nameMap with
-        | Some (AttribExpr (_, Expr.App (_, _, [ TType_app (tcref, _, _) ], _, _))) -> Some tcref
+        | Some(AttribExpr(_, Expr.App(_, _, [ TType_app(tcref, _, _) ], _, _))) -> Some tcref
         | _ -> None
 
     member _.FindInt16 x dflt =
         match findConst x with
-        | Some (Const.Int16 x) -> x
+        | Some(Const.Int16 x) -> x
         | _ -> dflt
 
     member _.FindInt32 x dflt =
         match findConst x with
-        | Some (Const.Int32 x) -> x
+        | Some(Const.Int32 x) -> x
         | _ -> dflt
 
     member _.FindBool x dflt =
         match findConst x with
-        | Some (Const.Bool x) -> x
+        | Some(Const.Bool x) -> x
         | _ -> dflt
 
     member _.FindString x dflt =
         match findConst x with
-        | Some (Const.String x) -> x
+        | Some(Const.String x) -> x
         | _ -> dflt
 
     member _.FindTypeName x dflt =
@@ -409,7 +409,7 @@ let CompLocForSubModuleOrNamespace cloc (submod: ModuleOrNamespace) =
             Namespace = Some(mkTopName cloc.Namespace n)
         }
 
-let CompLocForFixedPath fragName qname (CompPath (sref, cpath)) =
+let CompLocForFixedPath fragName qname (CompPath(sref, cpath)) =
     let ns, t =
         cpath
         |> List.takeUntil (fun (_, mkind) ->
@@ -604,7 +604,7 @@ and GenTyAppAux cenv m tyenv repr tinst =
         let ilTypeInst = GenTypeArgsAux cenv m tyenv tinst
         let ty = instILType ilTypeInst ty
         ty
-    | CompiledTypeRepr.ILAsmNamed (tref, boxity, ilTypeOpt) -> GenILTyAppAux cenv m tyenv (tref, boxity, ilTypeOpt) tinst
+    | CompiledTypeRepr.ILAsmNamed(tref, boxity, ilTypeOpt) -> GenILTyAppAux cenv m tyenv (tref, boxity, ilTypeOpt) tinst
 
 and GenILTyAppAux cenv m tyenv (tref, boxity, ilTypeOpt) tinst =
     match ilTypeOpt with
@@ -617,7 +617,7 @@ and GenNamedTyAppAux (cenv: cenv) m (tyenv: TypeReprEnv) ptrsOK tcref tinst =
     let g = cenv.g
 
     match tyenv.TemplateReplacement with
-    | Some (tcref2, ilCloTyRef, cloFreeTyvars, _) when tyconRefEq g tcref tcref2 ->
+    | Some(tcref2, ilCloTyRef, cloFreeTyvars, _) when tyconRefEq g tcref tcref2 ->
         let cloInst = List.map mkTyparTy cloFreeTyvars
         let ilTypeInst = GenTypeArgsAux cenv m tyenv cloInst
         mkILValueTy ilCloTyRef ilTypeInst
@@ -647,14 +647,14 @@ and GenTypeAux cenv m (tyenv: TypeReprEnv) voidOK ptrsOK ty =
     ignore voidOK
 #endif
     match stripTyEqnsAndMeasureEqns g ty with
-    | TType_app (tcref, tinst, _) -> GenNamedTyAppAux cenv m tyenv ptrsOK tcref tinst
+    | TType_app(tcref, tinst, _) -> GenNamedTyAppAux cenv m tyenv ptrsOK tcref tinst
 
-    | TType_tuple (tupInfo, args) -> GenTypeAux cenv m tyenv VoidNotOK ptrsOK (mkCompiledTupleTy g (evalTupInfoIsStruct tupInfo) args)
+    | TType_tuple(tupInfo, args) -> GenTypeAux cenv m tyenv VoidNotOK ptrsOK (mkCompiledTupleTy g (evalTupInfoIsStruct tupInfo) args)
 
-    | TType_fun (dty, returnTy, _) ->
+    | TType_fun(dty, returnTy, _) ->
         EraseClosures.mkILFuncTy cenv.ilxPubCloEnv (GenTypeArgAux cenv m tyenv dty) (GenTypeArgAux cenv m tyenv returnTy)
 
-    | TType_anon (anonInfo, tinst) ->
+    | TType_anon(anonInfo, tinst) ->
         let tref = anonInfo.ILTypeRef
 
         let boxity =
@@ -665,11 +665,11 @@ and GenTypeAux cenv m (tyenv: TypeReprEnv) voidOK ptrsOK ty =
 
         GenILTyAppAux cenv m tyenv (tref, boxity, None) tinst
 
-    | TType_ucase (ucref, args) ->
+    | TType_ucase(ucref, args) ->
         let cuspec, idx = GenUnionCaseSpec cenv m tyenv ucref args
         EraseUnions.GetILTypeForAlternative cuspec idx
 
-    | TType_forall (tps, tau) ->
+    | TType_forall(tps, tau) ->
         let tps = DropErasedTypars tps
 
         if tps.IsEmpty then
@@ -677,7 +677,7 @@ and GenTypeAux cenv m (tyenv: TypeReprEnv) voidOK ptrsOK ty =
         else
             EraseClosures.mkILTyFuncTy cenv.ilxPubCloEnv
 
-    | TType_var (tp, _) -> mkILTyvarTy tyenv[tp, m]
+    | TType_var(tp, _) -> mkILTyvarTy tyenv[tp, m]
 
     | TType_measure _ -> g.ilg.typ_Int32
 
@@ -716,7 +716,7 @@ and GenUnionRef (cenv: cenv) m (tcref: TyconRef) =
 
             match tcref.CompiledRepresentation with
             | CompiledTypeRepr.ILAsmOpen _ -> failwith "GenUnionRef m: unexpected ASM tyrep"
-            | CompiledTypeRepr.ILAsmNamed (tref, _, _) ->
+            | CompiledTypeRepr.ILAsmNamed(tref, _, _) ->
                 let alternatives =
                     tycon.UnionCasesArray
                     |> Array.mapi (fun i cspec ->
@@ -746,8 +746,8 @@ and ComputeUnionHasHelpers g (tcref: TyconRef) =
         SpecialFSharpOptionHelpers
     else
         match TryFindFSharpAttribute g g.attrib_DefaultAugmentationAttribute tcref.Attribs with
-        | Some (Attrib (_, _, [ AttribBoolArg b ], _, _, _, _)) -> if b then AllHelpers else NoHelpers
-        | Some (Attrib (_, _, _, _, _, _, m)) ->
+        | Some(Attrib(_, _, [ AttribBoolArg b ], _, _, _, _)) -> if b then AllHelpers else NoHelpers
+        | Some(Attrib(_, _, _, _, _, _, m)) ->
             errorR (Error(FSComp.SR.ilDefaultAugmentationAttributeCouldNotBeDecoded (), m))
             AllHelpers
         | _ -> AllHelpers (* not hiddenRepr *)
@@ -835,7 +835,7 @@ let GenFieldSpecForStaticField (isInteractive, g, ilContainerTy, vspec: Val, nm,
 
 let GenRecdFieldRef m cenv (tyenv: TypeReprEnv) (rfref: RecdFieldRef) tyargs =
     match tyenv.TemplateReplacement with
-    | Some (tcref2, ilCloTyRef, cloFreeTyvars, templateTypeInst) when tyconRefEq cenv.g rfref.TyconRef tcref2 ->
+    | Some(tcref2, ilCloTyRef, cloFreeTyvars, templateTypeInst) when tyconRefEq cenv.g rfref.TyconRef tcref2 ->
         // Fixup references to the fields of a struct machine template
         //     templateStructTy = ResumableStateMachine<TaskStateMachineData<SomeType['FreeTyVars]>
         //     templateTyconRef = ResumableStateMachine<'Data>
@@ -1614,7 +1614,8 @@ let rec AddStorageForNonLocalModuleOrNamespaceRef cenv g cloc acc (modref: Modul
 
     let acc =
         (acc, modul.ModuleOrNamespaceType.AllValsAndMembers)
-        ||> Seq.fold (fun acc v -> AddStorageForVal g (v, InterruptibleLazy(fun _ -> ComputeStorageForNonLocalVal cenv g cloc modref v)) acc)
+        ||> Seq.fold (fun acc v ->
+            AddStorageForVal g (v, InterruptibleLazy(fun _ -> ComputeStorageForNonLocalVal cenv g cloc modref v)) acc)
 
     acc
 
@@ -1725,7 +1726,7 @@ let AddDebugImportsToEnv (cenv: cenv) eenv (openDecls: OpenDeclaration list) =
 
 let rec AddBindingsForModuleOrNamespaceContents allocVal cloc eenv x =
     match x with
-    | TMDefRec (_isRec, _opens, tycons, mbinds, _) ->
+    | TMDefRec(_isRec, _opens, tycons, mbinds, _) ->
         // Virtual don't have 'let' bindings and must be added to the environment
         let eenv = List.foldBack (AddBindingsForTycon allocVal cloc) tycons eenv
 
@@ -1733,7 +1734,7 @@ let rec AddBindingsForModuleOrNamespaceContents allocVal cloc eenv x =
             List.foldBack (AddBindingsForModuleOrNamespaceBinding allocVal cloc) mbinds eenv
 
         eenv
-    | TMDefLet (bind, _) -> allocVal cloc bind.Var eenv
+    | TMDefLet(bind, _) -> allocVal cloc bind.Var eenv
     | TMDefDo _ -> eenv
     | TMDefOpens _ -> eenv
     | TMDefs mdefs ->
@@ -1744,7 +1745,7 @@ let rec AddBindingsForModuleOrNamespaceContents allocVal cloc eenv x =
 and AddBindingsForModuleOrNamespaceBinding allocVal cloc x eenv =
     match x with
     | ModuleOrNamespaceBinding.Binding bind -> allocVal cloc bind.Var eenv
-    | ModuleOrNamespaceBinding.Module (mspec, mdef) ->
+    | ModuleOrNamespaceBinding.Module(mspec, mdef) ->
         let cloc =
             if mspec.IsNamespace then
                 cloc
@@ -1775,7 +1776,7 @@ let AddIncrementalLocalAssemblyFragmentToIlxGenEnv
 
     (eenv, implFiles)
     ||> List.fold (fun eenv implFile ->
-        let (CheckedImplFile (qualifiedNameOfFile = qname; signature = signature; contents = contents)) =
+        let (CheckedImplFile(qualifiedNameOfFile = qname; signature = signature; contents = contents)) =
             implFile
 
         let cloc =
@@ -1815,7 +1816,7 @@ let GenPossibleILDebugRange (cenv: cenv) m =
 //--------------------------------------------------------------------------
 
 let HashRangeSorted (ht: IDictionary<_, int * _>) =
-    [ for KeyValue (_k, v) in ht -> v ] |> List.sortBy fst |> List.map snd
+    [ for KeyValue(_k, v) in ht -> v ] |> List.sortBy fst |> List.map snd
 
 let MergeOptions m o1 o2 =
     match o1, o2 with
@@ -1885,7 +1886,7 @@ type TypeDefBuilder(tdef: ILTypeDef, tdefDiscards) =
     member _.AddMethodDef ilMethodDef =
         let discard =
             match tdefDiscards with
-            | Some (mdefDiscard, _) -> mdefDiscard ilMethodDef
+            | Some(mdefDiscard, _) -> mdefDiscard ilMethodDef
             | None -> false
 
         if not discard then
@@ -1900,7 +1901,7 @@ type TypeDefBuilder(tdef: ILTypeDef, tdefDiscards) =
     member _.AddOrMergePropertyDef(pdef, m) =
         let discard =
             match tdefDiscards with
-            | Some (_, pdefDiscard) -> pdefDiscard pdef
+            | Some(_, pdefDiscard) -> pdefDiscard pdef
             | None -> false
 
         if not discard then
@@ -2198,7 +2199,7 @@ type AnonTypeGenerationTable() =
 
             let optimizedExtraBindings =
                 extraBindings
-                |> Array.map (fun (TBind (a, b, c)) ->
+                |> Array.map (fun (TBind(a, b, c)) ->
                     // Disable method splitting for bindings related to anonymous records
                     TBind(a, cenv.optimizeDuringCodeGen true b, c))
                 |> Array.rev
@@ -2799,7 +2800,7 @@ let BindingEmitsNoCode g (b: Binding) = IsFSharpValCompiledAsMethod g b.Var
 ///
 /// Returns (useWholeExprRange, sequencePointForBind, sequencePointGenerationFlagForRhsOfBind)
 let ComputeDebugPointForBinding g bind =
-    let (TBind (_, e, spBind)) = bind
+    let (TBind(_, e, spBind)) = bind
 
     if BindingEmitsNoCode g bind then
         false, None
@@ -2830,7 +2831,7 @@ and GenExprPreSteps (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr sequel =
 
     // Check for the '__debugPoint" construct for inlined code
     match expr with
-    | Expr.Sequential ((DebugPointExpr g debugPointName) as dpExpr, codeExpr, NormalSeq, m) ->
+    | Expr.Sequential((DebugPointExpr g debugPointName) as dpExpr, codeExpr, NormalSeq, m) ->
         match cenv.namedDebugPointsForInlinedCode.TryGetValue({ Range = m; Name = debugPointName }) with
         | false, _ when debugPointName = "" -> CG.EmitDebugPoint cgbuf m
         | false, _ ->
@@ -2888,7 +2889,7 @@ and GenExprPreSteps (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr sequel =
                     checkLanguageFeatureError cenv.g.langVersion LanguageFeature.ResumableStateMachines expr.Range
                     GenStructStateMachine cenv cgbuf eenv res sequel
                     true
-                | LoweredStateMachineResult.UseAlternative (msg, altExpr) ->
+                | LoweredStateMachineResult.UseAlternative(msg, altExpr) ->
                     // When prepping to generate a state machine, we can remove any trace of the template struct
                     // type for the internal state of any enclosing state machine, as they do not interact. This
                     // is important if the nested state machine generates dynamic code (LoweredStateMachineResult.UseAlternative).
@@ -2928,18 +2929,18 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
         | LinearOpExpr _
         | Expr.Match _ -> GenLinearExpr cenv cgbuf eenv expr sequel false id |> ignore<FakeUnit>
 
-        | Expr.DebugPoint (DebugPointAtLeafExpr.Yes m, innerExpr) ->
+        | Expr.DebugPoint(DebugPointAtLeafExpr.Yes m, innerExpr) ->
             CG.EmitDebugPoint cgbuf m
             GenExpr cenv cgbuf eenv innerExpr sequel
 
-        | Expr.Const (c, m, ty) -> GenConstant cenv cgbuf eenv (c, m, ty) sequel
+        | Expr.Const(c, m, ty) -> GenConstant cenv cgbuf eenv (c, m, ty) sequel
 
-        | Expr.LetRec (binds, body, m, _) -> GenLetRec cenv cgbuf eenv (binds, body, m) sequel
+        | Expr.LetRec(binds, body, m, _) -> GenLetRec cenv cgbuf eenv (binds, body, m) sequel
 
         | Expr.Lambda _
         | Expr.TyLambda _ -> GenLambda cenv cgbuf eenv false [] expr sequel
 
-        | Expr.App (Expr.Val (vref, _, m) as v, _, tyargs, [], _) when
+        | Expr.App(Expr.Val(vref, _, m) as v, _, tyargs, [], _) when
             List.forall (isMeasureTy g) tyargs
             && (
                 // inline only values that are stored in local variables
@@ -2950,46 +2951,45 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
             // application of local type functions with type parameters = measure types and body = local value - inline the body
             GenExpr cenv cgbuf eenv v sequel
 
-        | Expr.App (f, fty, tyargs, curriedArgs, m) -> GenApp cenv cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel
+        | Expr.App(f, fty, tyargs, curriedArgs, m) -> GenApp cenv cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel
 
-        | Expr.Val (v, _, m) -> GenGetVal cenv cgbuf eenv (v, m) sequel
+        | Expr.Val(v, _, m) -> GenGetVal cenv cgbuf eenv (v, m) sequel
 
-        | Expr.Op (op, tyargs, args, m) ->
+        | Expr.Op(op, tyargs, args, m) ->
             match op, args, tyargs with
             | TOp.ExnConstr c, _, _ -> GenAllocExn cenv cgbuf eenv (c, args, m) sequel
             | TOp.UnionCase c, _, _ -> GenAllocUnionCase cenv cgbuf eenv (c, tyargs, args, m) sequel
-            | TOp.Recd (isCtor, tcref), _, _ -> GenAllocRecd cenv cgbuf eenv isCtor (tcref, tyargs, args, m) sequel
+            | TOp.Recd(isCtor, tcref), _, _ -> GenAllocRecd cenv cgbuf eenv isCtor (tcref, tyargs, args, m) sequel
             | TOp.AnonRecd anonInfo, _, _ -> GenAllocAnonRecd cenv cgbuf eenv (anonInfo, tyargs, args, m) sequel
-            | TOp.AnonRecdGet (anonInfo, n), [ e ], _ -> GenGetAnonRecdField cenv cgbuf eenv (anonInfo, e, tyargs, n, m) sequel
-            | TOp.TupleFieldGet (tupInfo, n), [ e ], _ -> GenGetTupleField cenv cgbuf eenv (tupInfo, e, tyargs, n, m) sequel
-            | TOp.ExnFieldGet (ecref, n), [ e ], _ -> GenGetExnField cenv cgbuf eenv (e, ecref, n, m) sequel
-            | TOp.UnionCaseFieldGet (ucref, n), [ e ], _ -> GenGetUnionCaseField cenv cgbuf eenv (e, ucref, tyargs, n, m) sequel
-            | TOp.UnionCaseFieldGetAddr (ucref, n, _readonly), [ e ], _ ->
+            | TOp.AnonRecdGet(anonInfo, n), [ e ], _ -> GenGetAnonRecdField cenv cgbuf eenv (anonInfo, e, tyargs, n, m) sequel
+            | TOp.TupleFieldGet(tupInfo, n), [ e ], _ -> GenGetTupleField cenv cgbuf eenv (tupInfo, e, tyargs, n, m) sequel
+            | TOp.ExnFieldGet(ecref, n), [ e ], _ -> GenGetExnField cenv cgbuf eenv (e, ecref, n, m) sequel
+            | TOp.UnionCaseFieldGet(ucref, n), [ e ], _ -> GenGetUnionCaseField cenv cgbuf eenv (e, ucref, tyargs, n, m) sequel
+            | TOp.UnionCaseFieldGetAddr(ucref, n, _readonly), [ e ], _ ->
                 GenGetUnionCaseFieldAddr cenv cgbuf eenv (e, ucref, tyargs, n, m) sequel
             | TOp.UnionCaseTagGet ucref, [ e ], _ -> GenGetUnionCaseTag cenv cgbuf eenv (e, ucref, tyargs, m) sequel
             | TOp.UnionCaseProof ucref, [ e ], _ -> GenUnionCaseProof cenv cgbuf eenv (e, ucref, tyargs, m) sequel
-            | TOp.ExnFieldSet (ecref, n), [ e; e2 ], _ -> GenSetExnField cenv cgbuf eenv (e, ecref, n, e2, m) sequel
-            | TOp.UnionCaseFieldSet (ucref, n), [ e; e2 ], _ -> GenSetUnionCaseField cenv cgbuf eenv (e, ucref, tyargs, n, e2, m) sequel
+            | TOp.ExnFieldSet(ecref, n), [ e; e2 ], _ -> GenSetExnField cenv cgbuf eenv (e, ecref, n, e2, m) sequel
+            | TOp.UnionCaseFieldSet(ucref, n), [ e; e2 ], _ -> GenSetUnionCaseField cenv cgbuf eenv (e, ucref, tyargs, n, e2, m) sequel
             | TOp.ValFieldGet f, [ e ], _ -> GenGetRecdField cenv cgbuf eenv (e, f, tyargs, m) sequel
             | TOp.ValFieldGet f, [], _ -> GenGetStaticField cenv cgbuf eenv (f, tyargs, m) sequel
-            | TOp.ValFieldGetAddr (f, _readonly), [ e ], _ -> GenGetRecdFieldAddr cenv cgbuf eenv (e, f, tyargs, m) sequel
-            | TOp.ValFieldGetAddr (f, _readonly), [], _ -> GenGetStaticFieldAddr cenv cgbuf eenv (f, tyargs, m) sequel
+            | TOp.ValFieldGetAddr(f, _readonly), [ e ], _ -> GenGetRecdFieldAddr cenv cgbuf eenv (e, f, tyargs, m) sequel
+            | TOp.ValFieldGetAddr(f, _readonly), [], _ -> GenGetStaticFieldAddr cenv cgbuf eenv (f, tyargs, m) sequel
             | TOp.ValFieldSet f, [ e1; e2 ], _ -> GenSetRecdField cenv cgbuf eenv (e1, f, tyargs, e2, m) sequel
             | TOp.ValFieldSet f, [ e2 ], _ -> GenSetStaticField cenv cgbuf eenv (f, tyargs, e2, m) sequel
             | TOp.Tuple tupInfo, _, _ -> GenAllocTuple cenv cgbuf eenv (tupInfo, args, tyargs, m) sequel
-            | TOp.ILAsm (instrs, retTypes), _, _ -> GenAsmCode cenv cgbuf eenv (instrs, tyargs, args, retTypes, m) sequel
-            | TOp.While (sp, _), [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _) ], [] ->
+            | TOp.ILAsm(instrs, retTypes), _, _ -> GenAsmCode cenv cgbuf eenv (instrs, tyargs, args, retTypes, m) sequel
+            | TOp.While(sp, _), [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], e2, _, _) ], [] ->
                 GenWhileLoop cenv cgbuf eenv (sp, e1, e2, m) sequel
-            | TOp.IntegerForLoop (spFor, spTo, dir),
-              [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _); Expr.Lambda (_, _, _, [ v ], e3, _, _) ],
+            | TOp.IntegerForLoop(spFor, spTo, dir),
+              [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], e2, _, _); Expr.Lambda(_, _, _, [ v ], e3, _, _) ],
               [] -> GenIntegerForLoop cenv cgbuf eenv (spFor, spTo, v, e1, dir, e2, e3, m) sequel
-            | TOp.TryFinally (spTry, spFinally),
-              [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ _ ], e2, _, _) ],
-              [ resTy ] -> GenTryFinally cenv cgbuf eenv (e1, e2, m, resTy, spTry, spFinally) sequel
-            | TOp.TryWith (spTry, spWith),
-              [ Expr.Lambda (_, _, _, [ _ ], e1, _, _); Expr.Lambda (_, _, _, [ vf ], ef, _, _); Expr.Lambda (_, _, _, [ vh ], eh, _, _) ],
+            | TOp.TryFinally(spTry, spFinally), [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ _ ], e2, _, _) ], [ resTy ] ->
+                GenTryFinally cenv cgbuf eenv (e1, e2, m, resTy, spTry, spFinally) sequel
+            | TOp.TryWith(spTry, spWith),
+              [ Expr.Lambda(_, _, _, [ _ ], e1, _, _); Expr.Lambda(_, _, _, [ vf ], ef, _, _); Expr.Lambda(_, _, _, [ vh ], eh, _, _) ],
               [ resTy ] -> GenTryWith cenv cgbuf eenv (e1, vf, ef, vh, eh, m, resTy, spTry, spWith) sequel
-            | TOp.ILCall (isVirtual, _, isStruct, isCtor, valUseFlag, _, noTailCall, ilMethRef, enclTypeInst, methInst, returnTypes),
+            | TOp.ILCall(isVirtual, _, isStruct, isCtor, valUseFlag, _, noTailCall, ilMethRef, enclTypeInst, methInst, returnTypes),
               args,
               [] ->
                 GenILCall
@@ -3002,10 +3002,10 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
             | TOp.Coerce, [ e ], [ tgtTy; srcTy ] -> GenCoerce cenv cgbuf eenv (e, tgtTy, m, srcTy) sequel
             | TOp.Reraise, [], [ retTy ] -> GenReraise cenv cgbuf eenv (retTy, m) sequel
             | TOp.TraitCall traitInfo, args, [] -> GenTraitCall cenv cgbuf eenv (traitInfo, args, m) expr sequel
-            | TOp.LValueOp (LSet, v), [ e ], [] -> GenSetVal cenv cgbuf eenv (v, e, m) sequel
-            | TOp.LValueOp (LByrefGet, v), [], [] -> GenGetByref cenv cgbuf eenv (v, m) sequel
-            | TOp.LValueOp (LByrefSet, v), [ e ], [] -> GenSetByref cenv cgbuf eenv (v, e, m) sequel
-            | TOp.LValueOp (LAddrOf _, v), [], [] -> GenGetValAddr cenv cgbuf eenv (v, m) sequel
+            | TOp.LValueOp(LSet, v), [ e ], [] -> GenSetVal cenv cgbuf eenv (v, e, m) sequel
+            | TOp.LValueOp(LByrefGet, v), [], [] -> GenGetByref cenv cgbuf eenv (v, m) sequel
+            | TOp.LValueOp(LByrefSet, v), [ e ], [] -> GenSetByref cenv cgbuf eenv (v, e, m) sequel
+            | TOp.LValueOp(LAddrOf _, v), [], [] -> GenGetValAddr cenv cgbuf eenv (v, m) sequel
             | TOp.Array, elems, [ elemTy ] -> GenNewArray cenv cgbuf eenv (elems, elemTy, m) sequel
             | TOp.Bytes bytes, [], [] ->
                 if cenv.options.emitConstantArraysUsingStaticDataBlobs then
@@ -3035,22 +3035,22 @@ and GenExprAux (cenv: cenv) (cgbuf: CodeGenBuffer) eenv expr (sequel: sequel) =
                 GenUnitThenSequel cenv eenv m eenv.cloc cgbuf sequel
             | _ -> error (InternalError("Unexpected operator node expression", expr.Range))
 
-        | Expr.StaticOptimization (constraints, e2, e3, m) -> GenStaticOptimization cenv cgbuf eenv (constraints, e2, e3, m) sequel
+        | Expr.StaticOptimization(constraints, e2, e3, m) -> GenStaticOptimization cenv cgbuf eenv (constraints, e2, e3, m) sequel
 
-        | Expr.Obj (_, ty, _, _, [ meth ], [], m) when isDelegateTy g ty -> GenDelegateExpr cenv cgbuf eenv expr (meth, m) sequel
+        | Expr.Obj(_, ty, _, _, [ meth ], [], m) when isDelegateTy g ty -> GenDelegateExpr cenv cgbuf eenv expr (meth, m) sequel
 
-        | Expr.Obj (_, ty, basev, basecall, overrides, interfaceImpls, m) ->
+        | Expr.Obj(_, ty, basev, basecall, overrides, interfaceImpls, m) ->
             GenObjectExpr cenv cgbuf eenv expr (ty, basev, basecall, overrides, interfaceImpls, m) sequel
 
-        | Expr.Quote (ast, conv, _, m, ty) -> GenQuotation cenv cgbuf eenv (ast, conv, m, ty) sequel
+        | Expr.Quote(ast, conv, _, m, ty) -> GenQuotation cenv cgbuf eenv (ast, conv, m, ty) sequel
 
-        | Expr.WitnessArg (traitInfo, m) ->
+        | Expr.WitnessArg(traitInfo, m) ->
             GenWitnessArgFromTraitInfo cenv cgbuf eenv m traitInfo
             GenSequel cenv eenv.cloc cgbuf sequel
 
         | Expr.Link _ -> failwith "Unexpected reclink"
 
-        | Expr.TyChoose (_, _, m) -> error (InternalError("Unexpected Expr.TyChoose", m))
+        | Expr.TyChoose(_, _, m) -> error (InternalError("Unexpected Expr.TyChoose", m))
 
 and GenExprs cenv cgbuf eenv es =
     List.iter (fun e -> GenExpr cenv cgbuf eenv e Continue) es
@@ -3099,7 +3099,7 @@ and DelayCodeGenMethodForExpr cenv mgbuf ((_, _, eenv, _, _, _, _) as args) =
 /// not generating a 'unit' expression at all)
 and sequelAfterDiscard sequel =
     match sequel with
-    | LeaveHandler (isFinally, whereToSaveResultOpt, afterHandler, true) ->
+    | LeaveHandler(isFinally, whereToSaveResultOpt, afterHandler, true) ->
         // If we're not saving the result as we leave a handler and we're doing a discard
         // then we can just adjust the sequel to record the fact we've implicitly done a discard
         if isFinally || whereToSaveResultOpt.IsNone then
@@ -3107,7 +3107,7 @@ and sequelAfterDiscard sequel =
         else
             None
     | DiscardThen sequel -> Some sequel
-    | EndLocalScope (sq, mark) -> sequelAfterDiscard sq |> Option.map (fun sq -> EndLocalScope(sq, mark))
+    | EndLocalScope(sq, mark) -> sequelAfterDiscard sq |> Option.map (fun sq -> EndLocalScope(sq, mark))
     | _ -> None
 
 and sequelIgnoringEndScopesAndDiscard sequel =
@@ -3119,13 +3119,13 @@ and sequelIgnoringEndScopesAndDiscard sequel =
 
 and sequelIgnoreEndScopes sequel =
     match sequel with
-    | EndLocalScope (sq, _) -> sequelIgnoreEndScopes sq
+    | EndLocalScope(sq, _) -> sequelIgnoreEndScopes sq
     | sq -> sq
 
 (* commit any 'EndLocalScope' nodes in the sequel and return the residue *)
 and GenSequelEndScopes cgbuf sequel =
     match sequel with
-    | EndLocalScope (sq, m) ->
+    | EndLocalScope(sq, m) ->
         CG.SetMarkToHere cgbuf m
         GenSequelEndScopes cgbuf sq
     | _ -> ()
@@ -3137,8 +3137,8 @@ and StringOfSequel sequel =
     | ReturnVoid -> "ReturnVoid"
     | CmpThenBrOrContinue _ -> "CmpThenBrOrContinue"
     | Return -> "Return"
-    | EndLocalScope (sq, Mark k) -> "EndLocalScope(" + StringOfSequel sq + "," + formatCodeLabel k + ")"
-    | Br (Mark x) -> sprintf "Br L%s" (formatCodeLabel x)
+    | EndLocalScope(sq, Mark k) -> "EndLocalScope(" + StringOfSequel sq + "," + formatCodeLabel k + ")"
+    | Br(Mark x) -> sprintf "Br L%s" (formatCodeLabel x)
     | LeaveHandler _ -> "LeaveHandler"
     | EndFilter -> "EndFilter"
 
@@ -3151,7 +3151,7 @@ and GenSequel cenv cloc cgbuf sequel =
          CG.EmitInstr cgbuf (pop 1) Push0 AI_pop
          GenSequel cenv cloc cgbuf sq
      | ReturnVoid -> CG.EmitInstr cgbuf (pop 0) Push0 I_ret
-     | CmpThenBrOrContinue (pops, bri) -> CG.EmitInstrs cgbuf pops Push0 bri
+     | CmpThenBrOrContinue(pops, bri) -> CG.EmitInstrs cgbuf pops Push0 bri
      | Return -> CG.EmitInstr cgbuf (pop 1) Push0 I_ret
      | EndLocalScope _ -> failwith "EndLocalScope unexpected"
      | Br x ->
@@ -3164,14 +3164,14 @@ and GenSequel cenv cloc cgbuf sequel =
 
          CG.EmitInstr cgbuf (pop 0) Push0 (I_br x.CodeLabel)
 
-     | LeaveHandler (isFinally, whereToSaveResultOpt, afterHandler, hasResult) ->
+     | LeaveHandler(isFinally, whereToSaveResultOpt, afterHandler, hasResult) ->
          if hasResult then
              if isFinally then
                  CG.EmitInstr cgbuf (pop 1) Push0 AI_pop
              else
                  match whereToSaveResultOpt with
                  | None -> CG.EmitInstr cgbuf (pop 1) Push0 AI_pop
-                 | Some (whereToSaveResult, _) -> EmitSetLocal cgbuf whereToSaveResult
+                 | Some(whereToSaveResult, _) -> EmitSetLocal cgbuf whereToSaveResult
 
          CG.EmitInstr
              cgbuf
@@ -3333,7 +3333,7 @@ and GenLinearExpr cenv cgbuf eenv expr sequel preSteps (contf: FakeUnit -> FakeU
     let expr = stripExpr expr
 
     match expr with
-    | Expr.Sequential (e1, e2, specialSeqFlag, _) ->
+    | Expr.Sequential(e1, e2, specialSeqFlag, _) ->
         // Process the debug point and see if there's a replacement technique to process this expression
         if preSteps && GenExprPreSteps cenv cgbuf eenv expr sequel then
             contf Fake
@@ -3349,7 +3349,7 @@ and GenLinearExpr cenv cgbuf eenv expr sequel preSteps (contf: FakeUnit -> FakeU
                 // with tailcalls, so detect this case and throw the "then ()" away, having already
                 // worked out "spExpr" up above.
                 match e2 with
-                | Expr.Const (Const.Unit, _, _) -> GenExpr cenv cgbuf eenv e1 sequel
+                | Expr.Const(Const.Unit, _, _) -> GenExpr cenv cgbuf eenv e1 sequel
                 | _ ->
                     let g = cenv.g
                     let isUnit = isUnitTy g (tyOfExpr g e1)
@@ -3365,7 +3365,7 @@ and GenLinearExpr cenv cgbuf eenv expr sequel preSteps (contf: FakeUnit -> FakeU
 
                 contf Fake
 
-    | Expr.Let (bind, body, _, _) ->
+    | Expr.Let(bind, body, _, _) ->
         // Process the debug point and see if there's a replacement technique to process this expression
         if preSteps && GenExprPreSteps cenv cgbuf eenv expr sequel then
             contf Fake
@@ -3381,7 +3381,7 @@ and GenLinearExpr cenv cgbuf eenv expr sequel preSteps (contf: FakeUnit -> FakeU
             // Generate the body
             GenLinearExpr cenv cgbuf eenv body (EndLocalScope(sequel, endMark)) true contf
 
-    | Expr.Match (spBind, _exprm, tree, targets, m, ty) ->
+    | Expr.Match(spBind, _exprm, tree, targets, m, ty) ->
         // Process the debug point and see if there's a replacement technique to process this expression
         if preSteps && GenExprPreSteps cenv cgbuf eenv expr sequel then
             contf Fake
@@ -3441,11 +3441,11 @@ and GenLinearExpr cenv cgbuf eenv expr sequel preSteps (contf: FakeUnit -> FakeU
                          GenSequel cenv eenv.cloc cgbuf sequelAfterJoin
                          Fake))
 
-    | Expr.DebugPoint (DebugPointAtLeafExpr.Yes m, innerExpr) ->
+    | Expr.DebugPoint(DebugPointAtLeafExpr.Yes m, innerExpr) ->
         CG.EmitDebugPoint cgbuf m
         GenLinearExpr cenv cgbuf eenv innerExpr sequel true contf
 
-    | LinearOpExpr (TOp.UnionCase c, tyargs, argsFront, argLast, m) ->
+    | LinearOpExpr(TOp.UnionCase c, tyargs, argsFront, argLast, m) ->
         // Process the debug point and see if there's a replacement technique to process this expression
         if preSteps && GenExprPreSteps cenv cgbuf eenv expr sequel then
             contf Fake
@@ -3583,7 +3583,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
 
         let test, write =
             match stripDebugPoints elemsArray[0] with
-            | Expr.Const (Const.Bool _, _, _) ->
+            | Expr.Const(Const.Bool _, _, _) ->
                 (function
                 | Const.Bool _ -> true
                 | _ -> false),
@@ -3591,7 +3591,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.Bool b -> buf.EmitBoolAsByte b
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.Char _, _, _) ->
+            | Expr.Const(Const.Char _, _, _) ->
                 (function
                 | Const.Char _ -> true
                 | _ -> false),
@@ -3599,7 +3599,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.Char b -> buf.EmitInt32AsUInt16(int b)
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.Byte _, _, _) ->
+            | Expr.Const(Const.Byte _, _, _) ->
                 (function
                 | Const.Byte _ -> true
                 | _ -> false),
@@ -3607,7 +3607,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.Byte b -> buf.EmitByte b
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.UInt16 _, _, _) ->
+            | Expr.Const(Const.UInt16 _, _, _) ->
                 (function
                 | Const.UInt16 _ -> true
                 | _ -> false),
@@ -3615,7 +3615,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.UInt16 b -> buf.EmitUInt16 b
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.UInt32 _, _, _) ->
+            | Expr.Const(Const.UInt32 _, _, _) ->
                 (function
                 | Const.UInt32 _ -> true
                 | _ -> false),
@@ -3623,7 +3623,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.UInt32 b -> buf.EmitInt32(int32 b)
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.UInt64 _, _, _) ->
+            | Expr.Const(Const.UInt64 _, _, _) ->
                 (function
                 | Const.UInt64 _ -> true
                 | _ -> false),
@@ -3631,7 +3631,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.UInt64 b -> buf.EmitInt64(int64 b)
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.SByte _, _, _) ->
+            | Expr.Const(Const.SByte _, _, _) ->
                 (function
                 | Const.SByte _ -> true
                 | _ -> false),
@@ -3639,7 +3639,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.SByte b -> buf.EmitByte(byte b)
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.Int16 _, _, _) ->
+            | Expr.Const(Const.Int16 _, _, _) ->
                 (function
                 | Const.Int16 _ -> true
                 | _ -> false),
@@ -3647,7 +3647,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.Int16 b -> buf.EmitUInt16(uint16 b)
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.Int32 _, _, _) ->
+            | Expr.Const(Const.Int32 _, _, _) ->
                 (function
                 | Const.Int32 _ -> true
                 | _ -> false),
@@ -3655,7 +3655,7 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
                     function
                     | Const.Int32 b -> buf.EmitInt32 b
                     | _ -> failwith "unreachable")
-            | Expr.Const (Const.Int64 _, _, _) ->
+            | Expr.Const(Const.Int64 _, _, _) ->
                 (function
                 | Const.Int64 _ -> true
                 | _ -> false),
@@ -3671,14 +3671,14 @@ and GenNewArray cenv cgbuf eenv (elems: Expr list, elemTy, m) sequel =
         if
             elemsArray
             |> Array.forall (function
-                | Expr.Const (c, _, _) -> test c
+                | Expr.Const(c, _, _) -> test c
                 | _ -> false)
         then
             let ilElemTy = GenType cenv m eenv.tyenv elemTy
 
             GenConstArray cenv cgbuf eenv ilElemTy elemsArray (fun buf ->
                 function
-                | Expr.Const (c, _, _) -> write buf c
+                | Expr.Const(c, _, _) -> write buf c
                 | _ -> failwith "unreachable")
 
             GenSequel cenv eenv.cloc cgbuf sequel
@@ -4032,19 +4032,19 @@ and IsBranchTailcall (cenv: cenv) eenv (v: ValRef, tyargs, curriedArgs: _ list) 
     let g = cenv.g
 
     match ListAssoc.tryFind g.valRefEq v eenv.innerVals with
-    | Some (kind, _) ->
+    | Some(kind, _) ->
         not v.IsConstructor
         &&
         // when branch-calling methods we must have the right type parameters
         (match kind with
          | BranchCallClosure _ -> true
-         | BranchCallMethod (_, _, tps, _, _, _) -> (List.lengthsEqAndForall2 (fun ty tp -> typeEquiv g ty (mkTyparTy tp)) tyargs tps))
+         | BranchCallMethod(_, _, tps, _, _, _) -> (List.lengthsEqAndForall2 (fun ty tp -> typeEquiv g ty (mkTyparTy tp)) tyargs tps))
         &&
         // must be exact #args, ignoring tupling - we untuple if needed below
         (let arityInfo =
             match kind with
             | BranchCallClosure arityInfo
-            | BranchCallMethod (arityInfo, _, _, _, _, _) -> arityInfo
+            | BranchCallMethod(arityInfo, _, _, _, _, _) -> arityInfo
 
          arityInfo.Length = curriedArgs.Length)
         &&
@@ -4060,7 +4060,7 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
 
     match (stripDebugPoints f, tyargs, curriedArgs) with
     // Look for tailcall to turn into branch
-    | Expr.Val (v, _, _), _, _ when IsBranchTailcall cenv eenv (v, tyargs, curriedArgs) sequel ->
+    | Expr.Val(v, _, _), _, _ when IsBranchTailcall cenv eenv (v, tyargs, curriedArgs) sequel ->
         let kind, mark = ListAssoc.find g.valRefEq v eenv.innerVals // already checked above in when guard
 
         // Generate the arguments for the direct tail call.
@@ -4078,7 +4078,7 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
             for i = numArgs - 1 downto 0 do
                 CG.EmitInstr cgbuf (pop 1) Push0 (I_starg(uint16 (cgbuf.PreallocatedArgCount + i)))
 
-        | BranchCallMethod (arityInfo, curriedArgInfos, _, numObjArgs, numWitnessArgs, numMethodArgs) ->
+        | BranchCallMethod(arityInfo, curriedArgInfos, _, numObjArgs, numWitnessArgs, numMethodArgs) ->
             assert (curriedArgInfos.Length = arityInfo.Length)
             assert (curriedArgInfos.Length = curriedArgs.Length)
 
@@ -4115,14 +4115,14 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
     // PhysicalEquality becomes cheap reference equality once
     // a nominal type is known. We can't replace it for variable types since
     // a "ceq" instruction can't be applied to variable type values.
-    | Expr.Val (v, _, _), [ ty ], [ arg1; arg2 ] when (valRefEq g v g.reference_equality_inner_vref) && isAppTy g ty ->
+    | Expr.Val(v, _, _), [ ty ], [ arg1; arg2 ] when (valRefEq g v g.reference_equality_inner_vref) && isAppTy g ty ->
 
         GenExpr cenv cgbuf eenv arg1 Continue
         GenExpr cenv cgbuf eenv arg2 Continue
         CG.EmitInstr cgbuf (pop 2) (Push [ g.ilg.typ_Bool ]) AI_ceq
         GenSequel cenv eenv.cloc cgbuf sequel
 
-    | Expr.Val (v, _, m), _, _ when
+    | Expr.Val(v, _, m), _, _ when
         valRefEq g v g.cgh__resumeAt_vref
         || valRefEq g v g.cgh__resumableEntry_vref
         || valRefEq g v g.cgh__stateMachine_vref
@@ -4134,38 +4134,38 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
     // Emit "methodhandleof" calls as ldtoken instructions
     //
     // The token for the "GenericMethodDefinition" is loaded
-    | Expr.Val (v, _, m), _, [ arg ] when valRefEq g v g.methodhandleof_vref ->
+    | Expr.Val(v, _, m), _, [ arg ] when valRefEq g v g.methodhandleof_vref ->
         let (|OptionalCoerce|) x =
             match stripDebugPoints x with
-            | Expr.Op (TOp.Coerce, _, [ arg ], _) -> arg
+            | Expr.Op(TOp.Coerce, _, [ arg ], _) -> arg
             | x -> x
 
         let (|OptionalTyapp|) x =
             match stripDebugPoints x with
-            | Expr.App (f, _, [ _ ], [], _) -> f
+            | Expr.App(f, _, [ _ ], [], _) -> f
             | x -> x
 
         match stripDebugPoints arg with
         // Generate ldtoken instruction for "methodhandleof(fun (a, b, c) -> f(a, b, c))"
         // where f is an F# function value or F# method
-        | Expr.Lambda (_, _, _, _, DebugPoints (Expr.App (OptionalCoerce (OptionalTyapp (Expr.Val (vref, _, _))), _, _, _, _), _), _, _) ->
+        | Expr.Lambda(_, _, _, _, DebugPoints(Expr.App(OptionalCoerce(OptionalTyapp(Expr.Val(vref, _, _))), _, _, _, _), _), _, _) ->
 
             let storage = StorageForValRef m vref eenv
 
             match storage with
-            | Method (_, _, mspec, _, _, _, _, _, _, _, _, _) ->
+            | Method(_, _, mspec, _, _, _, _, _, _, _, _, _) ->
                 CG.EmitInstr cgbuf (pop 0) (Push [ g.iltyp_RuntimeMethodHandle ]) (I_ldtoken(ILToken.ILMethod mspec))
             | _ -> errorR (Error(FSComp.SR.ilxgenUnexpectedArgumentToMethodHandleOfDuringCodegen (), m))
 
         // Generate ldtoken instruction for "methodhandleof(fun (a, b, c) -> obj.M(a, b, c))"
         // where M is an IL method.
-        | Expr.Lambda (_,
-                       _,
-                       _,
-                       _,
-                       DebugPoints (Expr.Op (TOp.ILCall (_, _, isStruct, _, _, _, _, ilMethRef, enclTypeInst, methInst, _), _, _, _), _),
-                       _,
-                       _) ->
+        | Expr.Lambda(_,
+                      _,
+                      _,
+                      _,
+                      DebugPoints(Expr.Op(TOp.ILCall(_, _, isStruct, _, _, _, _, ilMethRef, enclTypeInst, methInst, _), _, _, _), _),
+                      _,
+                      _) ->
 
             let boxity = (if isStruct then AsValue else AsObject)
 
@@ -4186,11 +4186,11 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
         GenSequel cenv eenv.cloc cgbuf sequel
 
     // Optimize calls to top methods when given "enough" arguments.
-    | Expr.Val (vref, valUseFlags, _), _, _ when
+    | Expr.Val(vref, valUseFlags, _), _, _ when
         (let storage = StorageForValRef m vref eenv
 
          match storage with
-         | Method (valReprInfo, vref, _, _, _, _, _, _, _, _, _, _) ->
+         | Method(valReprInfo, vref, _, _, _, _, _, _, _, _, _, _) ->
              (let tps, argTys, _, _ = GetValReprTypeInFSharpForm g valReprInfo vref.Type m
               tps.Length = tyargs.Length && argTys.Length <= curriedArgs.Length)
          | _ -> false)
@@ -4199,7 +4199,7 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
         let storage = StorageForValRef m vref eenv
 
         match storage with
-        | Method (valReprInfo, vref, mspec, mspecW, _, ctps, mtps, curriedArgInfos, _, _, _, _) ->
+        | Method(valReprInfo, vref, mspec, mspecW, _, ctps, mtps, curriedArgInfos, _, _, _, _) ->
 
             let nowArgs, laterArgs = List.splitAt curriedArgInfos.Length curriedArgs
 
@@ -4351,7 +4351,7 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
                     //printfn "%d EXTRA ARGS IN TOP APP at %s" laterArgs.Length (stringOfRange m)
                     whereSaved
                     |> List.iter (function
-                        | Choice1Of2 (ilTy, loc) -> EmitGetLocal cgbuf ilTy loc
+                        | Choice1Of2(ilTy, loc) -> EmitGetLocal cgbuf ilTy loc
                         | Choice2Of2 expr -> GenExpr cenv cgbuf eenv expr Continue)
 
                     GenIndirectCall cenv cgbuf eenv (actualRetTy, [], laterArgs, m) sequel)
@@ -4362,7 +4362,7 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
     // However, we know the type instantiation for the value.
     // In this case we can often generate a type-specific local expression for the value.
     // This reduces the number of dynamic type applications.
-    | Expr.Val (vref, _, _), _, _ -> GenGetValRefAndSequel cenv cgbuf eenv m vref (Some(tyargs, curriedArgs, m, sequel))
+    | Expr.Val(vref, _, _), _, _ -> GenGetValRefAndSequel cenv cgbuf eenv m vref (Some(tyargs, curriedArgs, m, sequel))
 
     | _ ->
         (* worst case: generate a first-class function value and call *)
@@ -4455,7 +4455,7 @@ and FreeVarStorageForWitnessInfos (cenv: cenv) (eenv: IlxGenEnv) takenNames ilCl
 // `a` is an integer.
 and IsLocalErasedTyLambda eenv (v: Val) e =
     match e with
-    | Expr.TyLambda (_, tyargs, body, _, _) when
+    | Expr.TyLambda(_, tyargs, body, _, _) when
         tyargs |> List.forall (fun tp -> tp.IsErased)
         && (match StorageForVal v.Range v eenv with
             | Local _ -> true
@@ -4480,7 +4480,7 @@ and IsNamedLocalTypeFuncVal g (v: Val) expr =
 and AddDirectTyparWitnessParams cenv eenv cloinfo m =
     let directTypars =
         match cloinfo.cloExpr with
-        | Expr.TyLambda (_, tvs, _, _, _) -> tvs
+        | Expr.TyLambda(_, tvs, _, _, _) -> tvs
         | _ -> []
 
     let directWitnessInfos =
@@ -4513,7 +4513,7 @@ and GenNamedLocalTyFuncCall cenv (cgbuf: CodeGenBuffer) eenv ty cloinfo tyargs m
 
         let directTypars =
             match cloinfo.cloExpr with
-            | Expr.TyLambda (_, tvs, _, _, _) -> tvs
+            | Expr.TyLambda(_, tvs, _, _, _) -> tvs
             | _ -> []
 
         let eenvinner = AddTyparsToEnv directTypars eenvinner
@@ -4583,8 +4583,8 @@ and GenIndirectCall cenv cgbuf eenv (funcTy, tyargs, curriedArgs, m) sequel =
     let hasByrefArg =
         let rec check x =
             match x with
-            | Apps_tyapp (_, apps) -> check apps
-            | Apps_app (arg, apps) -> IsILTypeByref arg || check apps
+            | Apps_tyapp(_, apps) -> check apps
+            | Apps_app(arg, apps) -> IsILTypeByref arg || check apps
             | _ -> false
 
         check ilxClosureApps
@@ -4670,33 +4670,33 @@ and GenTry cenv cgbuf eenv scopeMarks (e1, m, resultTy, spTry) =
 and eligibleForFilter (cenv: cenv) expr =
     let rec check expr =
         match expr with
-        | Expr.Let (TBind (_, be, _), body, _, _) -> check be && check body
-        | Expr.DebugPoint (_, expr) -> check expr
-        | Expr.Match (_spBind, _exprm, dtree, targets, _, _) ->
+        | Expr.Let(TBind(_, be, _), body, _, _) -> check be && check body
+        | Expr.DebugPoint(_, expr) -> check expr
+        | Expr.Match(_spBind, _exprm, dtree, targets, _, _) ->
             checkDecisionTree dtree
-            && targets |> Array.forall (fun (TTarget (_, e, _)) -> check e)
+            && targets |> Array.forall (fun (TTarget(_, e, _)) -> check e)
         | Expr.Const _ -> true
-        | Expr.Op (TOp.ILAsm ([ I_isinst _ ], _), _, _, _) -> true
-        | Expr.Op (TOp.UnionCaseTagGet _, _, _, _) -> true
-        | Expr.Op (TOp.ExnFieldGet _, _, _, _) -> true
-        | Expr.Op (TOp.UnionCaseFieldGet _, _, _, _) -> true
-        | Expr.Op (TOp.ValFieldGet _, _, _, _) -> true
-        | Expr.Op (TOp.TupleFieldGet _, _, _, _) -> true
-        | Expr.Op (TOp.Coerce, _, _, _) -> true
+        | Expr.Op(TOp.ILAsm([ I_isinst _ ], _), _, _, _) -> true
+        | Expr.Op(TOp.UnionCaseTagGet _, _, _, _) -> true
+        | Expr.Op(TOp.ExnFieldGet _, _, _, _) -> true
+        | Expr.Op(TOp.UnionCaseFieldGet _, _, _, _) -> true
+        | Expr.Op(TOp.ValFieldGet _, _, _, _) -> true
+        | Expr.Op(TOp.TupleFieldGet _, _, _, _) -> true
+        | Expr.Op(TOp.Coerce, _, _, _) -> true
         | Expr.Val _ -> true
         | _ -> false
 
     and checkDecisionTree dtree =
         match dtree with
-        | TDSwitch (ve, cases, dflt, _) ->
+        | TDSwitch(ve, cases, dflt, _) ->
             check ve
             && cases |> List.forall checkDecisionTreeCase
             && dflt |> Option.forall checkDecisionTree
-        | TDSuccess (es, _) -> es |> List.forall check
-        | TDBind (bind, rest) -> check bind.Expr && checkDecisionTree rest
+        | TDSuccess(es, _) -> es |> List.forall check
+        | TDBind(bind, rest) -> check bind.Expr && checkDecisionTree rest
 
     and checkDecisionTreeCase dcase =
-        let (TCase (test, tree)) = dcase
+        let (TCase(test, tree)) = dcase
 
         checkDecisionTree tree
         && match test with
@@ -4710,7 +4710,7 @@ and eligibleForFilter (cenv: cenv) expr =
 
     let isTrivial =
         match expr with
-        | DebugPoints (Expr.Const _, _) -> true
+        | DebugPoints(Expr.Const _, _) -> true
         | _ -> false
 
     // Filters seem to generate invalid code for the ilreflect.fs backend
@@ -4827,7 +4827,7 @@ and GenTryWith cenv cgbuf eenv (e1, valForFilter: Val, filterExpr, valForHandler
         EmitRestoreStack cgbuf stack
 
         match whereToSaveOpt with
-        | Some (whereToSave, ilResultTy) ->
+        | Some(whereToSave, ilResultTy) ->
             EmitGetLocal cgbuf ilResultTy whereToSave
             GenSequel cenv eenv.cloc cgbuf sequel
         | None -> GenUnitThenSequel cenv eenv m eenv.cloc cgbuf sequel)
@@ -4867,7 +4867,7 @@ and GenTryFinally cenv cgbuf eenv (bodyExpr, handlerExpr, m, resTy, spTry, spFin
         EmitRestoreStack cgbuf stack
 
         match whereToSaveOpt with
-        | Some (whereToSave, ilResultTy) ->
+        | Some(whereToSave, ilResultTy) ->
             EmitGetLocal cgbuf ilResultTy whereToSave
             GenSequel cenv eenv.cloc cgbuf sequel
         | None -> GenUnitThenSequel cenv eenv m eenv.cloc cgbuf sequel)
@@ -5070,27 +5070,27 @@ and GenAsmCode cenv cgbuf eenv (il, tyargs, args, returnTys, m) sequel =
                     }
 
             match i, ilTyArgs with
-            | I_unbox_any (ILType.TypeVar _), [ tyarg ] -> I_unbox_any tyarg
-            | I_box (ILType.TypeVar _), [ tyarg ] -> I_box tyarg
-            | I_isinst (ILType.TypeVar _), [ tyarg ] -> I_isinst tyarg
-            | I_castclass (ILType.TypeVar _), [ tyarg ] -> I_castclass tyarg
-            | I_newarr (shape, ILType.TypeVar _), [ tyarg ] -> I_newarr(shape, tyarg)
-            | I_ldelem_any (shape, ILType.TypeVar _), [ tyarg ] -> I_ldelem_any(shape, tyarg)
-            | I_ldelema (ro, _, shape, ILType.TypeVar _), [ tyarg ] -> I_ldelema(ro, false, shape, tyarg)
-            | I_stelem_any (shape, ILType.TypeVar _), [ tyarg ] -> I_stelem_any(shape, tyarg)
-            | I_ldobj (a, b, ILType.TypeVar _), [ tyarg ] -> I_ldobj(a, b, tyarg)
-            | I_stobj (a, b, ILType.TypeVar _), [ tyarg ] -> I_stobj(a, b, tyarg)
-            | I_ldtoken (ILToken.ILType (ILType.TypeVar _)), [ tyarg ] -> I_ldtoken(ILToken.ILType tyarg)
-            | I_sizeof (ILType.TypeVar _), [ tyarg ] -> I_sizeof tyarg
-            | I_cpobj (ILType.TypeVar _), [ tyarg ] -> I_cpobj tyarg
-            | I_initobj (ILType.TypeVar _), [ tyarg ] -> I_initobj tyarg
-            | I_ldfld (al, vol, fspec), _ -> I_ldfld(al, vol, modFieldSpec fspec)
+            | I_unbox_any(ILType.TypeVar _), [ tyarg ] -> I_unbox_any tyarg
+            | I_box(ILType.TypeVar _), [ tyarg ] -> I_box tyarg
+            | I_isinst(ILType.TypeVar _), [ tyarg ] -> I_isinst tyarg
+            | I_castclass(ILType.TypeVar _), [ tyarg ] -> I_castclass tyarg
+            | I_newarr(shape, ILType.TypeVar _), [ tyarg ] -> I_newarr(shape, tyarg)
+            | I_ldelem_any(shape, ILType.TypeVar _), [ tyarg ] -> I_ldelem_any(shape, tyarg)
+            | I_ldelema(ro, _, shape, ILType.TypeVar _), [ tyarg ] -> I_ldelema(ro, false, shape, tyarg)
+            | I_stelem_any(shape, ILType.TypeVar _), [ tyarg ] -> I_stelem_any(shape, tyarg)
+            | I_ldobj(a, b, ILType.TypeVar _), [ tyarg ] -> I_ldobj(a, b, tyarg)
+            | I_stobj(a, b, ILType.TypeVar _), [ tyarg ] -> I_stobj(a, b, tyarg)
+            | I_ldtoken(ILToken.ILType(ILType.TypeVar _)), [ tyarg ] -> I_ldtoken(ILToken.ILType tyarg)
+            | I_sizeof(ILType.TypeVar _), [ tyarg ] -> I_sizeof tyarg
+            | I_cpobj(ILType.TypeVar _), [ tyarg ] -> I_cpobj tyarg
+            | I_initobj(ILType.TypeVar _), [ tyarg ] -> I_initobj tyarg
+            | I_ldfld(al, vol, fspec), _ -> I_ldfld(al, vol, modFieldSpec fspec)
             | I_ldflda fspec, _ -> I_ldflda(modFieldSpec fspec)
-            | I_stfld (al, vol, fspec), _ -> I_stfld(al, vol, modFieldSpec fspec)
-            | I_stsfld (vol, fspec), _ -> I_stsfld(vol, modFieldSpec fspec)
-            | I_ldsfld (vol, fspec), _ -> I_ldsfld(vol, modFieldSpec fspec)
+            | I_stfld(al, vol, fspec), _ -> I_stfld(al, vol, modFieldSpec fspec)
+            | I_stsfld(vol, fspec), _ -> I_stsfld(vol, modFieldSpec fspec)
+            | I_ldsfld(vol, fspec), _ -> I_ldsfld(vol, modFieldSpec fspec)
             | I_ldsflda fspec, _ -> I_ldsflda(modFieldSpec fspec)
-            | EI_ilzero (ILType.TypeVar _), [ tyarg ] -> EI_ilzero tyarg
+            | EI_ilzero(ILType.TypeVar _), [ tyarg ] -> EI_ilzero tyarg
             | AI_nop, _ -> i
             // These are embedded in the IL for a an initonly ldfld, i.e.
             // here's the relevant comment from tc.fs
@@ -5112,7 +5112,7 @@ and GenAsmCode cenv cgbuf eenv (il, tyargs, args, returnTys, m) sequel =
         | _ -> failwith "Bad polymorphic IL instruction"
 
     // ldnull; cgt.un then branch is used to test for null and can become a direct brtrue/brfalse
-    | [ AI_ldnull; AI_cgt_un ], [ arg1 ], CmpThenBrOrContinue (1, [ I_brcmp (bi, label1) ]), _ ->
+    | [ AI_ldnull; AI_cgt_un ], [ arg1 ], CmpThenBrOrContinue(1, [ I_brcmp(bi, label1) ]), _ ->
 
         GenExpr cenv cgbuf eenv arg1 (CmpThenBrOrContinue(pop 1, [ I_brcmp(bi, label1) ]))
 
@@ -5121,10 +5121,10 @@ and GenAsmCode cenv cgbuf eenv (il, tyargs, args, returnTys, m) sequel =
     // For these we can just generate the argument and change the test (from a brfalse to a brtrue and vice versa)
     | ([ AI_ceq ],
        [ arg1
-         Expr.Const ((Const.Bool false | Const.SByte 0y | Const.Int16 0s | Const.Int32 0 | Const.Int64 0L | Const.Byte 0uy | Const.UInt16 0us | Const.UInt32 0u | Const.UInt64 0UL),
-                     _,
-                     _) ],
-       CmpThenBrOrContinue (1, [ I_brcmp ((BI_brfalse | BI_brtrue) as bi, label1) ]),
+         Expr.Const((Const.Bool false | Const.SByte 0y | Const.Int16 0s | Const.Int32 0 | Const.Int64 0L | Const.Byte 0uy | Const.UInt16 0us | Const.UInt32 0u | Const.UInt64 0UL),
+                    _,
+                    _) ],
+       CmpThenBrOrContinue(1, [ I_brcmp((BI_brfalse | BI_brtrue) as bi, label1) ]),
        _) ->
 
         let bi =
@@ -5187,26 +5187,26 @@ and GenAsmCode cenv cgbuf eenv (il, tyargs, args, returnTys, m) sequel =
 
         // NOTE: THESE ARE NOT VALID ON FLOATING POINT DUE TO NaN. Hence INLINE ASM ON FP. MUST BE CAREFULLY WRITTEN
 
-        | [ AI_clt ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        | [ AI_clt ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bge, label1))
-        | [ AI_cgt ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        | [ AI_cgt ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_ble, label1))
-        | [ AI_clt_un ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        | [ AI_clt_un ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bge_un, label1))
-        | [ AI_cgt_un ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        | [ AI_cgt_un ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_ble_un, label1))
-        | [ AI_ceq ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
+        | [ AI_ceq ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brfalse, label1) ]) when not (anyfpType (tyOfExpr g args.Head)) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bne_un, label1))
 
         // THESE ARE VALID ON FP w.r.t. NaN
 
-        | [ AI_clt ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brtrue, label1) ]) -> CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt, label1))
-        | [ AI_cgt ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brtrue, label1) ]) -> CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt, label1))
-        | [ AI_clt_un ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brtrue, label1) ]) ->
+        | [ AI_clt ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brtrue, label1) ]) -> CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt, label1))
+        | [ AI_cgt ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brtrue, label1) ]) -> CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt, label1))
+        | [ AI_clt_un ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brtrue, label1) ]) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_blt_un, label1))
-        | [ AI_cgt_un ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brtrue, label1) ]) ->
+        | [ AI_cgt_un ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brtrue, label1) ]) ->
             CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_bgt_un, label1))
-        | [ AI_ceq ], CmpThenBrOrContinue (1, [ I_brcmp (BI_brtrue, label1) ]) -> CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_beq, label1))
+        | [ AI_ceq ], CmpThenBrOrContinue(1, [ I_brcmp(BI_brtrue, label1) ]) -> CG.EmitInstr cgbuf (pop 2) Push0 (I_brcmp(BI_beq, label1))
         | _ ->
             // Failing that, generate the real IL leaving value(s) on the stack
             CG.EmitInstrs cgbuf (pop args.Length) (Push ilReturnTys) ilAfterInst
@@ -5227,7 +5227,7 @@ and GenQuotation cenv cgbuf eenv (ast, qdataCell, m, ety) sequel =
 
     let referencedTypeDefs, typeSplices, exprSplices, astSpec =
         match qdataCell.Value with
-        | Some (data1, data2) -> if suppressWitnesses then data1 else data2
+        | Some(data1, data2) -> if suppressWitnesses then data1 else data2
 
         | None ->
             try
@@ -5438,11 +5438,11 @@ and GenGetValAddr cenv cgbuf eenv (v: ValRef, m) sequel =
     let storage = StorageForValRef m v eenv
 
     match storage with
-    | Local (idx, _, None) -> CG.EmitInstr cgbuf (pop 0) (Push [ ILType.Byref ilTy ]) (I_ldloca(uint16 idx))
+    | Local(idx, _, None) -> CG.EmitInstr cgbuf (pop 0) (Push [ ILType.Byref ilTy ]) (I_ldloca(uint16 idx))
 
     | Arg idx -> CG.EmitInstr cgbuf (pop 0) (Push [ ILType.Byref ilTy ]) (I_ldarga(uint16 idx))
 
-    | StaticPropertyWithField (fspec, _vref, hasLiteralAttr, _ilTyForProperty, _, ilTy, _, _, _) ->
+    | StaticPropertyWithField(fspec, _vref, hasLiteralAttr, _ilTyForProperty, _, ilTy, _, _, _) ->
         if hasLiteralAttr then
             errorR (Error(FSComp.SR.ilAddressOfLiteralFieldIsInvalid (), m))
 
@@ -5454,9 +5454,9 @@ and GenGetValAddr cenv cgbuf eenv (v: ValRef, m) sequel =
 
         EmitGetStaticFieldAddr cgbuf ilTy fspec
 
-    | Env (_, ilField, _) -> CG.EmitInstrs cgbuf (pop 0) (Push [ ILType.Byref ilTy ]) [ mkLdarg0; mkNormalLdflda ilField ]
+    | Env(_, ilField, _) -> CG.EmitInstrs cgbuf (pop 0) (Push [ ILType.Byref ilTy ]) [ mkLdarg0; mkNormalLdflda ilField ]
 
-    | Local (_, _, Some _)
+    | Local(_, _, Some _)
     | StaticProperty _
     | Method _
     | Env _
@@ -5551,7 +5551,7 @@ and GenGenericParam cenv eenv (tp: Typar) =
     let subTypeConstraints =
         tp.Constraints
         |> List.choose (function
-            | TyparConstraint.CoercesTo (ty, _) -> Some ty
+            | TyparConstraint.CoercesTo(ty, _) -> Some ty
             | _ -> None)
         |> List.map (GenTypeAux cenv tp.Range eenv.tyenv VoidNotOK PtrTypesNotOK)
 
@@ -5642,7 +5642,7 @@ and GenGenericParam cenv eenv (tp: Typar) =
 
 /// Generates the data used for parameters at definitions of abstract method slots such as interface methods or override methods.
 and GenSlotParam m cenv eenv slotParam : ILParameter =
-    let (TSlotParam (nm, ty, inFlag, outFlag, optionalFlag, attribs)) = slotParam
+    let (TSlotParam(nm, ty, inFlag, outFlag, optionalFlag, attribs)) = slotParam
     let ilTy = GenParamType cenv m eenv.tyenv true ty
 
     let inFlag2, outFlag2, optionalFlag2, defaultParamValue, paramMarshal2, attribs =
@@ -5668,7 +5668,7 @@ and GenSlotParam m cenv eenv slotParam : ILParameter =
     }
 
 and GenFormalSlotsig m cenv eenv slotsig =
-    let (TSlotSig (_, ty, ctps, mtps, paraml, returnTy)) = slotsig
+    let (TSlotSig(_, ty, ctps, mtps, paraml, returnTy)) = slotsig
     let paraml = List.concat paraml
     let ilTy = GenType cenv m eenv.tyenv ty
     let eenvForSlotSig = EnvForTypars (ctps @ mtps) eenv
@@ -5677,7 +5677,7 @@ and GenFormalSlotsig m cenv eenv slotsig =
     ilTy, ilParams, ilRet
 
 and GenOverridesSpec cenv eenv slotsig m isInstance =
-    let (TSlotSig (nameOfOverridenMethod, _, _, methodTypars, _, _)) = slotsig
+    let (TSlotSig(nameOfOverridenMethod, _, _, methodTypars, _, _)) = slotsig
 
     let ilOverrideTy, ilOverrideParams, ilOverrideRet =
         GenFormalSlotsig m cenv eenv slotsig
@@ -5713,14 +5713,14 @@ and GenFormalReturnType m cenv eenvFormal returnTy : ILReturn =
         | Some attr -> ilRet.WithCustomAttrs(mkILCustomAttrs (ilRet.CustomAttrs.AsList() @ [ attr ]))
         | None -> ilRet
 
-and instSlotParam inst (TSlotParam (nm, ty, inFlag, fl2, fl3, attrs)) =
+and instSlotParam inst (TSlotParam(nm, ty, inFlag, fl2, fl3, attrs)) =
     TSlotParam(nm, instType inst ty, inFlag, fl2, fl3, attrs)
 
 and GenActualSlotsig
     m
     cenv
     eenv
-    (TSlotSig (_, ty, ctps, mtps, ilSlotParams, ilSlotRetTy))
+    (TSlotSig(_, ty, ctps, mtps, ilSlotParams, ilSlotRetTy))
     methTyparsOfOverridingMethod
     (methodParams: Val list)
     =
@@ -5748,7 +5748,7 @@ and GenActualSlotsig
     ilParams, iLRet
 
 and GenNameOfOverridingMethod cenv (useMethodImpl, slotsig) =
-    let (TSlotSig (nameOfOverridenMethod, enclTypOfOverridenMethod, _, _, _, _)) =
+    let (TSlotSig(nameOfOverridenMethod, enclTypOfOverridenMethod, _, _, _, _)) =
         slotsig
 
     if useMethodImpl then
@@ -5807,9 +5807,10 @@ and renameMethodDef nameOfOverridingMethod (mdef: ILMethodDef) =
     mdef.With(name = nameOfOverridingMethod)
 
 and fixupMethodImplFlags (mdef: ILMethodDef) =
-    mdef.WithAccess(ILMemberAccess.Private).WithHideBySig().WithFinal(
-        true
-    )
+    mdef
+        .WithAccess(ILMemberAccess.Private)
+        .WithHideBySig()
+        .WithFinal(true)
         .WithNewSlot
 
 and fixupStaticAbstractSlotFlags (mdef: ILMethodDef) = mdef.WithHideBySig(true)
@@ -5817,10 +5818,10 @@ and fixupStaticAbstractSlotFlags (mdef: ILMethodDef) = mdef.WithHideBySig(true)
 and GenObjectExprMethod cenv eenvinner (cgbuf: CodeGenBuffer) useMethodImpl tmethod =
     let g = cenv.g
 
-    let (TObjExprMethod (slotsig, attribs, methTyparsOfOverridingMethod, methParams, methBodyExpr, m)) =
+    let (TObjExprMethod(slotsig, attribs, methTyparsOfOverridingMethod, methParams, methBodyExpr, m)) =
         tmethod
 
-    let (TSlotSig (nameOfOverridenMethod, _, _, _, _, _)) = slotsig
+    let (TSlotSig(nameOfOverridenMethod, _, _, _, _, _)) = slotsig
 
     // Check if we're compiling the property as a .NET event
     if CompileAsEvent g attribs then
@@ -5874,13 +5875,13 @@ and GenObjectExprMethod cenv eenvinner (cgbuf: CodeGenBuffer) useMethodImpl tmet
 
 and GenStructStateMachine cenv cgbuf eenvouter (res: LoweredStateMachine) sequel =
 
-    let (LoweredStateMachine (templateStructTy,
-                              dataTy,
-                              stateVars,
-                              thisVars,
-                              (moveNextThisVar, moveNextBody),
-                              (setStateMachineThisVar, setStateMachineStateVar, setStateMachineBody),
-                              (afterCodeThisVar, afterCodeBody))) =
+    let (LoweredStateMachine(templateStructTy,
+                             dataTy,
+                             stateVars,
+                             thisVars,
+                             (moveNextThisVar, moveNextBody),
+                             (setStateMachineThisVar, setStateMachineStateVar, setStateMachineBody),
+                             (afterCodeThisVar, afterCodeBody))) =
         res
 
     let m = moveNextBody.Range
@@ -6404,7 +6405,12 @@ and GenSequenceExpr
                          else
                              GenGetLocalVal cenv cgbuf eenv m fv None
 
-                     CG.EmitInstr cgbuf (pop ilCloAllFreeVars.Length) (Push [ ilCloRetTyInner ]) (I_newobj(formalClospec.Constructor, None))
+                     CG.EmitInstr
+                         cgbuf
+                         (pop ilCloAllFreeVars.Length)
+                         (Push [ ilCloRetTyInner ])
+                         (I_newobj(formalClospec.Constructor, None))
+
                      GenSequel cenv eenv.cloc cgbuf Return),
                  m)
 
@@ -6471,15 +6477,7 @@ and GenSequenceExpr
         |> AddNonUserCompilerGeneratedAttribs g
 
     let ilCtorBody =
-        mkILSimpleStorageCtor(
-            Some ilCloBaseTy.TypeSpec,
-            ilCloTyInner,
-            [],
-            [],
-            ILMemberAccess.Assembly,
-            None,
-            eenvouter.imports
-        )
+        mkILSimpleStorageCtor(Some ilCloBaseTy.TypeSpec, ilCloTyInner, [], [], ILMemberAccess.Assembly, None, eenvouter.imports)
             .MethodBody
 
     let cloMethods =
@@ -6647,7 +6645,7 @@ and GenClosureAsLocalTypeFunction cenv (cgbuf: CodeGenBuffer) eenv thisVars expr
     let ilCloFormalReturnTy, ilCloLambdas =
         let rec strip lambdas =
             match lambdas with
-            | Lambdas_forall (_, r) -> strip r
+            | Lambdas_forall(_, r) -> strip r
             | Lambdas_return returnTy -> returnTy, lambdas
             | _ -> failwith "AdjustNamedLocalTypeFuncIlxClosureInfo: local functions can currently only be type functions"
 
@@ -6723,8 +6721,8 @@ and GenClosureAsFirstClassFunction cenv (cgbuf: CodeGenBuffer) eenv thisVars m e
 /// Generate the closure class for a function
 and GenLambdaClosure cenv (cgbuf: CodeGenBuffer) eenv isLocalTypeFunc thisVars expr =
     match expr with
-    | Expr.Lambda (_, _, _, _, _, m, _)
-    | Expr.TyLambda (_, _, _, m, _) ->
+    | Expr.Lambda(_, _, _, _, _, m, _)
+    | Expr.TyLambda(_, _, _, m, _) ->
 
         let cloinfo, ilCloTypeRef, cloTypeDefs =
             if isLocalTypeFunc then
@@ -6769,8 +6767,8 @@ and GenFreevar cenv m eenvouter tyenvinner (fv: Val) =
 
     match StorageForVal m fv eenvouter with
     // Local type functions
-    | Local (_, _, Some _)
-    | Env (_, _, Some _) -> g.ilg.typ_Object
+    | Local(_, _, Some _)
+    | Env(_, _, Some _) -> g.ilg.typ_Object
 #if DEBUG
     // Check for things that should never make it into the free variable set. Only do this in debug for performance reasons
     | StaticPropertyWithField _
@@ -6795,9 +6793,9 @@ and GetIlxClosureFreeVars cenv m (thisVars: ValRef list) boxity eenvouter takenN
     // Get a unique stamp for the closure. This must be stable for things that can be part of a let rec.
     let uniq =
         match expr with
-        | Expr.Obj (uniq, _, _, _, _, _, _)
-        | Expr.Lambda (uniq, _, _, _, _, _, _)
-        | Expr.TyLambda (uniq, _, _, _, _) -> uniq
+        | Expr.Obj(uniq, _, _, _, _, _, _)
+        | Expr.Lambda(uniq, _, _, _, _, _, _)
+        | Expr.TyLambda(uniq, _, _, _, _) -> uniq
         | _ -> newUnique ()
 
     // Choose a name for the closure
@@ -6820,7 +6818,7 @@ and GetIlxClosureFreeVars cenv m (thisVars: ValRef list) boxity eenvouter takenN
         let opts =
             match eenvouter.tyenv.TemplateReplacement with
             | None -> opts
-            | Some (tcref, _, typars, _) -> opts.WithTemplateReplacement(tyconRefEq g tcref, typars)
+            | Some(tcref, _, typars, _) -> opts.WithTemplateReplacement(tyconRefEq g tcref, typars)
 
         freeInExpr opts expr
 
@@ -6846,8 +6844,8 @@ and GetIlxClosureFreeVars cenv m (thisVars: ValRef list) boxity eenvouter takenN
         (cloFreeVarResults.FreeTyvars, freeLocals)
         ||> List.fold (fun ftyvs fv ->
             match StorageForVal m fv eenvouter with
-            | Env (_, _, Some (moreFtyvs, _))
-            | Local (_, _, Some (moreFtyvs, _)) -> unionFreeTyvars ftyvs moreFtyvs
+            | Env(_, _, Some(moreFtyvs, _))
+            | Local(_, _, Some(moreFtyvs, _)) -> unionFreeTyvars ftyvs moreFtyvs
             | _ -> ftyvs)
 
     let cloFreeTyvars = cloFreeTyvars.FreeTypars |> Zset.elements
@@ -6889,8 +6887,8 @@ and GetIlxClosureFreeVars cenv m (thisVars: ValRef list) boxity eenvouter takenN
         ||> List.map2 (fun fv nm ->
             let localCloInfo =
                 match StorageForVal m fv eenvouter with
-                | Local (_, _, localCloInfo)
-                | Env (_, _, localCloInfo) -> localCloInfo
+                | Local(_, _, localCloInfo)
+                | Env(_, _, localCloInfo) -> localCloInfo
                 | _ -> None
 
             let ilFv =
@@ -6915,8 +6913,8 @@ and GetIlxClosureInfo cenv m boxity isLocalTypeFunc canUseStaticField thisVars e
 
     let returnTy =
         match expr with
-        | Expr.Lambda (_, _, _, _, _, _, returnTy)
-        | Expr.TyLambda (_, _, _, _, returnTy) -> returnTy
+        | Expr.Lambda(_, _, _, _, _, _, returnTy)
+        | Expr.TyLambda(_, _, _, _, returnTy) -> returnTy
         | _ -> tyOfExpr g expr
 
     // Determine the structure of the closure. We do this before analyzing free variables to
@@ -6924,8 +6922,8 @@ and GetIlxClosureInfo cenv m boxity isLocalTypeFunc canUseStaticField thisVars e
     let tvsl, vs, body, returnTy =
         let rec getCallStructure tvacc vacc (e, ety) =
             match e with
-            | Expr.TyLambda (_, tvs, body, _m, bty) -> getCallStructure ((DropErasedTypars tvs) :: tvacc) vacc (body, bty)
-            | Expr.Lambda (_, _, _, vs, body, _, bty) when not isLocalTypeFunc ->
+            | Expr.TyLambda(_, tvs, body, _m, bty) -> getCallStructure ((DropErasedTypars tvs) :: tvacc) vacc (body, bty)
+            | Expr.Lambda(_, _, _, vs, body, _, bty) when not isLocalTypeFunc ->
                 // Transform a lambda taking untupled arguments into one
                 // taking only a single tupled argument if necessary. REVIEW: do this earlier
                 let tupledv, body = MultiLambdaToTupledLambda g vs body
@@ -7002,9 +7000,9 @@ and GetIlxClosureInfo cenv m boxity isLocalTypeFunc canUseStaticField thisVars e
 
 /// Generate a new delegate construction including a closure class if necessary. This is a lot like generating function closures
 /// and object expression closures, and most of the code is shared.
-and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod (slotsig, _attribs, methTyparsOfOverridingMethod, tmvs, body, _), m) sequel =
+and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod(slotsig, _attribs, methTyparsOfOverridingMethod, tmvs, body, _), m) sequel =
     let g = cenv.g
-    let (TSlotSig (_, delegateTy, _, _, _, _)) = slotsig
+    let (TSlotSig(_, delegateTy, _, _, _, _)) = slotsig
 
     // Get the instantiation of the delegate type
     let ilCtxtDelTy = GenType cenv m eenvouter.tyenv delegateTy
@@ -7078,14 +7076,13 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod (slotsig, _attribs
         (if useStaticClosure then
              mkILNonGenericStaticMethod
          else
-             mkILNonGenericInstanceMethod)
-            (
-                delegeeMethName,
-                ILMemberAccess.Assembly,
-                ilDelegeeParams,
-                ilDelegeeRet,
-                MethodBody.IL(InterruptibleLazy.FromValue ilMethodBody)
-            )
+             mkILNonGenericInstanceMethod) (
+            delegeeMethName,
+            ILMemberAccess.Assembly,
+            ilDelegeeParams,
+            ilDelegeeRet,
+            MethodBody.IL(InterruptibleLazy.FromValue ilMethodBody)
+        )
 
     let delegeeCtorMeth =
         mkILSimpleStorageCtor (Some g.ilg.typ_Object.TypeSpec, ilDelegeeTyInner, [], [], ILMemberAccess.Assembly, None, eenvouter.imports)
@@ -7142,13 +7139,12 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod (slotsig, _attribs
         (if useStaticClosure then
              mkILNonGenericStaticMethSpecInTy
          else
-             mkILNonGenericInstanceMethSpecInTy)
-            (
-                ilDelegeeTyOuter,
-                "Invoke",
-                typesOfILParams ilDelegeeParams,
-                ilDelegeeRet.Type
-            )
+             mkILNonGenericInstanceMethSpecInTy) (
+            ilDelegeeTyOuter,
+            "Invoke",
+            typesOfILParams ilDelegeeParams,
+            ilDelegeeRet.Type
+        )
 
     CG.EmitInstr cgbuf (pop 0) (Push [ g.ilg.typ_IntPtr ]) (I_ldftn ilDelegeeInvokeMethOuter)
 
@@ -7162,17 +7158,17 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod (slotsig, _attribs
 /// Used to search FSharp.Core implementations of "^T : ^T" and decide whether the conditional activates
 and ExprIsTraitCall expr =
     match expr with
-    | Expr.Op (TOp.TraitCall _, _, _, _) -> true
+    | Expr.Op(TOp.TraitCall _, _, _, _) -> true
     | _ -> false
 
 /// Used to search FSharp.Core implementations of "^T : ^T" and decide whether the conditional activates
 and ExprIndicatesGenericStaticConstrainedCall g expr =
     match expr with
-    | Expr.Val (vref, PossibleConstrainedCall ty, _) ->
+    | Expr.Val(vref, PossibleConstrainedCall ty, _) ->
         vref.IsMember
         && not vref.MemberInfo.Value.MemberFlags.IsInstance
         && isTyparTy g ty
-    | Expr.Op (TOp.ILCall (valUseFlag = PossibleConstrainedCall ty; ilMethRef = ilMethRef), _, _, _) ->
+    | Expr.Op(TOp.ILCall(valUseFlag = PossibleConstrainedCall ty; ilMethRef = ilMethRef), _, _, _) ->
         not ilMethRef.CallingConv.IsInstance && isTyparTy g ty
     | _ -> false
 
@@ -7181,7 +7177,7 @@ and ExprRequiresWitness cenv m expr =
     let g = cenv.g
 
     match expr with
-    | Expr.Op (TOp.TraitCall (traitInfo), _, _, _) ->
+    | Expr.Op(TOp.TraitCall(traitInfo), _, _, _) ->
         ConstraintSolver.CodegenWitnessExprForTraitConstraintWillRequireWitnessArgs cenv.tcVal g cenv.amap m traitInfo
         |> CommitOperationResult
     | _ -> false
@@ -7263,7 +7259,7 @@ and GenJoinPoint cenv cgbuf pos eenv ty m sequel =
         sequel, afterJoin, stackAfterJoin, Continue
 
     // We end scopes at the join point, if any
-    | EndLocalScope (sq, mark) ->
+    | EndLocalScope(sq, mark) ->
         let sequelNow, afterJoin, stackAfterJoin, sequelAfterJoin =
             GenJoinPoint cenv cgbuf pos eenv ty m sq
 
@@ -7304,9 +7300,9 @@ and GenDecisionTreeAndTargets cenv cgbuf stackAtTargets eenv tree targets sequel
         (fun targetInfos ->
             let sortedTargetInfos =
                 targetInfos
-                |> Seq.sortBy (fun (KeyValue (targetIdx, _)) -> targetIdx)
-                |> Seq.filter (fun (KeyValue (_, (_, isTargetPostponed))) -> isTargetPostponed)
-                |> Seq.map (fun (KeyValue (_, (targetInfo, _))) -> targetInfo)
+                |> Seq.sortBy (fun (KeyValue(targetIdx, _)) -> targetIdx)
+                |> Seq.filter (fun (KeyValue(_, (_, isTargetPostponed))) -> isTargetPostponed)
+                |> Seq.map (fun (KeyValue(_, (targetInfo, _))) -> targetInfo)
                 |> List.ofSeq
 
             GenPostponedDecisionTreeTargets cenv cgbuf sortedTargetInfos stackAtTargets sequel contf)
@@ -7341,7 +7337,7 @@ and GenDecisionTreeAndTargetsInner
     CG.SetStack cgbuf stackAtTargets // Set the expected initial stack.
 
     match tree with
-    | TDBind (bind, rest) ->
+    | TDBind(bind, rest) ->
         cgbuf.SetMarkToHereIfNecessary inplabOpt
         let startMark, endMark as scopeMarks = StartDelayedLocalScope "dtreeBind" cgbuf
         let eenv = AllocStorageForBind cenv cgbuf scopeMarks eenv bind
@@ -7354,16 +7350,16 @@ and GenDecisionTreeAndTargetsInner
         CG.SetMarkToHere cgbuf endMark
         GenDecisionTreeAndTargetsInner cenv cgbuf None stackAtTargets eenv rest targets targetCounts targetInfos sequel contf
 
-    | TDSuccess (es, targetIdx) ->
+    | TDSuccess(es, targetIdx) ->
         let targetInfos, genTargetInfoOpt =
             GenDecisionTreeSuccess cenv cgbuf inplabOpt stackAtTargets eenv es targetIdx targets targetCounts targetInfos sequel
 
         match genTargetInfoOpt with
-        | Some (eenvAtTarget, exprAtTarget, sequelAtTarget) ->
+        | Some(eenvAtTarget, exprAtTarget, sequelAtTarget) ->
             GenLinearExpr cenv cgbuf eenvAtTarget exprAtTarget sequelAtTarget true (fun Fake -> contf targetInfos)
         | _ -> contf targetInfos
 
-    | TDSwitch (e, cases, dflt, m) ->
+    | TDSwitch(e, cases, dflt, m) ->
         GenDecisionTreeSwitch cenv cgbuf inplabOpt stackAtTargets eenv e cases dflt m targets targetCounts targetInfos sequel contf
 
 and GetTarget (targets: _[]) n =
@@ -7388,10 +7384,10 @@ and GenDecisionTreeSuccess
     targetInfos
     sequel
     =
-    let (TTarget (vs, successExpr, stateVarFlagsOpt)) = GetTarget targets targetIdx
+    let (TTarget(vs, successExpr, stateVarFlagsOpt)) = GetTarget targets targetIdx
 
     match IntMap.tryFind targetIdx targetInfos with
-    | Some (targetInfo, isTargetPostponed) ->
+    | Some(targetInfo, isTargetPostponed) ->
 
         let (targetMarkBeforeBinds, targetMarkAfterBinds: Mark, eenvAtTarget, _, _, _, _, _, _) =
             targetInfo
@@ -7536,7 +7532,7 @@ and GenDecisionTreeSwitch
 
     match cases with
     // optimize a test against a boolean value, i.e. the all-important if-then-else
-    | TCase (DecisionTreeTest.Const (Const.Bool b), successTree) :: _ ->
+    | TCase(DecisionTreeTest.Const(Const.Bool b), successTree) :: _ ->
         let failureTree =
             (match defaultTargetOpt with
              | None -> cases.Tail.Head.CaseTree
@@ -7561,7 +7557,7 @@ and GenDecisionTreeSwitch
 
     // Optimize a single test for a union case to an "isdata" test - much
     // more efficient code, and this case occurs in the generated equality testers where perf is important
-    | TCase (DecisionTreeTest.UnionCase (c, tyargs), successTree) :: rest when
+    | TCase(DecisionTreeTest.UnionCase(c, tyargs), successTree) :: rest when
         rest.Length = (match defaultTargetOpt with
                        | None -> 1
                        | Some _ -> 0)
@@ -7597,7 +7593,7 @@ and GenDecisionTreeSwitch
 
     // Use GenDecisionTreeTest to generate a single test for null (when no box required) where the success
     // is going to the immediate first node in the tree
-    | TCase (DecisionTreeTest.IsNull, (TDSuccess ([], 0) as successTree)) :: rest when
+    | TCase(DecisionTreeTest.IsNull, (TDSuccess([], 0) as successTree)) :: rest when
         rest.Length = (match defaultTargetOpt with
                        | None -> 1
                        | Some _ -> 0)
@@ -7635,13 +7631,13 @@ and GenDecisionTreeSwitch
         | DecisionTreeTest.ArrayLength _
         | DecisionTreeTest.IsInst _
         | DecisionTreeTest.IsNull
-        | DecisionTreeTest.Const (Const.Zero) ->
+        | DecisionTreeTest.Const(Const.Zero) ->
             if not (isSingleton cases) || Option.isNone defaultTargetOpt then
                 failwith "internal error: GenDecisionTreeSwitch: DecisionTreeTest.IsInst/isnull/query"
 
             let bi =
                 match firstDiscrim with
-                | DecisionTreeTest.Const (Const.Zero) ->
+                | DecisionTreeTest.Const(Const.Zero) ->
                     GenExpr cenv cgbuf eenv e Continue
                     BI_brfalse
                 | DecisionTreeTest.IsNull ->
@@ -7653,7 +7649,7 @@ and GenDecisionTreeSwitch
                         CG.EmitInstr cgbuf (pop 1) (Push [ g.ilg.typ_Object ]) (I_box ilFromTy)
 
                     BI_brfalse
-                | DecisionTreeTest.IsInst (_srcTy, tgtTy) ->
+                | DecisionTreeTest.IsInst(_srcTy, tgtTy) ->
                     let e = mkCallTypeTest g m tgtTy e
                     GenExpr cenv cgbuf eenv e Continue
                     BI_brtrue
@@ -7678,7 +7674,7 @@ and GenDecisionTreeSwitch
         | DecisionTreeTest.ActivePatternCase _ ->
             error (InternalError("internal error in codegen: DecisionTreeTest.ActivePatternCase", switchm))
 
-        | DecisionTreeTest.UnionCase (hdc, tyargs) ->
+        | DecisionTreeTest.UnionCase(hdc, tyargs) ->
             GenExpr cenv cgbuf eenv e Continue
             let cuspec = GenUnionSpec cenv m eenv.tyenv hdc.TyconRef tyargs
 
@@ -7689,7 +7685,7 @@ and GenDecisionTreeSwitch
                 (cases, caseLabels)
                 ||> List.map2 (fun case label ->
                     match case with
-                    | TCase (DecisionTreeTest.UnionCase (c, _), _) -> (c.Index, label.CodeLabel)
+                    | TCase(DecisionTreeTest.UnionCase(c, _), _) -> (c.Index, label.CodeLabel)
                     | _ -> failwith "error: mixed constructor/const test?")
 
             let avoidHelpers = entityRefInThisAssembly g.compilingFSharpCore hdc.TyconRef
@@ -7814,7 +7810,7 @@ and GenDecisionTreeCases
                 GenDecisionTreeCases cenv cgbuf stackAtTargets eenv None targets targetCounts targetInfos sequel caseLabels cases contf)
     | None ->
         match caseLabels, cases with
-        | caseLabel :: caseLabelsTail, TCase (_, caseTree) :: casesTail ->
+        | caseLabel :: caseLabelsTail, TCase(_, caseTree) :: casesTail ->
             GenDecisionTreeAndTargetsInner
                 cenv
                 cgbuf
@@ -7845,7 +7841,7 @@ and GenDecisionTreeCases
 // Used for the peephole optimization below
 and (|BoolExpr|_|) =
     function
-    | Expr.Const (Const.Bool b1, _, _) -> Some b1
+    | Expr.Const(Const.Bool b1, _, _) -> Some b1
     | _ -> None
 
 and GenDecisionTreeTest
@@ -7871,24 +7867,24 @@ and GenDecisionTreeTest
 
     // Peephole: if generating a boolean value or its negation then just leave it on the stack
     // This comes up in the generated equality functions. REVIEW: do this as a peephole optimization elsewhere
-    | TDSuccess (es1, n1), TDSuccess (es2, n2) when
+    | TDSuccess(es1, n1), TDSuccess(es2, n2) when
         not isNullTest
         && isNil es1
         && isNil es2
         && (match GetTarget targets n1, GetTarget targets n2 with
-            | TTarget (_, BoolExpr b1, _), TTarget (_, BoolExpr b2, _) -> b1 = not b2
+            | TTarget(_, BoolExpr b1, _), TTarget(_, BoolExpr b2, _) -> b1 = not b2
             | _ -> false)
         ->
 
         match GetTarget targets n1, GetTarget targets n2 with
 
-        | TTarget (_, BoolExpr b1, _), _ ->
+        | TTarget(_, BoolExpr b1, _), _ ->
             GenExpr cenv cgbuf eenv e Continue
 
             match tester with
-            | Some (pops, pushes, i) ->
+            | Some(pops, pushes, i) ->
                 match i with
-                | Choice1Of2 (avoidHelpers, cuspec, idx) ->
+                | Choice1Of2(avoidHelpers, cuspec, idx) ->
                     CG.EmitInstrs cgbuf pops pushes (EraseUnions.mkIsData g.ilg (avoidHelpers, cuspec, idx))
                 | Choice2Of2 i -> CG.EmitInstr cgbuf pops pushes i
             | _ -> ()
@@ -7980,7 +7976,7 @@ and GenDecisionTreeTest
                             contf)
 
         // Turn 'isdata' tests that branch into EI_brisdata tests
-        | Some (_, _, Choice1Of2 (avoidHelpers, cuspec, idx)) ->
+        | Some(_, _, Choice1Of2(avoidHelpers, cuspec, idx)) ->
             let failure = CG.GenerateDelayMark cgbuf "testFailure"
 
             GenExpr
@@ -8015,12 +8011,12 @@ and GenDecisionTreeTest
                         sequel
                         contf)
 
-        | Some (pops, pushes, i) ->
+        | Some(pops, pushes, i) ->
             let failure = CG.GenerateDelayMark cgbuf "testFailure"
             GenExpr cenv cgbuf eenv e Continue
 
             match i with
-            | Choice1Of2 (avoidHelpers, cuspec, idx) ->
+            | Choice1Of2(avoidHelpers, cuspec, idx) ->
                 CG.EmitInstrs cgbuf pops pushes (EraseUnions.mkIsData g.ilg (avoidHelpers, cuspec, idx))
             | Choice2Of2 i -> CG.EmitInstr cgbuf pops pushes i
 
@@ -8113,14 +8109,14 @@ and GenLetRecBindings cenv (cgbuf: CodeGenBuffer) eenv (allBinds: Bindings, m) =
             for fv in clo.cloFreeVars do
                 if Zset.contains fv forwardReferenceSet then
                     match StorageForVal m fv eenvclo with
-                    | Env (_, ilField, _) ->
+                    | Env(_, ilField, _) ->
                         let fixup =
                             (boundv, fv, (fun () -> GenLetRecFixup cenv cgbuf eenv (clo.cloSpec, access, ilField, exprForVal m fv, m)))
 
                         fixups.Value <- fixup :: fixups.Value
                     | _ -> error (InternalError("GenLetRec: " + fv.LogicalName + " was not in the environment", m))
 
-        | Expr.Val (vref, _, _) ->
+        | Expr.Val(vref, _, _) ->
             let fv = vref.Deref
             let needsFixup = Zset.contains fv forwardReferenceSet
 
@@ -8211,7 +8207,7 @@ and ComputeMethodAccessRestrictedBySig eenv vspec =
 
 and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
     let g = cenv.g
-    let (TBind (vspec, rhsExpr, _)) = bind
+    let (TBind(vspec, rhsExpr, _)) = bind
 
     // Record the closed reflection definition if publishing
     // There is no real reason we're doing this so late in the day
@@ -8267,7 +8263,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
         CommitStartScope cgbuf startMarkOpt
         GenExpr cenv cgbuf eenv cctorBody discard
 
-    | Method (valReprInfo, _, mspec, mspecW, _, ctps, mtps, curriedArgInfos, paramInfos, witnessInfos, argTys, retInfo) when not isStateVar ->
+    | Method(valReprInfo, _, mspec, mspecW, _, ctps, mtps, curriedArgInfos, paramInfos, witnessInfos, argTys, retInfo) when not isStateVar ->
 
         let methLambdaTypars, methLambdaCtorThisValOpt, methLambdaBaseValOpt, methLambdaCurriedVars, methLambdaBody, methLambdaBodyTy =
             IteratedAdjustLambdaToMatchValReprInfo g cenv.amap valReprInfo rhsExpr
@@ -8331,7 +8327,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
                  copyOfLambdaBody,
                  methLambdaBodyTy)
 
-    | StaticProperty (ilGetterMethSpec, optShadowLocal) when not isStateVar ->
+    | StaticProperty(ilGetterMethSpec, optShadowLocal) when not isStateVar ->
 
         let ilAttribs = GenAttrs cenv eenv vspec.Attribs
         let ilTy = ilGetterMethSpec.FormalReturnType
@@ -8369,20 +8365,20 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
         match optShadowLocal with
         | NoShadowLocal -> ()
 
-        | ShadowLocal (startMark, storage) ->
+        | ShadowLocal(startMark, storage) ->
             CG.EmitInstr cgbuf (pop 0) (Push [ ilTy ]) (I_call(Normalcall, ilGetterMethSpec, None))
             GenSetStorage m cgbuf storage
             cgbuf.SetMarkToHere startMark
 
-    | StaticPropertyWithField (fspec,
-                               vref,
-                               hasLiteralAttr,
-                               ilTyForProperty,
-                               ilPropName,
-                               fty,
-                               ilGetterMethRef,
-                               ilSetterMethRef,
-                               optShadowLocal) ->
+    | StaticPropertyWithField(fspec,
+                              vref,
+                              hasLiteralAttr,
+                              ilTyForProperty,
+                              ilPropName,
+                              fty,
+                              ilGetterMethRef,
+                              ilSetterMethRef,
+                              optShadowLocal) ->
         let mut = vspec.IsMutable
 
         let canTarget (targets, goal: System.AttributeTargets) =
@@ -8417,7 +8413,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
             let ilAttribs =
                 if not hasLiteralAttr then
                     vspec.Attribs
-                    |> List.filter (fun (Attrib (_, _, _, _, _, targets, _)) -> canTarget (targets, System.AttributeTargets.Field))
+                    |> List.filter (fun (Attrib(_, _, _, _, _, targets, _)) -> canTarget (targets, System.AttributeTargets.Field))
                     |> GenAttrs cenv eenv // backing field only gets attributes that target fields
                 else
                     GenAttrs cenv eenv vspec.Attribs // literals have no property, so preserve all the attributes on the field itself
@@ -8437,11 +8433,11 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
         if hasLiteralAttr then
             match optShadowLocal with
             | NoShadowLocal -> ()
-            | ShadowLocal (startMark, _storage) -> cgbuf.SetMarkToHere startMark
+            | ShadowLocal(startMark, _storage) -> cgbuf.SetMarkToHere startMark
         else
             let ilAttribs =
                 vspec.Attribs
-                |> List.filter (fun (Attrib (_, _, _, _, _, targets, _)) -> canTarget (targets, System.AttributeTargets.Property))
+                |> List.filter (fun (Attrib(_, _, _, _, _, targets, _)) -> canTarget (targets, System.AttributeTargets.Property))
                 |> GenAttrs cenv eenv // property only gets attributes that target properties
 
             let ilPropDef =
@@ -8467,14 +8463,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
                 let body =
                     mkMethodBody (true, [], 2, nonBranchingInstrsToCode [ mkNormalLdsfld fspec ], None, eenv.imports)
 
-                mkILStaticMethod(
-                    [],
-                    ilGetterMethRef.Name,
-                    access,
-                    [],
-                    mkILReturn fty,
-                    body
-                )
+                mkILStaticMethod([], ilGetterMethRef.Name, access, [], mkILReturn fty, body)
                     .WithSpecialName
 
             cgbuf.mgbuf.AddMethodDef(ilTypeRefForProperty, getterMethod)
@@ -8484,14 +8473,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
                     mkMethodBody (true, [], 2, nonBranchingInstrsToCode [ mkLdarg0; mkNormalStsfld fspec ], None, eenv.imports)
 
                 let setterMethod =
-                    mkILStaticMethod(
-                        [],
-                        ilSetterMethRef.Name,
-                        access,
-                        [ mkILParamNamed ("value", fty) ],
-                        mkILReturn ILType.Void,
-                        body
-                    )
+                    mkILStaticMethod([], ilSetterMethRef.Name, access, [ mkILParamNamed ("value", fty) ], mkILReturn ILType.Void, body)
                         .WithSpecialName
 
                 cgbuf.mgbuf.AddMethodDef(ilTypeRefForProperty, setterMethod)
@@ -8502,7 +8484,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
             match optShadowLocal with
             | NoShadowLocal -> EmitSetStaticField cgbuf fspec
 
-            | ShadowLocal (startMark, storage) ->
+            | ShadowLocal(startMark, storage) ->
                 CG.EmitInstr cgbuf (pop 0) (Push [ fty ]) AI_dup
                 EmitSetStaticField cgbuf fspec
                 GenSetStorage m cgbuf storage
@@ -8513,7 +8495,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
 
         match storage, rhsExpr with
         // locals are zero-init, no need to initialize them, except if you are in a loop and the local is mutable.
-        | Local (_, realloc, _), Expr.Const (Const.Zero, _, _) when not realloc && not (eenv.isInLoop && vspec.IsMutable) ->
+        | Local(_, realloc, _), Expr.Const(Const.Zero, _, _) when not realloc && not (eenv.isInLoop && vspec.IsMutable) ->
             CommitStartScope cgbuf startMarkOpt
         | _ ->
             GetStoreValCtxt cgbuf eenv vspec
@@ -8524,7 +8506,7 @@ and GenBindingAfterDebugPoint cenv cgbuf eenv bind isStateVar startMarkOpt =
 and GetStoreValCtxt cgbuf eenv (vspec: Val) =
     // Emit the ldarg0 if needed
     match StorageForVal vspec.Range vspec eenv with
-    | Env (ilCloTy, _, _) ->
+    | Env(ilCloTy, _, _) ->
         let ilCloAddrTy =
             if ilCloTy.Boxity = ILBoxity.AsValue then
                 ILType.Byref ilCloTy
@@ -8553,7 +8535,7 @@ and GenMarshal cenv attribs =
             |> List.filter (IsMatchingFSharpAttributeOpt g g.attrib_MarshalAsAttribute >> not)
 
     match TryFindFSharpAttributeOpt g g.attrib_MarshalAsAttribute attribs with
-    | Some (Attrib (_, _, [ AttribInt32Arg unmanagedType ], namedArgs, _, _, m)) ->
+    | Some(Attrib(_, _, [ AttribInt32Arg unmanagedType ], namedArgs, _, _, m)) ->
         let decoder = AttributeDecoder namedArgs
 
         let rec decodeUnmanagedType unmanagedType =
@@ -8673,7 +8655,7 @@ and GenMarshal cenv attribs =
             | _ -> ILNativeType.Empty
 
         Some(decodeUnmanagedType unmanagedType), otherAttribs
-    | Some (Attrib (_, _, _, _, _, _, m)) ->
+    | Some(Attrib(_, _, _, _, _, _, m)) ->
         errorR (Error(FSComp.SR.ilMarshalAsAttributeCannotBeDecoded (), m))
         None, attribs
     | _ ->
@@ -8891,7 +8873,7 @@ and ComputeMethodImplAttribs cenv (_v: Val) attrs =
 
     let implflags =
         match TryFindFSharpAttribute g g.attrib_MethodImplAttribute attrs with
-        | Some (Attrib (_, _, [ AttribInt32Arg flags ], _, _, _, _)) -> flags
+        | Some(Attrib(_, _, [ AttribInt32Arg flags ], _, _, _, _)) -> flags
         | _ -> 0x0
 
     let hasPreserveSigAttr =
@@ -9036,7 +9018,7 @@ and GenMethodForBinding
     // Now generate the code.
     let hasPreserveSigNamedArg, ilMethodBody, hasDllImport =
         match TryFindFSharpAttributeOpt g g.attrib_DllImportAttribute v.Attribs with
-        | Some (Attrib (_, _, [ AttribStringArg dll ], namedArgs, _, _, m)) ->
+        | Some(Attrib(_, _, [ AttribStringArg dll ], namedArgs, _, _, m)) ->
             if not (isNil methLambdaTypars) then
                 error (Error(FSComp.SR.ilSignatureForExternalFunctionContainsTypeParameters (), m))
 
@@ -9045,7 +9027,7 @@ and GenMethodForBinding
 
             hasPreserveSigNamedArg, mbody, true
 
-        | Some (Attrib (_, _, _, _, _, _, m)) -> error (Error(FSComp.SR.ilDllImportAttributeCouldNotBeDecoded (), m))
+        | Some(Attrib(_, _, _, _, _, _, m)) -> error (Error(FSComp.SR.ilDllImportAttributeCouldNotBeDecoded (), m))
 
         | _ ->
             // Replace the body of ValInline.PseudoVal "must inline" methods with a 'throw'
@@ -9085,14 +9067,14 @@ and GenMethodForBinding
         |> List.filter (IsMatchingFSharpAttribute g g.attrib_CompiledNameAttribute >> not)
 
     let attrsAppliedToGetterOrSetter, attrs =
-        List.partition (fun (Attrib (_, _, _, _, isAppliedToGetterOrSetter, _, _)) -> isAppliedToGetterOrSetter) attrs
+        List.partition (fun (Attrib(_, _, _, _, isAppliedToGetterOrSetter, _, _)) -> isAppliedToGetterOrSetter) attrs
 
     let sourceNameAttribs, compiledName =
         match
             v.Attribs
             |> List.tryFind (IsMatchingFSharpAttribute g g.attrib_CompiledNameAttribute)
         with
-        | Some (Attrib (_, _, [ AttribStringArg b ], _, _, _, _)) -> [ mkCompilationSourceNameAttr g v.LogicalName ], Some b
+        | Some(Attrib(_, _, [ AttribStringArg b ], _, _, _, _)) -> [ mkCompilationSourceNameAttr g v.LogicalName ], Some b
         | _ -> [], None
 
     // check if the hasPreserveSigNamedArg and hasSynchronizedImplFlag implementation flags have been specified
@@ -9327,7 +9309,8 @@ and GenMethodForBinding
                                 customAttrs =
                                     mkILCustomAttrs (
                                         (GenAttrs cenv eenv attrsAppliedToGetterOrSetter)
-                                        @ sourceNameAttribs @ ilAttrsCompilerGenerated
+                                        @ sourceNameAttribs
+                                        @ ilAttrsCompilerGenerated
                                     )
                             )
 
@@ -9498,57 +9481,57 @@ and EmitGetStaticField cgbuf ty fspec =
 
 and GenSetStorage m cgbuf storage =
     match storage with
-    | Local (idx, _, _) -> EmitSetLocal cgbuf idx
+    | Local(idx, _, _) -> EmitSetLocal cgbuf idx
 
-    | StaticPropertyWithField (_, _, hasLiteralAttr, ilContainerTy, _, _, _, ilSetterMethRef, _) ->
+    | StaticPropertyWithField(_, _, hasLiteralAttr, ilContainerTy, _, _, _, ilSetterMethRef, _) ->
         if hasLiteralAttr then
             errorR (Error(FSComp.SR.ilLiteralFieldsCannotBeSet (), m))
 
         CG.EmitInstr cgbuf (pop 1) Push0 (I_call(Normalcall, mkILMethSpecForMethRefInTy (ilSetterMethRef, ilContainerTy, []), None))
 
-    | StaticProperty (ilGetterMethSpec, _) -> error (Error(FSComp.SR.ilStaticMethodIsNotLambda (ilGetterMethSpec.Name), m))
+    | StaticProperty(ilGetterMethSpec, _) -> error (Error(FSComp.SR.ilStaticMethodIsNotLambda (ilGetterMethSpec.Name), m))
 
-    | Method (_, _, mspec, _, m, _, _, _, _, _, _, _) -> error (Error(FSComp.SR.ilStaticMethodIsNotLambda (mspec.Name), m))
+    | Method(_, _, mspec, _, m, _, _, _, _, _, _, _) -> error (Error(FSComp.SR.ilStaticMethodIsNotLambda (mspec.Name), m))
 
     | Null -> CG.EmitInstr cgbuf (pop 1) Push0 AI_pop
 
     | Arg _ -> error (Error(FSComp.SR.ilMutableVariablesCannotEscapeMethod (), m))
 
-    | Env (_, ilField, _) ->
+    | Env(_, ilField, _) ->
         // Note: ldarg0 has already been emitted in GenSetVal
         CG.EmitInstr cgbuf (pop 2) Push0 (mkNormalStfld ilField)
 
 and CommitGetStorageSequel cenv cgbuf eenv m ty localCloInfo storeSequel =
     match localCloInfo, storeSequel with
-    | Some (_,
-            {
-                contents = NamedLocalIlxClosureInfoGenerator _cloinfo
-            }),
+    | Some(_,
+           {
+               contents = NamedLocalIlxClosureInfoGenerator _cloinfo
+           }),
       _ -> error (InternalError("Unexpected generator", m))
 
-    | Some (_,
-            {
-                contents = NamedLocalIlxClosureInfoGenerated cloinfo
-            }),
-      Some (tyargs, args, m, sequel) when not (isNil tyargs) ->
+    | Some(_,
+           {
+               contents = NamedLocalIlxClosureInfoGenerated cloinfo
+           }),
+      Some(tyargs, args, m, sequel) when not (isNil tyargs) ->
         let actualRetTy = GenNamedLocalTyFuncCall cenv cgbuf eenv ty cloinfo tyargs m
         CommitGetStorageSequel cenv cgbuf eenv m actualRetTy None (Some([], args, m, sequel))
 
     | _, None -> ()
 
-    | _, Some ([], [], _, sequel) -> GenSequel cenv eenv.cloc cgbuf sequel
+    | _, Some([], [], _, sequel) -> GenSequel cenv eenv.cloc cgbuf sequel
 
-    | _, Some (tyargs, args, m, sequel) -> GenCurriedArgsAndIndirectCall cenv cgbuf eenv (ty, tyargs, args, m) sequel
+    | _, Some(tyargs, args, m, sequel) -> GenCurriedArgsAndIndirectCall cenv cgbuf eenv (ty, tyargs, args, m) sequel
 
 and GenGetStorageAndSequel (cenv: cenv) cgbuf eenv m (ty, ilTy) storage storeSequel =
     let g = cenv.g
 
     match storage with
-    | Local (idx, _, localCloInfo) ->
+    | Local(idx, _, localCloInfo) ->
         EmitGetLocal cgbuf ilTy idx
         CommitGetStorageSequel cenv cgbuf eenv m ty localCloInfo storeSequel
 
-    | StaticPropertyWithField (fspec, _, hasLiteralAttr, ilContainerTy, _, _, ilGetterMethRef, _, _) ->
+    | StaticPropertyWithField(fspec, _, hasLiteralAttr, ilContainerTy, _, _, ilGetterMethRef, _, _) ->
         // References to literals go directly to the field - no property is used
         if hasLiteralAttr then
             EmitGetStaticField cgbuf ilTy fspec
@@ -9561,11 +9544,11 @@ and GenGetStorageAndSequel (cenv: cenv) cgbuf eenv m (ty, ilTy) storage storeSeq
 
         CommitGetStorageSequel cenv cgbuf eenv m ty None storeSequel
 
-    | StaticProperty (ilGetterMethSpec, _) ->
+    | StaticProperty(ilGetterMethSpec, _) ->
         CG.EmitInstr cgbuf (pop 0) (Push [ ilTy ]) (I_call(Normalcall, ilGetterMethSpec, None))
         CommitGetStorageSequel cenv cgbuf eenv m ty None storeSequel
 
-    | Method (valReprInfo, vref, _, _, _, _, _, _, _, _, _, _) ->
+    | Method(valReprInfo, vref, _, _, _, _, _, _, _, _, _, _) ->
         // Get a toplevel value as a first-class value.
         // We generate a lambda expression and that simply calls
         // the toplevel method. However we optimize the case where we are
@@ -9578,7 +9561,7 @@ and GenGetStorageAndSequel (cenv: cenv) cgbuf eenv m (ty, ilTy) storage storeSeq
         // Then reduce out any arguments (i.e. apply the sequel immediately if we can...)
         match storeSequel with
         | None -> GenLambda cenv cgbuf eenv false [] expr Continue
-        | Some (tyargs', args, m, sequel) ->
+        | Some(tyargs', args, m, sequel) ->
             let specializedExpr =
                 if isNil args && isNil tyargs' then
                     failwith ("non-lambda at use of method " + vref.LogicalName)
@@ -9595,7 +9578,7 @@ and GenGetStorageAndSequel (cenv: cenv) cgbuf eenv m (ty, ilTy) storage storeSeq
         CG.EmitInstr cgbuf (pop 0) (Push [ ilTy ]) (mkLdarg (uint16 i))
         CommitGetStorageSequel cenv cgbuf eenv m ty None storeSequel
 
-    | Env (_, ilField, localCloInfo) ->
+    | Env(_, ilField, localCloInfo) ->
         CG.EmitInstrs cgbuf (pop 0) (Push [ ilTy ]) [ mkLdarg0; mkNormalLdfld ilField ]
         CommitGetStorageSequel cenv cgbuf eenv m ty localCloInfo storeSequel
 
@@ -9698,8 +9681,8 @@ and AllocStorageForBinds cenv cgbuf scopeMarks eenv binds =
         match reprOpt with
         | Some repr ->
             match repr with
-            | Local (_, _, Some (_, g))
-            | Env (_, _, Some (_, g)) ->
+            | Local(_, _, Some(_, g))
+            | Env(_, _, Some(_, g)) ->
                 match g.Value with
                 | NamedLocalIlxClosureInfoGenerator f -> g.Value <- NamedLocalIlxClosureInfoGenerated(f eenv)
                 | NamedLocalIlxClosureInfoGenerated _ -> ()
@@ -9708,7 +9691,7 @@ and AllocStorageForBinds cenv cgbuf scopeMarks eenv binds =
 
     eenv
 
-and AllocValForBind cenv cgbuf (scopeMarks: Mark * Mark) eenv (TBind (v, repr, _)) =
+and AllocValForBind cenv cgbuf (scopeMarks: Mark * Mark) eenv (TBind(v, repr, _)) =
     match v.ValReprInfo with
     | None ->
         let repr, eenv = AllocLocalVal cenv cgbuf v eenv (Some repr) scopeMarks
@@ -9782,10 +9765,10 @@ and GenAttribArg amap g eenv x (ilArgTy: ILType) =
 
     match stripDebugPoints x, ilArgTy with
     // Detect 'null' used for an array argument
-    | Expr.Const (Const.Zero, _, _), ILType.Array _ -> ILAttribElem.Null
+    | Expr.Const(Const.Zero, _, _), ILType.Array _ -> ILAttribElem.Null
 
     // Detect standard constants
-    | Expr.Const (c, m, _), _ ->
+    | Expr.Const(c, m, _), _ ->
         let tynm = ilArgTy.TypeSpec.Name
         let isobj = (tynm = "System.Object")
 
@@ -9816,7 +9799,7 @@ and GenAttribArg amap g eenv x (ilArgTy: ILType) =
         | _ -> error (InternalError("The type '" + tynm + "' may not be used as a custom attribute value", m))
 
     // Detect '[| ... |]' nodes
-    | Expr.Op (TOp.Array, [ elemTy ], args, m), _ ->
+    | Expr.Op(TOp.Array, [ elemTy ], args, m), _ ->
         let ilElemTy = GenType amap m eenv.tyenv elemTy
         ILAttribElem.Array(ilElemTy, List.map (fun arg -> GenAttribArg amap g eenv arg ilElemTy) args)
 
@@ -9827,7 +9810,7 @@ and GenAttribArg amap g eenv x (ilArgTy: ILType) =
     | TypeDefOfExpr g ty, _ -> ILAttribElem.TypeRef(Some (GenType amap x.Range eenv.tyenv ty).TypeRef)
 
     // Ignore upcasts
-    | Expr.Op (TOp.Coerce, _, [ arg2 ], _), _ -> GenAttribArg amap g eenv arg2 ilArgTy
+    | Expr.Op(TOp.Coerce, _, [ arg2 ], _), _ -> GenAttribArg amap g eenv arg2 ilArgTy
 
     // Detect explicit enum values
     | EnumExpr g arg1, _ -> GenAttribArg amap g eenv arg1 ilArgTy
@@ -9852,10 +9835,10 @@ and GenAttribArg amap g eenv x (ilArgTy: ILType) =
     // Other expressions are not valid custom attribute values
     | _ -> error (InternalError("invalid custom attribute value (not a constant): " + showL (exprL x), x.Range))
 
-and GenAttr cenv g eenv (Attrib (_, k, args, props, _, _, _)) =
+and GenAttr cenv g eenv (Attrib(_, k, args, props, _, _, _)) =
     let props =
         props
-        |> List.map (fun (AttribNamedArg (s, ty, fld, AttribExpr (_, expr))) ->
+        |> List.map (fun (AttribNamedArg(s, ty, fld, AttribExpr(_, expr))) ->
             let m = expr.Range
             let ilTy = GenType cenv m eenv.tyenv ty
             let cval = GenAttribArg cenv g eenv expr ilTy
@@ -9873,7 +9856,7 @@ and GenAttr cenv g eenv (Attrib (_, k, args, props, _, _, _)) =
             mspec
 
     let ilArgs =
-        List.map2 (fun (AttribExpr (_, vexpr)) ty -> GenAttribArg cenv g eenv vexpr ty) args mspec.FormalArgTypes
+        List.map2 (fun (AttribExpr(_, vexpr)) ty -> GenAttribArg cenv g eenv vexpr ty) args mspec.FormalArgTypes
 
     mkILCustomAttribMethRef (mspec, ilArgs, props)
 
@@ -9902,7 +9885,7 @@ and CreatePermissionSets cenv eenv (securityAttributes: Attrib list) =
     let g = cenv.g
 
     [
-        for Attrib (tcref, _, actions, _, _, _, _) as attr in securityAttributes do
+        for Attrib(tcref, _, actions, _, _, _, _) as attr in securityAttributes do
             let action =
                 match actions with
                 | [ AttribInt32Arg act ] -> act
@@ -9914,7 +9897,7 @@ and CreatePermissionSets cenv eenv (securityAttributes: Attrib list) =
 
             let _, ilNamedArgs =
                 match TryDecodeILAttribute tref (mkILCustomAttrs [ ilattr ]) with
-                | Some (ae, na) -> ae, na
+                | Some(ae, na) -> ae, na
                 | _ -> [], []
 
             let setArgs = ilNamedArgs |> List.map (fun (n, ilt, _, ilae) -> (n, ilt, ilae))
@@ -9980,7 +9963,7 @@ and GenImplFileContents cenv cgbuf qname lazyInitInfo eenv mty def =
 
 and GenModuleOrNamespaceContents cenv (cgbuf: CodeGenBuffer) qname lazyInitInfo eenv x =
     match x with
-    | TMDefRec (_isRec, opens, tycons, mbinds, m) ->
+    | TMDefRec(_isRec, opens, tycons, mbinds, m) ->
         let eenvinner = AddDebugImportsToEnv cenv eenv opens
 
         for tc in tycons do
@@ -10019,7 +10002,7 @@ and GenModuleOrNamespaceContents cenv (cgbuf: CodeGenBuffer) qname lazyInitInfo 
 
         eenvinner
 
-    | TMDefLet (bind, _) ->
+    | TMDefLet(bind, _) ->
         GenBindings cenv cgbuf eenv [ bind ] None
         eenv
 
@@ -10027,7 +10010,7 @@ and GenModuleOrNamespaceContents cenv (cgbuf: CodeGenBuffer) qname lazyInitInfo 
         let eenvinner = AddDebugImportsToEnv cenv eenv openDecls
         eenvinner
 
-    | TMDefDo (e, _) ->
+    | TMDefDo(e, _) ->
         GenExpr cenv cgbuf eenv e discard
         eenv
 
@@ -10040,7 +10023,7 @@ and GenModuleBinding cenv (cgbuf: CodeGenBuffer) (qname: QualifiedNameOfFile) la
     match x with
     | ModuleOrNamespaceBinding.Binding bind -> GenLetRecBindings cenv cgbuf eenv ([ bind ], m)
 
-    | ModuleOrNamespaceBinding.Module (mspec, mdef) ->
+    | ModuleOrNamespaceBinding.Module(mspec, mdef) ->
         let hidden = IsHiddenTycon eenv.sigToImplRemapInfo mspec
 
         let eenvinner =
@@ -10102,7 +10085,7 @@ and GenModuleBinding cenv (cgbuf: CodeGenBuffer) (qname: QualifiedNameOfFile) la
 
 /// Generate the namespace fragments in a single file
 and GenImplFile cenv (mgbuf: AssemblyBuilder) mainInfoOpt eenv (implFile: CheckedImplFileAfterOptimization) =
-    let (CheckedImplFile (qname, _, signature, contents, hasExplicitEntryPoint, isScript, anonRecdTypes, _)) =
+    let (CheckedImplFile(qname, _, signature, contents, hasExplicitEntryPoint, isScript, anonRecdTypes, _)) =
         implFile.ImplFile
 
     let optimizeDuringCodeGen = implFile.OptimizeDuringCodeGen
@@ -10475,8 +10458,8 @@ and GenPrintingMethod cenv eenv methName ilThisTy m =
     [
         if not g.useReflectionFreeCodeGen then
             match (eenv.valsInScope.TryFind g.sprintf_vref.Deref, eenv.valsInScope.TryFind g.new_format_vref.Deref) with
-            | Some (InterruptibleLazy (Method (_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
-              Some (InterruptibleLazy (Method (_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
+            | Some(InterruptibleLazy(Method(_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
+              Some(InterruptibleLazy(Method(_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
                 // The type returned by the 'sprintf' call
                 let funcTy = EraseClosures.mkILFuncTy cenv.ilxPubCloEnv ilThisTy g.ilg.typ_String
 
@@ -10626,7 +10609,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
                                     | Some _ ->
                                         let memberParentTypars, memberMethodTypars =
                                             match PartitionValRefTypars g vref with
-                                            | Some (_, memberParentTypars, memberMethodTypars, _, _) ->
+                                            | Some(_, memberParentTypars, memberMethodTypars, _, _) ->
                                                 memberParentTypars, memberMethodTypars
                                             | None -> [], []
 
@@ -10790,7 +10773,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
 
                         let ilFieldOffset =
                             match TryFindFSharpAttribute g g.attrib_FieldOffsetAttribute fspec.FieldAttribs with
-                            | Some (Attrib (_, _, [ AttribInt32Arg fieldOffset ], _, _, _, _)) -> Some fieldOffset
+                            | Some(Attrib(_, _, [ AttribInt32Arg fieldOffset ], _, _, _, _)) -> Some fieldOffset
                             | Some attrib ->
                                 errorR (Error(FSComp.SR.ilFieldOffsetAttributeCouldNotBeDecoded (), attrib.Range))
                                 None
@@ -10960,8 +10943,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
 
                     if generateDebugDisplayAttribute then
                         match (eenv.valsInScope.TryFind g.sprintf_vref.Deref, eenv.valsInScope.TryFind g.new_format_vref.Deref) with
-                        | Some (InterruptibleLazy (Method (_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
-                          Some (InterruptibleLazy (Method (_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
+                        | Some(InterruptibleLazy(Method(_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
+                          Some(InterruptibleLazy(Method(_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
                             // The type returned by the 'sprintf' call
                             let funcTy = EraseClosures.mkILFuncTy cenv.ilxPubCloEnv ilThisTy g.ilg.typ_String
                             // Give the instantiation of the printf format object, i.e. a Format`5 object compatible with StringFormat<ilThisTy>
@@ -11041,7 +11024,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
 
                         let fieldNamesAndTypes =
                             relevantFields
-                            |> List.map (fun (_, ilFieldName, _, _, _, ilPropType, _, fspec) -> (fspec.LogicalName, ilFieldName, ilPropType))
+                            |> List.map (fun (_, ilFieldName, _, _, _, ilPropType, _, fspec) ->
+                                (fspec.LogicalName, ilFieldName, ilPropType))
 
                         let isStructRecord = tycon.IsStructRecordOrUnionTycon
 
@@ -11087,7 +11071,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
                             let parameters, ret =
                                 // When "type delegateTy = delegate of unit -> returnTy",
                                 // suppress the unit arg from delegate .Invoke vslot.
-                                let (TSlotSig (nm, ty, ctps, mtps, paraml, returnTy)) = slotSig
+                                let (TSlotSig(nm, ty, ctps, mtps, paraml, returnTy)) = slotSig
 
                                 let paraml =
                                     match paraml with
@@ -11201,7 +11185,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
 
                     let tdLayout, tdEncoding =
                         match TryFindFSharpAttribute g g.attrib_StructLayoutAttribute tycon.Attribs with
-                        | Some (Attrib (_, _, [ AttribInt32Arg layoutKind ], namedArgs, _, _, _)) ->
+                        | Some(Attrib(_, _, [ AttribInt32Arg layoutKind ], namedArgs, _, _, _)) ->
                             let decoder = AttributeDecoder namedArgs
                             let ilPack = decoder.FindInt32 "Pack" 0x0
                             let ilSize = decoder.FindInt32 "Size" 0x0
@@ -11230,7 +11214,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
                                 | _ -> ILTypeDefLayout.Auto
 
                             tdLayout, tdEncoding
-                        | Some (Attrib (_, _, _, _, _, _, m)) ->
+                        | Some(Attrib(_, _, _, _, _, _, m)) ->
                             errorR (Error(FSComp.SR.ilStructLayoutAttributeCouldNotBeDecoded (), m))
                             ILTypeDefLayout.Auto, ILDefaultPInvokeEncoding.Ansi
 
@@ -11588,7 +11572,7 @@ and GenExnDef cenv mgbuf eenv m (exnc: Tycon) =
 let CodegenAssembly cenv eenv mgbuf implFiles =
     match List.tryFrontAndBack implFiles with
     | None -> ()
-    | Some (firstImplFiles, lastImplFile) ->
+    | Some(firstImplFiles, lastImplFile) ->
 
         let eenv = List.fold (GenImplFile cenv mgbuf None) eenv firstImplFiles
         let eenv = GenImplFile cenv mgbuf cenv.options.mainMethodInfo eenv lastImplFile
@@ -11781,7 +11765,7 @@ let defaultOf =
     let gminfo =
         lazy
             (match <@@ Unchecked.defaultof<int> @@> with
-             | Quotations.Patterns.Call (_, minfo, _) -> minfo.GetGenericMethodDefinition()
+             | Quotations.Patterns.Call(_, minfo, _) -> minfo.GetGenericMethodDefinition()
              | _ -> failwith "unexpected failure decoding quotation at ilxgen startup")
 
     fun ty -> gminfo.Value.MakeGenericMethod([| ty |]).Invoke(null, [||])
@@ -11799,7 +11783,7 @@ let LookupGeneratedValue (cenv: cenv) (ctxt: ExecutionContext) eenv (v: Val) =
             ctxt.LookupType ilTy
         // Lookup the compiled v value (as an object).
         match StorageForVal v.Range v eenv with
-        | StaticPropertyWithField (fspec, _, hasLiteralAttr, ilContainerTy, _, _, ilGetterMethRef, _, _) ->
+        | StaticPropertyWithField(fspec, _, hasLiteralAttr, ilContainerTy, _, _, ilGetterMethRef, _, _) ->
             let obj =
                 if hasLiteralAttr then
                     let staticTy = ctxt.LookupTypeRef fspec.DeclaringTypeRef
@@ -11817,7 +11801,7 @@ let LookupGeneratedValue (cenv: cenv) (ctxt: ExecutionContext) eenv (v: Val) =
 
             Some(obj, objTyp ())
 
-        | StaticProperty (ilGetterMethSpec, _) ->
+        | StaticProperty(ilGetterMethSpec, _) ->
             let obj =
                 let staticTy = ctxt.LookupTypeRef ilGetterMethSpec.MethodRef.DeclaringTypeRef
                 // We can't call .Invoke on the ILMethodRef's MethodInfo,
@@ -11845,7 +11829,7 @@ let LookupGeneratedValue (cenv: cenv) (ctxt: ExecutionContext) eenv (v: Val) =
 let SetGeneratedValue (ctxt: ExecutionContext) eenv isForced (v: Val) (value: obj) =
     try
         match StorageForVal v.Range v eenv with
-        | StaticPropertyWithField (fspec, _, hasLiteralAttr, _, _, _, _f, ilSetterMethRef, _) ->
+        | StaticPropertyWithField(fspec, _, hasLiteralAttr, _, _, _, _f, ilSetterMethRef, _) ->
             if not hasLiteralAttr && (v.IsMutable || isForced) then
                 if isForced then
                     let staticTy = ctxt.LookupTypeRef fspec.DeclaringTypeRef
@@ -11872,7 +11856,7 @@ let SetGeneratedValue (ctxt: ExecutionContext) eenv isForced (v: Val) (value: ob
 let ClearGeneratedValue (ctxt: ExecutionContext) eenv (v: Val) =
     try
         match StorageForVal v.Range v eenv with
-        | StaticPropertyWithField (fspec, _, hasLiteralAttr, _, _, _, _ilGetterMethRef, _ilSetterMethRef, _) ->
+        | StaticPropertyWithField(fspec, _, hasLiteralAttr, _, _, _, _ilGetterMethRef, _ilSetterMethRef, _) ->
             if not hasLiteralAttr && v.IsMutable then
                 let ty = ctxt.LookupType fspec.ActualType
                 SetGeneratedValue ctxt eenv false v (defaultOf ty)
@@ -11944,9 +11928,9 @@ type IlxAssemblyGenerator(amap: ImportMap, tcGlobals: TcGlobals, tcVal: Constrai
 
             [|
                 for impl in impls do
-                    let (CheckedImplFile (namedDebugPointsForInlinedCode = dps)) = impl.ImplFile
+                    let (CheckedImplFile(namedDebugPointsForInlinedCode = dps)) = impl.ImplFile
 
-                    for KeyValue (k, v) in dps do
+                    for KeyValue(k, v) in dps do
                         yield (k, v)
             |]
 

--- a/src/Compiler/DependencyManager/DependencyProvider.fs
+++ b/src/Compiler/DependencyManager/DependencyProvider.fs
@@ -481,12 +481,8 @@ type ReflectionDependencyManagerProvider
 /// Provides DependencyManagement functions.
 /// Class is IDisposable
 type DependencyProvider
-    internal
-    (
-        assemblyProbingPaths: AssemblyResolutionProbe option,
-        nativeProbingRoots: NativeResolutionProbe option,
-        useResultsCache: bool
-    ) =
+    internal (assemblyProbingPaths: AssemblyResolutionProbe option, nativeProbingRoots: NativeResolutionProbe option, useResultsCache: bool)
+    =
 
     // Note: creating a NativeDllResolveHandler currently installs process-wide handlers
     let dllResolveHandler = new NativeDllResolveHandler(nativeProbingRoots)
@@ -709,7 +705,7 @@ type DependencyProvider
         | Ok res ->
             dllResolveHandler.RefreshPathsInEnvironment(res.Roots)
             res
-        | Error (errorNumber, errorData) ->
+        | Error(errorNumber, errorData) ->
             reportError.Invoke(ErrorReportType.Error, errorNumber, errorData)
             ReflectionDependencyManagerProvider.MakeResultFromFields(false, arrEmpty, arrEmpty, seqEmpty, seqEmpty, seqEmpty)
 

--- a/src/Compiler/DependencyManager/NativeDllResolveHandler.fs
+++ b/src/Compiler/DependencyManager/NativeDllResolveHandler.fs
@@ -73,7 +73,7 @@ type internal NativeDllResolveHandlerCoreClr(nativeProbingRoots: NativeResolutio
         let nativeLibraryType: Type =
             Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices", false)
 
-        nativeLibraryType.GetMethod("TryLoad", [| typeof<string>; typeof<IntPtr>.MakeByRefType () |])
+        nativeLibraryType.GetMethod("TryLoad", [| typeof<string>; typeof<IntPtr>.MakeByRefType() |])
 
     let loadNativeLibrary path =
         let arguments = [| path :> obj; IntPtr.Zero :> obj |]

--- a/src/Compiler/Driver/CompilerConfig.fs
+++ b/src/Compiler/Driver/CompilerConfig.fs
@@ -267,11 +267,11 @@ and IProjectReference =
 type AssemblyReference =
     | AssemblyReference of range: range * text: string * projectReference: IProjectReference option
 
-    member x.Range = (let (AssemblyReference (m, _, _)) = x in m)
+    member x.Range = (let (AssemblyReference(m, _, _)) = x in m)
 
-    member x.Text = (let (AssemblyReference (_, text, _)) = x in text)
+    member x.Text = (let (AssemblyReference(_, text, _)) = x in text)
 
-    member x.ProjectReference = (let (AssemblyReference (_, _, contents)) = x in contents)
+    member x.ProjectReference = (let (AssemblyReference(_, _, contents)) = x in contents)
 
     member x.SimpleAssemblyNameIs name =
         (String.Compare(FileSystemUtils.fileNameWithoutExtensionWithValidate false x.Text, name, StringComparison.OrdinalIgnoreCase) = 0)

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -79,130 +79,130 @@ type Exception with
 
     member exn.DiagnosticRange =
         match exn with
-        | ArgumentsInSigAndImplMismatch (_, implArg) -> Some implArg.idRange
-        | ErrorFromAddingConstraint (_, exn2, _) -> exn2.DiagnosticRange
+        | ArgumentsInSigAndImplMismatch(_, implArg) -> Some implArg.idRange
+        | ErrorFromAddingConstraint(_, exn2, _) -> exn2.DiagnosticRange
 #if !NO_TYPEPROVIDERS
         | TypeProviders.ProvidedTypeResolutionNoRange exn -> exn.DiagnosticRange
-        | TypeProviders.ProvidedTypeResolution (m, _)
+        | TypeProviders.ProvidedTypeResolution(m, _)
 #endif
-        | ReservedKeyword (_, m)
-        | IndentationProblem (_, m)
-        | ErrorFromAddingTypeEquation (_, _, _, _, _, m)
-        | ErrorFromApplyingDefault (_, _, _, _, _, m)
-        | ErrorsFromAddingSubsumptionConstraint (_, _, _, _, _, _, m)
-        | FunctionExpected (_, _, m)
-        | BakedInMemberConstraintName (_, m)
-        | StandardOperatorRedefinitionWarning (_, m)
+        | ReservedKeyword(_, m)
+        | IndentationProblem(_, m)
+        | ErrorFromAddingTypeEquation(_, _, _, _, _, m)
+        | ErrorFromApplyingDefault(_, _, _, _, _, m)
+        | ErrorsFromAddingSubsumptionConstraint(_, _, _, _, _, _, m)
+        | FunctionExpected(_, _, m)
+        | BakedInMemberConstraintName(_, m)
+        | StandardOperatorRedefinitionWarning(_, m)
         | BadEventTransformation m
         | ParameterlessStructCtor m
-        | FieldNotMutable (_, _, m)
-        | Recursion (_, _, _, _, m)
-        | InvalidRuntimeCoercion (_, _, _, m)
-        | IndeterminateRuntimeCoercion (_, _, _, m)
-        | IndeterminateStaticCoercion (_, _, _, m)
-        | StaticCoercionShouldUseBox (_, _, _, m)
-        | CoercionTargetSealed (_, _, m)
+        | FieldNotMutable(_, _, m)
+        | Recursion(_, _, _, _, m)
+        | InvalidRuntimeCoercion(_, _, _, m)
+        | IndeterminateRuntimeCoercion(_, _, _, m)
+        | IndeterminateStaticCoercion(_, _, _, m)
+        | StaticCoercionShouldUseBox(_, _, _, m)
+        | CoercionTargetSealed(_, _, m)
         | UpcastUnnecessary m
-        | QuotationTranslator.IgnoringPartOfQuotedTermWarning (_, m)
+        | QuotationTranslator.IgnoringPartOfQuotedTermWarning(_, m)
 
         | TypeTestUnnecessary m
-        | RuntimeCoercionSourceSealed (_, _, m)
-        | OverrideDoesntOverride (_, _, _, _, _, m)
+        | RuntimeCoercionSourceSealed(_, _, m)
+        | OverrideDoesntOverride(_, _, _, _, _, m)
         | UnionPatternsBindDifferentNames m
-        | UnionCaseWrongArguments (_, _, _, m)
+        | UnionCaseWrongArguments(_, _, _, m)
         | TypeIsImplicitlyAbstract m
-        | RequiredButNotSpecified (_, _, _, _, m)
-        | FunctionValueUnexpected (_, _, m)
-        | UnitTypeExpected (_, _, m)
-        | UnitTypeExpectedWithEquality (_, _, m)
-        | UnitTypeExpectedWithPossiblePropertySetter (_, _, _, _, m)
-        | UnitTypeExpectedWithPossibleAssignment (_, _, _, _, m)
+        | RequiredButNotSpecified(_, _, _, _, m)
+        | FunctionValueUnexpected(_, _, m)
+        | UnitTypeExpected(_, _, m)
+        | UnitTypeExpectedWithEquality(_, _, m)
+        | UnitTypeExpectedWithPossiblePropertySetter(_, _, _, _, m)
+        | UnitTypeExpectedWithPossibleAssignment(_, _, _, _, m)
         | UseOfAddressOfOperator m
         | DeprecatedThreadStaticBindingWarning m
-        | NonUniqueInferredAbstractSlot (_, _, _, _, _, m)
-        | DefensiveCopyWarning (_, m)
+        | NonUniqueInferredAbstractSlot(_, _, _, _, _, m)
+        | DefensiveCopyWarning(_, m)
         | LetRecCheckedAtRuntime m
         | UpperCaseIdentifierInPattern m
         | NotUpperCaseConstructor m
         | NotUpperCaseConstructorWithoutRQA m
-        | RecursiveUseCheckedAtRuntime (_, _, m)
-        | LetRecEvaluatedOutOfOrder (_, _, _, m)
-        | DiagnosticWithText (_, _, m)
-        | DiagnosticWithSuggestions (_, _, m, _, _)
-        | DiagnosticEnabledWithLanguageFeature (_, _, m, _)
-        | SyntaxError (_, m)
-        | InternalError (_, m)
-        | InternalException (_, _, m)
-        | InterfaceNotRevealed (_, _, m)
-        | WrappedError (_, m)
-        | PatternMatchCompilation.MatchIncomplete (_, _, m)
-        | PatternMatchCompilation.EnumMatchIncomplete (_, _, m)
+        | RecursiveUseCheckedAtRuntime(_, _, m)
+        | LetRecEvaluatedOutOfOrder(_, _, _, m)
+        | DiagnosticWithText(_, _, m)
+        | DiagnosticWithSuggestions(_, _, m, _, _)
+        | DiagnosticEnabledWithLanguageFeature(_, _, m, _)
+        | SyntaxError(_, m)
+        | InternalError(_, m)
+        | InternalException(_, _, m)
+        | InterfaceNotRevealed(_, _, m)
+        | WrappedError(_, m)
+        | PatternMatchCompilation.MatchIncomplete(_, _, m)
+        | PatternMatchCompilation.EnumMatchIncomplete(_, _, m)
         | PatternMatchCompilation.RuleNeverMatched m
-        | ValNotMutable (_, _, m)
-        | ValNotLocal (_, _, m)
-        | MissingFields (_, m)
+        | ValNotMutable(_, _, m)
+        | ValNotLocal(_, _, m)
+        | MissingFields(_, m)
         | OverrideInIntrinsicAugmentation m
         | IntfImplInIntrinsicAugmentation m
         | OverrideInExtrinsicAugmentation m
         | IntfImplInExtrinsicAugmentation m
-        | ValueRestriction (_, _, _, _, _, m)
-        | LetRecUnsound (_, _, m)
-        | ObsoleteError (_, m)
-        | ObsoleteWarning (_, m)
-        | Experimental (_, m)
+        | ValueRestriction(_, _, _, _, _, m)
+        | LetRecUnsound(_, _, m)
+        | ObsoleteError(_, m)
+        | ObsoleteWarning(_, m)
+        | Experimental(_, m)
         | PossibleUnverifiableCode m
-        | UserCompilerMessage (_, _, m)
-        | Deprecated (_, m)
+        | UserCompilerMessage(_, _, m)
+        | Deprecated(_, m)
         | LibraryUseOnly m
-        | FieldsFromDifferentTypes (_, _, _, m)
+        | FieldsFromDifferentTypes(_, _, _, m)
         | IndeterminateType m
-        | TyconBadArgs (_, _, _, m) -> Some m
+        | TyconBadArgs(_, _, _, m) -> Some m
 
-        | FieldNotContained (_, _, _, _, arf, _, _) -> Some arf.Range
-        | ValueNotContained (_, _, _, aval, _, _) -> Some aval.Range
-        | UnionCaseNotContained (_, _, _, aval, _, _) -> Some aval.Id.idRange
-        | FSharpExceptionNotContained (_, _, aexnc, _, _) -> Some aexnc.Range
+        | FieldNotContained(_, _, _, _, arf, _, _) -> Some arf.Range
+        | ValueNotContained(_, _, _, aval, _, _) -> Some aval.Range
+        | UnionCaseNotContained(_, _, _, aval, _, _) -> Some aval.Id.idRange
+        | FSharpExceptionNotContained(_, _, aexnc, _, _) -> Some aexnc.Range
 
         | VarBoundTwice id
-        | UndefinedName (_, _, id, _) -> Some id.idRange
+        | UndefinedName(_, _, id, _) -> Some id.idRange
 
-        | Duplicate (_, _, m)
-        | NameClash (_, _, _, m, _, _, _)
-        | UnresolvedOverloading (_, _, _, m)
-        | UnresolvedConversionOperator (_, _, _, m)
+        | Duplicate(_, _, m)
+        | NameClash(_, _, _, m, _, _, _)
+        | UnresolvedOverloading(_, _, _, m)
+        | UnresolvedConversionOperator(_, _, _, m)
         | VirtualAugmentationOnNullValuedType m
         | NonVirtualAugmentationOnNullValuedType m
-        | NonRigidTypar (_, _, _, _, _, m)
-        | ConstraintSolverTupleDiffLengths (_, _, _, _, m, _)
-        | ConstraintSolverInfiniteTypes (_, _, _, _, m, _)
-        | ConstraintSolverMissingConstraint (_, _, _, m, _)
-        | ConstraintSolverTypesNotInEqualityRelation (_, _, _, m, _, _)
-        | ConstraintSolverError (_, m, _)
-        | ConstraintSolverTypesNotInSubsumptionRelation (_, _, _, m, _)
-        | SelfRefObjCtor (_, m) -> Some m
+        | NonRigidTypar(_, _, _, _, _, m)
+        | ConstraintSolverTupleDiffLengths(_, _, _, _, m, _)
+        | ConstraintSolverInfiniteTypes(_, _, _, _, m, _)
+        | ConstraintSolverMissingConstraint(_, _, _, m, _)
+        | ConstraintSolverTypesNotInEqualityRelation(_, _, _, m, _, _)
+        | ConstraintSolverError(_, m, _)
+        | ConstraintSolverTypesNotInSubsumptionRelation(_, _, _, m, _)
+        | SelfRefObjCtor(_, m) -> Some m
 
-        | NotAFunction (_, _, mfun, _) -> Some mfun
+        | NotAFunction(_, _, mfun, _) -> Some mfun
 
-        | NotAFunctionButIndexer (_, _, _, mfun, _, _) -> Some mfun
+        | NotAFunctionButIndexer(_, _, _, mfun, _, _) -> Some mfun
 
         | IllegalFileNameChar _ -> Some rangeCmdArgs
 
-        | UnresolvedReferenceError (_, m)
-        | UnresolvedPathReference (_, _, m)
-        | DeprecatedCommandLineOptionFull (_, m)
-        | DeprecatedCommandLineOptionForHtmlDoc (_, m)
-        | DeprecatedCommandLineOptionSuggestAlternative (_, _, m)
-        | DeprecatedCommandLineOptionNoDescription (_, m)
-        | InternalCommandLineOption (_, m)
+        | UnresolvedReferenceError(_, m)
+        | UnresolvedPathReference(_, _, m)
+        | DeprecatedCommandLineOptionFull(_, m)
+        | DeprecatedCommandLineOptionForHtmlDoc(_, m)
+        | DeprecatedCommandLineOptionSuggestAlternative(_, _, m)
+        | DeprecatedCommandLineOptionNoDescription(_, m)
+        | InternalCommandLineOption(_, m)
         | HashIncludeNotAllowedInNonScript m
         | HashReferenceNotAllowedInNonScript m
         | HashDirectiveNotAllowedInNonScript m
-        | FileNameNotResolved (_, _, m)
-        | LoadedSourceNotFoundIgnoring (_, m)
-        | MSBuildReferenceResolutionWarning (_, _, m)
-        | MSBuildReferenceResolutionError (_, _, m)
-        | AssemblyNotResolved (_, m)
-        | HashLoadedSourceHasIssues (_, _, _, m)
+        | FileNameNotResolved(_, _, m)
+        | LoadedSourceNotFoundIgnoring(_, m)
+        | MSBuildReferenceResolutionWarning(_, _, m)
+        | MSBuildReferenceResolutionError(_, _, m)
+        | AssemblyNotResolved(_, m)
+        | HashLoadedSourceHasIssues(_, _, _, m)
         | HashLoadedScriptConsideredSource m -> Some m
         // Strip TargetInvocationException wrappers
         | :? System.Reflection.TargetInvocationException as e -> e.InnerException.DiagnosticRange
@@ -279,7 +279,7 @@ type Exception with
         | CoercionTargetSealed _ -> 59
         | OverrideInIntrinsicAugmentation _ -> 60
         | NonVirtualAugmentationOnNullValuedType _ -> 61
-        | UserCompilerMessage (_, n, _) -> n
+        | UserCompilerMessage(_, n, _) -> n
         | FSharpExceptionNotContained _ -> 63
         | NonRigidTypar _ -> 64
         // 65 cannot be reused
@@ -331,16 +331,16 @@ type Exception with
 
         // Strip TargetInvocationException wrappers
         | :? TargetInvocationException as e -> e.InnerException.DiagnosticNumber
-        | WrappedError (e, _) -> e.DiagnosticNumber
-        | DiagnosticWithText (n, _, _) -> n
-        | DiagnosticWithSuggestions (n, _, _, _, _) -> n
-        | DiagnosticEnabledWithLanguageFeature (n, _, _, _) -> n
+        | WrappedError(e, _) -> e.DiagnosticNumber
+        | DiagnosticWithText(n, _, _) -> n
+        | DiagnosticWithSuggestions(n, _, _, _, _) -> n
+        | DiagnosticEnabledWithLanguageFeature(n, _, _, _) -> n
         | Failure _ -> 192
-        | IllegalFileNameChar (fileName, invalidChar) -> fst (FSComp.SR.buildUnexpectedFileNameCharacter (fileName, string invalidChar))
+        | IllegalFileNameChar(fileName, invalidChar) -> fst (FSComp.SR.buildUnexpectedFileNameCharacter (fileName, string invalidChar))
 #if !NO_TYPEPROVIDERS
         | :? TypeProviderError as e -> e.Number
 #endif
-        | ErrorsFromAddingSubsumptionConstraint (_, _, _, _, _, ContextInfo.DowncastUsedInsteadOfUpcast _, _) ->
+        | ErrorsFromAddingSubsumptionConstraint(_, _, _, _, _, ContextInfo.DowncastUsedInsteadOfUpcast _, _) ->
             fst (FSComp.SR.considerUpcast ("", ""))
         | _ -> 193
 
@@ -357,9 +357,9 @@ type PhasedDiagnostic with
         | LetRecEvaluatedOutOfOrder _
         | DefensiveCopyWarning _ -> 5
 
-        | DiagnosticWithText (n, _, _)
-        | DiagnosticEnabledWithLanguageFeature (n, _, _, _)
-        | DiagnosticWithSuggestions (n, _, _, _, _) ->
+        | DiagnosticWithText(n, _, _)
+        | DiagnosticEnabledWithLanguageFeature(n, _, _, _)
+        | DiagnosticWithSuggestions(n, _, _, _, _) ->
             // 1178, tcNoComparisonNeeded1, "The struct, record or union type '%s' is not structurally comparable because the type parameter %s does not satisfy the 'comparison' constraint..."
             // 1178, tcNoComparisonNeeded2, "The struct, record or union type '%s' is not structurally comparable because the type '%s' does not satisfy the 'comparison' constraint...."
             // 1178, tcNoEqualityNeeded1, "The struct, record or union type '%s' does not support structural equality because the type parameter %s does not satisfy the 'equality' constraint..."
@@ -391,7 +391,7 @@ type PhasedDiagnostic with
         | 3582 -> false // infoIfFunctionShadowsUnionCase - off by default
         | _ ->
             match x.Exception with
-            | DiagnosticEnabledWithLanguageFeature (_, _, _, enabled) -> enabled
+            | DiagnosticEnabledWithLanguageFeature(_, _, _, enabled) -> enabled
             | _ ->
                 (severity = FSharpDiagnosticSeverity.Info && level > 0)
                 || (severity = FSharpDiagnosticSeverity.Warning && level >= x.WarningLevel)
@@ -635,7 +635,7 @@ let OutputNameSuggestions (os: StringBuilder) suggestNames suggestionsF idText =
 let OutputTypesNotInEqualityRelationContextInfo contextInfo ty1 ty2 m (os: StringBuilder) fallback =
     match contextInfo with
     | ContextInfo.IfExpression range when equals range m -> os.AppendString(FSComp.SR.ifExpression (ty1, ty2))
-    | ContextInfo.CollectionElement (isArray, range) when equals range m ->
+    | ContextInfo.CollectionElement(isArray, range) when equals range m ->
         if isArray then
             os.AppendString(FSComp.SR.arrayElementHasWrongType (ty1, ty2))
         else
@@ -653,13 +653,13 @@ type Exception with
 
         match exn with
         // TODO: this is now unused...?
-        | ConstraintSolverTupleDiffLengths (_, _, tl1, tl2, m, m2) ->
+        | ConstraintSolverTupleDiffLengths(_, _, tl1, tl2, m, m2) ->
             os.AppendString(ConstraintSolverTupleDiffLengthsE().Format tl1.Length tl2.Length)
 
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m))
 
-        | ConstraintSolverInfiniteTypes (denv, contextInfo, ty1, ty2, m, m2) ->
+        | ConstraintSolverInfiniteTypes(denv, contextInfo, ty1, ty2, m, m2) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty1, ty2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(ConstraintSolverInfiniteTypesE().Format ty1 ty2)
@@ -672,7 +672,7 @@ type Exception with
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m))
 
-        | ConstraintSolverMissingConstraint (denv, tpr, tpc, m, m2) ->
+        | ConstraintSolverMissingConstraint(denv, tpr, tpc, m, m2) ->
             os.AppendString(
                 ConstraintSolverMissingConstraintE()
                     .Format(NicePrint.stringOfTyparConstraint denv (tpr, tpc))
@@ -681,7 +681,7 @@ type Exception with
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m))
 
-        | ConstraintSolverTypesNotInEqualityRelation (denv, (TType_measure _ as ty1), (TType_measure _ as ty2), m, m2, _) ->
+        | ConstraintSolverTypesNotInEqualityRelation(denv, (TType_measure _ as ty1), (TType_measure _ as ty2), m, m2, _) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty1, ty2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
 
@@ -690,7 +690,7 @@ type Exception with
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m))
 
-        | ConstraintSolverTypesNotInEqualityRelation (denv, ty1, ty2, m, m2, contextInfo) ->
+        | ConstraintSolverTypesNotInEqualityRelation(denv, ty1, ty2, m, m2, contextInfo) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty1, ty2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
 
@@ -700,7 +700,7 @@ type Exception with
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m))
 
-        | ConstraintSolverTypesNotInSubsumptionRelation (denv, ty1, ty2, m, m2) ->
+        | ConstraintSolverTypesNotInSubsumptionRelation(denv, ty1, ty2, m, m2) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty1, ty2, cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(ConstraintSolverTypesNotInSubsumptionRelationE().Format ty2 ty1 cxs)
@@ -708,13 +708,13 @@ type Exception with
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m2))
 
-        | ConstraintSolverError (msg, m, m2) ->
+        | ConstraintSolverError(msg, m, m2) ->
             os.AppendString msg
 
             if m.StartLine <> m2.StartLine then
                 os.AppendString(SeeAlsoE().Format(stringOfRange m2))
 
-        | ErrorFromAddingTypeEquation (g, denv, ty1, ty2, ConstraintSolverTypesNotInEqualityRelation (_, ty1b, ty2b, m, _, contextInfo), _) when
+        | ErrorFromAddingTypeEquation(g, denv, ty1, ty2, ConstraintSolverTypesNotInEqualityRelation(_, ty1b, ty2b, m, _, contextInfo), _) when
             typeEquiv g ty1 ty1b && typeEquiv g ty2 ty2b
             ->
             let ty1, ty2, tpcs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
@@ -729,7 +729,7 @@ type Exception with
                     os.AppendString(Environment.NewLine + FSComp.SR.derefInsteadOfNot ())
                 | _ -> os.AppendString(ErrorFromAddingTypeEquation1E().Format ty2 ty1 tpcs))
 
-        | ErrorFromAddingTypeEquation (_, _, _, _, (ConstraintSolverTypesNotInEqualityRelation (_, _, _, _, _, contextInfo) as e), _) when
+        | ErrorFromAddingTypeEquation(_, _, _, _, (ConstraintSolverTypesNotInEqualityRelation(_, _, _, _, _, contextInfo) as e), _) when
             (match contextInfo with
              | ContextInfo.NoContext -> false
              | _ -> true)
@@ -740,7 +740,7 @@ type Exception with
 
         | ErrorFromAddingTypeEquation(error = ConstraintSolverError _ as e) -> e.Output(os, suggestNames)
 
-        | ErrorFromAddingTypeEquation (_g, denv, ty1, ty2, ConstraintSolverTupleDiffLengths (_, contextInfo, tl1, tl2, _, _), m) ->
+        | ErrorFromAddingTypeEquation(_g, denv, ty1, ty2, ConstraintSolverTupleDiffLengths(_, contextInfo, tl1, tl2, _, _), m) ->
             let ty1, ty2, tpcs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             let messageArgs = tl1.Length, ty1, tl2.Length, ty2
 
@@ -751,14 +751,14 @@ type Exception with
                     os.AppendString(FSComp.SR.elseBranchHasWrongTypeTuple messageArgs)
                 | ContextInfo.FollowingPatternMatchClause range when equals range m ->
                     os.AppendString(FSComp.SR.followingPatternMatchClauseHasWrongTypeTuple messageArgs)
-                | ContextInfo.CollectionElement (isArray, range) when equals range m ->
+                | ContextInfo.CollectionElement(isArray, range) when equals range m ->
                     if isArray then
                         os.AppendString(FSComp.SR.arrayElementHasWrongTypeTuple messageArgs)
                     else
                         os.AppendString(FSComp.SR.listElementHasWrongTypeTuple messageArgs)
                 | _ -> os.AppendString(ErrorFromAddingTypeEquationTuplesE().Format tl1.Length ty1 tl2.Length ty2 tpcs)
 
-        | ErrorFromAddingTypeEquation (g, denv, ty1, ty2, e, _) ->
+        | ErrorFromAddingTypeEquation(g, denv, ty1, ty2, e, _) ->
             if not (typeEquiv g ty1 ty2) then
                 let ty1, ty2, tpcs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
 
@@ -767,13 +767,13 @@ type Exception with
 
             e.Output(os, suggestNames)
 
-        | ErrorFromApplyingDefault (_, denv, _, defaultType, e, _) ->
+        | ErrorFromApplyingDefault(_, denv, _, defaultType, e, _) ->
             let defaultType = NicePrint.minimalStringOfType denv defaultType
             os.AppendString(ErrorFromApplyingDefault1E().Format defaultType)
             e.Output(os, suggestNames)
             os.AppendString(ErrorFromApplyingDefault2E().Format)
 
-        | ErrorsFromAddingSubsumptionConstraint (g, denv, ty1, ty2, e, contextInfo, _) ->
+        | ErrorsFromAddingSubsumptionConstraint(g, denv, ty1, ty2, e, contextInfo, _) ->
             match contextInfo with
             | ContextInfo.DowncastUsedInsteadOfUpcast isOperator ->
                 let ty1, ty2, _ = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
@@ -799,17 +799,17 @@ type Exception with
 
         | NotUpperCaseConstructorWithoutRQA _ -> os.AppendString(NotUpperCaseConstructorWithoutRQAE().Format)
 
-        | ErrorFromAddingConstraint (_, e, _) -> e.Output(os, suggestNames)
+        | ErrorFromAddingConstraint(_, e, _) -> e.Output(os, suggestNames)
 
 #if !NO_TYPEPROVIDERS
         | TypeProviders.ProvidedTypeResolutionNoRange e
 
-        | TypeProviders.ProvidedTypeResolution (_, e) -> e.Output(os, suggestNames)
+        | TypeProviders.ProvidedTypeResolution(_, e) -> e.Output(os, suggestNames)
 
         | :? TypeProviderError as e -> os.AppendString(e.ContextualErrorMessage)
 #endif
 
-        | UnresolvedOverloading (denv, callerArgs, failure, m) ->
+        | UnresolvedOverloading(denv, callerArgs, failure, m) ->
 
             let g = denv.g
             // extract eventual information (return type and type parameters)
@@ -899,36 +899,36 @@ type Exception with
                         | result -> nl + nl + result + nl + nl
 
                 match failure with
-                | NoOverloadsFound (methodName, overloads, _) ->
+                | NoOverloadsFound(methodName, overloads, _) ->
                     FSComp.SR.csNoOverloadsFound methodName
                     + optionalParts
                     + (FSComp.SR.csAvailableOverloads (formatOverloads overloads))
-                | PossibleCandidates (methodName, [], _) -> FSComp.SR.csMethodIsOverloaded methodName
-                | PossibleCandidates (methodName, overloads, _) ->
+                | PossibleCandidates(methodName, [], _) -> FSComp.SR.csMethodIsOverloaded methodName
+                | PossibleCandidates(methodName, overloads, _) ->
                     FSComp.SR.csMethodIsOverloaded methodName
                     + optionalParts
                     + FSComp.SR.csCandidates (formatOverloads overloads)
 
             os.AppendString msg
 
-        | UnresolvedConversionOperator (denv, fromTy, toTy, _) ->
+        | UnresolvedConversionOperator(denv, fromTy, toTy, _) ->
             let ty1, ty2, _tpcs = NicePrint.minimalStringsOfTwoTypes denv fromTy toTy
             os.AppendString(FSComp.SR.csTypeDoesNotSupportConversion (ty1, ty2))
 
         | FunctionExpected _ -> os.AppendString(FunctionExpectedE().Format)
 
-        | BakedInMemberConstraintName (nm, _) -> os.AppendString(BakedInMemberConstraintNameE().Format nm)
+        | BakedInMemberConstraintName(nm, _) -> os.AppendString(BakedInMemberConstraintNameE().Format nm)
 
-        | StandardOperatorRedefinitionWarning (msg, _) -> os.AppendString msg
+        | StandardOperatorRedefinitionWarning(msg, _) -> os.AppendString msg
 
         | BadEventTransformation _ -> os.AppendString(BadEventTransformationE().Format)
 
         | ParameterlessStructCtor _ -> os.AppendString(ParameterlessStructCtorE().Format)
 
-        | InterfaceNotRevealed (denv, intfTy, _) ->
+        | InterfaceNotRevealed(denv, intfTy, _) ->
             os.AppendString(InterfaceNotRevealedE().Format(NicePrint.minimalStringOfType denv intfTy))
 
-        | NotAFunctionButIndexer (_, _, name, _, _, old) ->
+        | NotAFunctionButIndexer(_, _, name, _, _, old) ->
             if old then
                 match name with
                 | Some name -> os.AppendString(FSComp.SR.notAFunctionButMaybeIndexerWithName name)
@@ -938,13 +938,13 @@ type Exception with
                 | Some name -> os.AppendString(FSComp.SR.notAFunctionButMaybeIndexerWithName2 name)
                 | _ -> os.AppendString(FSComp.SR.notAFunctionButMaybeIndexer2 ())
 
-        | NotAFunction (_, _, _, marg) ->
+        | NotAFunction(_, _, _, marg) ->
             if marg.StartColumn = 0 then
                 os.AppendString(FSComp.SR.notAFunctionButMaybeDeclaration ())
             else
                 os.AppendString(FSComp.SR.notAFunction ())
 
-        | TyconBadArgs (_, tcref, d, _) ->
+        | TyconBadArgs(_, tcref, d, _) ->
             let exp = tcref.TyparsNoRange.Length
 
             if exp = 0 then
@@ -954,58 +954,58 @@ type Exception with
 
         | IndeterminateType _ -> os.AppendString(IndeterminateTypeE().Format)
 
-        | NameClash (nm, k1, nm1, _, k2, nm2, _) ->
+        | NameClash(nm, k1, nm1, _, k2, nm2, _) ->
             if nm = nm1 && nm1 = nm2 && k1 = k2 then
                 os.AppendString(NameClash1E().Format k1 nm1)
             else
                 os.AppendString(NameClash2E().Format k1 nm1 nm k2 nm2)
 
-        | Duplicate (k, s, _) ->
+        | Duplicate(k, s, _) ->
             if k = "member" then
                 os.AppendString(Duplicate1E().Format(ConvertValLogicalNameToDisplayNameCore s))
             else
                 os.AppendString(Duplicate2E().Format k (ConvertValLogicalNameToDisplayNameCore s))
 
-        | UndefinedName (_, k, id, suggestionsF) ->
+        | UndefinedName(_, k, id, suggestionsF) ->
             os.AppendString(k (ConvertValLogicalNameToDisplayNameCore id.idText))
             OutputNameSuggestions os suggestNames suggestionsF id.idText
 
-        | InternalUndefinedItemRef (f, smr, ccuName, s) ->
+        | InternalUndefinedItemRef(f, smr, ccuName, s) ->
             let _, errs = f (smr, ccuName, s)
             os.AppendString errs
 
         | FieldNotMutable _ -> os.AppendString(FieldNotMutableE().Format)
 
-        | FieldsFromDifferentTypes (_, fref1, fref2, _) ->
+        | FieldsFromDifferentTypes(_, fref1, fref2, _) ->
             os.AppendString(FieldsFromDifferentTypesE().Format fref1.FieldName fref2.FieldName)
 
         | VarBoundTwice id -> os.AppendString(VarBoundTwiceE().Format(ConvertValLogicalNameToDisplayNameCore id.idText))
 
-        | Recursion (denv, id, ty1, ty2, _) ->
+        | Recursion(denv, id, ty1, ty2, _) ->
             let ty1, ty2, tpcs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(RecursionE().Format (ConvertValLogicalNameToDisplayNameCore id.idText) ty1 ty2 tpcs)
 
-        | InvalidRuntimeCoercion (denv, ty1, ty2, _) ->
+        | InvalidRuntimeCoercion(denv, ty1, ty2, _) ->
             let ty1, ty2, tpcs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(InvalidRuntimeCoercionE().Format ty1 ty2 tpcs)
 
-        | IndeterminateRuntimeCoercion (denv, ty1, ty2, _) ->
+        | IndeterminateRuntimeCoercion(denv, ty1, ty2, _) ->
             let ty1, ty2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(IndeterminateRuntimeCoercionE().Format ty1 ty2)
 
-        | IndeterminateStaticCoercion (denv, ty1, ty2, _) ->
+        | IndeterminateStaticCoercion(denv, ty1, ty2, _) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty1, ty2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(IndeterminateStaticCoercionE().Format ty1 ty2)
 
-        | StaticCoercionShouldUseBox (denv, ty1, ty2, _) ->
+        | StaticCoercionShouldUseBox(denv, ty1, ty2, _) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty1, ty2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
             os.AppendString(StaticCoercionShouldUseBoxE().Format ty1 ty2)
 
         | TypeIsImplicitlyAbstract _ -> os.AppendString(TypeIsImplicitlyAbstractE().Format)
 
-        | NonRigidTypar (denv, tpnmOpt, typarRange, ty1, ty2, _) ->
+        | NonRigidTypar(denv, tpnmOpt, typarRange, ty1, ty2, _) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let (ty1, ty2), _cxs = PrettyTypes.PrettifyTypePair denv.g (ty1, ty2)
 
@@ -1016,7 +1016,7 @@ type Exception with
                 | TType_measure _ -> os.AppendString(NonRigidTypar2E().Format tpnm (NicePrint.stringOfTy denv ty2))
                 | _ -> os.AppendString(NonRigidTypar3E().Format tpnm (NicePrint.stringOfTy denv ty2))
 
-        | SyntaxError (ctxt, _) ->
+        | SyntaxError(ctxt, _) ->
             let ctxt = unbox<Parsing.ParseErrorContext<Parser.token>> (ctxt)
 
             let (|EndOfStructuredConstructToken|_|) token =
@@ -1500,7 +1500,7 @@ type Exception with
                   (List.mapSquared Parser.prodIdxToNonTerminal ctxt.ReducibleProductions)
         *)
 
-        | RuntimeCoercionSourceSealed (denv, ty, _) ->
+        | RuntimeCoercionSourceSealed(denv, ty, _) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
 
@@ -1509,7 +1509,7 @@ type Exception with
             else
                 os.AppendString(RuntimeCoercionSourceSealed2E().Format(NicePrint.stringOfTy denv ty))
 
-        | CoercionTargetSealed (denv, ty, _) ->
+        | CoercionTargetSealed(denv, ty, _) ->
             // REVIEW: consider if we need to show _cxs (the type parameter constraints)
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
             os.AppendString(CoercionTargetSealedE().Format(NicePrint.stringOfTy denv ty))
@@ -1518,9 +1518,9 @@ type Exception with
 
         | TypeTestUnnecessary _ -> os.AppendString(TypeTestUnnecessaryE().Format)
 
-        | QuotationTranslator.IgnoringPartOfQuotedTermWarning (msg, _) -> Printf.bprintf os "%s" msg
+        | QuotationTranslator.IgnoringPartOfQuotedTermWarning(msg, _) -> Printf.bprintf os "%s" msg
 
-        | OverrideDoesntOverride (denv, impl, minfoVirtOpt, g, amap, m) ->
+        | OverrideDoesntOverride(denv, impl, minfoVirtOpt, g, amap, m) ->
             let sig1 = DispatchSlotChecking.FormatOverride denv impl
 
             match minfoVirtOpt with
@@ -1532,14 +1532,14 @@ type Exception with
                 let hasUnitTType_app (types: TType list) =
                     types
                     |> List.exists (function
-                        | TType_app (maybeUnit, [], _) ->
+                        | TType_app(maybeUnit, [], _) ->
                             match maybeUnit.TypeAbbrev with
                             | Some ty when isUnitTy g ty -> true
                             | _ -> false
                         | _ -> false)
 
                 match minfoVirt.ApparentEnclosingType with
-                | TType_app (tycon, tyargs, _) when tycon.IsFSharpInterfaceTycon && hasUnitTType_app tyargs ->
+                | TType_app(tycon, tyargs, _) when tycon.IsFSharpInterfaceTycon && hasUnitTType_app tyargs ->
                     // match abstract member with 'unit' passed as generic argument
                     os.AppendString(OverrideDoesntOverride4E().Format sig1)
                 | _ ->
@@ -1557,17 +1557,17 @@ type Exception with
                         else
                             os.AppendString(OverrideShouldBeInstance().Format)
 
-        | UnionCaseWrongArguments (_, n1, n2, _) -> os.AppendString(UnionCaseWrongArgumentsE().Format n2 n1)
+        | UnionCaseWrongArguments(_, n1, n2, _) -> os.AppendString(UnionCaseWrongArgumentsE().Format n2 n1)
 
         | UnionPatternsBindDifferentNames _ -> os.AppendString(UnionPatternsBindDifferentNamesE().Format)
 
-        | ValueNotContained (denv, infoReader, mref, implVal, sigVal, f) ->
+        | ValueNotContained(denv, infoReader, mref, implVal, sigVal, f) ->
             let text1, text2 =
                 NicePrint.minimalStringsOfTwoValues denv infoReader (mkLocalValRef implVal) (mkLocalValRef sigVal)
 
             os.AppendString(f ((fullDisplayTextOfModRef mref), text1, text2))
 
-        | UnionCaseNotContained (denv, infoReader, enclosingTycon, v1, v2, f) ->
+        | UnionCaseNotContained(denv, infoReader, enclosingTycon, v1, v2, f) ->
             let enclosingTcref = mkLocalEntityRef enclosingTycon
 
             os.AppendString(
@@ -1577,7 +1577,7 @@ type Exception with
                 )
             )
 
-        | FSharpExceptionNotContained (denv, infoReader, v1, v2, f) ->
+        | FSharpExceptionNotContained(denv, infoReader, v1, v2, f) ->
             os.AppendString(
                 f (
                     (NicePrint.stringOfExnDef denv infoReader (mkLocalEntityRef v1)),
@@ -1585,7 +1585,7 @@ type Exception with
                 )
             )
 
-        | FieldNotContained (denv, infoReader, enclosingTycon, _, v1, v2, f) ->
+        | FieldNotContained(denv, infoReader, enclosingTycon, _, v1, v2, f) ->
             let enclosingTcref = mkLocalEntityRef enclosingTycon
 
             os.AppendString(
@@ -1595,28 +1595,28 @@ type Exception with
                 )
             )
 
-        | RequiredButNotSpecified (_, mref, k, name, _) ->
+        | RequiredButNotSpecified(_, mref, k, name, _) ->
             let nsb = StringBuilder()
             name nsb
             os.AppendString(RequiredButNotSpecifiedE().Format (fullDisplayTextOfModRef mref) k (nsb.ToString()))
 
         | UseOfAddressOfOperator _ -> os.AppendString(UseOfAddressOfOperatorE().Format)
 
-        | DefensiveCopyWarning (s, _) -> os.AppendString(DefensiveCopyWarningE().Format s)
+        | DefensiveCopyWarning(s, _) -> os.AppendString(DefensiveCopyWarningE().Format s)
 
         | DeprecatedThreadStaticBindingWarning _ -> os.AppendString(DeprecatedThreadStaticBindingWarningE().Format)
 
-        | FunctionValueUnexpected (denv, ty, _) ->
+        | FunctionValueUnexpected(denv, ty, _) ->
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
             let errorText = FunctionValueUnexpectedE().Format(NicePrint.stringOfTy denv ty)
             os.AppendString errorText
 
-        | UnitTypeExpected (denv, ty, _) ->
+        | UnitTypeExpected(denv, ty, _) ->
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
             let warningText = UnitTypeExpectedE().Format(NicePrint.stringOfTy denv ty)
             os.AppendString warningText
 
-        | UnitTypeExpectedWithEquality (denv, ty, _) ->
+        | UnitTypeExpectedWithEquality(denv, ty, _) ->
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
 
             let warningText =
@@ -1624,7 +1624,7 @@ type Exception with
 
             os.AppendString warningText
 
-        | UnitTypeExpectedWithPossiblePropertySetter (denv, ty, bindingName, propertyName, _) ->
+        | UnitTypeExpectedWithPossiblePropertySetter(denv, ty, bindingName, propertyName, _) ->
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
 
             let warningText =
@@ -1632,7 +1632,7 @@ type Exception with
 
             os.AppendString warningText
 
-        | UnitTypeExpectedWithPossibleAssignment (denv, ty, isAlreadyMutable, bindingName, _) ->
+        | UnitTypeExpectedWithPossibleAssignment(denv, ty, isAlreadyMutable, bindingName, _) ->
             let ty, _cxs = PrettyTypes.PrettifyType denv.g ty
 
             let warningText =
@@ -1645,9 +1645,9 @@ type Exception with
 
         | RecursiveUseCheckedAtRuntime _ -> os.AppendString(RecursiveUseCheckedAtRuntimeE().Format)
 
-        | LetRecUnsound (_, [ v ], _) -> os.AppendString(LetRecUnsound1E().Format v.DisplayName)
+        | LetRecUnsound(_, [ v ], _) -> os.AppendString(LetRecUnsound1E().Format v.DisplayName)
 
-        | LetRecUnsound (_, path, _) ->
+        | LetRecUnsound(_, path, _) ->
             let bos = StringBuilder()
 
             (path.Tail @ [ path.Head ])
@@ -1655,19 +1655,19 @@ type Exception with
 
             os.AppendString(LetRecUnsound2E().Format (List.head path).DisplayName (bos.ToString()))
 
-        | LetRecEvaluatedOutOfOrder (_, _, _, _) -> os.AppendString(LetRecEvaluatedOutOfOrderE().Format)
+        | LetRecEvaluatedOutOfOrder(_, _, _, _) -> os.AppendString(LetRecEvaluatedOutOfOrderE().Format)
 
         | LetRecCheckedAtRuntime _ -> os.AppendString(LetRecCheckedAtRuntimeE().Format)
 
-        | SelfRefObjCtor (false, _) -> os.AppendString(SelfRefObjCtor1E().Format)
+        | SelfRefObjCtor(false, _) -> os.AppendString(SelfRefObjCtor1E().Format)
 
-        | SelfRefObjCtor (true, _) -> os.AppendString(SelfRefObjCtor2E().Format)
+        | SelfRefObjCtor(true, _) -> os.AppendString(SelfRefObjCtor2E().Format)
 
         | VirtualAugmentationOnNullValuedType _ -> os.AppendString(VirtualAugmentationOnNullValuedTypeE().Format)
 
         | NonVirtualAugmentationOnNullValuedType _ -> os.AppendString(NonVirtualAugmentationOnNullValuedTypeE().Format)
 
-        | NonUniqueInferredAbstractSlot (_, denv, bindnm, bvirt1, bvirt2, _) ->
+        | NonUniqueInferredAbstractSlot(_, denv, bindnm, bvirt1, bvirt2, _) ->
             os.AppendString(NonUniqueInferredAbstractSlot1E().Format bindnm)
             let ty1 = bvirt1.ApparentEnclosingType
             let ty2 = bvirt2.ApparentEnclosingType
@@ -1680,15 +1680,15 @@ type Exception with
 
             os.AppendString(NonUniqueInferredAbstractSlot4E().Format)
 
-        | DiagnosticWithText (_, s, _)
-        | DiagnosticEnabledWithLanguageFeature (_, s, _, _) -> os.AppendString s
+        | DiagnosticWithText(_, s, _)
+        | DiagnosticEnabledWithLanguageFeature(_, s, _, _) -> os.AppendString s
 
-        | DiagnosticWithSuggestions (_, s, _, idText, suggestionF) ->
+        | DiagnosticWithSuggestions(_, s, _, idText, suggestionF) ->
             os.AppendString(ConvertValLogicalNameToDisplayNameCore s)
             OutputNameSuggestions os suggestNames suggestionF idText
 
-        | InternalError (s, _)
-        | InternalException (_, s, _)
+        | InternalError(s, _)
+        | InternalException(_, s, _)
         | InvalidArgument s
         | Failure s as exn ->
             ignore exn // use the argument, even in non DEBUG
@@ -1704,57 +1704,57 @@ type Exception with
             Debug.Assert(false, sprintf "Unexpected exception seen in compiler: %s\n%s" s (exn.ToString()))
 #endif
 
-        | WrappedError (e, _) -> e.Output(os, suggestNames)
+        | WrappedError(e, _) -> e.Output(os, suggestNames)
 
-        | PatternMatchCompilation.MatchIncomplete (isComp, cexOpt, _) ->
+        | PatternMatchCompilation.MatchIncomplete(isComp, cexOpt, _) ->
             os.AppendString(MatchIncomplete1E().Format)
 
             match cexOpt with
             | None -> ()
-            | Some (cex, false) -> os.AppendString(MatchIncomplete2E().Format cex)
-            | Some (cex, true) -> os.AppendString(MatchIncomplete3E().Format cex)
+            | Some(cex, false) -> os.AppendString(MatchIncomplete2E().Format cex)
+            | Some(cex, true) -> os.AppendString(MatchIncomplete3E().Format cex)
 
             if isComp then
                 os.AppendString(MatchIncomplete4E().Format)
 
-        | PatternMatchCompilation.EnumMatchIncomplete (isComp, cexOpt, _) ->
+        | PatternMatchCompilation.EnumMatchIncomplete(isComp, cexOpt, _) ->
             os.AppendString(EnumMatchIncomplete1E().Format)
 
             match cexOpt with
             | None -> ()
-            | Some (cex, false) -> os.AppendString(MatchIncomplete2E().Format cex)
-            | Some (cex, true) -> os.AppendString(MatchIncomplete3E().Format cex)
+            | Some(cex, false) -> os.AppendString(MatchIncomplete2E().Format cex)
+            | Some(cex, true) -> os.AppendString(MatchIncomplete3E().Format cex)
 
             if isComp then
                 os.AppendString(MatchIncomplete4E().Format)
 
         | PatternMatchCompilation.RuleNeverMatched _ -> os.AppendString(RuleNeverMatchedE().Format)
 
-        | ValNotMutable (_, vref, _) -> os.AppendString(ValNotMutableE().Format(vref.DisplayName))
+        | ValNotMutable(_, vref, _) -> os.AppendString(ValNotMutableE().Format(vref.DisplayName))
 
         | ValNotLocal _ -> os.AppendString(ValNotLocalE().Format)
 
-        | ObsoleteError (s, _)
+        | ObsoleteError(s, _)
 
-        | ObsoleteWarning (s, _) ->
+        | ObsoleteWarning(s, _) ->
             os.AppendString(Obsolete1E().Format)
 
             if s <> "" then
                 os.AppendString(Obsolete2E().Format s)
 
-        | Experimental (s, _) -> os.AppendString(ExperimentalE().Format s)
+        | Experimental(s, _) -> os.AppendString(ExperimentalE().Format s)
 
         | PossibleUnverifiableCode _ -> os.AppendString(PossibleUnverifiableCodeE().Format)
 
-        | UserCompilerMessage (msg, _, _) -> os.AppendString msg
+        | UserCompilerMessage(msg, _, _) -> os.AppendString msg
 
-        | Deprecated (s, _) -> os.AppendString(DeprecatedE().Format s)
+        | Deprecated(s, _) -> os.AppendString(DeprecatedE().Format s)
 
         | LibraryUseOnly _ -> os.AppendString(LibraryUseOnlyE().Format)
 
-        | MissingFields (sl, _) -> os.AppendString(MissingFieldsE().Format(String.concat "," sl + "."))
+        | MissingFields(sl, _) -> os.AppendString(MissingFieldsE().Format(String.concat "," sl + "."))
 
-        | ValueRestriction (denv, infoReader, hasSig, v, _, _) ->
+        | ValueRestriction(denv, infoReader, hasSig, v, _, _) ->
             let denv =
                 { denv with
                     showInferenceTyparAnnotations = true
@@ -1814,9 +1814,9 @@ type Exception with
 
         | Parsing.RecoverableParseError -> os.AppendString(RecoverableParseErrorE().Format)
 
-        | ReservedKeyword (s, _) -> os.AppendString(ReservedKeywordE().Format s)
+        | ReservedKeyword(s, _) -> os.AppendString(ReservedKeywordE().Format s)
 
-        | IndentationProblem (s, _) -> os.AppendString(IndentationProblemE().Format s)
+        | IndentationProblem(s, _) -> os.AppendString(IndentationProblemE().Format s)
 
         | OverrideInIntrinsicAugmentation _ -> os.AppendString(OverrideInIntrinsicAugmentationE().Format)
 
@@ -1826,24 +1826,24 @@ type Exception with
 
         | IntfImplInExtrinsicAugmentation _ -> os.AppendString(IntfImplInExtrinsicAugmentationE().Format)
 
-        | UnresolvedReferenceError (assemblyName, _)
+        | UnresolvedReferenceError(assemblyName, _)
         | UnresolvedReferenceNoRange assemblyName -> os.AppendString(UnresolvedReferenceNoRangeE().Format assemblyName)
 
-        | UnresolvedPathReference (assemblyName, pathname, _)
+        | UnresolvedPathReference(assemblyName, pathname, _)
 
-        | UnresolvedPathReferenceNoRange (assemblyName, pathname) ->
+        | UnresolvedPathReferenceNoRange(assemblyName, pathname) ->
             os.AppendString(UnresolvedPathReferenceNoRangeE().Format pathname assemblyName)
 
-        | DeprecatedCommandLineOptionFull (fullText, _) -> os.AppendString fullText
+        | DeprecatedCommandLineOptionFull(fullText, _) -> os.AppendString fullText
 
-        | DeprecatedCommandLineOptionForHtmlDoc (optionName, _) -> os.AppendString(FSComp.SR.optsDCLOHtmlDoc optionName)
+        | DeprecatedCommandLineOptionForHtmlDoc(optionName, _) -> os.AppendString(FSComp.SR.optsDCLOHtmlDoc optionName)
 
-        | DeprecatedCommandLineOptionSuggestAlternative (optionName, altOption, _) ->
+        | DeprecatedCommandLineOptionSuggestAlternative(optionName, altOption, _) ->
             os.AppendString(FSComp.SR.optsDCLODeprecatedSuggestAlternative (optionName, altOption))
 
-        | InternalCommandLineOption (optionName, _) -> os.AppendString(FSComp.SR.optsInternalNoDescription optionName)
+        | InternalCommandLineOption(optionName, _) -> os.AppendString(FSComp.SR.optsInternalNoDescription optionName)
 
-        | DeprecatedCommandLineOptionNoDescription (optionName, _) -> os.AppendString(FSComp.SR.optsDCLONoDescription optionName)
+        | DeprecatedCommandLineOptionNoDescription(optionName, _) -> os.AppendString(FSComp.SR.optsDCLONoDescription optionName)
 
         | HashIncludeNotAllowedInNonScript _ -> os.AppendString(HashIncludeNotAllowedInNonScriptE().Format)
 
@@ -1851,14 +1851,14 @@ type Exception with
 
         | HashDirectiveNotAllowedInNonScript _ -> os.AppendString(HashDirectiveNotAllowedInNonScriptE().Format)
 
-        | FileNameNotResolved (fileName, locations, _) -> os.AppendString(FileNameNotResolvedE().Format fileName locations)
+        | FileNameNotResolved(fileName, locations, _) -> os.AppendString(FileNameNotResolvedE().Format fileName locations)
 
-        | AssemblyNotResolved (originalName, _) -> os.AppendString(AssemblyNotResolvedE().Format originalName)
+        | AssemblyNotResolved(originalName, _) -> os.AppendString(AssemblyNotResolvedE().Format originalName)
 
-        | IllegalFileNameChar (fileName, invalidChar) ->
+        | IllegalFileNameChar(fileName, invalidChar) ->
             os.AppendString(FSComp.SR.buildUnexpectedFileNameCharacter (fileName, string invalidChar) |> snd)
 
-        | HashLoadedSourceHasIssues (infos, warnings, errors, _) ->
+        | HashLoadedSourceHasIssues(infos, warnings, errors, _) ->
 
             match warnings, errors with
             | _, e :: _ ->
@@ -1873,18 +1873,18 @@ type Exception with
 
         | HashLoadedScriptConsideredSource _ -> os.AppendString(HashLoadedScriptConsideredSourceE().Format)
 
-        | InvalidInternalsVisibleToAssemblyName (badName, fileNameOption) ->
+        | InvalidInternalsVisibleToAssemblyName(badName, fileNameOption) ->
             match fileNameOption with
             | Some file -> os.AppendString(InvalidInternalsVisibleToAssemblyName1E().Format badName file)
             | None -> os.AppendString(InvalidInternalsVisibleToAssemblyName2E().Format badName)
 
-        | LoadedSourceNotFoundIgnoring (fileName, _) -> os.AppendString(LoadedSourceNotFoundIgnoringE().Format fileName)
+        | LoadedSourceNotFoundIgnoring(fileName, _) -> os.AppendString(LoadedSourceNotFoundIgnoringE().Format fileName)
 
-        | MSBuildReferenceResolutionWarning (code, message, _)
+        | MSBuildReferenceResolutionWarning(code, message, _)
 
-        | MSBuildReferenceResolutionError (code, message, _) -> os.AppendString(MSBuildReferenceResolutionErrorE().Format message code)
+        | MSBuildReferenceResolutionError(code, message, _) -> os.AppendString(MSBuildReferenceResolutionErrorE().Format message code)
 
-        | ArgumentsInSigAndImplMismatch (sigArg, implArg) ->
+        | ArgumentsInSigAndImplMismatch(sigArg, implArg) ->
             os.AppendString(ArgumentsInSigAndImplMismatchE().Format sigArg.idText implArg.idText)
 
         // Strip TargetInvocationException wrappers
@@ -2139,8 +2139,8 @@ type PhasedDiagnostic with
             Printf.bprintf buf "\n"
 
             match e with
-            | FormattedDiagnostic.Short (_, txt) -> buf.AppendString txt
-            | FormattedDiagnostic.Long (_, details) ->
+            | FormattedDiagnostic.Short(_, txt) -> buf.AppendString txt
+            | FormattedDiagnostic.Long(_, details) ->
                 match details.Location with
                 | Some l when not l.IsEmpty -> buf.AppendString l.TextRepresentation
                 | _ -> ()
@@ -2181,12 +2181,7 @@ type PhasedDiagnostic with
 // sensitive operations (lexfilter and warning filtering) do not always
 // interact well with #line directives.
 type DiagnosticsLoggerFilteringByScopedPragmas
-    (
-        checkFile,
-        scopedPragmas,
-        diagnosticOptions: FSharpDiagnosticOptions,
-        diagnosticsLogger: DiagnosticsLogger
-    ) =
+    (checkFile, scopedPragmas, diagnosticOptions: FSharpDiagnosticOptions, diagnosticsLogger: DiagnosticsLogger) =
     inherit DiagnosticsLogger("DiagnosticsLoggerFilteringByScopedPragmas")
 
     override _.DiagnosticSink(diagnostic: PhasedDiagnostic, severity) =
@@ -2200,7 +2195,7 @@ type DiagnosticsLoggerFilteringByScopedPragmas
                 | Some m ->
                     scopedPragmas
                     |> List.exists (fun pragma ->
-                        let (ScopedPragma.WarningOff (pragmaRange, warningNumFromPragma)) = pragma
+                        let (ScopedPragma.WarningOff(pragmaRange, warningNumFromPragma)) = pragma
 
                         warningNum = warningNumFromPragma
                         && (not checkFile || m.FileIndex = pragmaRange.FileIndex)

--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -79,15 +79,15 @@ and CompilerOptionBlock =
 
 let GetOptionsOfBlock block =
     match block with
-    | PublicOptions (_, opts) -> opts
+    | PublicOptions(_, opts) -> opts
     | PrivateOptions opts -> opts
 
 let FilterCompilerOptionBlock pred block =
     match block with
-    | PublicOptions (heading, opts) -> PublicOptions(heading, List.filter pred opts)
+    | PublicOptions(heading, opts) -> PublicOptions(heading, List.filter pred opts)
     | PrivateOptions opts -> PrivateOptions(List.filter pred opts)
 
-let compilerOptionUsage (CompilerOption (s, tag, spec, _, _)) =
+let compilerOptionUsage (CompilerOption(s, tag, spec, _, _)) =
     let s =
         if s = "--" then
             ""
@@ -116,7 +116,7 @@ let compilerOptionUsage (CompilerOption (s, tag, spec, _, _)) =
 
 let nl = Environment.NewLine
 
-let getCompilerOption (CompilerOption (_s, _tag, _spec, _, help) as compilerOption) width =
+let getCompilerOption (CompilerOption(_s, _tag, _spec, _, help) as compilerOption) width =
     let sb = StringBuilder()
 
     let flagWidth = 42 // fixed width for printing of flags, e.g. --debug:{full|pdbonly|portable|embedded}
@@ -178,7 +178,7 @@ let GetCompilerOptionBlocks blocks width =
         blocks
         |> List.choose (function
             | PrivateOptions _ -> None
-            | PublicOptions (heading, opts) -> Some(heading, opts))
+            | PublicOptions(heading, opts) -> Some(heading, opts))
 
     let consider doneHeadings (heading, _opts) =
         if Set.contains heading doneHeadings then
@@ -194,7 +194,7 @@ let GetCompilerOptionBlocks blocks width =
     sb.ToString()
 
 (* For QA *)
-let dumpCompilerOption prefix (CompilerOption (str, _, spec, _, _)) =
+let dumpCompilerOption prefix (CompilerOption(str, _, spec, _, _)) =
     printf "section='%-25s' ! option=%-30s kind=" prefix str
 
     match spec with
@@ -217,14 +217,14 @@ let dumpCompilerOption prefix (CompilerOption (str, _, spec, _, _)) =
 
 let dumpCompilerOptionBlock =
     function
-    | PublicOptions (heading, opts) -> List.iter (dumpCompilerOption heading) opts
+    | PublicOptions(heading, opts) -> List.iter (dumpCompilerOption heading) opts
     | PrivateOptions opts -> List.iter (dumpCompilerOption "NoSection") opts
 
 let DumpCompilerOptionBlocks blocks =
     List.iter dumpCompilerOptionBlock blocks
 
 let isSlashOpt (opt: string) =
-    opt[0] = '/' && (opt.Length = 1 || not (opt[ 1.. ].Contains "/"))
+    opt[0] = '/' && (opt.Length = 1 || not (opt[1..].Contains "/"))
 
 module ResponseFile =
 
@@ -371,27 +371,27 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
 
             let rec attempt l =
                 match l with
-                | CompilerOption (s, _, OptionConsoleOnly f, d, _) :: _ when option = s ->
+                | CompilerOption(s, _, OptionConsoleOnly f, d, _) :: _ when option = s ->
                     reportDeprecatedOption d
                     f blocks
                     t
-                | CompilerOption (s, _, OptionUnit f, d, _) :: _ when optToken = s && argString = "" ->
+                | CompilerOption(s, _, OptionUnit f, d, _) :: _ when optToken = s && argString = "" ->
                     reportDeprecatedOption d
                     f ()
                     t
-                | CompilerOption (s, _, OptionSwitch f, d, _) :: _ when getSwitchOpt optToken = s && argString = "" ->
+                | CompilerOption(s, _, OptionSwitch f, d, _) :: _ when getSwitchOpt optToken = s && argString = "" ->
                     reportDeprecatedOption d
                     f (getSwitch opt)
                     t
-                | CompilerOption (s, _, OptionSet f, d, _) :: _ when optToken = s && argString = "" ->
+                | CompilerOption(s, _, OptionSet f, d, _) :: _ when optToken = s && argString = "" ->
                     reportDeprecatedOption d
                     f.Value <- true
                     t
-                | CompilerOption (s, _, OptionClear f, d, _) :: _ when optToken = s && argString = "" ->
+                | CompilerOption(s, _, OptionClear f, d, _) :: _ when optToken = s && argString = "" ->
                     reportDeprecatedOption d
                     f.Value <- false
                     t
-                | CompilerOption (s, _, OptionString f, d, _) as compilerOption :: _ when optToken = s ->
+                | CompilerOption(s, _, OptionString f, d, _) as compilerOption :: _ when optToken = s ->
                     reportDeprecatedOption d
                     let oa = getOptionArg compilerOption argString
 
@@ -399,7 +399,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
                         f (getOptionArg compilerOption oa)
 
                     t
-                | CompilerOption (s, _, OptionInt f, d, _) as compilerOption :: _ when optToken = s ->
+                | CompilerOption(s, _, OptionInt f, d, _) as compilerOption :: _ when optToken = s ->
                     reportDeprecatedOption d
                     let oa = getOptionArg compilerOption argString
 
@@ -413,7 +413,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
                         )
 
                     t
-                | CompilerOption (s, _, OptionFloat f, d, _) as compilerOption :: _ when optToken = s ->
+                | CompilerOption(s, _, OptionFloat f, d, _) as compilerOption :: _ when optToken = s ->
                     reportDeprecatedOption d
                     let oa = getOptionArg compilerOption argString
 
@@ -427,11 +427,11 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
                         )
 
                     t
-                | CompilerOption (s, _, OptionRest f, d, _) :: _ when optToken = s ->
+                | CompilerOption(s, _, OptionRest f, d, _) :: _ when optToken = s ->
                     reportDeprecatedOption d
                     List.iter f t
                     []
-                | CompilerOption (s, _, OptionIntList f, d, _) as compilerOption :: _ when optToken = s ->
+                | CompilerOption(s, _, OptionIntList f, d, _) as compilerOption :: _ when optToken = s ->
                     reportDeprecatedOption d
                     let al = getOptionArgList compilerOption argString
 
@@ -448,7 +448,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
                             al
 
                     t
-                | CompilerOption (s, _, OptionIntListSwitch f, d, _) as compilerOption :: _ when getSwitchOpt optToken = s ->
+                | CompilerOption(s, _, OptionIntListSwitch f, d, _) as compilerOption :: _ when getSwitchOpt optToken = s ->
                     reportDeprecatedOption d
                     let al = getOptionArgList compilerOption argString
 
@@ -468,7 +468,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
 
                     t
                 // here
-                | CompilerOption (s, _, OptionStringList f, d, _) as compilerOption :: _ when optToken = s ->
+                | CompilerOption(s, _, OptionStringList f, d, _) as compilerOption :: _ when optToken = s ->
                     reportDeprecatedOption d
                     let al = getOptionArgList compilerOption argString
 
@@ -476,7 +476,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
                         List.iter f (getOptionArgList compilerOption argString)
 
                     t
-                | CompilerOption (s, _, OptionStringListSwitch f, d, _) as compilerOption :: _ when getSwitchOpt optToken = s ->
+                | CompilerOption(s, _, OptionStringListSwitch f, d, _) as compilerOption :: _ when getSwitchOpt optToken = s ->
                     reportDeprecatedOption d
                     let al = getOptionArgList compilerOption argString
 
@@ -485,7 +485,7 @@ let ParseCompilerOptions (collectOtherArgument: string -> unit, blocks: Compiler
                         List.iter (fun s -> f s switch) (getOptionArgList compilerOption argString)
 
                     t
-                | CompilerOption (_, _, OptionGeneral (pred, exec), d, _) :: _ when pred args ->
+                | CompilerOption(_, _, OptionGeneral(pred, exec), d, _) :: _ when pred args ->
                     reportDeprecatedOption d
                     let rest = exec args in
                     rest // arguments taken, rest remaining
@@ -2186,8 +2186,8 @@ let GetAbbrevFlagSet tcConfigB isFsc =
 
     for c in ((if isFsc then abbreviatedFlagsFsc else abbreviatedFlagsFsi) tcConfigB) do
         match c with
-        | CompilerOption (arg, _, OptionString _, _, _)
-        | CompilerOption (arg, _, OptionStringList _, _, _) -> argList <- argList @ [ "-" + arg; "/" + arg ]
+        | CompilerOption(arg, _, OptionString _, _, _)
+        | CompilerOption(arg, _, OptionStringList _, _, _) -> argList <- argList @ [ "-" + arg; "/" + arg ]
         | _ -> ()
 
     Set.ofList argList
@@ -2279,7 +2279,7 @@ let GetCoreFscCompilerOptions (tcConfigB: TcConfigBuilder) =
 let GetCoreServiceCompilerOptions (tcConfigB: TcConfigBuilder) =
     let isConsoleOnlyOption =
         function
-        | CompilerOption (_, _, OptionConsoleOnly _, _, _) -> true
+        | CompilerOption(_, _, OptionConsoleOnly _, _, _) -> true
         | _ -> false
 
     List.map (FilterCompilerOptionBlock(isConsoleOnlyOption >> not)) (GetCoreFscCompilerOptions tcConfigB)
@@ -2344,25 +2344,25 @@ let ApplyCommandLineArgs (tcConfigB: TcConfigBuilder, sourceFiles: string list, 
 
 let private SimulateException simulateConfig =
     match simulateConfig with
-    | Some ("fsc-oom") -> raise (OutOfMemoryException())
-    | Some ("fsc-an") -> raise (ArgumentNullException("simulated"))
-    | Some ("fsc-invop") -> raise (InvalidOperationException())
-    | Some ("fsc-av") -> raise (AccessViolationException())
-    | Some ("fsc-aor") -> raise (ArgumentOutOfRangeException())
-    | Some ("fsc-dv0") -> raise (DivideByZeroException())
-    | Some ("fsc-nfn") -> raise (NotFiniteNumberException())
-    | Some ("fsc-oe") -> raise (OverflowException())
-    | Some ("fsc-atmm") -> raise (ArrayTypeMismatchException())
-    | Some ("fsc-bif") -> raise (BadImageFormatException())
-    | Some ("fsc-knf") -> raise (System.Collections.Generic.KeyNotFoundException())
-    | Some ("fsc-ior") -> raise (IndexOutOfRangeException())
-    | Some ("fsc-ic") -> raise (InvalidCastException())
-    | Some ("fsc-ip") -> raise (InvalidProgramException())
-    | Some ("fsc-ma") -> raise (MemberAccessException())
-    | Some ("fsc-ni") -> raise (NotImplementedException())
-    | Some ("fsc-nr") -> raise (NullReferenceException())
-    | Some ("fsc-oc") -> raise (OperationCanceledException())
-    | Some ("fsc-fail") -> failwith "simulated"
+    | Some("fsc-oom") -> raise (OutOfMemoryException())
+    | Some("fsc-an") -> raise (ArgumentNullException("simulated"))
+    | Some("fsc-invop") -> raise (InvalidOperationException())
+    | Some("fsc-av") -> raise (AccessViolationException())
+    | Some("fsc-aor") -> raise (ArgumentOutOfRangeException())
+    | Some("fsc-dv0") -> raise (DivideByZeroException())
+    | Some("fsc-nfn") -> raise (NotFiniteNumberException())
+    | Some("fsc-oe") -> raise (OverflowException())
+    | Some("fsc-atmm") -> raise (ArrayTypeMismatchException())
+    | Some("fsc-bif") -> raise (BadImageFormatException())
+    | Some("fsc-knf") -> raise (System.Collections.Generic.KeyNotFoundException())
+    | Some("fsc-ior") -> raise (IndexOutOfRangeException())
+    | Some("fsc-ic") -> raise (InvalidCastException())
+    | Some("fsc-ip") -> raise (InvalidProgramException())
+    | Some("fsc-ma") -> raise (MemberAccessException())
+    | Some("fsc-ni") -> raise (NotImplementedException())
+    | Some("fsc-nr") -> raise (NullReferenceException())
+    | Some("fsc-oc") -> raise (OperationCanceledException())
+    | Some("fsc-fail") -> failwith "simulated"
     | _ -> ()
 
 let ReportTime =
@@ -2404,7 +2404,7 @@ let DoWithColor newColor f =
     | true, None ->
         // could not get console colours, so no attempt to change colours, can not set them back
         f ()
-    | true, Some (c, _) ->
+    | true, Some(c, _) ->
         try
             ignoreFailureOnMono1_1_16 (fun () -> Console.ForegroundColor <- newColor)
             f ()
@@ -2414,7 +2414,7 @@ let DoWithColor newColor f =
 let DoWithDiagnosticColor severity f =
     match foreBackColor () with
     | None -> f ()
-    | Some (_, backColor) ->
+    | Some(_, backColor) ->
         let infoColor =
             if backColor = ConsoleColor.White then
                 ConsoleColor.Blue

--- a/src/Compiler/Driver/CreateILModule.fs
+++ b/src/Compiler/Driver/CreateILModule.fs
@@ -35,7 +35,7 @@ module AttributeHelpers =
         | None -> None
         | Some attribRef ->
             match TryFindFSharpAttribute g attribRef attribs with
-            | Some (Attrib (_, _, [ AttribStringArg s ], _, _, _, _)) -> Some s
+            | Some(Attrib(_, _, [ AttribStringArg s ], _, _, _, _)) -> Some s
             | _ -> None
 
     let TryFindIntAttribute (g: TcGlobals) attrib attribs =
@@ -43,7 +43,7 @@ module AttributeHelpers =
         | None -> None
         | Some attribRef ->
             match TryFindFSharpAttribute g attribRef attribs with
-            | Some (Attrib (_, _, [ AttribInt32Arg i ], _, _, _, _)) -> Some i
+            | Some(Attrib(_, _, [ AttribInt32Arg i ], _, _, _, _)) -> Some i
             | _ -> None
 
     let TryFindBoolAttribute (g: TcGlobals) attrib attribs =
@@ -51,7 +51,7 @@ module AttributeHelpers =
         | None -> None
         | Some attribRef ->
             match TryFindFSharpAttribute g attribRef attribs with
-            | Some (Attrib (_, _, [ AttribBoolArg p ], _, _, _, _)) -> Some p
+            | Some(Attrib(_, _, [ AttribBoolArg p ], _, _, _, _)) -> Some p
             | _ -> None
 
     let (|ILVersion|_|) (versionString: string) =
@@ -134,7 +134,7 @@ let ValidateKeySigningAttributes (tcConfig: TcConfig, tcGlobals, topAttrs) =
 
 /// Get the object used to perform strong-name signing
 let GetStrongNameSigner signingInfo =
-    let (StrongNameSigningInfo (delaysign, publicsign, signer, container)) = signingInfo
+    let (StrongNameSigningInfo(delaysign, publicsign, signer, container)) = signingInfo
     // REVIEW: favor the container over the key file - C# appears to do this
     match container with
     | Some container -> Some(ILStrongNameSigner.OpenKeyContainer container)
@@ -238,7 +238,7 @@ module MainModuleBuilder =
 
         match findStringAttr attrName with
         | None -> assemblyVersion
-        | Some (AttributeHelpers.ILVersion v) -> v
+        | Some(AttributeHelpers.ILVersion v) -> v
         | Some _ ->
             // Warning will be reported by CheckExpressions.fs
             assemblyVersion
@@ -252,7 +252,7 @@ module MainModuleBuilder =
         match findStringAttr attrName with
         | None
         | Some "" -> fileVersion |> toDotted
-        | Some (AttributeHelpers.ILVersion v) -> v |> toDotted
+        | Some(AttributeHelpers.ILVersion v) -> v |> toDotted
         | Some v ->
             // Warning will be reported by CheckExpressions.fs
             v

--- a/src/Compiler/Driver/FxResolver.fs
+++ b/src/Compiler/Driver/FxResolver.fs
@@ -403,7 +403,7 @@ type internal FxResolver
             | ".NET", "Core" when arr.Length >= 3 -> Some("netcoreapp" + (getTfmNumber arr[2]))
 
             | ".NET", "Framework" when arr.Length >= 3 ->
-                if arr[ 2 ].StartsWith("4.8") then
+                if arr[2].StartsWith("4.8") then
                     Some "net48"
                 else
                     Some "net472"

--- a/src/Compiler/Driver/GraphChecking/DependencyResolution.fs
+++ b/src/Compiler/Driver/GraphChecking/DependencyResolution.fs
@@ -69,7 +69,7 @@ let processIdentifier (queryResult: QueryTrieNodeResult) (state: FileContentQuer
 /// Typically used to fold FileContentEntry items over a FileContentQueryState
 let rec processStateEntry (trie: TrieNode) (state: FileContentQueryState) (entry: FileContentEntry) : FileContentQueryState =
     match entry with
-    | FileContentEntry.TopLevelNamespace (topLevelPath, content) ->
+    | FileContentEntry.TopLevelNamespace(topLevelPath, content) ->
         let state =
             match topLevelPath with
             | [] -> state
@@ -107,7 +107,7 @@ let rec processStateEntry (trie: TrieNode) (state: FileContentQueryState) (entry
                     let queryResult = queryTrieDual trie openNS path
                     processIdentifier queryResult acc))
 
-    | FileContentEntry.NestedModule (nestedContent = nestedContent) ->
+    | FileContentEntry.NestedModule(nestedContent = nestedContent) ->
         // We don't want our current state to be affect by any open statements in the nested module
         let nestedState = List.fold (processStateEntry trie) state nestedContent
         // Afterward we are only interested in the found dependencies in the nested module
@@ -154,7 +154,7 @@ let collectGhostDependencies (fileIndex: FileIndex) (trie: TrieNode) (result: Fi
             // Both Root and module would expose data, so we can ignore them.
             | Root _
             | Module _ -> None
-            | Namespace (filesDefiningNamespaceWithoutTypes = filesDefiningNamespaceWithoutTypes) ->
+            | Namespace(filesDefiningNamespaceWithoutTypes = filesDefiningNamespaceWithoutTypes) ->
                 if filesDefiningNamespaceWithoutTypes.Overlaps(result.FoundDependencies) then
                     // The ghost dependency is already covered by a real dependency.
                     None

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -43,24 +43,23 @@ let visitSynAttributes (attributes: SynAttributes) : FileContentEntry list =
 let visitSynModuleDecl (decl: SynModuleDecl) : FileContentEntry list =
     [
         match decl with
-        | SynModuleDecl.Open(target = SynOpenDeclTarget.ModuleOrNamespace (longId, _)) ->
+        | SynModuleDecl.Open(target = SynOpenDeclTarget.ModuleOrNamespace(longId, _)) ->
             yield FileContentEntry.OpenStatement(synLongIdentToPath false longId)
-        | SynModuleDecl.Open(target = SynOpenDeclTarget.Type (typeName, _)) -> yield! visitSynType typeName
-        | SynModuleDecl.Attributes (attributes, _) -> yield! List.collect visitSynAttributeList attributes
-        | SynModuleDecl.Expr (expr, _) -> yield! visitSynExpr expr
-        | SynModuleDecl.NestedModule (moduleInfo = SynComponentInfo (longId = [ ident ]; attributes = attributes); decls = decls) ->
+        | SynModuleDecl.Open(target = SynOpenDeclTarget.Type(typeName, _)) -> yield! visitSynType typeName
+        | SynModuleDecl.Attributes(attributes, _) -> yield! List.collect visitSynAttributeList attributes
+        | SynModuleDecl.Expr(expr, _) -> yield! visitSynExpr expr
+        | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ ident ]; attributes = attributes); decls = decls) ->
             yield! visitSynAttributes attributes
             yield FileContentEntry.NestedModule(ident.idText, List.collect visitSynModuleDecl decls)
         | SynModuleDecl.NestedModule _ -> failwith "A nested module cannot have multiple identifiers"
-        | SynModuleDecl.Let (bindings = bindings) -> yield! List.collect visitBinding bindings
-        | SynModuleDecl.Types (typeDefns = typeDefns) -> yield! List.collect visitSynTypeDefn typeDefns
+        | SynModuleDecl.Let(bindings = bindings) -> yield! List.collect visitBinding bindings
+        | SynModuleDecl.Types(typeDefns = typeDefns) -> yield! List.collect visitSynTypeDefn typeDefns
         | SynModuleDecl.HashDirective _ -> ()
-        | SynModuleDecl.ModuleAbbrev (longId = longId) -> yield! visitLongIdentForModuleAbbrev longId
+        | SynModuleDecl.ModuleAbbrev(longId = longId) -> yield! visitLongIdentForModuleAbbrev longId
         | SynModuleDecl.NamespaceFragment _ -> ()
-        | SynModuleDecl.Exception(exnDefn = SynExceptionDefn (exnRepr = SynExceptionDefnRepr (attributes = attributes
-                                                                                              caseName = caseName
-                                                                                              longId = longId)
-                                                              members = members)) ->
+        | SynModuleDecl.Exception(
+            exnDefn = SynExceptionDefn(
+                exnRepr = SynExceptionDefnRepr(attributes = attributes; caseName = caseName; longId = longId); members = members)) ->
             yield! visitSynAttributes attributes
             yield! visitSynUnionCase caseName
             yield! collectFromOption visitLongIdent longId
@@ -70,20 +69,19 @@ let visitSynModuleDecl (decl: SynModuleDecl) : FileContentEntry list =
 let visitSynModuleSigDecl (md: SynModuleSigDecl) =
     [
         match md with
-        | SynModuleSigDecl.Open(target = SynOpenDeclTarget.ModuleOrNamespace (longId, _)) ->
+        | SynModuleSigDecl.Open(target = SynOpenDeclTarget.ModuleOrNamespace(longId, _)) ->
             yield FileContentEntry.OpenStatement(synLongIdentToPath false longId)
-        | SynModuleSigDecl.Open(target = SynOpenDeclTarget.Type (typeName, _)) -> yield! visitSynType typeName
-        | SynModuleSigDecl.NestedModule (moduleInfo = SynComponentInfo (longId = [ ident ]; attributes = attributes); moduleDecls = decls) ->
+        | SynModuleSigDecl.Open(target = SynOpenDeclTarget.Type(typeName, _)) -> yield! visitSynType typeName
+        | SynModuleSigDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ ident ]; attributes = attributes); moduleDecls = decls) ->
             yield! visitSynAttributes attributes
             yield FileContentEntry.NestedModule(ident.idText, List.collect visitSynModuleSigDecl decls)
         | SynModuleSigDecl.NestedModule _ -> failwith "A nested module cannot have multiple identifiers"
-        | SynModuleSigDecl.ModuleAbbrev (longId = longId) -> yield! visitLongIdentForModuleAbbrev longId
-        | SynModuleSigDecl.Val (valSig, _) -> yield! visitSynValSig valSig
-        | SynModuleSigDecl.Types (types = types) -> yield! List.collect visitSynTypeDefnSig types
-        | SynModuleSigDecl.Exception(exnSig = SynExceptionSig (exnRepr = SynExceptionDefnRepr (attributes = attributes
-                                                                                               caseName = caseName
-                                                                                               longId = longId)
-                                                               members = members)) ->
+        | SynModuleSigDecl.ModuleAbbrev(longId = longId) -> yield! visitLongIdentForModuleAbbrev longId
+        | SynModuleSigDecl.Val(valSig, _) -> yield! visitSynValSig valSig
+        | SynModuleSigDecl.Types(types = types) -> yield! List.collect visitSynTypeDefnSig types
+        | SynModuleSigDecl.Exception(
+            exnSig = SynExceptionSig(
+                exnRepr = SynExceptionDefnRepr(attributes = attributes; caseName = caseName; longId = longId); members = members)) ->
             yield! visitSynAttributes attributes
             yield! visitSynUnionCase caseName
             yield! collectFromOption visitLongIdent longId
@@ -92,43 +90,44 @@ let visitSynModuleSigDecl (md: SynModuleSigDecl) =
         | SynModuleSigDecl.NamespaceFragment _ -> ()
     ]
 
-let visitSynUnionCase (SynUnionCase (attributes = attributes; caseType = caseType)) =
+let visitSynUnionCase (SynUnionCase(attributes = attributes; caseType = caseType)) =
     [
         yield! visitSynAttributes attributes
         match caseType with
         | SynUnionCaseKind.Fields cases -> yield! List.collect visitSynField cases
-        | SynUnionCaseKind.FullType (fullType = fullType) -> yield! visitSynType fullType
+        | SynUnionCaseKind.FullType(fullType = fullType) -> yield! visitSynType fullType
     ]
 
-let visitSynEnumCase (SynEnumCase (attributes = attributes)) = visitSynAttributes attributes
+let visitSynEnumCase (SynEnumCase(attributes = attributes)) = visitSynAttributes attributes
 
 let visitSynTypeDefn
-    (SynTypeDefn (typeInfo = SynComponentInfo (attributes = attributes; longId = longId; typeParams = typeParams; constraints = constraints)
-                  typeRepr = typeRepr
-                  members = members))
+    (SynTypeDefn(
+        typeInfo = SynComponentInfo(attributes = attributes; longId = longId; typeParams = typeParams; constraints = constraints)
+        typeRepr = typeRepr
+        members = members))
     : FileContentEntry list =
     [
         yield! visitSynAttributes attributes
         yield! collectFromOption visitSynTyparDecls typeParams
         yield! List.collect visitSynTypeConstraint constraints
         match typeRepr with
-        | SynTypeDefnRepr.Simple (simpleRepr, _) ->
+        | SynTypeDefnRepr.Simple(simpleRepr, _) ->
             match simpleRepr with
-            | SynTypeDefnSimpleRepr.Union (unionCases = unionCases) -> yield! List.collect visitSynUnionCase unionCases
-            | SynTypeDefnSimpleRepr.Enum (cases = cases) -> yield! List.collect visitSynEnumCase cases
-            | SynTypeDefnSimpleRepr.Record (recordFields = recordFields) -> yield! List.collect visitSynField recordFields
+            | SynTypeDefnSimpleRepr.Union(unionCases = unionCases) -> yield! List.collect visitSynUnionCase unionCases
+            | SynTypeDefnSimpleRepr.Enum(cases = cases) -> yield! List.collect visitSynEnumCase cases
+            | SynTypeDefnSimpleRepr.Record(recordFields = recordFields) -> yield! List.collect visitSynField recordFields
             // This is only used in the typed tree
             // The parser doesn't construct this
             | SynTypeDefnSimpleRepr.General _
             | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _ -> ()
-            | SynTypeDefnSimpleRepr.TypeAbbrev (rhsType = rhsType) -> yield! visitSynType rhsType
+            | SynTypeDefnSimpleRepr.TypeAbbrev(rhsType = rhsType) -> yield! visitSynType rhsType
             | SynTypeDefnSimpleRepr.None _
             // This is only used in the typed tree
             // The parser doesn't construct this
             | SynTypeDefnSimpleRepr.Exception _ -> ()
-        | SynTypeDefnRepr.ObjectModel (kind, members, _) ->
+        | SynTypeDefnRepr.ObjectModel(kind, members, _) ->
             match kind with
-            | SynTypeDefnKind.Delegate (signature, _) ->
+            | SynTypeDefnKind.Delegate(signature, _) ->
                 yield! visitSynType signature
                 yield! List.collect visitSynMemberDefn members
             | SynTypeDefnKind.Augmentation _ ->
@@ -143,28 +142,26 @@ let visitSynTypeDefn
     ]
 
 let visitSynTypeDefnSig
-    (SynTypeDefnSig (typeInfo = SynComponentInfo (attributes = attributes
-                                                  longId = longId
-                                                  typeParams = typeParams
-                                                  constraints = constraints)
-                     typeRepr = typeRepr
-                     members = members))
+    (SynTypeDefnSig(
+        typeInfo = SynComponentInfo(attributes = attributes; longId = longId; typeParams = typeParams; constraints = constraints)
+        typeRepr = typeRepr
+        members = members))
     =
     [
         yield! visitSynAttributes attributes
         yield! collectFromOption visitSynTyparDecls typeParams
         yield! List.collect visitSynTypeConstraint constraints
         match typeRepr with
-        | SynTypeDefnSigRepr.Simple (simpleRepr, _) ->
+        | SynTypeDefnSigRepr.Simple(simpleRepr, _) ->
             match simpleRepr with
-            | SynTypeDefnSimpleRepr.Union (unionCases = unionCases) -> yield! List.collect visitSynUnionCase unionCases
-            | SynTypeDefnSimpleRepr.Enum (cases = cases) -> yield! List.collect visitSynEnumCase cases
-            | SynTypeDefnSimpleRepr.Record (recordFields = recordFields) -> yield! List.collect visitSynField recordFields
+            | SynTypeDefnSimpleRepr.Union(unionCases = unionCases) -> yield! List.collect visitSynUnionCase unionCases
+            | SynTypeDefnSimpleRepr.Enum(cases = cases) -> yield! List.collect visitSynEnumCase cases
+            | SynTypeDefnSimpleRepr.Record(recordFields = recordFields) -> yield! List.collect visitSynField recordFields
             // This is only used in the typed tree
             // The parser doesn't construct this
             | SynTypeDefnSimpleRepr.General _
             | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _ -> ()
-            | SynTypeDefnSimpleRepr.TypeAbbrev (rhsType = rhsType) -> yield! visitSynType rhsType
+            | SynTypeDefnSimpleRepr.TypeAbbrev(rhsType = rhsType) -> yield! visitSynType rhsType
             // This is a type augmentation in a signature file
             | SynTypeDefnSimpleRepr.None _ ->
                 yield! visitLongIdent longId
@@ -172,9 +169,9 @@ let visitSynTypeDefnSig
             // This is only used in the typed tree
             // The parser doesn't construct this
             | SynTypeDefnSimpleRepr.Exception _ -> ()
-        | SynTypeDefnSigRepr.ObjectModel (kind, members, _) ->
+        | SynTypeDefnSigRepr.ObjectModel(kind, members, _) ->
             match kind with
-            | SynTypeDefnKind.Delegate (signature, _) ->
+            | SynTypeDefnKind.Delegate(signature, _) ->
                 yield! visitSynType signature
                 yield! List.collect visitSynMemberSig members
             | _ -> yield! List.collect visitSynMemberSig members
@@ -185,43 +182,43 @@ let visitSynTypeDefnSig
         yield! List.collect visitSynMemberSig members
     ]
 
-let visitSynValSig (SynValSig (attributes = attributes; synType = synType; synExpr = synExpr)) =
+let visitSynValSig (SynValSig(attributes = attributes; synType = synType; synExpr = synExpr)) =
     [
         yield! visitSynAttributes attributes
         yield! visitSynType synType
         yield! collectFromOption visitSynExpr synExpr
     ]
 
-let visitSynField (SynField (attributes = attributes; fieldType = fieldType)) =
+let visitSynField (SynField(attributes = attributes; fieldType = fieldType)) =
     visitSynAttributes attributes @ visitSynType fieldType
 
 let visitSynMemberDefn (md: SynMemberDefn) : FileContentEntry list =
     [
         match md with
-        | SynMemberDefn.Member (memberDefn = binding) -> yield! visitBinding binding
+        | SynMemberDefn.Member(memberDefn = binding) -> yield! visitBinding binding
         | SynMemberDefn.Open _ -> ()
-        | SynMemberDefn.GetSetMember (memberDefnForGet, memberDefnForSet, _, _) ->
+        | SynMemberDefn.GetSetMember(memberDefnForGet, memberDefnForSet, _, _) ->
             yield! collectFromOption visitBinding memberDefnForGet
             yield! collectFromOption visitBinding memberDefnForSet
-        | SynMemberDefn.ImplicitCtor (ctorArgs = ctorArgs) -> yield! visitSynSimplePats ctorArgs
-        | SynMemberDefn.ImplicitInherit (inheritType, inheritArgs, _, _) ->
+        | SynMemberDefn.ImplicitCtor(ctorArgs = ctorArgs) -> yield! visitSynSimplePats ctorArgs
+        | SynMemberDefn.ImplicitInherit(inheritType, inheritArgs, _, _) ->
             yield! visitSynType inheritType
             yield! visitSynExpr inheritArgs
-        | SynMemberDefn.LetBindings (bindings = bindings) -> yield! List.collect visitBinding bindings
-        | SynMemberDefn.AbstractSlot (slotSig = slotSig) -> yield! visitSynValSig slotSig
-        | SynMemberDefn.Interface (interfaceType, _, members, _) ->
+        | SynMemberDefn.LetBindings(bindings = bindings) -> yield! List.collect visitBinding bindings
+        | SynMemberDefn.AbstractSlot(slotSig = slotSig) -> yield! visitSynValSig slotSig
+        | SynMemberDefn.Interface(interfaceType, _, members, _) ->
             yield! visitSynType interfaceType
             yield! collectFromOption (List.collect visitSynMemberDefn) members
-        | SynMemberDefn.Inherit (baseType, _, _) -> yield! visitSynType baseType
-        | SynMemberDefn.ValField (fieldInfo, _) -> yield! visitSynField fieldInfo
+        | SynMemberDefn.Inherit(baseType, _, _) -> yield! visitSynType baseType
+        | SynMemberDefn.ValField(fieldInfo, _) -> yield! visitSynField fieldInfo
         | SynMemberDefn.NestedType _ -> ()
-        | SynMemberDefn.AutoProperty (attributes = attributes; typeOpt = typeOpt; synExpr = synExpr) ->
+        | SynMemberDefn.AutoProperty(attributes = attributes; typeOpt = typeOpt; synExpr = synExpr) ->
             yield! visitSynAttributes attributes
             yield! collectFromOption visitSynType typeOpt
             yield! visitSynExpr synExpr
     ]
 
-let visitSynInterfaceImpl (SynInterfaceImpl (interfaceTy = t; bindings = bindings; members = members)) =
+let visitSynInterfaceImpl (SynInterfaceImpl(interfaceTy = t; bindings = bindings; members = members)) =
     [
         yield! visitSynType t
         yield! List.collect visitBinding bindings
@@ -232,62 +229,62 @@ let visitSynType (t: SynType) : FileContentEntry list =
     let rec visit (t: SynType) (continuation: FileContentEntry list -> FileContentEntry list) =
         match t with
         | SynType.LongIdent lid -> continuation (visitSynLongIdent lid)
-        | SynType.App (typeName = typeName; typeArgs = typeArgs) ->
+        | SynType.App(typeName = typeName; typeArgs = typeArgs) ->
             let continuations = List.map visit (typeName :: typeArgs)
             Continuation.concatenate continuations continuation
-        | SynType.LongIdentApp (typeName = typeName; longDotId = longDotId; typeArgs = typeArgs) ->
+        | SynType.LongIdentApp(typeName = typeName; longDotId = longDotId; typeArgs = typeArgs) ->
             let continuations = List.map visit (typeName :: typeArgs)
 
             let finalContinuation nodes =
                 visitSynLongIdent longDotId @ List.concat nodes |> continuation
 
             Continuation.sequence continuations finalContinuation
-        | SynType.Tuple (path = path) ->
+        | SynType.Tuple(path = path) ->
             let continuations = List.map visit (getTypeFromTuplePath path)
             Continuation.concatenate continuations continuation
-        | SynType.AnonRecd (fields = fields) ->
+        | SynType.AnonRecd(fields = fields) ->
             let continuations = List.map (snd >> visit) fields
             Continuation.concatenate continuations continuation
-        | SynType.Array (elementType = elementType) -> visit elementType continuation
-        | SynType.Fun (argType, returnType, _, _) ->
+        | SynType.Array(elementType = elementType) -> visit elementType continuation
+        | SynType.Fun(argType, returnType, _, _) ->
             let continuations = List.map visit [ argType; returnType ]
             Continuation.concatenate continuations continuation
         | SynType.Var _ -> continuation []
         | SynType.Anon _ -> continuation []
-        | SynType.WithGlobalConstraints (typeName, constraints, _) ->
+        | SynType.WithGlobalConstraints(typeName, constraints, _) ->
             visit typeName (fun nodes -> nodes @ List.collect visitSynTypeConstraint constraints |> continuation)
-        | SynType.HashConstraint (innerType, _) -> visit innerType continuation
-        | SynType.MeasurePower (baseMeasure = baseMeasure) -> visit baseMeasure continuation
+        | SynType.HashConstraint(innerType, _) -> visit innerType continuation
+        | SynType.MeasurePower(baseMeasure = baseMeasure) -> visit baseMeasure continuation
         | SynType.StaticConstant _ -> continuation []
-        | SynType.StaticConstantExpr (expr, _) -> continuation (visitSynExpr expr)
-        | SynType.StaticConstantNamed (ident, value, _) ->
+        | SynType.StaticConstantExpr(expr, _) -> continuation (visitSynExpr expr)
+        | SynType.StaticConstantNamed(ident, value, _) ->
             let continuations = List.map visit [ ident; value ]
             Continuation.concatenate continuations continuation
-        | SynType.Paren (innerType, _) -> visit innerType continuation
-        | SynType.SignatureParameter (attributes = attributes; usedType = usedType) ->
+        | SynType.Paren(innerType, _) -> visit innerType continuation
+        | SynType.SignatureParameter(attributes = attributes; usedType = usedType) ->
             visit usedType (fun nodes -> [ yield! visitSynAttributes attributes; yield! nodes ] |> continuation)
-        | SynType.Or (lhsType, rhsType, _, _) ->
+        | SynType.Or(lhsType, rhsType, _, _) ->
             let continuations = List.map visit [ lhsType; rhsType ]
             Continuation.concatenate continuations continuation
         | SynType.FromParseError _ -> continuation []
-        | SynType.Intersection (types = types) ->
+        | SynType.Intersection(types = types) ->
             let continuations = List.map visit types
             Continuation.concatenate continuations continuation
 
     visit t id
 
-let visitSynValTyparDecls (SynValTyparDecls (typars = typars)) =
+let visitSynValTyparDecls (SynValTyparDecls(typars = typars)) =
     collectFromOption visitSynTyparDecls typars
 
 let visitSynTyparDecls (td: SynTyparDecls) : FileContentEntry list =
     match td with
-    | SynTyparDecls.PostfixList (decls, constraints, _) ->
+    | SynTyparDecls.PostfixList(decls, constraints, _) ->
         List.collect visitSynTyparDecl decls
         @ List.collect visitSynTypeConstraint constraints
-    | SynTyparDecls.PrefixList (decls = decls) -> List.collect visitSynTyparDecl decls
-    | SynTyparDecls.SinglePrefix (decl = decl) -> visitSynTyparDecl decl
+    | SynTyparDecls.PrefixList(decls = decls) -> List.collect visitSynTyparDecl decls
+    | SynTyparDecls.SinglePrefix(decl = decl) -> visitSynTyparDecl decl
 
-let visitSynTyparDecl (SynTyparDecl (attributes = attributes; intersectionConstraints = constraints)) =
+let visitSynTyparDecl (SynTyparDecl(attributes = attributes; intersectionConstraints = constraints)) =
     visitSynAttributes attributes @ List.collect visitSynType constraints
 
 let visitSynTypeConstraint (tc: SynTypeConstraint) : FileContentEntry list =
@@ -299,50 +296,49 @@ let visitSynTypeConstraint (tc: SynTypeConstraint) : FileContentEntry list =
     | SynTypeConstraint.WhereTyparSupportsNull _
     | SynTypeConstraint.WhereTyparIsComparable _
     | SynTypeConstraint.WhereTyparIsEquatable _ -> []
-    | SynTypeConstraint.WhereTyparDefaultsToType (typeName = typeName) -> visitSynType typeName
-    | SynTypeConstraint.WhereTyparSubtypeOfType (typeName = typeName) -> visitSynType typeName
-    | SynTypeConstraint.WhereTyparSupportsMember (typars, memberSig, _) -> visitSynType typars @ visitSynMemberSig memberSig
-    | SynTypeConstraint.WhereTyparIsEnum (typeArgs = typeArgs) -> List.collect visitSynType typeArgs
-    | SynTypeConstraint.WhereTyparIsDelegate (typeArgs = typeArgs) -> List.collect visitSynType typeArgs
+    | SynTypeConstraint.WhereTyparDefaultsToType(typeName = typeName) -> visitSynType typeName
+    | SynTypeConstraint.WhereTyparSubtypeOfType(typeName = typeName) -> visitSynType typeName
+    | SynTypeConstraint.WhereTyparSupportsMember(typars, memberSig, _) -> visitSynType typars @ visitSynMemberSig memberSig
+    | SynTypeConstraint.WhereTyparIsEnum(typeArgs = typeArgs) -> List.collect visitSynType typeArgs
+    | SynTypeConstraint.WhereTyparIsDelegate(typeArgs = typeArgs) -> List.collect visitSynType typeArgs
 
 let visitSynExpr (e: SynExpr) : FileContentEntry list =
     let rec visit (e: SynExpr) (continuation: FileContentEntry list -> FileContentEntry list) : FileContentEntry list =
         match e with
         | SynExpr.Const _ -> continuation []
-        | SynExpr.Paren (expr = expr) -> visit expr continuation
-        | SynExpr.Quote (operator = operator; quotedExpr = quotedExpr) ->
+        | SynExpr.Paren(expr = expr) -> visit expr continuation
+        | SynExpr.Quote(operator = operator; quotedExpr = quotedExpr) ->
             visit operator (fun operatorNodes -> visit quotedExpr (fun quotedNodes -> operatorNodes @ quotedNodes |> continuation))
-        | SynExpr.Typed (expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
-        | SynExpr.Tuple (exprs = exprs) ->
+        | SynExpr.Typed(expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
+        | SynExpr.Tuple(exprs = exprs) ->
             let continuations: ((FileContentEntry list -> FileContentEntry list) -> FileContentEntry list) list =
                 List.map visit exprs
 
             Continuation.concatenate continuations continuation
-        | SynExpr.AnonRecd (copyInfo = copyInfo; recordFields = recordFields) ->
+        | SynExpr.AnonRecd(copyInfo = copyInfo; recordFields = recordFields) ->
             let continuations =
                 match copyInfo with
                 | None -> List.map (fun (_, _, e) -> visit e) recordFields
-                | Some (cp, _) -> visit cp :: List.map (fun (_, _, e) -> visit e) recordFields
+                | Some(cp, _) -> visit cp :: List.map (fun (_, _, e) -> visit e) recordFields
 
             Continuation.concatenate continuations continuation
-        | SynExpr.ArrayOrList (exprs = exprs) ->
+        | SynExpr.ArrayOrList(exprs = exprs) ->
             let continuations = List.map visit exprs
             Continuation.concatenate continuations continuation
-        | SynExpr.Record (baseInfo = baseInfo; copyInfo = copyInfo; recordFields = recordFields) ->
+        | SynExpr.Record(baseInfo = baseInfo; copyInfo = copyInfo; recordFields = recordFields) ->
             let fieldNodes =
                 [
-                    for SynExprRecordField (fieldName = (si, _); expr = expr) in recordFields do
+                    for SynExprRecordField(fieldName = (si, _); expr = expr) in recordFields do
                         yield! visitSynLongIdent si
                         yield! collectFromOption visitSynExpr expr
                 ]
 
             match baseInfo, copyInfo with
-            | Some (t, e, _, _, _), None ->
-                visit e (fun nodes -> [ yield! visitSynType t; yield! nodes; yield! fieldNodes ] |> continuation)
-            | None, Some (e, _) -> visit e (fun nodes -> nodes @ fieldNodes |> continuation)
+            | Some(t, e, _, _, _), None -> visit e (fun nodes -> [ yield! visitSynType t; yield! nodes; yield! fieldNodes ] |> continuation)
+            | None, Some(e, _) -> visit e (fun nodes -> nodes @ fieldNodes |> continuation)
             | _ -> continuation fieldNodes
-        | SynExpr.New (targetType = targetType; expr = expr) -> visit expr (fun nodes -> visitSynType targetType @ nodes |> continuation)
-        | SynExpr.ObjExpr (objType, argOptions, _, bindings, members, extraImpls, _, _) ->
+        | SynExpr.New(targetType = targetType; expr = expr) -> visit expr (fun nodes -> visitSynType targetType @ nodes |> continuation)
+        | SynExpr.ObjExpr(objType, argOptions, _, bindings, members, extraImpls, _, _) ->
             [
                 yield! visitSynType objType
                 yield! collectFromOption (fst >> visitSynExpr) argOptions
@@ -351,88 +347,88 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
                 yield! List.collect visitSynInterfaceImpl extraImpls
             ]
             |> continuation
-        | SynExpr.While (whileExpr = whileExpr; doExpr = doExpr) ->
+        | SynExpr.While(whileExpr = whileExpr; doExpr = doExpr) ->
             visit whileExpr (fun whileNodes -> visit doExpr (fun doNodes -> whileNodes @ doNodes |> continuation))
-        | SynExpr.For (identBody = identBody; toBody = toBody; doBody = doBody) ->
+        | SynExpr.For(identBody = identBody; toBody = toBody; doBody = doBody) ->
             let continuations = List.map visit [ identBody; toBody; doBody ]
             Continuation.concatenate continuations continuation
-        | SynExpr.ForEach (pat = pat; enumExpr = enumExpr; bodyExpr = bodyExpr) ->
+        | SynExpr.ForEach(pat = pat; enumExpr = enumExpr; bodyExpr = bodyExpr) ->
             visit enumExpr (fun enumNodes ->
                 visit bodyExpr (fun bodyNodes -> [ yield! visitPat pat; yield! enumNodes; yield! bodyNodes ] |> continuation))
-        | SynExpr.ArrayOrListComputed (expr = expr) -> visit expr continuation
-        | SynExpr.IndexRange (expr1 = expr1; expr2 = expr2) ->
+        | SynExpr.ArrayOrListComputed(expr = expr) -> visit expr continuation
+        | SynExpr.IndexRange(expr1 = expr1; expr2 = expr2) ->
             match expr1, expr2 with
             | None, None -> continuation []
             | Some e, None
             | None, Some e -> visit e continuation
             | Some e1, Some e2 -> visit e1 (fun e1Nodes -> visit e2 (fun e2Nodes -> e1Nodes @ e2Nodes |> continuation))
-        | SynExpr.IndexFromEnd (expr, _) -> visit expr continuation
-        | SynExpr.ComputationExpr (expr = expr) -> visit expr continuation
-        | SynExpr.Lambda (args = args; body = body) -> visit body (fun bodyNodes -> visitSynSimplePats args @ bodyNodes |> continuation)
-        | SynExpr.DotLambda (expr = expr) -> visit expr continuation
-        | SynExpr.MatchLambda (matchClauses = clauses) -> List.collect visitSynMatchClause clauses |> continuation
-        | SynExpr.Match (expr = expr; clauses = clauses) ->
+        | SynExpr.IndexFromEnd(expr, _) -> visit expr continuation
+        | SynExpr.ComputationExpr(expr = expr) -> visit expr continuation
+        | SynExpr.Lambda(args = args; body = body) -> visit body (fun bodyNodes -> visitSynSimplePats args @ bodyNodes |> continuation)
+        | SynExpr.DotLambda(expr = expr) -> visit expr continuation
+        | SynExpr.MatchLambda(matchClauses = clauses) -> List.collect visitSynMatchClause clauses |> continuation
+        | SynExpr.Match(expr = expr; clauses = clauses) ->
             visit expr (fun exprNodes ->
                 [ yield! exprNodes; yield! List.collect visitSynMatchClause clauses ]
                 |> continuation)
-        | SynExpr.Do (expr, _) -> visit expr continuation
-        | SynExpr.Assert (expr, _) -> visit expr continuation
-        | SynExpr.App (funcExpr = funcExpr; argExpr = argExpr) ->
+        | SynExpr.Do(expr, _) -> visit expr continuation
+        | SynExpr.Assert(expr, _) -> visit expr continuation
+        | SynExpr.App(funcExpr = funcExpr; argExpr = argExpr) ->
             visit funcExpr (fun funcNodes -> visit argExpr (fun argNodes -> funcNodes @ argNodes |> continuation))
-        | SynExpr.TypeApp (expr = expr; typeArgs = typeArgs) ->
+        | SynExpr.TypeApp(expr = expr; typeArgs = typeArgs) ->
             visit expr (fun exprNodes -> exprNodes @ List.collect visitSynType typeArgs |> continuation)
-        | SynExpr.LetOrUse (bindings = bindings; body = body) ->
+        | SynExpr.LetOrUse(bindings = bindings; body = body) ->
             visit body (fun nodes -> List.collect visitBinding bindings @ nodes |> continuation)
-        | SynExpr.TryWith (tryExpr = tryExpr; withCases = withCases) ->
+        | SynExpr.TryWith(tryExpr = tryExpr; withCases = withCases) ->
             visit tryExpr (fun nodes -> nodes @ List.collect visitSynMatchClause withCases |> continuation)
-        | SynExpr.TryFinally (tryExpr = tryExpr; finallyExpr = finallyExpr) ->
+        | SynExpr.TryFinally(tryExpr = tryExpr; finallyExpr = finallyExpr) ->
             visit tryExpr (fun tNodes -> visit finallyExpr (fun fNodes -> tNodes @ fNodes |> continuation))
-        | SynExpr.Lazy (expr, _) -> visit expr continuation
-        | SynExpr.Sequential (expr1 = expr1; expr2 = expr2) ->
+        | SynExpr.Lazy(expr, _) -> visit expr continuation
+        | SynExpr.Sequential(expr1 = expr1; expr2 = expr2) ->
             visit expr1 (fun nodes1 -> visit expr2 (fun nodes2 -> nodes1 @ nodes2 |> continuation))
-        | SynExpr.IfThenElse (ifExpr = ifExpr; thenExpr = thenExpr; elseExpr = elseExpr) ->
+        | SynExpr.IfThenElse(ifExpr = ifExpr; thenExpr = thenExpr; elseExpr = elseExpr) ->
             let continuations = List.map visit (ifExpr :: thenExpr :: Option.toList elseExpr)
             Continuation.concatenate continuations continuation
         | SynExpr.Typar _ -> continuation []
         | SynExpr.Ident _ -> continuation []
-        | SynExpr.LongIdent (longDotId = longDotId) -> continuation (visitSynLongIdent longDotId)
-        | SynExpr.LongIdentSet (longDotId, expr, _) -> visit expr (fun nodes -> visitSynLongIdent longDotId @ nodes |> continuation)
-        | SynExpr.DotGet (expr = expr; longDotId = longDotId) ->
+        | SynExpr.LongIdent(longDotId = longDotId) -> continuation (visitSynLongIdent longDotId)
+        | SynExpr.LongIdentSet(longDotId, expr, _) -> visit expr (fun nodes -> visitSynLongIdent longDotId @ nodes |> continuation)
+        | SynExpr.DotGet(expr = expr; longDotId = longDotId) ->
             visit expr (fun nodes -> visitSynLongIdent longDotId @ nodes |> continuation)
-        | SynExpr.DotSet (targetExpr, longDotId, rhsExpr, _) ->
+        | SynExpr.DotSet(targetExpr, longDotId, rhsExpr, _) ->
             visit targetExpr (fun tNodes ->
                 visit rhsExpr (fun rNodes ->
                     [ yield! tNodes; yield! visitSynLongIdent longDotId; yield! rNodes ]
                     |> continuation))
-        | SynExpr.Set (targetExpr, rhsExpr, _) ->
+        | SynExpr.Set(targetExpr, rhsExpr, _) ->
             let continuations = List.map visit [ targetExpr; rhsExpr ]
             Continuation.concatenate continuations continuation
-        | SynExpr.DotIndexedGet (objectExpr, indexArgs, _, _) ->
+        | SynExpr.DotIndexedGet(objectExpr, indexArgs, _, _) ->
             let continuations = List.map visit [ objectExpr; indexArgs ]
             Continuation.concatenate continuations continuation
-        | SynExpr.DotIndexedSet (objectExpr, indexArgs, valueExpr, _, _, _) ->
+        | SynExpr.DotIndexedSet(objectExpr, indexArgs, valueExpr, _, _, _) ->
             let continuations = List.map visit [ objectExpr; indexArgs; valueExpr ]
             Continuation.concatenate continuations continuation
-        | SynExpr.NamedIndexedPropertySet (longDotId, expr1, expr2, _) ->
+        | SynExpr.NamedIndexedPropertySet(longDotId, expr1, expr2, _) ->
             visit expr1 (fun nodes1 ->
                 visit expr2 (fun nodes2 ->
                     [ yield! visitSynLongIdent longDotId; yield! nodes1; yield! nodes2 ]
                     |> continuation))
-        | SynExpr.DotNamedIndexedPropertySet (targetExpr, longDotId, argExpr, rhsExpr, _) ->
+        | SynExpr.DotNamedIndexedPropertySet(targetExpr, longDotId, argExpr, rhsExpr, _) ->
             let continuations = List.map visit [ targetExpr; argExpr; rhsExpr ]
 
             let finalContinuation nodes =
                 visitSynLongIdent longDotId @ List.concat nodes |> continuation
 
             Continuation.sequence continuations finalContinuation
-        | SynExpr.TypeTest (expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
-        | SynExpr.Upcast (expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
-        | SynExpr.Downcast (expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
-        | SynExpr.InferredUpcast (expr, _) -> visit expr continuation
-        | SynExpr.InferredDowncast (expr, _) -> visit expr continuation
+        | SynExpr.TypeTest(expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
+        | SynExpr.Upcast(expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
+        | SynExpr.Downcast(expr, targetType, _) -> visit expr (fun nodes -> nodes @ visitSynType targetType |> continuation)
+        | SynExpr.InferredUpcast(expr, _) -> visit expr continuation
+        | SynExpr.InferredDowncast(expr, _) -> visit expr continuation
         | SynExpr.Null _ -> continuation []
-        | SynExpr.AddressOf (expr = expr) -> visit expr continuation
-        | SynExpr.TraitCall (supportTys, traitSig, argExpr, _) ->
+        | SynExpr.AddressOf(expr = expr) -> visit expr continuation
+        | SynExpr.TraitCall(supportTys, traitSig, argExpr, _) ->
             visit argExpr (fun nodes ->
                 [
                     yield! visitSynType supportTys
@@ -440,38 +436,38 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
                     yield! nodes
                 ]
                 |> continuation)
-        | SynExpr.JoinIn (lhsExpr, _, rhsExpr, _) ->
+        | SynExpr.JoinIn(lhsExpr, _, rhsExpr, _) ->
             let continuations = List.map visit [ lhsExpr; rhsExpr ]
             Continuation.concatenate continuations continuation
         | SynExpr.ImplicitZero _ -> continuation []
-        | SynExpr.SequentialOrImplicitYield (_, expr1, expr2, _, _) ->
+        | SynExpr.SequentialOrImplicitYield(_, expr1, expr2, _, _) ->
             let continuations = List.map visit [ expr1; expr2 ]
             Continuation.concatenate continuations continuation
-        | SynExpr.YieldOrReturn (expr = expr) -> visit expr continuation
-        | SynExpr.YieldOrReturnFrom (expr = expr) -> visit expr continuation
-        | SynExpr.LetOrUseBang (pat = pat; rhs = rhs; andBangs = andBangs; body = body) ->
+        | SynExpr.YieldOrReturn(expr = expr) -> visit expr continuation
+        | SynExpr.YieldOrReturnFrom(expr = expr) -> visit expr continuation
+        | SynExpr.LetOrUseBang(pat = pat; rhs = rhs; andBangs = andBangs; body = body) ->
             let continuations =
-                let andBangExprs = List.map (fun (SynExprAndBang (body = body)) -> body) andBangs
+                let andBangExprs = List.map (fun (SynExprAndBang(body = body)) -> body) andBangs
                 List.map visit (body :: rhs :: andBangExprs)
 
             let finalContinuation nodes =
                 [
                     yield! List.concat nodes
                     yield! visitPat pat
-                    for SynExprAndBang (pat = pat) in andBangs do
+                    for SynExprAndBang(pat = pat) in andBangs do
                         yield! visitPat pat
                 ]
                 |> continuation
 
             Continuation.sequence continuations finalContinuation
-        | SynExpr.MatchBang (expr = expr; clauses = clauses) ->
+        | SynExpr.MatchBang(expr = expr; clauses = clauses) ->
             visit expr (fun exprNodes ->
                 [ yield! exprNodes; yield! List.collect visitSynMatchClause clauses ]
                 |> continuation)
-        | SynExpr.DoBang (expr, _) -> visit expr continuation
-        | SynExpr.WhileBang (whileExpr = whileExpr; doExpr = doExpr) ->
+        | SynExpr.DoBang(expr, _) -> visit expr continuation
+        | SynExpr.WhileBang(whileExpr = whileExpr; doExpr = doExpr) ->
             visit whileExpr (fun whileNodes -> visit doExpr (fun doNodes -> whileNodes @ doNodes |> continuation))
-        | SynExpr.LibraryOnlyILAssembly (typeArgs = typeArgs; args = args; retTy = retTy) ->
+        | SynExpr.LibraryOnlyILAssembly(typeArgs = typeArgs; args = args; retTy = retTy) ->
             let typeNodes = List.collect visitSynType (typeArgs @ retTy)
             let continuations = List.map visit args
 
@@ -479,11 +475,11 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
                 List.concat nodes @ typeNodes |> continuation
 
             Continuation.sequence continuations finalContinuation
-        | SynExpr.LibraryOnlyStaticOptimization (constraints, expr, optimizedExpr, _) ->
+        | SynExpr.LibraryOnlyStaticOptimization(constraints, expr, optimizedExpr, _) ->
             let constraintTypes =
                 constraints
                 |> List.choose (function
-                    | SynStaticOptimizationConstraint.WhenTyparTyconEqualsTycon (rhsType = t) -> Some t
+                    | SynStaticOptimizationConstraint.WhenTyparTyconEqualsTycon(rhsType = t) -> Some t
                     | SynStaticOptimizationConstraint.WhenTyparIsStruct _ -> None)
 
             visit expr (fun eNodes ->
@@ -494,28 +490,28 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
                         yield! oNodes
                     ]
                     |> continuation))
-        | SynExpr.LibraryOnlyUnionCaseFieldGet (expr, longId, _, _) ->
+        | SynExpr.LibraryOnlyUnionCaseFieldGet(expr, longId, _, _) ->
             visit expr (fun eNodes -> visitLongIdent longId @ eNodes |> continuation)
-        | SynExpr.LibraryOnlyUnionCaseFieldSet (expr, longId, _, rhsExpr, _) ->
+        | SynExpr.LibraryOnlyUnionCaseFieldSet(expr, longId, _, rhsExpr, _) ->
             visit expr (fun eNodes ->
                 visit rhsExpr (fun rhsNodes -> [ yield! visitLongIdent longId; yield! eNodes; yield! rhsNodes ] |> continuation))
         | SynExpr.ArbitraryAfterError _ -> continuation []
         | SynExpr.FromParseError _ -> continuation []
         | SynExpr.DiscardAfterMissingQualificationAfterDot _ -> continuation []
-        | SynExpr.Fixed (expr, _) -> visit expr continuation
-        | SynExpr.InterpolatedString (contents = contents) ->
+        | SynExpr.Fixed(expr, _) -> visit expr continuation
+        | SynExpr.InterpolatedString(contents = contents) ->
             let continuations =
                 List.map
                     visit
                     (List.choose
                         (function
-                        | SynInterpolatedStringPart.FillExpr (fillExpr = e) -> Some e
+                        | SynInterpolatedStringPart.FillExpr(fillExpr = e) -> Some e
                         | SynInterpolatedStringPart.String _ -> None)
                         contents)
 
             Continuation.concatenate continuations continuation
         | SynExpr.DebugPoint _ -> continuation []
-        | SynExpr.Dynamic (funcExpr, _, argExpr, _) ->
+        | SynExpr.Dynamic(funcExpr, _, argExpr, _) ->
             let continuations = List.map visit [ funcExpr; argExpr ]
             Continuation.concatenate continuations continuation
 
@@ -524,38 +520,38 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
 let visitPat (p: SynPat) : FileContentEntry list =
     let rec visit (p: SynPat) (continuation: FileContentEntry list -> FileContentEntry list) : FileContentEntry list =
         match p with
-        | SynPat.Paren (pat = pat) -> visit pat continuation
-        | SynPat.Typed (pat = pat; targetType = t) -> visit pat (fun nodes -> nodes @ visitSynType t)
+        | SynPat.Paren(pat = pat) -> visit pat continuation
+        | SynPat.Typed(pat = pat; targetType = t) -> visit pat (fun nodes -> nodes @ visitSynType t)
         | SynPat.Const _ -> continuation []
         | SynPat.Wild _ -> continuation []
         | SynPat.Named _ -> continuation []
-        | SynPat.Attrib (pat, attributes, _) -> visit pat (fun nodes -> visitSynAttributes attributes @ nodes |> continuation)
-        | SynPat.Or (lhsPat, rhsPat, _, _) ->
+        | SynPat.Attrib(pat, attributes, _) -> visit pat (fun nodes -> visitSynAttributes attributes @ nodes |> continuation)
+        | SynPat.Or(lhsPat, rhsPat, _, _) ->
             let continuations = List.map visit [ lhsPat; rhsPat ]
             Continuation.concatenate continuations continuation
-        | SynPat.ListCons (lhsPat, rhsPat, _, _) ->
+        | SynPat.ListCons(lhsPat, rhsPat, _, _) ->
             let continuations = List.map visit [ lhsPat; rhsPat ]
             Continuation.concatenate continuations continuation
-        | SynPat.Ands (pats, _) ->
+        | SynPat.Ands(pats, _) ->
             let continuations = List.map visit pats
             Continuation.concatenate continuations continuation
-        | SynPat.As (lhsPat, rhsPat, _) ->
+        | SynPat.As(lhsPat, rhsPat, _) ->
             let continuations = List.map visit [ lhsPat; rhsPat ]
             Continuation.concatenate continuations continuation
-        | SynPat.LongIdent (longDotId = longDotId; typarDecls = typarDecls; argPats = argPats) ->
+        | SynPat.LongIdent(longDotId = longDotId; typarDecls = typarDecls; argPats = argPats) ->
             continuation
                 [
                     yield! visitSynLongIdent longDotId
                     yield! collectFromOption visitSynValTyparDecls typarDecls
                     yield! visitSynArgPats argPats
                 ]
-        | SynPat.Tuple (elementPats = elementPats) ->
+        | SynPat.Tuple(elementPats = elementPats) ->
             let continuations = List.map visit elementPats
             Continuation.concatenate continuations continuation
-        | SynPat.ArrayOrList (_, elementPats, _) ->
+        | SynPat.ArrayOrList(_, elementPats, _) ->
             let continuations = List.map visit elementPats
             Continuation.concatenate continuations continuation
-        | SynPat.Record (fieldPats, _) ->
+        | SynPat.Record(fieldPats, _) ->
             let pats = List.map (fun (_, _, p) -> p) fieldPats
 
             let lids =
@@ -572,8 +568,8 @@ let visitPat (p: SynPat) : FileContentEntry list =
             Continuation.sequence continuations finalContinuation
         | SynPat.Null _ -> continuation []
         | SynPat.OptionalVal _ -> continuation []
-        | SynPat.IsInst (t, _) -> continuation (visitSynType t)
-        | SynPat.QuoteExpr (expr, _) -> continuation (visitSynExpr expr)
+        | SynPat.IsInst(t, _) -> continuation (visitSynType t)
+        | SynPat.QuoteExpr(expr, _) -> continuation (visitSynExpr expr)
         | SynPat.InstanceMember _ -> continuation []
         | SynPat.FromParseError _ -> continuation []
 
@@ -582,7 +578,7 @@ let visitPat (p: SynPat) : FileContentEntry list =
 let visitSynArgPats (argPat: SynArgPats) =
     match argPat with
     | SynArgPats.Pats args -> List.collect visitPat args
-    | SynArgPats.NamePatPairs (pats = pats) ->
+    | SynArgPats.NamePatPairs(pats = pats) ->
         [
             for _, _, p in pats do
                 yield! visitPat p
@@ -591,21 +587,21 @@ let visitSynArgPats (argPat: SynArgPats) =
 let visitSynSimplePat (pat: SynSimplePat) =
     match pat with
     | SynSimplePat.Id _ -> []
-    | SynSimplePat.Attrib (pat, attributes, _) -> visitSynSimplePat pat @ visitSynAttributes attributes
-    | SynSimplePat.Typed (pat, t, _) -> visitSynSimplePat pat @ visitSynType t
+    | SynSimplePat.Attrib(pat, attributes, _) -> visitSynSimplePat pat @ visitSynAttributes attributes
+    | SynSimplePat.Typed(pat, t, _) -> visitSynSimplePat pat @ visitSynType t
 
 let visitSynSimplePats (pats: SynSimplePats) =
     match pats with
-    | SynSimplePats.SimplePats (pats = pats) -> List.collect visitSynSimplePat pats
+    | SynSimplePats.SimplePats(pats = pats) -> List.collect visitSynSimplePat pats
 
-let visitSynMatchClause (SynMatchClause (pat = pat; whenExpr = whenExpr; resultExpr = resultExpr)) =
+let visitSynMatchClause (SynMatchClause(pat = pat; whenExpr = whenExpr; resultExpr = resultExpr)) =
     [
         yield! visitPat pat
         yield! collectFromOption visitSynExpr whenExpr
         yield! visitSynExpr resultExpr
     ]
 
-let visitBinding (SynBinding (attributes = attributes; headPat = headPat; returnInfo = returnInfo; expr = expr)) : FileContentEntry list =
+let visitBinding (SynBinding(attributes = attributes; headPat = headPat; returnInfo = returnInfo; expr = expr)) : FileContentEntry list =
     [
         yield! visitSynAttributes attributes
         match headPat with
@@ -615,22 +611,22 @@ let visitBinding (SynBinding (attributes = attributes; headPat = headPat; return
         yield! visitSynExpr expr
     ]
 
-let visitSynBindingReturnInfo (SynBindingReturnInfo (typeName = typeName; attributes = attributes)) =
+let visitSynBindingReturnInfo (SynBindingReturnInfo(typeName = typeName; attributes = attributes)) =
     visitSynAttributes attributes @ visitSynType typeName
 
 let visitSynMemberSig (ms: SynMemberSig) : FileContentEntry list =
     match ms with
-    | SynMemberSig.Member (memberSig = memberSig) -> visitSynValSig memberSig
-    | SynMemberSig.Interface (interfaceType, _) -> visitSynType interfaceType
-    | SynMemberSig.Inherit (inheritedType, _) -> visitSynType inheritedType
-    | SynMemberSig.ValField (field, _) -> visitSynField field
+    | SynMemberSig.Member(memberSig = memberSig) -> visitSynValSig memberSig
+    | SynMemberSig.Interface(interfaceType, _) -> visitSynType interfaceType
+    | SynMemberSig.Inherit(inheritedType, _) -> visitSynType inheritedType
+    | SynMemberSig.ValField(field, _) -> visitSynField field
     | SynMemberSig.NestedType _ -> []
 
 let mkFileContent (f: FileInProject) : FileContentEntry list =
     [
         match f.ParsedInput with
-        | ParsedInput.SigFile (ParsedSigFileInput (contents = contents)) ->
-            for SynModuleOrNamespaceSig (longId = longId; kind = kind; decls = decls; attribs = attribs) in contents do
+        | ParsedInput.SigFile(ParsedSigFileInput(contents = contents)) ->
+            for SynModuleOrNamespaceSig(longId = longId; kind = kind; decls = decls; attribs = attribs) in contents do
                 yield! List.collect visitSynAttributeList attribs
 
                 match kind with
@@ -642,8 +638,8 @@ let mkFileContent (f: FileInProject) : FileContentEntry list =
                 | SynModuleOrNamespaceKind.NamedModule ->
                     let path = longIdentToPath true longId
                     yield FileContentEntry.TopLevelNamespace(path, List.collect visitSynModuleSigDecl decls)
-        | ParsedInput.ImplFile (ParsedImplFileInput (contents = contents)) ->
-            for SynModuleOrNamespace (longId = longId; attribs = attribs; kind = kind; decls = decls) in contents do
+        | ParsedInput.ImplFile(ParsedImplFileInput(contents = contents)) ->
+            for SynModuleOrNamespace(longId = longId; attribs = attribs; kind = kind; decls = decls) in contents do
                 yield! List.collect visitSynAttributeList attribs
 
                 match kind with

--- a/src/Compiler/Driver/GraphChecking/Graph.fs
+++ b/src/Compiler/Driver/GraphChecking/Graph.fs
@@ -12,7 +12,7 @@ module internal Graph =
 
     let map (f: 'T -> 'U) (graph: Graph<'T>) : Graph<'U> =
         graph
-        |> Seq.map (fun (KeyValue (node, deps)) -> f node, deps |> Array.map f)
+        |> Seq.map (fun (KeyValue(node, deps)) -> f node, deps |> Array.map f)
         |> make
 
     let addIfMissing<'Node when 'Node: equality> (nodes: 'Node seq) (graph: Graph<'Node>) : Graph<'Node> =
@@ -24,7 +24,7 @@ module internal Graph =
         graph
         |> Seq.toArray
         |> Array.append entriesToAdd
-        |> Array.map (fun (KeyValue (k, v)) -> k, v)
+        |> Array.map (fun (KeyValue(k, v)) -> k, v)
         |> readOnlyDict
 
     let transitive<'Node when 'Node: equality> (graph: Graph<'Node>) : Graph<'Node> =
@@ -51,7 +51,7 @@ module internal Graph =
     let reverse (originalGraph: Graph<'Node>) : Graph<'Node> =
         originalGraph
         // Collect all edges
-        |> Seq.collect (fun (KeyValue (idx, deps)) -> deps |> Array.map (fun dep -> idx, dep))
+        |> Seq.collect (fun (KeyValue(idx, deps)) -> deps |> Array.map (fun dep -> idx, dep))
         // Group dependants of the same dependencies together
         |> Seq.groupBy snd
         // Construct reversed graph
@@ -64,7 +64,7 @@ module internal Graph =
         let join (xs: string[]) = System.String.Join(", ", xs)
 
         graph
-        |> Seq.iter (fun (KeyValue (file, deps)) -> printfn $"{file} -> {deps |> Array.map nodePrinter |> join}")
+        |> Seq.iter (fun (KeyValue(file, deps)) -> printfn $"{file} -> {deps |> Array.map nodePrinter |> join}")
 
     let print (graph: Graph<'Node>) : unit =
         printCustom graph (fun node -> node.ToString())
@@ -76,10 +76,10 @@ module internal Graph =
         appendLine "```mermaid"
         appendLine "flowchart RL"
 
-        for KeyValue ((idx, fileName), _) in graph do
+        for KeyValue((idx, fileName), _) in graph do
             appendLine $"    %i{idx}[\"%s{fileName}\"]"
 
-        for KeyValue ((idx, _), deps) in graph do
+        for KeyValue((idx, _), deps) in graph do
             for depIdx, _depFileName in deps do
                 appendLine $"    %i{idx} --> %i{depIdx}"
 

--- a/src/Compiler/Driver/GraphChecking/GraphProcessing.fs
+++ b/src/Compiler/Driver/GraphChecking/GraphProcessing.fs
@@ -114,7 +114,7 @@ let processGraph<'Item, 'Result when 'Item: equality and 'Item: comparison>
                 let! res = async { processNode node } |> Async.Catch
 
                 match res with
-                | Choice1Of2 () -> ()
+                | Choice1Of2() -> ()
                 | Choice2Of2 ex -> raiseExn (Some(node.Info.Item, ex))
             },
             cts.Token
@@ -150,7 +150,7 @@ let processGraph<'Item, 'Result when 'Item: equality and 'Item: comparison>
     // If we stopped early due to an exception, reraise it.
     match getExn () with
     | None -> ()
-    | Some (item, ex) -> raise (System.Exception($"Encountered exception when processing item '{item}'", ex))
+    | Some(item, ex) -> raise (System.Exception($"Encountered exception when processing item '{item}'", ex))
 
     // All calculations succeeded - extract the results and sort in input order.
     nodes.Values

--- a/src/Compiler/Driver/GraphChecking/TrieMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/TrieMapping.fs
@@ -48,15 +48,15 @@ let isAnyAttributeAutoOpen (attributes: SynAttributes) =
 /// This can happen when a `namespace global` is used, or when a module (with a single ident name) has the `[<AutoOpen>]` attribute.
 let doesFileExposeContentToTheRoot (ast: ParsedInput) : bool =
     match ast with
-    | ParsedInput.SigFile (ParsedSigFileInput (contents = contents)) ->
+    | ParsedInput.SigFile(ParsedSigFileInput(contents = contents)) ->
         contents
-        |> List.exists (fun (SynModuleOrNamespaceSig (attribs = attribs; longId = longId; kind = kind)) ->
+        |> List.exists (fun (SynModuleOrNamespaceSig(attribs = attribs; longId = longId; kind = kind)) ->
             (isAnyAttributeAutoOpen attribs && longId.Length < 2)
             || kind = SynModuleOrNamespaceKind.GlobalNamespace)
 
-    | ParsedInput.ImplFile (ParsedImplFileInput (contents = contents)) ->
+    | ParsedInput.ImplFile(ParsedImplFileInput(contents = contents)) ->
         contents
-        |> List.exists (fun (SynModuleOrNamespace (attribs = attribs; longId = longId; kind = kind)) ->
+        |> List.exists (fun (SynModuleOrNamespace(attribs = attribs; longId = longId; kind = kind)) ->
             (isAnyAttributeAutoOpen attribs && longId.Length < 2)
             || kind = SynModuleOrNamespaceKind.GlobalNamespace)
 
@@ -65,10 +65,9 @@ let rec mergeTrieNodes (accumulatorTrie: TrieNode) (currentTrie: TrieNode) : Tri
     let nextNodeInfo: TrieNodeInfo =
         match accumulatorTrie.Current, currentTrie.Current with
         | TrieNodeInfo.Root accFiles, TrieNodeInfo.Root currentFiles -> TrieNodeInfo.Root(accFiles.Union currentFiles)
-        | TrieNodeInfo.Namespace (name = name
-                                  filesThatExposeTypes = currentFilesThatExposeTypes
-                                  filesDefiningNamespaceWithoutTypes = currentFilesWithoutTypes),
-          TrieNodeInfo.Namespace (filesThatExposeTypes = otherFiles; filesDefiningNamespaceWithoutTypes = otherFilesWithoutTypes) ->
+        | TrieNodeInfo.Namespace(
+            name = name; filesThatExposeTypes = currentFilesThatExposeTypes; filesDefiningNamespaceWithoutTypes = currentFilesWithoutTypes),
+          TrieNodeInfo.Namespace(filesThatExposeTypes = otherFiles; filesDefiningNamespaceWithoutTypes = otherFilesWithoutTypes) ->
             TrieNodeInfo.Namespace(
                 name,
                 currentFilesThatExposeTypes.Union otherFiles,
@@ -76,15 +75,15 @@ let rec mergeTrieNodes (accumulatorTrie: TrieNode) (currentTrie: TrieNode) : Tri
             )
         // Edge case scenario detected in https://github.com/dotnet/fsharp/issues/15985
         // Keep the namespace (as it can still have nested children).
-        | TrieNodeInfo.Namespace (name, currentFilesThatExposeTypes, filesDefiningNamespaceWithoutTypes), TrieNodeInfo.Module (_name, file)
+        | TrieNodeInfo.Namespace(name, currentFilesThatExposeTypes, filesDefiningNamespaceWithoutTypes), TrieNodeInfo.Module(_name, file)
         // Replace the module in favour of the namespace (which can hold nested children).
-        | TrieNodeInfo.Module (_name, file), TrieNodeInfo.Namespace (name, currentFilesThatExposeTypes, filesDefiningNamespaceWithoutTypes) ->
+        | TrieNodeInfo.Module(_name, file), TrieNodeInfo.Namespace(name, currentFilesThatExposeTypes, filesDefiningNamespaceWithoutTypes) ->
             TrieNodeInfo.Namespace(name, currentFilesThatExposeTypes.Add file, filesDefiningNamespaceWithoutTypes)
         | _ -> accumulatorTrie.Current
 
     let nextChildren =
         (accumulatorTrie.Children, currentTrie.Children)
-        ||> Seq.fold (fun accChildren (KeyValue (k, v)) ->
+        ||> Seq.fold (fun accChildren (KeyValue(k, v)) ->
             if not (accChildren.ContainsKey k) then
                 accChildren.Add(k, v)
             else
@@ -207,37 +206,32 @@ let rec mkTrieNodeFor (file: FileInProject) : FileIndex * TrieNode =
     else
         let trie =
             match file.ParsedInput with
-            | ParsedInput.SigFile (ParsedSigFileInput (contents = contents)) ->
+            | ParsedInput.SigFile(ParsedSigFileInput(contents = contents)) ->
                 contents
                 |> List.map
-                    (fun (SynModuleOrNamespaceSig (longId = longId
-                                                   kind = kind
-                                                   attribs = attribs
-                                                   decls = decls
-                                                   accessibility = _accessibility)) ->
+                    (fun
+                        (SynModuleOrNamespaceSig(
+                            longId = longId; kind = kind; attribs = attribs; decls = decls; accessibility = _accessibility)) ->
                         let hasTypesOrAutoOpenNestedModules =
                             decls
                             |> List.exists (function
                                 | SynModuleSigDecl.Types _ -> true
-                                | SynModuleSigDecl.NestedModule(moduleInfo = SynComponentInfo (attributes = attributes)) ->
+                                | SynModuleSigDecl.NestedModule(moduleInfo = SynComponentInfo(attributes = attributes)) ->
                                     isAnyAttributeAutoOpen attributes
                                 | _ -> false)
 
                         processSynModuleOrNamespace mkTrieForSynModuleSigDecl idx longId attribs kind hasTypesOrAutoOpenNestedModules decls)
                 |> List.reduce mergeTrieNodes
-            | ParsedInput.ImplFile (ParsedImplFileInput (contents = contents)) ->
+            | ParsedInput.ImplFile(ParsedImplFileInput(contents = contents)) ->
                 contents
                 |> List.map
-                    (fun (SynModuleOrNamespace (longId = longId
-                                                attribs = attribs
-                                                kind = kind
-                                                decls = decls
-                                                accessibility = _accessibility)) ->
+                    (fun
+                        (SynModuleOrNamespace(longId = longId; attribs = attribs; kind = kind; decls = decls; accessibility = _accessibility)) ->
                         let hasTypesOrAutoOpenNestedModules =
                             List.exists
                                 (function
                                 | SynModuleDecl.Types _ -> true
-                                | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo (attributes = attributes)) ->
+                                | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(attributes = attributes)) ->
                                     isAnyAttributeAutoOpen attributes
                                 | _ -> false)
                                 decls
@@ -249,7 +243,7 @@ let rec mkTrieNodeFor (file: FileInProject) : FileIndex * TrieNode =
 
 and mkTrieForSynModuleDecl (fileIndex: FileIndex) (decl: SynModuleDecl) : KeyValuePair<string, TrieNode> option =
     match decl with
-    | SynModuleDecl.NestedModule (moduleInfo = SynComponentInfo(longId = [ nestedModuleIdent ]); decls = decls) ->
+    | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ nestedModuleIdent ]); decls = decls) ->
         let name = nestedModuleIdent.idText
 
         let children =
@@ -270,7 +264,7 @@ and mkTrieForSynModuleDecl (fileIndex: FileIndex) (decl: SynModuleDecl) : KeyVal
 
 and mkTrieForSynModuleSigDecl (fileIndex: FileIndex) (decl: SynModuleSigDecl) : KeyValuePair<string, TrieNode> option =
     match decl with
-    | SynModuleSigDecl.NestedModule (moduleInfo = SynComponentInfo(longId = [ nestedModuleIdent ]); moduleDecls = decls) ->
+    | SynModuleSigDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ nestedModuleIdent ]); moduleDecls = decls) ->
         let name = nestedModuleIdent.idText
 
         let children =
@@ -316,8 +310,8 @@ let serializeToMermaid (path: string) (filesInProject: FileInProject array) (tri
     let getName (node: TrieNodeInfo) =
         match node with
         | Root _ -> "root"
-        | Module (name, _) -> $"mod_{name}"
-        | Namespace (name, _, _) -> $"ns_{name}"
+        | Module(name, _) -> $"mod_{name}"
+        | Namespace(name, _, _) -> $"ns_{name}"
 
     let toBoxList (boxPos: MermaidBoxPos) (files: ImmutableHashSet<FileIndex>) =
         let sb = StringBuilder()
@@ -343,12 +337,12 @@ let serializeToMermaid (path: string) (filesInProject: FileInProject array) (tri
                 appendLine "class root\n"
             else
                 appendLine $"class root {{\n{firstBox}}}\n"
-        | TrieNodeInfo.Module (_name, file) as md ->
+        | TrieNodeInfo.Module(_name, file) as md ->
             let name = getName md
             let fileName = System.IO.Path.GetFileName(filesInProject[file].FileName)
             appendLine $"{getName parent.Current} <|-- {name}"
             appendLine $"class {name} {{\n    {fileName}[{file}]\n}}\n"
-        | TrieNodeInfo.Namespace (_name, filesThatExposeTypes, filesDefiningNamespaceWithoutTypes) as ns ->
+        | TrieNodeInfo.Namespace(_name, filesThatExposeTypes, filesDefiningNamespaceWithoutTypes) as ns ->
             let name = getName ns
             let firstBox = toBoxList First filesThatExposeTypes
             let secondBox = toBoxList Second filesDefiningNamespaceWithoutTypes

--- a/src/Compiler/Driver/GraphChecking/Types.fs
+++ b/src/Compiler/Driver/GraphChecking/Types.fs
@@ -40,8 +40,8 @@ type internal TrieNodeInfo =
     member x.Files: Set<FileIndex> =
         match x with
         | Root files -> set files
-        | Module (file = file) -> Set.singleton file
-        | Namespace (filesThatExposeTypes = files) -> set files
+        | Module(file = file) -> Set.singleton file
+        | Namespace(filesThatExposeTypes = files) -> set files
 
 type internal TrieNode =
     {

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -73,34 +73,34 @@ let ComputeQualifiedNameOfFileFromUniquePath (m, p: string list) =
 
 let QualFileNameOfSpecs fileName specs =
     match specs with
-    | [ SynModuleOrNamespaceSig (longId = modname; kind = kind; range = m) ] when kind.IsModule ->
+    | [ SynModuleOrNamespaceSig(longId = modname; kind = kind; range = m) ] when kind.IsModule ->
         QualFileNameOfModuleName m fileName modname
-    | [ SynModuleOrNamespaceSig (kind = kind; range = m) ] when not kind.IsModule -> QualFileNameOfFilename m fileName
+    | [ SynModuleOrNamespaceSig(kind = kind; range = m) ] when not kind.IsModule -> QualFileNameOfFilename m fileName
     | _ -> QualFileNameOfFilename (mkRange fileName pos0 pos0) fileName
 
 let QualFileNameOfImpls fileName specs =
     match specs with
-    | [ SynModuleOrNamespace (longId = modname; kind = kind; range = m) ] when kind.IsModule -> QualFileNameOfModuleName m fileName modname
-    | [ SynModuleOrNamespace (kind = kind; range = m) ] when not kind.IsModule -> QualFileNameOfFilename m fileName
+    | [ SynModuleOrNamespace(longId = modname; kind = kind; range = m) ] when kind.IsModule -> QualFileNameOfModuleName m fileName modname
+    | [ SynModuleOrNamespace(kind = kind; range = m) ] when not kind.IsModule -> QualFileNameOfFilename m fileName
     | _ -> QualFileNameOfFilename (mkRange fileName pos0 pos0) fileName
 
 let PrependPathToQualFileName x (QualifiedNameOfFile q) =
     ComputeQualifiedNameOfFileFromUniquePath(q.idRange, pathOfLid x @ [ q.idText ])
 
-let PrependPathToImpl x (SynModuleOrNamespace (longId, isRecursive, kind, decls, xmlDoc, attribs, accessibility, range, trivia)) =
+let PrependPathToImpl x (SynModuleOrNamespace(longId, isRecursive, kind, decls, xmlDoc, attribs, accessibility, range, trivia)) =
     SynModuleOrNamespace(x @ longId, isRecursive, kind, decls, xmlDoc, attribs, accessibility, range, trivia)
 
-let PrependPathToSpec x (SynModuleOrNamespaceSig (longId, isRecursive, kind, decls, xmlDoc, attribs, accessibility, range, trivia)) =
+let PrependPathToSpec x (SynModuleOrNamespaceSig(longId, isRecursive, kind, decls, xmlDoc, attribs, accessibility, range, trivia)) =
     SynModuleOrNamespaceSig(x @ longId, isRecursive, kind, decls, xmlDoc, attribs, accessibility, range, trivia)
 
 let PrependPathToInput x inp =
     match inp with
-    | ParsedInput.ImplFile (ParsedImplFileInput (b, c, q, d, hd, impls, e, trivia, i)) ->
+    | ParsedInput.ImplFile(ParsedImplFileInput(b, c, q, d, hd, impls, e, trivia, i)) ->
         ParsedInput.ImplFile(
             ParsedImplFileInput(b, c, PrependPathToQualFileName x q, d, hd, List.map (PrependPathToImpl x) impls, e, trivia, i)
         )
 
-    | ParsedInput.SigFile (ParsedSigFileInput (b, q, d, hd, specs, trivia, i)) ->
+    | ParsedInput.SigFile(ParsedSigFileInput(b, q, d, hd, specs, trivia, i)) ->
         ParsedInput.SigFile(ParsedSigFileInput(b, PrependPathToQualFileName x q, d, hd, List.map (PrependPathToSpec x) specs, trivia, i))
 
 let IsValidAnonModuleName (modname: string) =
@@ -128,7 +128,7 @@ let FileRequiresModuleOrNamespaceDecl isLast isExe fileName =
 
 let PostParseModuleImpl (_i, defaultNamespace, isLastCompiland, fileName, impl) =
     match impl with
-    | ParsedImplFileFragment.NamedModule (SynModuleOrNamespace (lid, isRec, kind, decls, xmlDoc, attribs, access, m, trivia)) ->
+    | ParsedImplFileFragment.NamedModule(SynModuleOrNamespace(lid, isRec, kind, decls, xmlDoc, attribs, access, m, trivia)) ->
         let lid =
             match lid with
             | [ id ] when kind.IsModule && id.idText = MangledGlobalName ->
@@ -138,7 +138,7 @@ let PostParseModuleImpl (_i, defaultNamespace, isLastCompiland, fileName, impl) 
 
         SynModuleOrNamespace(lid, isRec, kind, decls, xmlDoc, attribs, access, m, trivia)
 
-    | ParsedImplFileFragment.AnonModule (defs, m) ->
+    | ParsedImplFileFragment.AnonModule(defs, m) ->
         let isLast, isExe = isLastCompiland
 
         if FileRequiresModuleOrNamespaceDecl isLast isExe fileName then
@@ -156,7 +156,7 @@ let PostParseModuleImpl (_i, defaultNamespace, isLastCompiland, fileName, impl) 
 
         SynModuleOrNamespace(modname, false, SynModuleOrNamespaceKind.AnonModule, defs, PreXmlDoc.Empty, [], None, m, trivia)
 
-    | ParsedImplFileFragment.NamespaceFragment (lid, isRecursive, kind, decls, xmlDoc, attributes, range, trivia) ->
+    | ParsedImplFileFragment.NamespaceFragment(lid, isRecursive, kind, decls, xmlDoc, attributes, range, trivia) ->
         let lid, kind =
             match lid with
             | id :: rest when id.idText = MangledGlobalName ->
@@ -173,7 +173,7 @@ let PostParseModuleImpl (_i, defaultNamespace, isLastCompiland, fileName, impl) 
 
 let PostParseModuleSpec (_i, defaultNamespace, isLastCompiland, fileName, intf) =
     match intf with
-    | ParsedSigFileFragment.NamedModule (SynModuleOrNamespaceSig (lid, isRec, kind, decls, xmlDoc, attribs, access, m, trivia)) ->
+    | ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(lid, isRec, kind, decls, xmlDoc, attribs, access, m, trivia)) ->
         let lid =
             match lid with
             | [ id ] when kind.IsModule && id.idText = MangledGlobalName ->
@@ -183,7 +183,7 @@ let PostParseModuleSpec (_i, defaultNamespace, isLastCompiland, fileName, intf) 
 
         SynModuleOrNamespaceSig(lid, isRec, SynModuleOrNamespaceKind.NamedModule, decls, xmlDoc, attribs, access, m, trivia)
 
-    | ParsedSigFileFragment.AnonModule (defs, m) ->
+    | ParsedSigFileFragment.AnonModule(defs, m) ->
         let isLast, isExe = isLastCompiland
 
         if FileRequiresModuleOrNamespaceDecl isLast isExe fileName then
@@ -201,7 +201,7 @@ let PostParseModuleSpec (_i, defaultNamespace, isLastCompiland, fileName, intf) 
 
         SynModuleOrNamespaceSig(modname, false, SynModuleOrNamespaceKind.AnonModule, defs, PreXmlDoc.Empty, [], None, m, trivia)
 
-    | ParsedSigFileFragment.NamespaceFragment (lid, isRecursive, kind, decls, xmlDoc, attributes, range, trivia) ->
+    | ParsedSigFileFragment.NamespaceFragment(lid, isRecursive, kind, decls, xmlDoc, attributes, range, trivia) ->
         let lid, kind =
             match lid with
             | id :: rest when id.idText = MangledGlobalName ->
@@ -219,11 +219,11 @@ let PostParseModuleSpec (_i, defaultNamespace, isLastCompiland, fileName, intf) 
 let GetScopedPragmasForHashDirective hd =
     [
         match hd with
-        | ParsedHashDirective ("nowarn", numbers, m) ->
+        | ParsedHashDirective("nowarn", numbers, m) ->
             for s in numbers do
                 match s with
                 | ParsedHashDirectiveArgument.SourceIdentifier _ -> ()
-                | ParsedHashDirectiveArgument.String (s, _, _) ->
+                | ParsedHashDirectiveArgument.String(s, _, _) ->
                     match GetWarningNumber(m, s) with
                     | None -> ()
                     | Some n -> ScopedPragma.WarningOff(m, n)
@@ -244,7 +244,7 @@ let PostParseModuleImpls
         defaultNamespace,
         fileName,
         isLastCompiland,
-        ParsedImplFile (hashDirectives, impls),
+        ParsedImplFile(hashDirectives, impls),
         lexbuf: UnicodeLexing.Lexbuf,
         tripleSlashComments: range list,
         identifiers: Set<string>
@@ -253,7 +253,7 @@ let PostParseModuleImpls
         impls
         |> List.rev
         |> List.tryPick (function
-            | ParsedImplFileFragment.NamedModule (SynModuleOrNamespace (longId = lid)) -> Some lid
+            | ParsedImplFileFragment.NamedModule(SynModuleOrNamespace(longId = lid)) -> Some lid
             | _ -> None)
 
     match othersWithSameName with
@@ -269,10 +269,10 @@ let PostParseModuleImpls
 
     let scopedPragmas =
         [
-            for SynModuleOrNamespace (decls = decls) in impls do
+            for SynModuleOrNamespace(decls = decls) in impls do
                 for d in decls do
                     match d with
-                    | SynModuleDecl.HashDirective (hd, _) -> yield! GetScopedPragmasForHashDirective hd
+                    | SynModuleDecl.HashDirective(hd, _) -> yield! GetScopedPragmasForHashDirective hd
                     | _ -> ()
             for hd in hashDirectives do
                 yield! GetScopedPragmasForHashDirective hd
@@ -296,7 +296,7 @@ let PostParseModuleSpecs
         defaultNamespace,
         fileName,
         isLastCompiland,
-        ParsedSigFile (hashDirectives, specs),
+        ParsedSigFile(hashDirectives, specs),
         lexbuf: UnicodeLexing.Lexbuf,
         tripleSlashComments: range list,
         identifiers: Set<string>
@@ -305,7 +305,7 @@ let PostParseModuleSpecs
         specs
         |> List.rev
         |> List.tryPick (function
-            | ParsedSigFileFragment.NamedModule (SynModuleOrNamespaceSig (longId = lid)) -> Some lid
+            | ParsedSigFileFragment.NamedModule(SynModuleOrNamespaceSig(longId = lid)) -> Some lid
             | _ -> None)
 
     match othersWithSameName with
@@ -320,10 +320,10 @@ let PostParseModuleSpecs
 
     let scopedPragmas =
         [
-            for SynModuleOrNamespaceSig (decls = decls) in specs do
+            for SynModuleOrNamespaceSig(decls = decls) in specs do
                 for d in decls do
                     match d with
-                    | SynModuleSigDecl.HashDirective (hd, _) -> yield! GetScopedPragmasForHashDirective hd
+                    | SynModuleSigDecl.HashDirective(hd, _) -> yield! GetScopedPragmasForHashDirective hd
                     | _ -> ()
             for hd in hashDirectives do
                 yield! GetScopedPragmasForHashDirective hd
@@ -383,7 +383,7 @@ let DeduplicateModuleName (moduleNamesDict: ModuleNamesDict) fileName (qualNameO
 let DeduplicateParsedInputModuleName (moduleNamesDict: ModuleNamesDict) input =
     match input with
     | ParsedInput.ImplFile implFile ->
-        let (ParsedImplFileInput (fileName, isScript, qualNameOfFile, scopedPragmas, hashDirectives, modules, flags, trivia, identifiers)) =
+        let (ParsedImplFileInput(fileName, isScript, qualNameOfFile, scopedPragmas, hashDirectives, modules, flags, trivia, identifiers)) =
             implFile
 
         let qualNameOfFileR, moduleNamesDictR =
@@ -395,7 +395,7 @@ let DeduplicateParsedInputModuleName (moduleNamesDict: ModuleNamesDict) input =
         let inputR = ParsedInput.ImplFile implFileR
         inputR, moduleNamesDictR
     | ParsedInput.SigFile sigFile ->
-        let (ParsedSigFileInput (fileName, qualNameOfFile, scopedPragmas, hashDirectives, modules, trivia, identifiers)) =
+        let (ParsedSigFileInput(fileName, qualNameOfFile, scopedPragmas, hashDirectives, modules, trivia, identifiers)) =
             sigFile
 
         let qualNameOfFileR, moduleNamesDictR =
@@ -539,7 +539,7 @@ let ShowAllTokensAndExit (tokenizer: Tokenizer, lexbuf: LexBuffer<char>, exiter:
 let TestInteractionParserAndExit (tokenizer: Tokenizer, lexbuf: LexBuffer<char>, exiter: Exiter) =
     while true do
         match (Parser.interaction (fun _ -> tokenizer ()) lexbuf) with
-        | ParsedScriptInteraction.Definitions (l, m) -> printfn "Parsed OK, got %d defs @ %a" l.Length outputRange m
+        | ParsedScriptInteraction.Definitions(l, m) -> printfn "Parsed OK, got %d defs @ %a" l.Length outputRange m
 
     exiter.Exit 0
 
@@ -548,17 +548,17 @@ let ReportParsingStatistics res =
     let rec flattenSpecs specs =
         specs
         |> List.collect (function
-            | SynModuleSigDecl.NestedModule (moduleDecls = subDecls) -> flattenSpecs subDecls
+            | SynModuleSigDecl.NestedModule(moduleDecls = subDecls) -> flattenSpecs subDecls
             | spec -> [ spec ])
 
     let rec flattenDefns specs =
         specs
         |> List.collect (function
-            | SynModuleDecl.NestedModule (decls = subDecls) -> flattenDefns subDecls
+            | SynModuleDecl.NestedModule(decls = subDecls) -> flattenDefns subDecls
             | defn -> [ defn ])
 
-    let flattenModSpec (SynModuleOrNamespaceSig (decls = decls)) = flattenSpecs decls
-    let flattenModImpl (SynModuleOrNamespace (decls = decls)) = flattenDefns decls
+    let flattenModSpec (SynModuleOrNamespaceSig(decls = decls)) = flattenSpecs decls
+    let flattenModImpl (SynModuleOrNamespace(decls = decls)) = flattenDefns decls
 
     match res with
     | ParsedInput.SigFile sigFile -> printfn "parsing yielded %d specs" (List.collect flattenModSpec sigFile.Contents).Length
@@ -888,7 +888,7 @@ let ProcessMetaCommandsFromInput
 
         try
             match hash with
-            | ParsedHashDirective ("I", ParsedHashDirectiveArguments args, m) ->
+            | ParsedHashDirective("I", ParsedHashDirectiveArguments args, m) ->
                 if not canHaveScriptMetaCommands then
                     errorR (HashIncludeNotAllowedInNonScript m)
 
@@ -900,18 +900,18 @@ let ProcessMetaCommandsFromInput
                 | _ ->
                     errorR (Error(FSComp.SR.buildInvalidHashIDirective (), m))
                     state
-            | ParsedHashDirective ("nowarn", ParsedHashDirectiveArguments numbers, m) ->
+            | ParsedHashDirective("nowarn", ParsedHashDirectiveArguments numbers, m) ->
                 List.fold (fun state d -> nowarnF state (m, d)) state numbers
 
-            | ParsedHashDirective (("reference" | "r"), ParsedHashDirectiveArguments args, m) ->
+            | ParsedHashDirective(("reference" | "r"), ParsedHashDirectiveArguments args, m) ->
                 matchedm <- m
                 ProcessDependencyManagerDirective Directive.Resolution args m state
 
-            | ParsedHashDirective ("i", ParsedHashDirectiveArguments args, m) ->
+            | ParsedHashDirective("i", ParsedHashDirectiveArguments args, m) ->
                 matchedm <- m
                 ProcessDependencyManagerDirective Directive.Include args m state
 
-            | ParsedHashDirective ("load", ParsedHashDirectiveArguments args, m) ->
+            | ParsedHashDirective("load", ParsedHashDirectiveArguments args, m) ->
                 if not canHaveScriptMetaCommands then
                     errorR (HashDirectiveNotAllowedInNonScript m)
 
@@ -922,7 +922,7 @@ let ProcessMetaCommandsFromInput
                 | _ -> errorR (Error(FSComp.SR.buildInvalidHashloadDirective (), m))
 
                 state
-            | ParsedHashDirective ("time", ParsedHashDirectiveArguments args, m) ->
+            | ParsedHashDirective("time", ParsedHashDirectiveArguments args, m) ->
                 if not canHaveScriptMetaCommands then
                     errorR (HashDirectiveNotAllowedInNonScript m)
 
@@ -945,36 +945,36 @@ let ProcessMetaCommandsFromInput
         decls
         |> List.iter (fun d ->
             match d with
-            | SynModuleSigDecl.HashDirective (_, m) -> warning (Error(FSComp.SR.buildDirectivesInModulesAreIgnored (), m))
-            | SynModuleSigDecl.NestedModule (moduleDecls = subDecls) -> WarnOnIgnoredSpecDecls subDecls
+            | SynModuleSigDecl.HashDirective(_, m) -> warning (Error(FSComp.SR.buildDirectivesInModulesAreIgnored (), m))
+            | SynModuleSigDecl.NestedModule(moduleDecls = subDecls) -> WarnOnIgnoredSpecDecls subDecls
             | _ -> ())
 
     let rec WarnOnIgnoredImplDecls decls =
         decls
         |> List.iter (fun d ->
             match d with
-            | SynModuleDecl.HashDirective (_, m) -> warning (Error(FSComp.SR.buildDirectivesInModulesAreIgnored (), m))
-            | SynModuleDecl.NestedModule (decls = subDecls) -> WarnOnIgnoredImplDecls subDecls
+            | SynModuleDecl.HashDirective(_, m) -> warning (Error(FSComp.SR.buildDirectivesInModulesAreIgnored (), m))
+            | SynModuleDecl.NestedModule(decls = subDecls) -> WarnOnIgnoredImplDecls subDecls
             | _ -> ())
 
-    let ProcessMetaCommandsFromModuleSpec state (SynModuleOrNamespaceSig (decls = decls)) =
+    let ProcessMetaCommandsFromModuleSpec state (SynModuleOrNamespaceSig(decls = decls)) =
         List.fold
             (fun s d ->
                 match d with
-                | SynModuleSigDecl.HashDirective (h, _) -> ProcessMetaCommand s h
-                | SynModuleSigDecl.NestedModule (moduleDecls = subDecls) ->
+                | SynModuleSigDecl.HashDirective(h, _) -> ProcessMetaCommand s h
+                | SynModuleSigDecl.NestedModule(moduleDecls = subDecls) ->
                     WarnOnIgnoredSpecDecls subDecls
                     s
                 | _ -> s)
             state
             decls
 
-    let ProcessMetaCommandsFromModuleImpl state (SynModuleOrNamespace (decls = decls)) =
+    let ProcessMetaCommandsFromModuleImpl state (SynModuleOrNamespace(decls = decls)) =
         List.fold
             (fun s d ->
                 match d with
-                | SynModuleDecl.HashDirective (h, _) -> ProcessMetaCommand s h
-                | SynModuleDecl.NestedModule (decls = subDecls) ->
+                | SynModuleDecl.HashDirective(h, _) -> ProcessMetaCommand s h
+                | SynModuleDecl.NestedModule(decls = subDecls) ->
                     WarnOnIgnoredImplDecls subDecls
                     s
                 | _ -> s)
@@ -1045,25 +1045,25 @@ let GetInitialTcEnv (assemblyName: string, initm: range, tcConfig: TcConfig, tcI
 /// Inject faults into checking
 let CheckSimulateException (tcConfig: TcConfig) =
     match tcConfig.simulateException with
-    | Some ("tc-oom") -> raise (OutOfMemoryException())
-    | Some ("tc-an") -> raise (ArgumentNullException("simulated"))
-    | Some ("tc-invop") -> raise (InvalidOperationException())
-    | Some ("tc-av") -> raise (AccessViolationException())
-    | Some ("tc-nfn") -> raise (NotFiniteNumberException())
-    | Some ("tc-aor") -> raise (ArgumentOutOfRangeException())
-    | Some ("tc-dv0") -> raise (DivideByZeroException())
-    | Some ("tc-oe") -> raise (OverflowException())
-    | Some ("tc-atmm") -> raise (ArrayTypeMismatchException())
-    | Some ("tc-bif") -> raise (BadImageFormatException())
-    | Some ("tc-knf") -> raise (KeyNotFoundException())
-    | Some ("tc-ior") -> raise (IndexOutOfRangeException())
-    | Some ("tc-ic") -> raise (InvalidCastException())
-    | Some ("tc-ip") -> raise (InvalidProgramException())
-    | Some ("tc-ma") -> raise (MemberAccessException())
-    | Some ("tc-ni") -> raise (NotImplementedException())
-    | Some ("tc-nr") -> raise (NullReferenceException())
-    | Some ("tc-oc") -> raise (OperationCanceledException())
-    | Some ("tc-fail") -> failwith "simulated"
+    | Some("tc-oom") -> raise (OutOfMemoryException())
+    | Some("tc-an") -> raise (ArgumentNullException("simulated"))
+    | Some("tc-invop") -> raise (InvalidOperationException())
+    | Some("tc-av") -> raise (AccessViolationException())
+    | Some("tc-nfn") -> raise (NotFiniteNumberException())
+    | Some("tc-aor") -> raise (ArgumentOutOfRangeException())
+    | Some("tc-dv0") -> raise (DivideByZeroException())
+    | Some("tc-oe") -> raise (OverflowException())
+    | Some("tc-atmm") -> raise (ArrayTypeMismatchException())
+    | Some("tc-bif") -> raise (BadImageFormatException())
+    | Some("tc-knf") -> raise (KeyNotFoundException())
+    | Some("tc-ior") -> raise (IndexOutOfRangeException())
+    | Some("tc-ic") -> raise (InvalidCastException())
+    | Some("tc-ip") -> raise (InvalidProgramException())
+    | Some("tc-ma") -> raise (MemberAccessException())
+    | Some("tc-ni") -> raise (NotImplementedException())
+    | Some("tc-nr") -> raise (NullReferenceException())
+    | Some("tc-oc") -> raise (OperationCanceledException())
+    | Some("tc-fail") -> failwith "simulated"
     | _ -> ()
 
 //----------------------------------------------------------------------------
@@ -1484,7 +1484,8 @@ let CheckOneInputWithCallback
       tcSink,
       tcState: TcState,
       inp: ParsedInput,
-      _skipImplIfSigExists: bool): (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcResultsSink * TcState * ParsedInput * bool)
+      _skipImplIfSigExists: bool):
+        (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcResultsSink * TcState * ParsedInput * bool)
     : Cancellable<Finisher<NodeToTypeCheck, TcState, PartialResult>> =
     cancellable {
         try
@@ -1591,7 +1592,14 @@ let CheckOneInputWithCallback
 
                             let ccuSigForFile, fsTcState =
                                 AddCheckResultsToTcState
-                                    (tcGlobals, amap, false, prefixPathOpt, tcSink, tcState.tcsTcImplEnv, qualNameOfFile, implFile.Signature)
+                                    (tcGlobals,
+                                     amap,
+                                     false,
+                                     prefixPathOpt,
+                                     tcSink,
+                                     tcState.tcsTcImplEnv,
+                                     qualNameOfFile,
+                                     implFile.Signature)
                                     tcState
 
                             let partialResult = tcEnvAtEnd, topAttrs, Some implFile, ccuSigForFile
@@ -1703,7 +1711,7 @@ module private TypeCheckingGraphProcessing =
             (getProcessedNode: NodeToTypeCheck -> ProcessedNode<NodeToTypeCheck, State * Finisher<NodeToTypeCheck, State, FinalFileResult>>)
             (node: NodeInfo<NodeToTypeCheck>)
             : State * Finisher<NodeToTypeCheck, State, FinalFileResult> =
-            let folder (state: State) (Finisher (finisher = finisher)) : State = finisher state |> snd
+            let folder (state: State) (Finisher(finisher = finisher)) : State = finisher state |> snd
             let deps = node.Deps |> Array.except [| node.Item |] |> Array.map getProcessedNode
 
             let transitiveDeps =
@@ -1719,14 +1727,14 @@ module private TypeCheckingGraphProcessing =
 
         let results = processGraph graph workWrapper ct
 
-        let finalFileResults, state: (int * FinalFileResult) list * State =
+        let finalFileResults, state =
             (([], emptyState),
              results
              |> Array.choose (fun (item, res) ->
                  match item with
                  | NodeToTypeCheck.ArtificialImplFile _ -> None
                  | NodeToTypeCheck.PhysicalFile file -> Some(file, res)))
-            ||> Array.fold (fun (fileResults, state) (item, (_, Finisher (finisher = finisher))) ->
+            ||> Array.fold (fun (fileResults, state) (item, (_, Finisher(finisher = finisher))) ->
                 let fileResult, state = finisher state
                 (item, fileResult) :: fileResults, state)
 
@@ -1734,7 +1742,16 @@ module private TypeCheckingGraphProcessing =
 
 /// Constructs a file dependency graph and type-checks the files in parallel where possible.
 let CheckMultipleInputsUsingGraphMode
-    ((ctok, checkForErrors, tcConfig: TcConfig, tcImports: TcImports, tcGlobals, prefixPathOpt, tcState, eagerFormat, inputs): 'a * (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcState * (PhasedDiagnostic -> PhasedDiagnostic) * ParsedInput list)
+    ((ctok, checkForErrors, tcConfig: TcConfig, tcImports: TcImports, tcGlobals, prefixPathOpt, tcState, eagerFormat, inputs):
+        'a *
+        (unit -> bool) *
+        TcConfig *
+        TcImports *
+        TcGlobals *
+        LongIdent option *
+        TcState *
+        (PhasedDiagnostic -> PhasedDiagnostic) *
+        ParsedInput list)
     : FinalFileResult list * TcState =
     use cts = new CancellationTokenSource()
 
@@ -1775,7 +1792,7 @@ let CheckMultipleInputsUsingGraphMode
 
         // Transform the graph to include ArtificialImplFile nodes when necessary.
         graph
-        |> Seq.collect (fun (KeyValue (fileIdx, deps)) ->
+        |> Seq.collect (fun (KeyValue(fileIdx, deps)) ->
             if filePairs.IsSignature fileIdx then
                 // Add an additional ArtificialImplFile node for the signature file.
                 [|
@@ -1844,7 +1861,7 @@ let CheckMultipleInputsUsingGraphMode
         let checkForErrors2 () = priorErrors || (logger.ErrorCount > 0)
         let tcSink = TcResultsSink.NoSink
 
-        let (Finisher (finisher = finisher)) =
+        let (Finisher(finisher = finisher)) =
             CheckOneInputWithCallback
                 node
                 (checkForErrors2, tcConfig, tcImports, tcGlobals, prefixPathOpt, tcSink, currentTcState, input, false)

--- a/src/Compiler/Driver/ScriptClosure.fs
+++ b/src/Compiler/Driver/ScriptClosure.fs
@@ -218,7 +218,7 @@ module ScriptPreprocessClosure =
 
                 diagnosticsLogger.Diagnostics
 
-            | Some (rs, diagnostics) ->
+            | Some(rs, diagnostics) ->
                 for m, reference in rs do
                     tcConfigB.AddReferencedAssemblyByPath(m, reference)
 
@@ -250,7 +250,7 @@ module ScriptPreprocessClosure =
             use reader =
                 match inputCodePage with
                 | None -> new StreamReader(stream, true)
-                | Some (n: int) -> new StreamReader(stream, Encoding.GetEncoding n)
+                | Some(n: int) -> new StreamReader(stream, Encoding.GetEncoding n)
 
             let source = reader.ReadToEnd()
             [ ClosureSource(fileName, m, SourceText.ofString source, parseRequired) ]
@@ -443,7 +443,7 @@ module ScriptPreprocessClosure =
                     tcConfig <- TcConfig.Create(tcConfigB, validate = false)
             ]
 
-        and processClosureSource (ClosureSource (fileName, m, sourceText, parseRequired)) =
+        and processClosureSource (ClosureSource(fileName, m, sourceText, parseRequired)) =
             [
                 if not (observedSources.HaveSeen(fileName)) then
                     observedSources.SetSeen(fileName)
@@ -509,13 +509,13 @@ module ScriptPreprocessClosure =
 
     /// Mark the last file as isLastCompiland.
     let MarkLastCompiland (tcConfig: TcConfig, lastClosureFile) =
-        let (ClosureFile (fileName, m, lastParsedInput, parseDiagnostics, metaDiagnostics, nowarns)) =
+        let (ClosureFile(fileName, m, lastParsedInput, parseDiagnostics, metaDiagnostics, nowarns)) =
             lastClosureFile
 
         match lastParsedInput with
-        | Some (ParsedInput.ImplFile lastParsedImplFile) ->
+        | Some(ParsedInput.ImplFile lastParsedImplFile) ->
 
-            let (ParsedImplFileInput (name, isScript, qualNameOfFile, scopedPragmas, hashDirectives, implFileFlags, _, trivia, identifiers)) =
+            let (ParsedImplFileInput(name, isScript, qualNameOfFile, scopedPragmas, hashDirectives, implFileFlags, _, trivia, identifiers)) =
                 lastParsedImplFile
 
             let isLastCompiland = (true, tcConfig.target.IsExe)
@@ -546,18 +546,18 @@ module ScriptPreprocessClosure =
         let closureFiles =
             match List.tryFrontAndBack closureFiles with
             | None -> closureFiles
-            | Some (rest, lastClosureFile) ->
+            | Some(rest, lastClosureFile) ->
                 let lastClosureFileR = MarkLastCompiland(tcConfig, lastClosureFile)
                 rest @ [ lastClosureFileR ]
 
         // Get all source files.
         let sourceFiles =
-            [ for ClosureFile (fileName, m, _, _, _, _) in closureFiles -> (fileName, m) ]
+            [ for ClosureFile(fileName, m, _, _, _, _) in closureFiles -> (fileName, m) ]
 
         let sourceInputs =
             [
                 for closureFile in closureFiles ->
-                    let (ClosureFile (fileName, _, input, parseDiagnostics, metaDiagnostics, _nowarns)) =
+                    let (ClosureFile(fileName, _, input, parseDiagnostics, metaDiagnostics, _nowarns)) =
                         closureFile
 
                     let closureInput: LoadClosureInput =
@@ -573,7 +573,7 @@ module ScriptPreprocessClosure =
 
         let globalNoWarns =
             closureFiles
-            |> List.collect (fun (ClosureFile (_, _, _, _, _, noWarns)) -> noWarns)
+            |> List.collect (fun (ClosureFile(_, _, _, _, _, noWarns)) -> noWarns)
 
         // Resolve all references.
         let references, unresolvedReferences, resolutionDiagnostics =
@@ -590,7 +590,7 @@ module ScriptPreprocessClosure =
         // Root errors and warnings - look at the last item in the closureFiles list
         let loadClosureRootDiagnostics, allRootDiagnostics =
             match List.rev closureFiles with
-            | ClosureFile (_, _, _, parseDiagnostics, metaDiagnostics, _) :: _ ->
+            | ClosureFile(_, _, _, parseDiagnostics, metaDiagnostics, _) :: _ ->
                 (earlierDiagnostics @ metaDiagnostics @ resolutionDiagnostics),
                 (parseDiagnostics @ earlierDiagnostics @ metaDiagnostics @ resolutionDiagnostics)
             | _ -> [], [] // When no file existed.

--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -89,7 +89,7 @@ type DiagnosticsLoggerUpToMaxErrors(tcConfigB: TcConfigBuilder, exiter: Exiter, 
             errors <- errors + 1
 
             match diagnostic.Exception, tcConfigB.simulateException with
-            | InternalError (msg, _), None
+            | InternalError(msg, _), None
             | Failure msg, None -> Debug.Assert(false, sprintf "Bug in compiler: %s\n%s" msg (diagnostic.Exception.ToString()))
             | :? KeyNotFoundException, None ->
                 Debug.Assert(false, sprintf "Lookup exception in compiler: %s" (diagnostic.Exception.ToString()))
@@ -330,7 +330,7 @@ module InterfaceFileWriter =
                 printVerboseSignatures = true
             }
 
-        let writeToFile os (CheckedImplFile (contents = mexpr)) =
+        let writeToFile os (CheckedImplFile(contents = mexpr)) =
             let text =
                 NicePrint.layoutImpliedSignatureOfModuleOrNamespace true denv infoReader AccessibleFromSomewhere range0 mexpr
                 |> Display.squashTo 80
@@ -371,7 +371,7 @@ module InterfaceFileWriter =
                 ".fsi"
 
         let writeToSeparateFiles (declaredImpls: CheckedImplFile list) =
-            for CheckedImplFile (qualifiedNameOfFile = name) as impl in declaredImpls do
+            for CheckedImplFile(qualifiedNameOfFile = name) as impl in declaredImpls do
                 let fileName =
                     Path.ChangeExtension(name.Range.FileName, extensionForFile name.Range.FileName)
 
@@ -710,20 +710,20 @@ let main1
 /// Second phase of compilation.
 ///   - Write the signature file, check some attributes
 let main2
-    (Args (ctok,
-           tcGlobals,
-           tcImports: TcImports,
-           frameworkTcImports,
-           generatedCcu: CcuThunk,
-           typedImplFiles,
-           topAttrs,
-           tcConfig: TcConfig,
-           outfile,
-           pdbfile,
-           assemblyName,
-           diagnosticsLogger,
-           exiter: Exiter,
-           ilSourceDocs))
+    (Args(ctok,
+          tcGlobals,
+          tcImports: TcImports,
+          frameworkTcImports,
+          generatedCcu: CcuThunk,
+          typedImplFiles,
+          topAttrs,
+          tcConfig: TcConfig,
+          outfile,
+          pdbfile,
+          assemblyName,
+          diagnosticsLogger,
+          exiter: Exiter,
+          ilSourceDocs))
     =
     if tcConfig.typeCheckOnly then
         exiter.Exit 0
@@ -742,7 +742,7 @@ let main2
     let diagnosticsLogger =
         let scopedPragmas =
             [
-                for CheckedImplFile (pragmas = pragmas) in typedImplFiles do
+                for CheckedImplFile(pragmas = pragmas) in typedImplFiles do
                     yield! pragmas
             ]
 
@@ -815,22 +815,22 @@ let main2
 ///   - optimize
 ///   - encode optimization data
 let main3
-    (Args (ctok,
-           tcConfig,
-           tcImports,
-           frameworkTcImports: TcImports,
-           tcGlobals,
-           diagnosticsLogger: DiagnosticsLogger,
-           generatedCcu: CcuThunk,
-           outfile,
-           typedImplFiles,
-           topAttrs,
-           pdbfile,
-           assemblyName,
-           assemVerFromAttrib,
-           signingInfo,
-           exiter: Exiter,
-           ilSourceDocs))
+    (Args(ctok,
+          tcConfig,
+          tcImports,
+          frameworkTcImports: TcImports,
+          tcGlobals,
+          diagnosticsLogger: DiagnosticsLogger,
+          generatedCcu: CcuThunk,
+          outfile,
+          typedImplFiles,
+          topAttrs,
+          pdbfile,
+          assemblyName,
+          assemVerFromAttrib,
+          signingInfo,
+          exiter: Exiter,
+          ilSourceDocs))
     =
     // Encode the signature data
     ReportTime tcConfig "Encode Interface Data"
@@ -949,26 +949,26 @@ let main3
 ///   -  IL code generation
 let main4
     (tcImportsCapture, dynamicAssemblyCreator)
-    (Args (ctok,
-           tcConfig: TcConfig,
-           tcImports,
-           tcGlobals: TcGlobals,
-           diagnosticsLogger,
-           generatedCcu: CcuThunk,
-           outfile,
-           optimizedImpls,
-           topAttrs,
-           pdbfile,
-           assemblyName,
-           sigDataAttributes,
-           sigDataResources,
-           optDataResources,
-           assemVerFromAttrib,
-           signingInfo,
-           metadataVersion,
-           exiter: Exiter,
-           ilSourceDocs,
-           refAssemblySignatureHash))
+    (Args(ctok,
+          tcConfig: TcConfig,
+          tcImports,
+          tcGlobals: TcGlobals,
+          diagnosticsLogger,
+          generatedCcu: CcuThunk,
+          outfile,
+          optimizedImpls,
+          topAttrs,
+          pdbfile,
+          assemblyName,
+          sigDataAttributes,
+          sigDataResources,
+          optDataResources,
+          assemVerFromAttrib,
+          signingInfo,
+          metadataVersion,
+          exiter: Exiter,
+          ilSourceDocs,
+          refAssemblySignatureHash))
     =
     match tcImportsCapture with
     | None -> ()
@@ -1058,19 +1058,19 @@ let main4
 /// Fifth phase of compilation.
 ///   -  static linking
 let main5
-    (Args (ctok,
-           tcConfig,
-           tcImports,
-           tcGlobals,
-           diagnosticsLogger: DiagnosticsLogger,
-           staticLinker,
-           outfile,
-           pdbfile,
-           ilxMainModule,
-           signingInfo,
-           exiter: Exiter,
-           ilSourceDocs,
-           refAssemblySignatureHash))
+    (Args(ctok,
+          tcConfig,
+          tcImports,
+          tcGlobals,
+          diagnosticsLogger: DiagnosticsLogger,
+          staticLinker,
+          outfile,
+          pdbfile,
+          ilxMainModule,
+          signingInfo,
+          exiter: Exiter,
+          ilSourceDocs,
+          refAssemblySignatureHash))
     =
 
     use _ = UseBuildPhase BuildPhase.Output
@@ -1105,18 +1105,18 @@ let main5
 ///   -  write the binaries
 let main6
     dynamicAssemblyCreator
-    (Args (ctok,
-           tcConfig,
-           tcImports: TcImports,
-           tcGlobals: TcGlobals,
-           diagnosticsLogger: DiagnosticsLogger,
-           ilxMainModule,
-           outfile,
-           pdbfile,
-           signingInfo,
-           exiter: Exiter,
-           ilSourceDocs,
-           refAssemblySignatureHash))
+    (Args(ctok,
+          tcConfig,
+          tcImports: TcImports,
+          tcGlobals: TcGlobals,
+          diagnosticsLogger: DiagnosticsLogger,
+          ilxMainModule,
+          outfile,
+          pdbfile,
+          signingInfo,
+          exiter: Exiter,
+          ilSourceDocs,
+          refAssemblySignatureHash))
     =
     ReportTime tcConfig "Write .NET Binary"
 

--- a/src/Compiler/Facilities/BuildGraph.fs
+++ b/src/Compiler/Facilities/BuildGraph.fs
@@ -29,7 +29,7 @@ type Async<'T> with
 
     static member AwaitNodeCode(node: NodeCode<'T>) =
         match node with
-        | Node (computation) -> wrapThreadStaticInfo computation
+        | Node(computation) -> wrapThreadStaticInfo computation
 
 [<Sealed>]
 type NodeCodeBuilder() =
@@ -44,7 +44,7 @@ type NodeCodeBuilder() =
         Node(
             async.Delay(fun () ->
                 match f () with
-                | Node (p) -> p)
+                | Node(p) -> p)
         )
 
     [<DebuggerHidden; DebuggerStepThrough>]
@@ -54,7 +54,7 @@ type NodeCodeBuilder() =
     member _.ReturnFrom(computation: NodeCode<_>) = computation
 
     [<DebuggerHidden; DebuggerStepThrough>]
-    member _.Bind(Node (p): NodeCode<'a>, binder: 'a -> NodeCode<'b>) : NodeCode<'b> =
+    member _.Bind(Node(p): NodeCode<'a>, binder: 'a -> NodeCode<'b>) : NodeCode<'b> =
         Node(
             async.Bind(
                 p,
@@ -65,7 +65,7 @@ type NodeCodeBuilder() =
         )
 
     [<DebuggerHidden; DebuggerStepThrough>]
-    member _.TryWith(Node (p): NodeCode<'T>, binder: exn -> NodeCode<'T>) : NodeCode<'T> =
+    member _.TryWith(Node(p): NodeCode<'T>, binder: exn -> NodeCode<'T>) : NodeCode<'T> =
         Node(
             async.TryWith(
                 p,
@@ -76,7 +76,7 @@ type NodeCodeBuilder() =
         )
 
     [<DebuggerHidden; DebuggerStepThrough>]
-    member _.TryFinally(Node (p): NodeCode<'T>, binder: unit -> unit) : NodeCode<'T> = Node(async.TryFinally(p, binder))
+    member _.TryFinally(Node(p): NodeCode<'T>, binder: unit -> unit) : NodeCode<'T> = Node(async.TryFinally(p, binder))
 
     [<DebuggerHidden; DebuggerStepThrough>]
     member _.For(xs: 'T seq, binder: 'T -> NodeCode<unit>) : NodeCode<unit> =
@@ -90,7 +90,7 @@ type NodeCodeBuilder() =
         )
 
     [<DebuggerHidden; DebuggerStepThrough>]
-    member _.Combine(Node (p1): NodeCode<unit>, Node (p2): NodeCode<'T>) : NodeCode<'T> = Node(async.Combine(p1, p2))
+    member _.Combine(Node(p1): NodeCode<unit>, Node(p2): NodeCode<'T>) : NodeCode<'T> = Node(async.Combine(p1, p2))
 
     [<DebuggerHidden; DebuggerStepThrough>]
     member _.Using(value: CompilationGlobalsScope, binder: CompilationGlobalsScope -> NodeCode<'U>) =
@@ -261,7 +261,7 @@ type GraphNode<'T> private (computation: NodeCode<'T>, cachedResult: ValueOption
                         | ValueSome value -> return value
                         | _ ->
                             let tcs = TaskCompletionSource<'T>()
-                            let (Node (p)) = computation
+                            let (Node(p)) = computation
 
                             Async.StartWithContinuations(
                                 async {

--- a/src/Compiler/Facilities/CompilerLocation.fs
+++ b/src/Compiler/Facilities/CompilerLocation.fs
@@ -41,7 +41,8 @@ module internal FSharpEnvironment =
     let FSharpBinaryMetadataFormatRevision = "2.0.0.0"
 
     let isRunningOnCoreClr =
-        typeof<obj>.Assembly.FullName.StartsWith ("System.Private.CoreLib", StringComparison.InvariantCultureIgnoreCase)
+        typeof<obj>.Assembly.FullName
+            .StartsWith("System.Private.CoreLib", StringComparison.InvariantCultureIgnoreCase)
 
     module Option =
         /// Convert string into Option string where null and String.Empty result in None
@@ -181,7 +182,7 @@ module internal FSharpEnvironment =
             seq {
                 match path with
                 | None -> ()
-                | Some (p: string) ->
+                | Some(p: string) ->
                     match Path.GetDirectoryName(p) with
                     | s when s = "" || s = null || Path.GetFileName(p) = "packages" || s = p -> ()
                     | parentDir -> yield! searchParentDirChain (Some parentDir) assemblyName

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -27,7 +27,7 @@ type DiagnosticStyle =
 exception WrappedError of exn * range with
     override this.Message =
         match this :> exn with
-        | WrappedError (exn, _) -> "WrappedError(" + exn.Message + ")"
+        | WrappedError(exn, _) -> "WrappedError(" + exn.Message + ")"
         | _ -> "WrappedError"
 
 /// Thrown when immediate, local error recovery is not possible. This indicates
@@ -43,13 +43,13 @@ exception ReportedError of exn option with
             "The exception has been reported. This internal exception should now be caught at an error recovery point on the stack."
 
         match this :> exn with
-        | ReportedError (Some exn) -> msg + " Original message: " + exn.Message + ")"
+        | ReportedError(Some exn) -> msg + " Original message: " + exn.Message + ")"
         | _ -> msg
 
 let rec findOriginalException err =
     match err with
-    | ReportedError (Some err) -> err
-    | WrappedError (err, _) -> findOriginalException err
+    | ReportedError(Some err) -> err
+    | WrappedError(err, _) -> findOriginalException err
     | _ -> err
 
 type Suggestions = (string -> unit) -> unit
@@ -63,7 +63,7 @@ exception StopProcessingExn of exn option with
 
     override this.ToString() =
         match this :> exn with
-        | StopProcessingExn (Some exn) -> "StopProcessingExn, originally (" + exn.ToString() + ")"
+        | StopProcessingExn(Some exn) -> "StopProcessingExn, originally (" + exn.ToString() + ")"
         | _ -> "StopProcessingExn"
 
 let (|StopProcessing|_|) exn =
@@ -77,24 +77,24 @@ let StopProcessing<'T> = StopProcessingExn None
 exception DiagnosticWithText of number: int * message: string * range: range with
     override this.Message =
         match this :> exn with
-        | DiagnosticWithText (_, msg, _) -> msg
+        | DiagnosticWithText(_, msg, _) -> msg
         | _ -> "impossible"
 
 exception InternalError of message: string * range: range with
     override this.Message =
         match this :> exn with
-        | InternalError (msg, m) -> msg + m.ToString()
+        | InternalError(msg, m) -> msg + m.ToString()
         | _ -> "impossible"
 
 exception InternalException of exn: Exception * msg: string * range: range with
     override this.Message =
         match this :> exn with
-        | InternalException (_, msg, _) -> msg
+        | InternalException(_, msg, _) -> msg
         | _ -> "impossible"
 
     override this.ToString() =
         match this :> exn with
-        | InternalException (exn, _, _) -> exn.ToString()
+        | InternalException(exn, _, _) -> exn.ToString()
         | _ -> "impossible"
 
 exception UserCompilerMessage of message: string * number: int * range: range
@@ -114,7 +114,7 @@ exception UnresolvedReferenceError of assemblyName: string * range: range
 exception UnresolvedPathReferenceNoRange of assemblyName: string * path: string with
     override this.Message =
         match this :> exn with
-        | UnresolvedPathReferenceNoRange (assemblyName, path) -> sprintf "Assembly: %s, full path: %s" assemblyName path
+        | UnresolvedPathReferenceNoRange(assemblyName, path) -> sprintf "Assembly: %s, full path: %s" assemblyName path
         | _ -> "impossible"
 
 exception UnresolvedPathReference of assemblyName: string * path: string * range: range
@@ -122,7 +122,7 @@ exception UnresolvedPathReference of assemblyName: string * path: string * range
 exception DiagnosticWithSuggestions of number: int * message: string * range: range * identifier: string * suggestions: Suggestions with // int is e.g. 191 in FS0191
     override this.Message =
         match this :> exn with
-        | DiagnosticWithSuggestions (_, msg, _, _, _) -> msg
+        | DiagnosticWithSuggestions(_, msg, _, _, _) -> msg
         | _ -> "impossible"
 
 /// A diagnostic that is raised when enabled manually, or by default with a language feature
@@ -155,7 +155,7 @@ let inline protectAssemblyExplorationF dflt ([<InlineIfLambda>] f) =
     try
         f ()
     with
-    | UnresolvedPathReferenceNoRange (asmName, path) -> dflt (asmName, path)
+    | UnresolvedPathReferenceNoRange(asmName, path) -> dflt (asmName, path)
     | _ -> reraise ()
 
 let inline protectAssemblyExplorationNoReraise dflt1 dflt2 ([<InlineIfLambda>] f) =
@@ -174,7 +174,7 @@ let rec AttachRange m (exn: exn) =
         // Strip TargetInvocationException wrappers
         | :? TargetInvocationException -> AttachRange m exn.InnerException
         | UnresolvedReferenceNoRange a -> UnresolvedReferenceError(a, m)
-        | UnresolvedPathReferenceNoRange (a, p) -> UnresolvedPathReference(a, p, m)
+        | UnresolvedPathReferenceNoRange(a, p) -> UnresolvedPathReference(a, p, m)
         | :? NotSupportedException -> exn
         | :? SystemException -> InternalException(exn, exn.Message, m)
         | _ -> exn
@@ -415,7 +415,8 @@ module DiagnosticsLoggerExtensions =
         try
             if not tryAndDetectDev15 then
                 let preserveStackTrace =
-                    typeof<Exception>.GetMethod ("InternalPreserveStackTrace", BindingFlags.Instance ||| BindingFlags.NonPublic)
+                    typeof<Exception>
+                        .GetMethod("InternalPreserveStackTrace", BindingFlags.Instance ||| BindingFlags.NonPublic)
 
                 preserveStackTrace.Invoke(exn, null) |> ignore
         with _ ->
@@ -427,8 +428,8 @@ module DiagnosticsLoggerExtensions =
 
         member x.EmitDiagnostic(exn, severity) =
             match exn with
-            | InternalError (s, _)
-            | InternalException (_, s, _)
+            | InternalError(s, _)
+            | InternalException(_, s, _)
             | Failure s as exn -> Debug.Assert(false, sprintf "Unexpected exception raised in compiler: %s\n%s" s (exn.ToString()))
             | _ -> ()
 
@@ -462,11 +463,11 @@ module DiagnosticsLoggerExtensions =
             match exn with
             // Don't send ThreadAbortException down the error channel
             | :? System.Threading.ThreadAbortException
-            | WrappedError (:? System.Threading.ThreadAbortException, _) -> ()
+            | WrappedError(:? System.Threading.ThreadAbortException, _) -> ()
             | ReportedError _
-            | WrappedError (ReportedError _, _) -> ()
+            | WrappedError(ReportedError _, _) -> ()
             | StopProcessing
-            | WrappedError (StopProcessing, _) ->
+            | WrappedError(StopProcessing, _) ->
                 PreserveStackTrace exn
                 raise exn
             | _ ->
@@ -474,7 +475,7 @@ module DiagnosticsLoggerExtensions =
                     x.ErrorR(AttachRange m exn) // may raise exceptions, e.g. an fsi error sink raises StopProcessing.
                 with
                 | ReportedError _
-                | WrappedError (ReportedError _, _) -> ()
+                | WrappedError(ReportedError _, _) -> ()
 
         member x.StopProcessingRecovery (exn: exn) (m: range) =
             // Do standard error recovery.
@@ -483,15 +484,15 @@ module DiagnosticsLoggerExtensions =
             // Can throw other exceptions raised by the DiagnosticSink(exn) handler.
             match exn with
             | StopProcessing
-            | WrappedError (StopProcessing, _) -> () // suppress, so skip error recovery.
+            | WrappedError(StopProcessing, _) -> () // suppress, so skip error recovery.
             | _ ->
                 try
                     x.ErrorRecovery exn m
                 with
                 | StopProcessing
-                | WrappedError (StopProcessing, _) -> () // catch, e.g. raised by DiagnosticSink.
+                | WrappedError(StopProcessing, _) -> () // catch, e.g. raised by DiagnosticSink.
                 | ReportedError _
-                | WrappedError (ReportedError _, _) -> () // catch, but not expected unless ErrorRecovery is changed.
+                | WrappedError(ReportedError _, _) -> () // catch, but not expected unless ErrorRecovery is changed.
 
         member x.ErrorRecoveryNoRange(exn: exn) = x.ErrorRecovery exn range0
 
@@ -633,10 +634,10 @@ let ReportWarnings warns =
 
 let CommitOperationResult res =
     match res with
-    | OkResult (warns, res) ->
+    | OkResult(warns, res) ->
         ReportWarnings warns
         res
-    | ErrorResult (warns, err) ->
+    | ErrorResult(warns, err) ->
         ReportWarnings warns
         error err
 
@@ -652,18 +653,18 @@ let inline ResultD x = OkResult([], x)
 
 let CheckNoErrorsAndGetWarnings res =
     match res with
-    | OkResult (warns, res2) -> Some(warns, res2)
+    | OkResult(warns, res2) -> Some(warns, res2)
     | ErrorResult _ -> None
 
 [<DebuggerHidden; DebuggerStepThrough>]
 let inline bind f res =
     match res with
-    | OkResult ([], res) -> (* tailcall *) f res
-    | OkResult (warns, res) ->
+    | OkResult([], res) -> (* tailcall *) f res
+    | OkResult(warns, res) ->
         match f res with
-        | OkResult (warns2, res2) -> OkResult(warns @ warns2, res2)
-        | ErrorResult (warns2, err) -> ErrorResult(warns @ warns2, err)
-    | ErrorResult (warns, err) -> ErrorResult(warns, err)
+        | OkResult(warns2, res2) -> OkResult(warns @ warns2, res2)
+        | ErrorResult(warns2, err) -> ErrorResult(warns @ warns2, err)
+    | ErrorResult(warns, err) -> ErrorResult(warns, err)
 
 /// Stop on first error. Accumulate warnings and continue.
 [<DebuggerHidden; DebuggerStepThrough>]
@@ -730,7 +731,7 @@ let rec Iterate2D f xs ys =
 [<DebuggerHidden; DebuggerStepThrough>]
 let TryD f g =
     match f () with
-    | ErrorResult (warns, err) ->
+    | ErrorResult(warns, err) ->
         trackErrors {
             do! OkResult(warns, ())
             return! g err
@@ -768,8 +769,8 @@ let inline MapReduce2D mapper zero reducer xs ys =
 module OperationResult =
     let inline ignore (res: OperationResult<'a>) =
         match res with
-        | OkResult (warnings, _) -> OkResult(warnings, ())
-        | ErrorResult (warnings, err) -> ErrorResult(warnings, err)
+        | OkResult(warnings, _) -> OkResult(warnings, ())
+        | ErrorResult(warnings, err) -> ErrorResult(warnings, err)
 
 // Code below is for --flaterrors flag that is only used by the IDE
 let stringThatIsAProxyForANewlineInFlatErrors = String [| char 29 |]

--- a/src/Compiler/Facilities/TextLayoutRender.fs
+++ b/src/Compiler/Facilities/TextLayoutRender.fs
@@ -104,13 +104,13 @@ module LayoutRender =
             match layout with
             | ObjLeaf _ -> failwith "ObjLeaf should never appear here"
             (* pos is tab level *)
-            | Leaf (_, text, _) -> k (rr.AddText z text, i + text.Text.Length)
-            | Node (l, r, Broken indent) ->
+            | Leaf(_, text, _) -> k (rr.AddText z text, i + text.Text.Length)
+            | Node(l, r, Broken indent) ->
                 addL z pos i l
                 <| fun (z, _i) ->
                     let z, i = rr.AddBreak z (pos + indent), (pos + indent)
                     addL z (pos + indent) i r k
-            | Node (l, r, _) ->
+            | Node(l, r, _) ->
                 let jm = Layout.JuxtapositionMiddle(l, r)
 
                 addL z pos i l
@@ -118,7 +118,7 @@ module LayoutRender =
                     let z, i = if jm then z, i else rr.AddText z TaggedText.space, i + 1
                     let pos = i
                     addL z pos i r k
-            | Attr (tag, attrs, l) ->
+            | Attr(tag, attrs, l) ->
                 let z = rr.AddTag z (tag, attrs, true)
 
                 addL z pos i l

--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -199,12 +199,7 @@ type internal Position =
 type internal LexBufferFiller<'Char> = LexBuffer<'Char> -> unit
 
 and [<Sealed>] internal LexBuffer<'Char>
-    (
-        filler: LexBufferFiller<'Char>,
-        reportLibraryOnlyFeatures: bool,
-        langVersion: LanguageVersion,
-        strictIndentation: bool option
-    ) =
+    (filler: LexBufferFiller<'Char>, reportLibraryOnlyFeatures: bool, langVersion: LanguageVersion, strictIndentation: bool option) =
     let context = Dictionary<string, obj>(1)
     let mutable buffer = [||]
     /// number of valid characters beyond bufferScanStart.
@@ -339,7 +334,9 @@ and [<Sealed>] internal LexBuffer<'Char>
     // Important: this method does copy the array
     static member FromArray(reportLibraryOnlyFeatures, langVersion, strictIndentation, s: 'Char[]) : LexBuffer<'Char> =
         let buffer = Array.copy s
-        LexBuffer<'Char>.FromArrayNoCopy (reportLibraryOnlyFeatures, langVersion, strictIndentation, buffer)
+
+        LexBuffer<'Char>
+            .FromArrayNoCopy(reportLibraryOnlyFeatures, langVersion, strictIndentation, buffer)
 
     // Important: This method takes ownership of the array
     static member FromChars(reportLibraryOnlyFeatures, langVersion, strictIndentation, arr: char[]) =
@@ -348,23 +345,25 @@ and [<Sealed>] internal LexBuffer<'Char>
     static member FromSourceText(reportLibraryOnlyFeatures, langVersion, strictIndentation, sourceText: ISourceText) =
         let mutable currentSourceIndex = 0
 
-        LexBuffer<char>.FromFunction
-            (reportLibraryOnlyFeatures,
-             langVersion,
-             strictIndentation,
-             fun (chars, start, length) ->
-                 let lengthToCopy =
-                     if currentSourceIndex + length <= sourceText.Length then
-                         length
-                     else
-                         sourceText.Length - currentSourceIndex
+        LexBuffer<char>
+            .FromFunction(
+                reportLibraryOnlyFeatures,
+                langVersion,
+                strictIndentation,
+                fun (chars, start, length) ->
+                    let lengthToCopy =
+                        if currentSourceIndex + length <= sourceText.Length then
+                            length
+                        else
+                            sourceText.Length - currentSourceIndex
 
-                 if lengthToCopy <= 0 then
-                     0
-                 else
-                     sourceText.CopyTo(currentSourceIndex, chars, start, lengthToCopy)
-                     currentSourceIndex <- currentSourceIndex + lengthToCopy
-                     lengthToCopy)
+                    if lengthToCopy <= 0 then
+                        0
+                    else
+                        sourceText.CopyTo(currentSourceIndex, chars, start, lengthToCopy)
+                        currentSourceIndex <- currentSourceIndex + lengthToCopy
+                        lengthToCopy
+            )
 
 module GenericImplFragments =
     let startInterpret (lexBuffer: LexBuffer<char>) =

--- a/src/Compiler/Facilities/prim-parsing.fs
+++ b/src/Compiler/Facilities/prim-parsing.fs
@@ -14,13 +14,7 @@ exception Accept of obj
 
 [<Sealed>]
 type internal IParseState
-    (
-        ruleStartPoss: Position[],
-        ruleEndPoss: Position[],
-        lhsPos: Position[],
-        ruleValues: obj[],
-        lexbuf: LexBuffer<char>
-    ) =
+    (ruleStartPoss: Position[], ruleEndPoss: Position[], lhsPos: Position[], ruleValues: obj[], lexbuf: LexBuffer<char>) =
     member _.LexBuffer = lexbuf
 
     member _.InputRange index =
@@ -281,8 +275,8 @@ module internal Implementation =
         let cacheSize = 7919 // the 1000'th prime
         // Use a simpler hash table with faster lookup, but only one
         // hash bucket per key.
-        let actionTableCache = ArrayPool<int>.Shared.Rent (cacheSize * 2)
-        let gotoTableCache = ArrayPool<int>.Shared.Rent (cacheSize * 2)
+        let actionTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
+        let gotoTableCache = ArrayPool<int>.Shared.Rent(cacheSize * 2)
         // Clear the arrays since ArrayPool does not
         Array.Clear(actionTableCache, 0, actionTableCache.Length)
         Array.Clear(gotoTableCache, 0, gotoTableCache.Length)
@@ -336,7 +330,7 @@ module internal Implementation =
                 actionKind action = shiftFlag
                 && (match tokenOpt with
                     | None -> true
-                    | Some (token) ->
+                    | Some(token) ->
                         let nextState = actionValue action
                         actionKind (actionTable.Read(nextState, tables.tagOfToken (token))) = shiftFlag)
             then

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -296,11 +296,7 @@ type internal FsiTimeReporter(outWriter: TextWriter) =
 /// Manages the emit of one logical assembly into multiple assemblies. Gives warnings
 /// on cross-fragment internal access.
 type ILMultiInMemoryAssemblyEmitEnv
-    (
-        ilg: ILGlobals,
-        resolveAssemblyRef: ILAssemblyRef -> Choice<string, Assembly> option,
-        dynamicCcuName: string
-    ) =
+    (ilg: ILGlobals, resolveAssemblyRef: ILAssemblyRef -> Choice<string, Assembly> option, dynamicCcuName: string) =
 
     let typeMap = Dictionary<ILTypeRef, Type * ILTypeRef>(HashIdentity.Structural)
     let reverseTypeMap = Dictionary<ILTypeRef, ILTypeRef>(HashIdentity.Structural)
@@ -316,8 +312,8 @@ type ILMultiInMemoryAssemblyEmitEnv
 
         match aref.PublicKey with
         | None -> ()
-        | Some (PublicKey bytes) -> asmName.SetPublicKey bytes
-        | Some (PublicKeyToken bytes) -> asmName.SetPublicKeyToken bytes
+        | Some(PublicKey bytes) -> asmName.SetPublicKey bytes
+        | Some(PublicKeyToken bytes) -> asmName.SetPublicKeyToken bytes
 
         match aref.Version with
         | None -> ()
@@ -330,12 +326,12 @@ type ILMultiInMemoryAssemblyEmitEnv
     let convResolveAssemblyRef (asmref: ILAssemblyRef) qualifiedName =
         let assembly =
             match resolveAssemblyRef asmref with
-            | Some (Choice1Of2 path) ->
+            | Some(Choice1Of2 path) ->
                 // asmRef is a path but the runtime is smarter with assembly names so make one
                 let asmName = AssemblyName.GetAssemblyName(path)
                 asmName.CodeBase <- path
                 FileSystem.AssemblyLoader.AssemblyLoad asmName
-            | Some (Choice2Of2 assembly) -> assembly
+            | Some(Choice2Of2 assembly) -> assembly
             | None ->
                 let asmName = convAssemblyRef asmref
                 FileSystem.AssemblyLoader.AssemblyLoad asmName
@@ -393,7 +389,7 @@ type ILMultiInMemoryAssemblyEmitEnv
     and convTypeAux ty =
         match ty with
         | ILType.Void -> Type.GetType("System.Void")
-        | ILType.Array (shape, eltType) ->
+        | ILType.Array(shape, eltType) ->
             let baseT = convTypeAux eltType
 
             if shape.Rank = 1 then
@@ -409,7 +405,7 @@ type ILMultiInMemoryAssemblyEmitEnv
             let baseT = convTypeAux eltType
             baseT.MakeByRefType()
         | ILType.TypeVar _tv -> failwith "open generic type"
-        | ILType.Modified (_, _, modifiedTy) -> convTypeAux modifiedTy
+        | ILType.Modified(_, _, modifiedTy) -> convTypeAux modifiedTy
         | ILType.FunctionPointer _callsig -> failwith "convType: fptr"
 
     /// Map the given ILTypeRef to the appropriate assembly fragment
@@ -609,7 +605,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, outWriter: Te
                 let makeListL itemLs =
                     (leftL (TaggedText.tagText "["))
                     ^^ sepListL (rightL (TaggedText.tagText ";")) itemLs
-                       ^^ (rightL (TaggedText.tagText "]"))
+                    ^^ (rightL (TaggedText.tagText "]"))
 
                 Some(wordL (TaggedText.tagText "dict") --- makeListL itemLs)
             finally
@@ -630,7 +626,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, outWriter: Te
                 [
                     for x in fsi.AddedPrinters do
                         match x with
-                        | Choice1Of2 (aty: Type, printer) ->
+                        | Choice1Of2(aty: Type, printer) ->
                             yield
                                 (fun _ienv (obj: obj) ->
                                     match obj with
@@ -643,7 +639,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, outWriter: Te
                                         | _ -> Some(wordL (TaggedText.tagText text))
                                     | _ -> None)
 
-                        | Choice2Of2 (aty: Type, converter) ->
+                        | Choice2Of2(aty: Type, converter) ->
                             yield
                                 (fun ienv (obj: obj) ->
                                     match obj with
@@ -667,7 +663,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, outWriter: Te
     /// Get the evaluation context used when inverting the storage mapping of the ILDynamicAssemblyWriter.
     member _.GetEvaluationContext(emEnv: ILAssemblyEmitEnv) =
         match emEnv with
-        | SingleRefEmitAssembly (cenv, emEnv) ->
+        | SingleRefEmitAssembly(cenv, emEnv) ->
             {
                 LookupTypeRef = LookupTypeRef cenv emEnv
                 LookupType = LookupType cenv emEnv
@@ -749,7 +745,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, outWriter: Te
 
             match res with
             | None -> None
-            | Some (obj, objTy) ->
+            | Some(obj, objTy) ->
                 let lay = valuePrinter.PrintValue(FsiValuePrinterMode.PrintDecl, opts, obj, objTy)
                 if isEmptyL lay then None else Some lay // suppress empty layout
 
@@ -772,7 +768,7 @@ type internal FsiValuePrinter(fsi: FsiEvaluationSessionHostConfig, outWriter: Te
         let rhsL =
             match res with
             | None -> None
-            | Some (obj, objTy) ->
+            | Some(obj, objTy) ->
                 let lay = valuePrinter.PrintValue(FsiValuePrinterMode.PrintExpr, opts, obj, objTy)
                 if isEmptyL lay then None else Some lay // suppress empty layout
 
@@ -889,11 +885,7 @@ type internal FsiConsoleOutput(tcConfigB, outWriter: TextWriter, errorWriter: Te
 
 /// This DiagnosticsLogger reports all warnings, but raises StopProcessing on first error or early exit
 type internal DiagnosticsLoggerThatStopsOnFirstError
-    (
-        tcConfigB: TcConfigBuilder,
-        fsiStdinSyphon: FsiStdinSyphon,
-        fsiConsoleOutput: FsiConsoleOutput
-    ) =
+    (tcConfigB: TcConfigBuilder, fsiStdinSyphon: FsiStdinSyphon, fsiConsoleOutput: FsiConsoleOutput) =
     inherit DiagnosticsLogger("DiagnosticsLoggerThatStopsOnFirstError")
     let mutable errorCount = 0
 
@@ -1079,7 +1071,7 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig, argv: s
                                 interact <- false (* --exec, exit after eval *)
                                 [] (* no arguments passed on, all consumed here *)
 
-                                )
+                            )
                         ),
                         None,
                         None
@@ -1189,7 +1181,8 @@ type internal FsiCommandLineOptions(fsi: FsiEvaluationSessionHostConfig, argv: s
         try
             let fsiCompilerOptions =
                 fsiUsagePrefix tcConfigB
-                @ GetCoreFsiCompilerOptions tcConfigB @ fsiUsageSuffix tcConfigB
+                @ GetCoreFsiCompilerOptions tcConfigB
+                @ fsiUsageSuffix tcConfigB
 
             let abbrevArgs = GetAbbrevFlagSet tcConfigB false
             ParseCompilerOptions(collect, fsiCompilerOptions, List.tail (PostProcessCompilerArgs abbrevArgs argv))
@@ -1344,7 +1337,7 @@ let internal SetServerCodePages (fsiOptions: FsiCommandLineOptions) =
                 do
                     match inputCodePageOpt with
                     | None -> ()
-                    | Some (n: int) ->
+                    | Some(n: int) ->
                         let encoding = Encoding.GetEncoding(n)
                         // Note this modifies the real honest-to-goodness settings for the current shell.
                         // and the modifications hang around even after the process has exited.
@@ -1353,7 +1346,7 @@ let internal SetServerCodePages (fsiOptions: FsiCommandLineOptions) =
                 do
                     match outputCodePageOpt with
                     | None -> ()
-                    | Some (n: int) ->
+                    | Some(n: int) ->
                         let encoding = Encoding.GetEncoding n
                         // Note this modifies the real honest-to-goodness settings for the current shell.
                         // and the modifications hang around even after the process has exited.
@@ -1420,12 +1413,7 @@ type internal FsiConsolePrompt(fsiOptions: FsiCommandLineOptions, fsiConsoleOutp
 // Startup processing
 //----------------------------------------------------------------------------
 type internal FsiConsoleInput
-    (
-        fsi: FsiEvaluationSessionHostConfig,
-        fsiOptions: FsiCommandLineOptions,
-        inReader: TextReader,
-        outWriter: TextWriter
-    ) =
+    (fsi: FsiEvaluationSessionHostConfig, fsiOptions: FsiCommandLineOptions, inReader: TextReader, outWriter: TextWriter) =
 
     let consoleOpt =
         // The "console.fs" code does a limited form of "TAB-completion".
@@ -1570,7 +1558,7 @@ let rec ConvReflectionTypeToILType (reflectionTy: Type) =
 
             if
                 ctors.Length = 1
-                && ctors[ 0 ].GetCustomAttribute<CompilerGeneratedAttribute>() <> null
+                && ctors[0].GetCustomAttribute<CompilerGeneratedAttribute>() <> null
                 && not ctors[0].IsPublic
                 && IsCompilerGeneratedName reflectionTy.Name
             then
@@ -1988,7 +1976,7 @@ type internal FsiDynamicCompiler
 
         let emEnv, execs =
             match emEnv with
-            | SingleRefEmitAssembly (cenv, emEnv) ->
+            | SingleRefEmitAssembly(cenv, emEnv) ->
 
                 let assemblyBuilder, moduleBuilder = builders.Value
 
@@ -2017,7 +2005,7 @@ type internal FsiDynamicCompiler
 
         // Explicitly register the resources with the QuotationPickler module
         match emEnv with
-        | SingleRefEmitAssembly (cenv, emEnv) ->
+        | SingleRefEmitAssembly(cenv, emEnv) ->
 
             let assemblyBuilder, _moduleBuilder = builders.Value
 
@@ -2085,7 +2073,7 @@ type internal FsiDynamicCompiler
             // 'Open' the path for the fragment we just compiled for any future printing.
             let denv = denv.AddOpenPath(pathOfLid prefixPath)
 
-            for CheckedImplFile (contents = mexpr) in declaredImpls do
+            for CheckedImplFile(contents = mexpr) in declaredImpls do
                 let responseL =
                     NicePrint.layoutImpliedSignatureOfModuleOrNamespace false denv infoReader AccessibleFromSomewhere m mexpr
 
@@ -2156,21 +2144,21 @@ type internal FsiDynamicCompiler
 
     /// Check FSI entries for the presence of EntryPointAttribute and issue a warning if it's found
     let CheckEntryPoint (tcGlobals: TcGlobals) (declaredImpls: CheckedImplFile list) =
-        let tryGetEntryPoint (TBind (var = value)) =
+        let tryGetEntryPoint (TBind(var = value)) =
             TryFindFSharpAttribute tcGlobals tcGlobals.attrib_EntryPointAttribute value.Attribs
             |> Option.map (fun attrib -> value.DisplayName, attrib)
 
         let rec findEntryPointInContents =
             function
-            | TMDefLet (binding = binding) -> tryGetEntryPoint binding
+            | TMDefLet(binding = binding) -> tryGetEntryPoint binding
             | TMDefs defs -> defs |> List.tryPick findEntryPointInContents
-            | TMDefRec (bindings = bindings) -> bindings |> List.tryPick findEntryPointInBinding
+            | TMDefRec(bindings = bindings) -> bindings |> List.tryPick findEntryPointInBinding
             | _ -> None
 
         and findEntryPointInBinding =
             function
             | ModuleOrNamespaceBinding.Binding binding -> tryGetEntryPoint binding
-            | ModuleOrNamespaceBinding.Module (moduleOrNamespaceContents = contents) -> findEntryPointInContents contents
+            | ModuleOrNamespaceBinding.Module(moduleOrNamespaceContents = contents) -> findEntryPointInContents contents
 
         let entryPointBindings =
             declaredImpls
@@ -2253,7 +2241,7 @@ type internal FsiDynamicCompiler
 
     let tryGetGeneratedValue istate cenv v =
         match istate.ilxGenerator.LookupGeneratedValue(valuePrinter.GetEvaluationContext(istate.emEnv), v) with
-        | Some (res, ty) -> Some(FsiValue(res, ty, FSharpType(cenv, v.Type)))
+        | Some(res, ty) -> Some(FsiValue(res, ty, FSharpType(cenv, v.Type)))
         | _ -> None
 
     let nextFragmentId () =
@@ -2277,13 +2265,13 @@ type internal FsiDynamicCompiler
 
             // Skip the "FSI_NNNN"
             match contentFile.Declarations with
-            | [ FSharpImplementationFileDeclaration.Entity (_eFakeModule, modDecls) ] ->
+            | [ FSharpImplementationFileDeclaration.Entity(_eFakeModule, modDecls) ] ->
                 let cenv =
                     SymbolEnv(istate.tcGlobals, istate.tcState.Ccu, Some istate.tcState.CcuSig, istate.tcImports)
 
                 for decl in modDecls do
                     match decl with
-                    | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (v, _, _) ->
+                    | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue(v, _, _) ->
                         // Report a top-level function or value definition
                         if v.IsModuleValueOrMember && not v.IsMember then
                             let fsiValueOpt =
@@ -2317,7 +2305,7 @@ type internal FsiDynamicCompiler
 
                             fsi.TriggerEvaluation(fsiValueOpt, symbolUse, decl)
 
-                    | FSharpImplementationFileDeclaration.Entity (e, _) ->
+                    | FSharpImplementationFileDeclaration.Entity(e, _) ->
                         // Report a top-level module or namespace definition
                         let symbol = FSharpSymbol.Create(cenv, e.Item)
 
@@ -2547,7 +2535,7 @@ type internal FsiDynamicCompiler
 
             let fsiValue =
                 match optValue with
-                | Some (res, ty) ->
+                | Some(res, ty) ->
                     Some(FsiValue(res, ty, FSharpType(tcGlobals, istate.tcState.Ccu, istate.tcState.CcuSig, istate.tcImports, vref.Type)))
                 | _ -> None
 
@@ -2695,7 +2683,7 @@ type internal FsiDynamicCompiler
 
             (istate, tcConfigB.packageManagerLines)
             ||> Seq.fold (fun istate kv ->
-                let (KeyValue (packageManagerKey, packageManagerLines)) = kv
+                let (KeyValue(packageManagerKey, packageManagerLines)) = kv
 
                 match packageManagerLines with
                 | [] -> istate
@@ -3114,11 +3102,7 @@ type internal FsiInterruptControllerKillerThreadRequest =
     | PrintInterruptRequest
 
 type internal FsiInterruptController
-    (
-        fsiOptions: FsiCommandLineOptions,
-        controlledExecution: ControlledExecution,
-        fsiConsoleOutput: FsiConsoleOutput
-    ) =
+    (fsiOptions: FsiCommandLineOptions, controlledExecution: ControlledExecution, fsiConsoleOutput: FsiConsoleOutput) =
 
     let mutable stdinInterruptState = StdinNormal
     let CTRL_C = 0
@@ -3339,7 +3323,7 @@ type internal MagicAssemblyResolution() =
                                     )
 
                                 match searchResult with
-                                | OkResult (warns, [ r ]) -> OkResult(warns, Choice1Of2 r.resolvedPath)
+                                | OkResult(warns, [ r ]) -> OkResult(warns, Choice1Of2 r.resolvedPath)
                                 | _ ->
 
                                     // OK, try to resolve as a .exe
@@ -3351,7 +3335,7 @@ type internal MagicAssemblyResolution() =
                                         )
 
                                     match searchResult with
-                                    | OkResult (warns, [ r ]) -> OkResult(warns, Choice1Of2 r.resolvedPath)
+                                    | OkResult(warns, [ r ]) -> OkResult(warns, Choice1Of2 r.resolvedPath)
                                     | _ ->
 
                                         if progress then
@@ -3389,7 +3373,7 @@ type internal MagicAssemblyResolution() =
                                                     None)
 
                                         match searchResult with
-                                        | Some (OkResult (warns, [ r ])) -> OkResult(warns, Choice1Of2 r.resolvedPath)
+                                        | Some(OkResult(warns, [ r ])) -> OkResult(warns, Choice1Of2 r.resolvedPath)
                                         | _ ->
 
 #if !NO_TYPEPROVIDERS
@@ -3541,7 +3525,7 @@ type FsiStdinLexerProvider
                         fprintfn fsiConsoleOutput.Out "End of file from TextReader.ReadLine"
 
                     0
-                | Some (input: string) ->
+                | Some(input: string) ->
                     let input = input + "\n"
 
                     if input.Length > len then
@@ -3740,34 +3724,34 @@ type FsiInteractionProcessor
     /// Partially process a hash directive, leaving state in packageManagerLines and required assemblies
     let PartiallyProcessHashDirective (ctok, istate, hash, diagnosticsLogger: DiagnosticsLogger) =
         match hash with
-        | ParsedHashDirective ("load", ParsedHashDirectiveArguments sourceFiles, m) ->
+        | ParsedHashDirective("load", ParsedHashDirectiveArguments sourceFiles, m) ->
             let istate =
                 fsiDynamicCompiler.EvalSourceFiles(ctok, istate, m, sourceFiles, lexResourceManager, diagnosticsLogger)
 
             istate, Completed None
 
-        | ParsedHashDirective (("reference" | "r"), ParsedHashDirectiveArguments [ path ], m) ->
+        | ParsedHashDirective(("reference" | "r"), ParsedHashDirectiveArguments [ path ], m) ->
             fsiDynamicCompiler.PartiallyProcessReferenceOrPackageIncudePathDirective(ctok, istate, Directive.Resolution, path, true, m)
 
-        | ParsedHashDirective ("i", ParsedHashDirectiveArguments [ path ], m) ->
+        | ParsedHashDirective("i", ParsedHashDirectiveArguments [ path ], m) ->
             fsiDynamicCompiler.PartiallyProcessReferenceOrPackageIncudePathDirective(ctok, istate, Directive.Include, path, true, m)
 
-        | ParsedHashDirective ("I", ParsedHashDirectiveArguments [ path ], m) ->
+        | ParsedHashDirective("I", ParsedHashDirectiveArguments [ path ], m) ->
             tcConfigB.AddIncludePath(m, path, tcConfigB.implicitIncludeDir)
             let tcConfig = TcConfig.Create(tcConfigB, validate = false)
             fsiConsoleOutput.uprintnfnn "%s" (FSIstrings.SR.fsiDidAHashI (tcConfig.MakePathAbsolute path))
             istate, Completed None
 
-        | ParsedHashDirective ("cd", ParsedHashDirectiveArguments [ path ], m) ->
+        | ParsedHashDirective("cd", ParsedHashDirectiveArguments [ path ], m) ->
             ChangeDirectory path m
             istate, Completed None
 
-        | ParsedHashDirective ("silentCd", ParsedHashDirectiveArguments [ path ], m) ->
+        | ParsedHashDirective("silentCd", ParsedHashDirectiveArguments [ path ], m) ->
             ChangeDirectory path m
             fsiConsolePrompt.SkipNext() (* "silent" directive *)
             istate, Completed None
 
-        | ParsedHashDirective ("interactiveprompt", ParsedHashDirectiveArguments [ "show" | "hide" | "skip" as showPrompt ], m) ->
+        | ParsedHashDirective("interactiveprompt", ParsedHashDirectiveArguments [ "show" | "hide" | "skip" as showPrompt ], m) ->
             match showPrompt with
             | "show" -> fsiConsolePrompt.ShowPrompt <- true
             | "hide" -> fsiConsolePrompt.ShowPrompt <- false
@@ -3776,11 +3760,11 @@ type FsiInteractionProcessor
 
             istate, Completed None
 
-        | ParsedHashDirective ("dbgbreak", [], _) ->
+        | ParsedHashDirective("dbgbreak", [], _) ->
             let istate = { istate with debugBreak = true }
             istate, Completed None
 
-        | ParsedHashDirective ("time", [], _) ->
+        | ParsedHashDirective("time", [], _) ->
             if istate.timing then
                 fsiConsoleOutput.uprintnfnn "%s" (FSIstrings.SR.fsiTurnedTimingOff ())
             else
@@ -3793,7 +3777,7 @@ type FsiInteractionProcessor
 
             istate, Completed None
 
-        | ParsedHashDirective ("time", ParsedHashDirectiveArguments [ "on" | "off" as v ], _) ->
+        | ParsedHashDirective("time", ParsedHashDirectiveArguments [ "on" | "off" as v ], _) ->
             if v <> "on" then
                 fsiConsoleOutput.uprintnfnn "%s" (FSIstrings.SR.fsiTurnedTimingOff ())
             else
@@ -3802,38 +3786,38 @@ type FsiInteractionProcessor
             let istate = { istate with timing = (v = "on") }
             istate, Completed None
 
-        | ParsedHashDirective ("nowarn", ParsedHashDirectiveArguments numbers, m) ->
+        | ParsedHashDirective("nowarn", ParsedHashDirectiveArguments numbers, m) ->
             List.iter (fun (d: string) -> tcConfigB.TurnWarningOff(m, d)) numbers
             istate, Completed None
 
-        | ParsedHashDirective ("terms", [], _) ->
+        | ParsedHashDirective("terms", [], _) ->
             tcConfigB.showTerms <- not tcConfigB.showTerms
             istate, Completed None
 
-        | ParsedHashDirective ("types", [], _) ->
+        | ParsedHashDirective("types", [], _) ->
             fsiOptions.ShowTypes <- not fsiOptions.ShowTypes
             istate, Completed None
 
 #if DEBUG
-        | ParsedHashDirective ("ilcode", [], _m) ->
+        | ParsedHashDirective("ilcode", [], _m) ->
             fsiOptions.ShowILCode <- not fsiOptions.ShowILCode
             istate, Completed None
 
-        | ParsedHashDirective ("info", [], _m) ->
+        | ParsedHashDirective("info", [], _m) ->
             PrintOptionInfo tcConfigB
             istate, Completed None
 #endif
-        | ParsedHashDirective (("clear"), [], _) ->
+        | ParsedHashDirective(("clear"), [], _) ->
             fsiOptions.ClearScreen()
             istate, Completed None
 
-        | ParsedHashDirective (("q" | "quit"), [], _) -> fsiInterruptController.Exit()
+        | ParsedHashDirective(("q" | "quit"), [], _) -> fsiInterruptController.Exit()
 
-        | ParsedHashDirective ("help", [], m) ->
+        | ParsedHashDirective("help", [], m) ->
             fsiOptions.ShowHelp(m)
             istate, Completed None
 
-        | ParsedHashDirective (c, ParsedHashDirectiveArguments arg, m) ->
+        | ParsedHashDirective(c, ParsedHashDirectiveArguments arg, m) ->
             warning (Error((FSComp.SR.fsiInvalidDirective (c, String.concat " " arg)), m))
             istate, Completed None
 
@@ -3864,7 +3848,7 @@ type FsiInteractionProcessor
                 match action with
                 | InteractionGroup.Definitions _
                 | InteractionGroup.HashDirectives []
-                | InteractionGroup.HashDirectives (ParsedHashDirective ("load", _, _) :: _) ->
+                | InteractionGroup.HashDirectives(ParsedHashDirective("load", _, _) :: _) ->
                     if fsiDynamicCompiler.HasDelayedDependencyManagerText then
                         let istate =
                             fsiDynamicCompiler.ProcessDelayedDependencyManagerText(ctok, istate, lexResourceManager, diagnosticsLogger)
@@ -3875,21 +3859,21 @@ type FsiInteractionProcessor
                         loop istate action
                     else
                         match action with
-                        | InteractionGroup.Definitions ([], _)
+                        | InteractionGroup.Definitions([], _)
                         | InteractionGroup.HashDirectives [] -> istate, Completed None
 
-                        | InteractionGroup.Definitions ([ SynModuleDecl.Expr (expr, _) ], _) ->
+                        | InteractionGroup.Definitions([ SynModuleDecl.Expr(expr, _) ], _) ->
                             fsiDynamicCompiler.EvalParsedExpression(ctok, diagnosticsLogger, istate, expr)
 
-                        | InteractionGroup.Definitions (defs, _) ->
+                        | InteractionGroup.Definitions(defs, _) ->
                             fsiDynamicCompiler.EvalParsedDefinitions(ctok, diagnosticsLogger, istate, true, false, defs)
 
-                        | InteractionGroup.HashDirectives (hash :: rest) ->
+                        | InteractionGroup.HashDirectives(hash :: rest) ->
                             let status = PartiallyProcessHashDirective(ctok, istate, hash, diagnosticsLogger)
                             ProcessStepStatus status None (fun _ istate -> loop istate (InteractionGroup.HashDirectives rest))
 
                 // Other hash directives do not terminate a dependency manager and/or references group
-                | InteractionGroup.HashDirectives (hash :: rest) ->
+                | InteractionGroup.HashDirectives(hash :: rest) ->
                     let status = PartiallyProcessHashDirective(ctok, istate, hash, diagnosticsLogger)
                     ProcessStepStatus status None (fun _ istate -> loop istate (InteractionGroup.HashDirectives rest))
 
@@ -3926,7 +3910,7 @@ type FsiInteractionProcessor
             match synInteraction with
             | None -> None, None, istate
 
-            | Some (ParsedScriptInteraction.Definitions (defs, m)) ->
+            | Some(ParsedScriptInteraction.Definitions(defs, m)) ->
                 match defs with
                 | [] -> None, None, istate
 
@@ -3934,7 +3918,7 @@ type FsiInteractionProcessor
                     let hashes =
                         List.takeWhile isDefHash defs
                         |> List.choose (function
-                            | (SynModuleDecl.HashDirective (hash, _)) -> Some(hash)
+                            | (SynModuleDecl.HashDirective(hash, _)) -> Some(hash)
                             | _ -> None)
 
                     let defsB = List.skipWhile isDefHash defs
@@ -3975,7 +3959,7 @@ type FsiInteractionProcessor
                             | [ _ ] -> defsA
                             | _ ->
                                 match List.rev defsA with
-                                | SynModuleDecl.Expr (expr, _) :: rest -> (rest |> List.rev) @ (fsiDynamicCompiler.BuildItBinding expr)
+                                | SynModuleDecl.Expr(expr, _) :: rest -> (rest |> List.rev) @ (fsiDynamicCompiler.BuildItBinding expr)
                                 | _ -> defsA
 
                     let group = InteractionGroup.Definitions(defsA, m)
@@ -4082,7 +4066,7 @@ type FsiInteractionProcessor
         | FsiInteractionStepStatus.Completed res ->
             setCurrState istate
             Choice1Of2 res
-        | FsiInteractionStepStatus.CompletedWithReportedError (StopProcessingExn userExnOpt) -> Choice2Of2 userExnOpt
+        | FsiInteractionStepStatus.CompletedWithReportedError(StopProcessingExn userExnOpt) -> Choice2Of2 userExnOpt
         | FsiInteractionStepStatus.CompletedWithReportedError _
         | FsiInteractionStepStatus.CompletedWithAlreadyReportedError -> Choice2Of2 None
 
@@ -4703,7 +4687,7 @@ type FsiEvaluationSession
         match res with
         | Choice1Of2 r -> r
         | Choice2Of2 None -> raise (FsiCompilationException(FSIstrings.SR.fsiOperationFailed (), None))
-        | Choice2Of2 (Some userExn) -> raise (makeNestedException userExn)
+        | Choice2Of2(Some userExn) -> raise (makeNestedException userExn)
 
     let commitResultNonThrowing errorOptions scriptFile (diagnosticsLogger: CompilationDiagnosticLogger) res =
         let errs = diagnosticsLogger.GetDiagnostics()
@@ -4716,7 +4700,7 @@ type FsiEvaluationSession
             | Choice1Of2 r -> Choice1Of2 r
             | Choice2Of2 None ->
                 Choice2Of2(FsiCompilationException(FSIstrings.SR.fsiOperationCouldNotBeCompleted (), Some errorInfos) :> exn)
-            | Choice2Of2 (Some userExn) -> Choice2Of2 userExn
+            | Choice2Of2(Some userExn) -> Choice2Of2 userExn
 
         // 'true' is passed for "suggestNames" because we want the FSI session to suggest names for misspellings and it won't affect IDE perf much
         userRes, errorInfos

--- a/src/Compiler/Legacy/LegacyHostedCompilerForTesting.fs
+++ b/src/Compiler/Legacy/LegacyHostedCompilerForTesting.fs
@@ -116,7 +116,7 @@ type internal InProcCompiler(legacyReferenceResolver) =
         with
         | StopProcessing -> ()
         | ReportedError _
-        | WrappedError (ReportedError _, _) ->
+        | WrappedError(ReportedError _, _) ->
             exiter.ExitCode <- 1
             ()
 
@@ -143,7 +143,7 @@ type internal FscCompiler(legacyReferenceResolver) =
     /// Converts short and long issue types to the same CompilationIssue representation
     let convert issue =
         match issue with
-        | FormattedDiagnostic.Short (severity, text) ->
+        | FormattedDiagnostic.Short(severity, text) ->
             {
                 Location = emptyLocation
                 Code = ""
@@ -156,7 +156,7 @@ type internal FscCompiler(legacyReferenceResolver) =
                     else
                         CompilationIssueType.Warning
             }
-        | FormattedDiagnostic.Long (severity, details) ->
+        | FormattedDiagnostic.Long(severity, details) ->
             let loc, file =
                 match details.Location with
                 | Some l when not l.IsEmpty ->

--- a/src/Compiler/Service/ExternalSymbol.fs
+++ b/src/Compiler/Service/ExternalSymbol.fs
@@ -33,7 +33,7 @@ type FindDeclExternalType =
 
     override this.ToString() =
         match this with
-        | Type (name, genericArgs) ->
+        | Type(name, genericArgs) ->
             match genericArgs with
             | [] -> ""
             | args -> args |> List.map (sprintf "%O") |> String.concat ", " |> sprintf "<%s>"
@@ -46,7 +46,7 @@ module FindDeclExternalType =
     let rec tryOfILType (typeVarNames: string array) (ilType: ILType) =
 
         match ilType with
-        | ILType.Array (_, inner) -> tryOfILType typeVarNames inner |> Option.map FindDeclExternalType.Array
+        | ILType.Array(_, inner) -> tryOfILType typeVarNames inner |> Option.map FindDeclExternalType.Array
         | ILType.Boxed tyspec
         | ILType.Value tyspec ->
             tyspec.GenericArgs
@@ -111,21 +111,21 @@ type FindDeclExternalSymbol =
     override this.ToString() =
         match this with
         | Type fullName -> fullName
-        | Constructor (typeName, args) ->
+        | Constructor(typeName, args) ->
             args
             |> List.map (sprintf "%O")
             |> String.concat ", "
             |> sprintf "%s..ctor(%s)" typeName
-        | Method (typeName, name, args, genericArity) ->
+        | Method(typeName, name, args, genericArity) ->
             let genericAritySuffix = if genericArity > 0 then sprintf "`%d" genericArity else ""
 
             args
             |> List.map (sprintf "%O")
             |> String.concat ", "
             |> sprintf "%s.%s%s(%s)" typeName name genericAritySuffix
-        | Field (typeName, name)
-        | Event (typeName, name)
-        | Property (typeName, name) -> sprintf "%s.%s" typeName name
+        | Field(typeName, name)
+        | Event(typeName, name)
+        | Property(typeName, name) -> sprintf "%s.%s" typeName name
 
     member this.ToDebuggerDisplay() =
         let caseInfo, _ = FSharpValue.GetUnionFields(this, typeof<FindDeclExternalSymbol>)

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -118,20 +118,20 @@ type FSharpReferencedProject =
 
     member this.OutputFile =
         match this with
-        | FSharpReference (projectOutputFile = projectOutputFile)
-        | ILModuleReference (projectOutputFile = projectOutputFile) -> projectOutputFile
-        | PEReference (delayedReader = reader) -> reader.OutputFile
+        | FSharpReference(projectOutputFile = projectOutputFile)
+        | ILModuleReference(projectOutputFile = projectOutputFile) -> projectOutputFile
+        | PEReference(delayedReader = reader) -> reader.OutputFile
 
     override this.Equals(o) =
         match o with
         | :? FSharpReferencedProject as o ->
             match this, o with
-            | FSharpReference (projectOutputFile1, options1), FSharpReference (projectOutputFile2, options2) ->
+            | FSharpReference(projectOutputFile1, options1), FSharpReference(projectOutputFile2, options2) ->
                 projectOutputFile1 = projectOutputFile2
                 && FSharpProjectOptions.AreSameForChecking(options1, options2)
-            | PEReference (getStamp1, reader1), PEReference (getStamp2, reader2) ->
+            | PEReference(getStamp1, reader1), PEReference(getStamp2, reader2) ->
                 reader1.OutputFile = reader2.OutputFile && (getStamp1 ()) = (getStamp2 ())
-            | ILModuleReference (projectOutputFile1, getStamp1, _), ILModuleReference (projectOutputFile2, getStamp2, _) ->
+            | ILModuleReference(projectOutputFile1, getStamp1, _), ILModuleReference(projectOutputFile2, getStamp2, _) ->
                 projectOutputFile1 = projectOutputFile2 && (getStamp1 ()) = (getStamp2 ())
             | _ -> false
         | _ -> false
@@ -156,7 +156,7 @@ and FSharpProjectOptions =
 
     static member UseSameProject(options1, options2) =
         match options1.ProjectId, options2.ProjectId with
-        | Some (projectId1), Some (projectId2) when
+        | Some(projectId1), Some(projectId2) when
             not (String.IsNullOrWhiteSpace(projectId1))
             && not (String.IsNullOrWhiteSpace(projectId2))
             ->
@@ -194,9 +194,7 @@ module internal FSharpCheckerResultsSettings =
     // Look for DLLs in the location of the service DLL first.
     let defaultFSharpBinariesDir =
         FSharpEnvironment
-            .BinFolderOfDefaultFSharpCompiler(
-                Some(Path.GetDirectoryName(typeof<IncrementalBuilder>.Assembly.Location))
-            )
+            .BinFolderOfDefaultFSharpCompiler(Some(Path.GetDirectoryName(typeof<IncrementalBuilder>.Assembly.Location)))
             .Value
 
 [<Sealed>]
@@ -372,7 +370,7 @@ type internal TypeCheckInfo
         |> ResizeArray.iter (fun (mPossible, env, ad) ->
             if rangeContainsPos mPossible cursorPos then
                 match bestSoFar with
-                | Some (bestm, _, _) ->
+                | Some(bestm, _, _) ->
                     if rangeContainsRange bestm mPossible then
                         bestSoFar <- Some(mPossible, env, ad)
                 | None -> bestSoFar <- Some(mPossible, env, ad))
@@ -393,12 +391,12 @@ type internal TypeCheckInfo
             if rangeBeforePos mPossible cursorPos && not (posEq mPossible.End cursorPos) then
                 let contained =
                     match mostDeeplyNestedEnclosingScope with
-                    | Some (bestm, _, _) -> rangeContainsRange bestm mPossible
+                    | Some(bestm, _, _) -> rangeContainsRange bestm mPossible
                     | None -> true
 
                 if contained then
                     match bestAlmostIncludedSoFar with
-                    | Some (mRight: range, _, _) ->
+                    | Some(mRight: range, _, _) ->
                         if
                             posGt mPossible.End mRight.End
                             || (posEq mPossible.End mRight.End && posGt mPossible.Start mRight.Start)
@@ -408,14 +406,14 @@ type internal TypeCheckInfo
 
         let resEnv =
             match bestAlmostIncludedSoFar, mostDeeplyNestedEnclosingScope with
-            | Some (_, env, ad), None -> env, ad
-            | Some (_, almostIncludedEnv, ad), Some (_, mostDeeplyNestedEnv, _) when
+            | Some(_, env, ad), None -> env, ad
+            | Some(_, almostIncludedEnv, ad), Some(_, mostDeeplyNestedEnv, _) when
                 almostIncludedEnv.eFieldLabels.Count >= mostDeeplyNestedEnv.eFieldLabels.Count
                 ->
                 almostIncludedEnv, ad
             | _ ->
                 match mostDeeplyNestedEnclosingScope with
-                | Some (_, env, ad) -> env, ad
+                | Some(_, env, ad) -> env, ad
                 | None -> sFallback, AccessibleFromSomeFSharpCode
 
         let pm = mkRange mainInputFileName cursorPos cursorPos
@@ -485,7 +483,7 @@ type internal TypeCheckInfo
         //
         // If we're looking for members using a residue, we'd expect only
         // a single item (pick the first one) and we need the residue (which may be "")
-        | CNR (Item.Types (_, ty :: _), _, denv, nenv, ad, m) :: _, Some _ ->
+        | CNR(Item.Types(_, ty :: _), _, denv, nenv, ad, m) :: _, Some _ ->
             let targets =
                 ResolveCompletionTargets.All(ConstraintSolver.IsApplicableMethApprox g amap m)
 
@@ -494,7 +492,7 @@ type internal TypeCheckInfo
             ReturnItemsOfType items g denv m filterCtors
 
         // Exact resolution via 'T.$
-        | CNR (Item.TypeVar (_, tp), _, denv, nenv, ad, m) :: _, Some _ ->
+        | CNR(Item.TypeVar(_, tp), _, denv, nenv, ad, m) :: _, Some _ ->
             let targets =
                 ResolveCompletionTargets.All(ConstraintSolver.IsApplicableMethApprox g amap m)
 
@@ -509,7 +507,7 @@ type internal TypeCheckInfo
         //   let varA = if b then 0 else varA.
         // then the expression typings get confused (thinking 'varA:int'), so we use name resolution even for usual values.
 
-        | CNR (Item.Value (vref), occurence, denv, nenv, ad, m) :: _, Some _ ->
+        | CNR(Item.Value(vref), occurence, denv, nenv, ad, m) :: _, Some _ ->
             if occurence = ItemOccurence.Binding || occurence = ItemOccurence.Pattern then
                 // Return empty list to stop further lookup - for value declarations
                 NameResResult.Cancel(denv, m)
@@ -520,7 +518,7 @@ type internal TypeCheckInfo
                 // patch accessibility domain to remove protected members if accessing NormalVal
                 let ad =
                     match vref.BaseOrThisInfo, ad with
-                    | ValBaseOrThisInfo.NormalVal, AccessibleFrom (paths, Some tcref) ->
+                    | ValBaseOrThisInfo.NormalVal, AccessibleFrom(paths, Some tcref) ->
                         let thisTy = generalizedTyconRef g tcref
                         // check that type of value is the same or subtype of tcref
                         // yes - allow access to protected members
@@ -539,7 +537,7 @@ type internal TypeCheckInfo
                 ReturnItemsOfType items g denv m filterCtors
 
         // No residue, so the items are the full resolution of the name
-        | CNR (_, _, denv, _, _, m) :: _, None ->
+        | CNR(_, _, denv, _, _, m) :: _, None ->
             let items =
                 cnrs
                 |> List.map (fun cnr -> cnr.ItemWithInst)
@@ -547,7 +545,7 @@ type internal TypeCheckInfo
                 // implementation detail of syntax coloring, but we should not report name resolution results for it, to prevent spurious QuickInfo.
                 |> List.filter (fun item ->
                     match item.Item with
-                    | Item.CustomOperation (CustomOperations.Into, _, _) -> false
+                    | Item.CustomOperation(CustomOperations.Into, _, _) -> false
                     | _ -> true)
 
             ReturnItemsOfType items g denv m filterCtors
@@ -562,8 +560,8 @@ type internal TypeCheckInfo
             |> List.rev
 
         match items, membersByResidue with
-        | CNR (Item.Types (_, ty :: _), _, _, _, _, _) :: _, Some _ -> Some ty
-        | CNR (Item.Value (vref), occurence, _, _, _, _) :: _, Some _ ->
+        | CNR(Item.Types(_, ty :: _), _, _, _, _, _) :: _, Some _ -> Some ty
+        | CNR(Item.Value(vref), occurence, _, _, _, _) :: _, Some _ ->
             if (occurence = ItemOccurence.Binding || occurence = ItemOccurence.Pattern) then
                 None
             else
@@ -576,7 +574,7 @@ type internal TypeCheckInfo
             match meth.GetParamDatas(amap, m, meth.FormalMethodInst) with
             | x :: _ ->
                 x
-                |> List.choose (fun (ParamData (_isParamArray, _isInArg, _isOutArg, _optArgInfo, _callerInfo, name, _, ty)) ->
+                |> List.choose (fun (ParamData(_isParamArray, _isInArg, _isOutArg, _optArgInfo, _callerInfo, name, _, ty)) ->
                     match name with
                     | Some id -> Some(Item.OtherName(Some id, ty, None, Some(ArgumentContainer.Method meth), id.idRange))
                     | None -> None)
@@ -590,7 +588,7 @@ type internal TypeCheckInfo
 
         let result =
             match cnrs with
-            | CNR (Item.CtorGroup (_, (ctor :: _ as ctors)), _, denv, nenv, ad, m) :: _ ->
+            | CNR(Item.CtorGroup(_, (ctor :: _ as ctors)), _, denv, nenv, ad, m) :: _ ->
                 let props =
                     ResolveCompletionsInType
                         ncenv
@@ -604,7 +602,7 @@ type internal TypeCheckInfo
                 let parameters = CollectParameters ctors amap m
                 let items = props @ parameters
                 Some(denv, m, items)
-            | CNR (Item.MethodGroup (_, methods, _), _, denv, nenv, ad, m) :: _ ->
+            | CNR(Item.MethodGroup(_, methods, _), _, denv, nenv, ad, m) :: _ ->
                 let props =
                     methods
                     |> List.collect (fun meth ->
@@ -618,7 +616,7 @@ type internal TypeCheckInfo
 
         match result with
         | None -> NameResResult.Empty
-        | Some (denv, m, items) ->
+        | Some(denv, m, items) ->
             let items = List.map ItemWithNoInst items
             ReturnItemsOfType items g denv m TypeNameResolutionFlag.ResolveTypeNamesToTypeRefs
 
@@ -674,7 +672,7 @@ type internal TypeCheckInfo
                             dive ty denv ad m rest false wasPathEmpty
             else
                 match tryDestAnonRecdTy denv.g ty with
-                | ValueSome (anonInfo, tys) ->
+                | ValueSome(anonInfo, tys) ->
                     match plid with
                     | [] ->
                         let items =
@@ -695,7 +693,7 @@ type internal TypeCheckInfo
             |> snd
             |> Array.tryFind (fun (_, _, _, rq) -> posEq identRange.Start rq.Start)
         with
-        | Some (ty, nenv, ad, m) -> dive ty nenv.DisplayEnv ad m plid false plid.IsEmpty
+        | Some(ty, nenv, ad, m) -> dive ty nenv.DisplayEnv ad m plid false plid.IsEmpty
         | _ -> None
 
     /// Looks at the exact expression types at the position to the left of the
@@ -715,7 +713,7 @@ type internal TypeCheckInfo
                 let input = parseResults.ParseTree
 
                 match ParsedInput.GetRangeOfExprLeftOfDot(endOfExprPos, input) with // TODO we say "colAtEndOfNames" everywhere, but that's not really a good name ("foo  .  $" hit Ctrl-Space at $)
-                | Some (exprRange) ->
+                | Some(exprRange) ->
                     // We have an up-to-date sync parse, and know the exact range of the prior expression.
                     // The quals all already have the same ending position, so find one with a matching starting position, if it exists.
                     // If not, then the stale typecheck info does not have a capturedExpressionTyping for this exact expression, and the
@@ -784,14 +782,14 @@ type internal TypeCheckInfo
     let IsInheritsCompletionCandidate item =
         match item with
         | Item.ModuleOrNamespaces _ -> true
-        | Item.Types (_, ty :: _) when isClassTy g ty && not (isSealedTy g ty) -> true
+        | Item.Types(_, ty :: _) when isClassTy g ty && not (isSealedTy g ty) -> true
         | _ -> false
 
     /// Is the item suitable for completion at "interface $"
     let IsInterfaceCompletionCandidate item =
         match item with
         | Item.ModuleOrNamespaces _ -> true
-        | Item.Types (_, ty :: _) when isInterfaceTy g ty -> true
+        | Item.Types(_, ty :: _) when isInterfaceTy g ty -> true
         | _ -> false
 
     /// Is the item suitable for completion in a pattern
@@ -830,7 +828,7 @@ type internal TypeCheckInfo
 
             match item with
             | Item.Types _ -> nameMatchesResidue n1
-            | Item.CtorGroup (_, meths) ->
+            | Item.CtorGroup(_, meths) ->
                 nameMatchesResidue n1
                 || meths
                    |> List.exists (fun meth ->
@@ -896,7 +894,7 @@ type internal TypeCheckInfo
             | Item.FakeInterfaceCtor _
             | Item.DelegateCtor _
             | Item.CtorGroup _ -> CompletionItemKind.Method false
-            | Item.MethodGroup (_, minfos, _) ->
+            | Item.MethodGroup(_, minfos, _) ->
                 match minfos with
                 | [] -> CompletionItemKind.Method false
                 | minfo :: _ -> CompletionItemKind.Method minfo.IsExtensionMember
@@ -982,7 +980,7 @@ type internal TypeCheckInfo
     /// Suggest name based on type
     let SuggestNameBasedOnType (g: TcGlobals) pos ty =
         match stripTyparEqns ty with
-        | TType_app (tyconRef = tcref) when tcref.IsTypeAbbrev && (tcref.IsLocalRef || not (ccuEq g.fslibCcu tcref.nlr.Ccu)) ->
+        | TType_app(tyconRef = tcref) when tcref.IsTypeAbbrev && (tcref.IsLocalRef || not (ccuEq g.fslibCcu tcref.nlr.Ccu)) ->
             // Respect user-defined aliases
             CreateCompletionItemForSuggestedPatternName pos tcref.DisplayName
         | ty ->
@@ -1050,7 +1048,7 @@ type internal TypeCheckInfo
         sResolutions.CapturedNameResolutions
         |> ResizeArray.tryPick (fun r ->
             match r.Item with
-            | Item.Types (_, ty :: _) when equals r.Range typeNameRange && isAppTy g ty ->
+            | Item.Types(_, ty :: _) when equals r.Range typeNameRange && isAppTy g ty ->
                 let superTy =
                     (tcrefOfAppTy g ty).TypeContents.tcaug_super |> Option.defaultValue g.obj_ty
 
@@ -1082,7 +1080,7 @@ type internal TypeCheckInfo
         sResolutions.CapturedNameResolutions
         |> ResizeArray.tryPick (fun r ->
             match r.Item with
-            | Item.UnionCase (uci, _) when equals r.Range caseIdRange ->
+            | Item.UnionCase(uci, _) when equals r.Range caseIdRange ->
                 uci.UnionCase.RecdFields
                 |> List.indexed
                 |> List.choose (fun (index, field) ->
@@ -1105,7 +1103,7 @@ type internal TypeCheckInfo
         // so let's show options for both.
         let fields indexOrName isTheOnlyField (uci: UnionCaseInfo) =
             match indexOrName, isTheOnlyField with
-            | Choice1Of2 (Some 0), true ->
+            | Choice1Of2(Some 0), true ->
                 uci.UnionCase.RecdFields
                 |> List.mapi (fun index _ -> Item.UnionCaseField(uci, index) |> ItemWithNoInst |> DefaultCompletionItem)
             | _ -> []
@@ -1113,7 +1111,7 @@ type internal TypeCheckInfo
         sResolutions.CapturedNameResolutions
         |> ResizeArray.tryPick (fun r ->
             match r.Item with
-            | Item.UnionCase (uci, _) when equals r.Range caseIdRange ->
+            | Item.UnionCase(uci, _) when equals r.Range caseIdRange ->
                 let list =
                     declaredItems
                     |> Option.map p13
@@ -1157,7 +1155,7 @@ type internal TypeCheckInfo
                 |> List.filter (fun item ->
                     match item.Item with
                     | Item.ModuleOrNamespaces _ -> true
-                    | Item.Types (_, ty :: _) -> isRecdTy g ty
+                    | Item.Types(_, ty :: _) -> isRecdTy g ty
                     | _ -> false)
                 |> List.append fields
 
@@ -1217,8 +1215,8 @@ type internal TypeCheckInfo
             let plid, exactMatchResidueOpt =
                 match origLongIdentOpt, residueOpt with
                 | None, _ -> [], None
-                | Some (origLongIdent), Some _ -> origLongIdent, None
-                | Some (origLongIdent), None ->
+                | Some(origLongIdent), Some _ -> origLongIdent, None
+                | Some(origLongIdent), None ->
                     Debug.Assert(not (isNil origLongIdent), "origLongIdent is empty")
                     // note: as above, this happens when we are called for "precise" resolution - (F1 keyword, data tip etc..)
                     let plid, residue = List.frontAndBack origLongIdent
@@ -1247,8 +1245,8 @@ type internal TypeCheckInfo
                     | _ -> ValueNone
 
             match nameResItems with
-            | NameResResult.Cancel (denv, m) -> Some([], denv, m)
-            | NameResResult.Members (FilterRelevantItems getItem exactMatchResidueOpt (items, denv, m)) ->
+            | NameResResult.Cancel(denv, m) -> Some([], denv, m)
+            | NameResResult.Members(FilterRelevantItems getItem exactMatchResidueOpt (items, denv, m)) ->
                 // lookup based on name resolution results successful
                 Some(items |> List.map (CompletionItem (getType ()) ValueNone), denv, m)
             | _ ->
@@ -1275,7 +1273,7 @@ type internal TypeCheckInfo
                                 )
 
                             match leftOfDot with
-                            | Some (pos, _) -> GetPreciseCompletionListFromExprTypings(parseResults, pos, filterCtors), true
+                            | Some(pos, _) -> GetPreciseCompletionListFromExprTypings(parseResults, pos, filterCtors), true
                             | None ->
                                 // Can get here in a case like: if "f xxx yyy" is legal, and we do "f xxx y"
                                 // We have no interest in expression typings, those are only useful for dot-completion.  We want to fallback
@@ -1283,7 +1281,7 @@ type internal TypeCheckInfo
                                 ExprTypingsResult.None, false
 
                     match qualItems, thereIsADotInvolved with
-                    | ExprTypingsResult.Some (FilterRelevantItems getItem exactMatchResidueOpt (items, denv, m), ty), _ when
+                    | ExprTypingsResult.Some(FilterRelevantItems getItem exactMatchResidueOpt (items, denv, m), ty), _ when
                         // Initially we only use the expression typings when looking up, e.g. (expr).Nam or (expr).Name1.Nam
                         // These come through as an empty plid and residue "". Otherwise we try an environment lookup
                         // and then return to the qualItems. This is because the expression typings are a little inaccurate, primarily because
@@ -1313,7 +1311,7 @@ type internal TypeCheckInfo
                             match nameResItems, (envItems, denv, m), qualItems with
 
                             // First, use unfiltered name resolution items, if they're not empty
-                            | NameResResult.Members (items, denv, m), _, _ when not (isNil items) ->
+                            | NameResResult.Members(items, denv, m), _, _ when not (isNil items) ->
                                 // lookup based on name resolution results successful
                                 ValueSome(items |> List.map (CompletionItem (getType ()) ValueNone), denv, m)
 
@@ -1324,7 +1322,7 @@ type internal TypeCheckInfo
                                 ValueSome(items |> List.map (CompletionItem (getType ()) ValueNone), denv, m)
 
                             // Try again with the qualItems
-                            | _, _, ExprTypingsResult.Some (FilterRelevantItems getItem exactMatchResidueOpt (items, denv, m), ty) ->
+                            | _, _, ExprTypingsResult.Some(FilterRelevantItems getItem exactMatchResidueOpt (items, denv, m), ty) ->
                                 ValueSome(items |> List.map (CompletionItem (tryTcrefOfAppTy g ty) ValueNone), denv, m)
 
                             | _ -> ValueNone
@@ -1360,7 +1358,7 @@ type internal TypeCheckInfo
                             | _ -> ValueNone // do not return unresolved items after dot
 
                         match envResult, globalResult with
-                        | ValueSome (items, denv, m), ValueSome (gItems, _, _) -> Some(items @ gItems, denv, m)
+                        | ValueSome(items, denv, m), ValueSome(gItems, _, _) -> Some(items @ gItems, denv, m)
                         | ValueSome x, ValueNone -> Some x
                         | ValueNone, ValueSome y -> Some y
                         | ValueNone, ValueNone -> None
@@ -1383,7 +1381,7 @@ type internal TypeCheckInfo
             (fieldItems, nenv.DisplayEnv, m) |> toCompletionItems
 
         match envItems with
-        | Some (items, denv, m) -> Some(fieldCompletionItems @ items, denv, m)
+        | Some(items, denv, m) -> Some(fieldCompletionItems @ items, denv, m)
         | _ -> Some(fieldsResult)
 
     /// Get the auto-complete items at a particular location.
@@ -1432,7 +1430,7 @@ type internal TypeCheckInfo
             // If the completion context we have computed higher up the stack is for the same position,
             // reuse it, otherwise recompute
             match completionContextAtPos with
-            | Some (contextForPos, context) when contextForPos = pos -> context
+            | Some(contextForPos, context) when contextForPos = pos -> context
             | _ ->
                 parseResultsOpt
                 |> Option.map (fun x -> x.ParseTree)
@@ -1444,19 +1442,19 @@ type internal TypeCheckInfo
             | Some CompletionContext.Invalid -> None
 
             // Completion at 'inherit C(...)"
-            | Some (CompletionContext.Inherit (InheritanceContext.Class, (plid, _))) ->
+            | Some(CompletionContext.Inherit(InheritanceContext.Class, (plid, _))) ->
                 GetEnvironmentLookupResolutionsAtPosition(mkPos line loc, plid, filterCtors, false)
                 |> FilterRelevantItemsBy getItem None (getItem >> IsInheritsCompletionCandidate)
                 |> Option.map toCompletionItems
 
             // Completion at 'interface ..."
-            | Some (CompletionContext.Inherit (InheritanceContext.Interface, (plid, _))) ->
+            | Some(CompletionContext.Inherit(InheritanceContext.Interface, (plid, _))) ->
                 GetEnvironmentLookupResolutionsAtPosition(mkPos line loc, plid, filterCtors, false)
                 |> FilterRelevantItemsBy getItem None (getItem >> IsInterfaceCompletionCandidate)
                 |> Option.map toCompletionItems
 
             // Completion at 'implement ..."
-            | Some (CompletionContext.Inherit (InheritanceContext.Unknown, (plid, _))) ->
+            | Some(CompletionContext.Inherit(InheritanceContext.Unknown, (plid, _))) ->
                 GetEnvironmentLookupResolutionsAtPosition(mkPos line loc, plid, filterCtors, false)
                 |> FilterRelevantItemsBy
                     getItem
@@ -1466,7 +1464,7 @@ type internal TypeCheckInfo
                 |> Option.map toCompletionItems
 
             // Completion at ' { XXX = ... } "
-            | Some (CompletionContext.RecordField (RecordContext.New ((plid, _), isFirstField))) ->
+            | Some(CompletionContext.RecordField(RecordContext.New((plid, _), isFirstField))) ->
                 if isFirstField then
                     let cursorPos = mkPos line loc
 
@@ -1512,7 +1510,7 @@ type internal TypeCheckInfo
                     | result -> Some(result)
 
             // Completion at '{ ... }'
-            | Some (CompletionContext.RecordField RecordContext.Empty) ->
+            | Some(CompletionContext.RecordField RecordContext.Empty) ->
                 let cursorPos = mkPos line loc
 
                 let envItems =
@@ -1534,30 +1532,30 @@ type internal TypeCheckInfo
                 GetEnvironmentLookupResolutionsIncludingRecordFieldsAtPosition cursorPos [] envItems
 
             // Completion at ' { XXX = ... with ... } "
-            | Some (CompletionContext.RecordField (RecordContext.CopyOnUpdate (identRange, (plid, _)))) ->
+            | Some(CompletionContext.RecordField(RecordContext.CopyOnUpdate(identRange, (plid, _)))) ->
                 match GetRecdFieldsForCopyAndUpdateExpr(identRange, plid) with
                 | None ->
                     Some(GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, plid, false))
                     |> Option.map toCompletionItems
-                | Some (items, denv, m) -> Some(List.map ItemWithNoInst items, denv, m) |> Option.map toCompletionItems
+                | Some(items, denv, m) -> Some(List.map ItemWithNoInst items, denv, m) |> Option.map toCompletionItems
 
             // Completion at ' { XXX = ... with ... } "
-            | Some (CompletionContext.RecordField (RecordContext.Constructor (typeName))) ->
+            | Some(CompletionContext.RecordField(RecordContext.Constructor(typeName))) ->
                 GetClassOrRecordFieldsEnvironmentLookupResolutions(mkPos line loc, [ typeName ], false)
                 |> toCompletionItems
                 |> Some
 
             // No completion at '...: string'
-            | Some (CompletionContext.RecordField (RecordContext.Declaration true)) -> None
+            | Some(CompletionContext.RecordField(RecordContext.Declaration true)) -> None
 
             // Completion at ' SomeMethod( ... ) ' or ' [<SomeAttribute( ... )>] ' with named arguments
-            | Some (CompletionContext.ParameterList (endPos, fields)) ->
+            | Some(CompletionContext.ParameterList(endPos, fields)) ->
                 let results = GetNamedParametersAndSettableFields endPos
 
                 let declaredItems = getDeclaredItemsNotInRangeOpWithAllSymbols ()
 
                 match results with
-                | NameResResult.Members (items, denv, m) ->
+                | NameResResult.Members(items, denv, m) ->
                     let filtered =
                         items
                         |> RemoveDuplicateItems g
@@ -1575,10 +1573,10 @@ type internal TypeCheckInfo
 
                     match declaredItems with
                     | None -> Some(toCompletionItems (items, denv, m))
-                    | Some (declItems, declaredDisplayEnv, declaredRange) -> Some(filtered @ declItems, declaredDisplayEnv, declaredRange)
+                    | Some(declItems, declaredDisplayEnv, declaredRange) -> Some(filtered @ declItems, declaredDisplayEnv, declaredRange)
                 | _ -> declaredItems
 
-            | Some (CompletionContext.AttributeApplication) ->
+            | Some(CompletionContext.AttributeApplication) ->
                 getDeclaredItemsNotInRangeOpWithAllSymbols ()
                 |> Option.map (fun (items, denv, m) ->
                     items
@@ -1590,7 +1588,7 @@ type internal TypeCheckInfo
                     denv,
                     m)
 
-            | Some (CompletionContext.OpenDeclaration isOpenType) ->
+            | Some(CompletionContext.OpenDeclaration isOpenType) ->
                 getDeclaredItemsNotInRangeOpWithAllSymbols ()
                 |> Option.map (fun (items, denv, m) ->
                     items
@@ -1609,21 +1607,21 @@ type internal TypeCheckInfo
             // Completion at 'type Long = int6...' or 'type SomeUnion = Abc...'
             | Some CompletionContext.TypeAbbreviationOrSingleCaseUnion
             // Completion at 'Field1: ...'
-            | Some (CompletionContext.RecordField (RecordContext.Declaration false)) ->
+            | Some(CompletionContext.RecordField(RecordContext.Declaration false)) ->
                 getDeclaredItemsNotInRangeOpWithAllSymbols ()
                 |> Option.bind (FilterRelevantItemsBy getItem2 None IsTypeCandidate)
 
-            | Some (CompletionContext.Pattern patternContext) ->
+            | Some(CompletionContext.Pattern patternContext) ->
                 match patternContext with
-                | PatternContext.UnionCaseFieldIdentifier (referencedFields, caseIdRange) ->
+                | PatternContext.UnionCaseFieldIdentifier(referencedFields, caseIdRange) ->
                     GetUnionCaseFields caseIdRange referencedFields
                     |> Option.map (fun completions ->
                         let (nenv, _ad), m = GetBestEnvForPos pos
                         completions, nenv.DisplayEnv, m)
-                | PatternContext.PositionalUnionCaseField (fieldIndex, isTheOnlyField, caseIdRange) ->
+                | PatternContext.PositionalUnionCaseField(fieldIndex, isTheOnlyField, caseIdRange) ->
                     getDeclaredItemsNotInRangeOpWithAllSymbols ()
                     |> GetCompletionsForUnionCaseField pos (Choice1Of2 fieldIndex) caseIdRange isTheOnlyField
-                | PatternContext.NamedUnionCaseField (fieldName, caseIdRange) ->
+                | PatternContext.NamedUnionCaseField(fieldName, caseIdRange) ->
                     getDeclaredItemsNotInRangeOpWithAllSymbols ()
                     |> GetCompletionsForUnionCaseField pos (Choice2Of2 fieldName) caseIdRange false
                 | PatternContext.RecordFieldIdentifier referencedFields ->
@@ -1633,7 +1631,7 @@ type internal TypeCheckInfo
                     getDeclaredItemsNotInRangeOpWithAllSymbols ()
                     |> Option.bind (FilterRelevantItemsBy getItem2 None IsPatternCandidate)
 
-            | Some (CompletionContext.MethodOverride enclosingTypeNameRange) -> GetOverridableMethods pos enclosingTypeNameRange
+            | Some(CompletionContext.MethodOverride enclosingTypeNameRange) -> GetOverridableMethods pos enclosingTypeNameRange
 
             // Other completions
             | cc ->
@@ -1724,7 +1722,7 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None -> DeclarationListInfo.Empty
-                | Some (items, denv, ctx, m) ->
+                | Some(items, denv, ctx, m) ->
                     let items =
                         if isSigFile then
                             items |> List.filter (fun x -> IsValidSignatureFileItem x.Item)
@@ -1784,7 +1782,7 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None -> List.Empty
-                | Some (items, denv, _, m) ->
+                | Some(items, denv, _, m) ->
                     let items =
                         if isSigFile then
                             items |> List.filter (fun x -> IsValidSignatureFileItem x.Item)
@@ -1802,12 +1800,12 @@ type internal TypeCheckInfo
                         |> List.sortBy (fun d ->
                             let n =
                                 match d.Item with
-                                | Item.Types (_, AbbrevOrAppTy tcref :: _) -> 1 + tcref.TyparsNoRange.Length
+                                | Item.Types(_, AbbrevOrAppTy tcref :: _) -> 1 + tcref.TyparsNoRange.Length
                                 // Put delegate ctors after types, sorted by #typars. RemoveDuplicateItems will remove FakeInterfaceCtor and DelegateCtor if an earlier type is also reported with this name
-                                | Item.FakeInterfaceCtor (AbbrevOrAppTy tcref)
-                                | Item.DelegateCtor (AbbrevOrAppTy tcref) -> 1000 + tcref.TyparsNoRange.Length
+                                | Item.FakeInterfaceCtor(AbbrevOrAppTy tcref)
+                                | Item.DelegateCtor(AbbrevOrAppTy tcref) -> 1000 + tcref.TyparsNoRange.Length
                                 // Put type ctors after types, sorted by #typars. RemoveDuplicateItems will remove DefaultStructCtors if a type is also reported with this name
-                                | Item.CtorGroup (_, cinfo :: _) -> 1000 + 10 * cinfo.DeclaringTyconRef.TyparsNoRange.Length
+                                | Item.CtorGroup(_, cinfo :: _) -> 1000 + 10 * cinfo.DeclaringTyconRef.TyparsNoRange.Length
                                 | _ -> 0
 
                             (d.Item.DisplayName, n))
@@ -1821,12 +1819,12 @@ type internal TypeCheckInfo
                         items
                         |> List.groupBy (fun d ->
                             match d.Item with
-                            | Item.Types (_, AbbrevOrAppTy tcref :: _)
+                            | Item.Types(_, AbbrevOrAppTy tcref :: _)
                             | Item.ExnCase tcref -> tcref.LogicalName
-                            | Item.UnqualifiedType (tcref :: _)
-                            | Item.FakeInterfaceCtor (AbbrevOrAppTy tcref)
-                            | Item.DelegateCtor (AbbrevOrAppTy tcref) -> tcref.CompiledName
-                            | Item.CtorGroup (_, cinfo :: _) -> cinfo.ApparentEnclosingTyconRef.CompiledName
+                            | Item.UnqualifiedType(tcref :: _)
+                            | Item.FakeInterfaceCtor(AbbrevOrAppTy tcref)
+                            | Item.DelegateCtor(AbbrevOrAppTy tcref) -> tcref.CompiledName
+                            | Item.CtorGroup(_, cinfo :: _) -> cinfo.ApparentEnclosingTyconRef.CompiledName
                             | _ -> d.Item.DisplayName)
 
                     // Filter out operators (and list)
@@ -1835,7 +1833,7 @@ type internal TypeCheckInfo
                         let isOpItem (nm, item: CompletionItem list) =
                             match item |> List.map (fun x -> x.Item) with
                             | [ Item.Value _ ]
-                            | [ Item.MethodGroup (_, [ _ ], _) ] -> IsOperatorDisplayName nm
+                            | [ Item.MethodGroup(_, [ _ ], _) ] -> IsOperatorDisplayName nm
                             | [ Item.UnionCase _ ] -> IsOperatorDisplayName nm
                             | _ -> false
 
@@ -1882,7 +1880,7 @@ type internal TypeCheckInfo
             let matches =
                 match loadClosure with
                 | None -> []
-                | Some (loadClosure) ->
+                | Some(loadClosure) ->
                     loadClosure.References
                     |> List.collect snd
                     |> List.filter (fun ar -> isPosMatch (pos, ar.originalReference))
@@ -1902,13 +1900,13 @@ type internal TypeCheckInfo
                 let matches =
                     match loadClosure with
                     | None -> None
-                    | Some (loadClosure) ->
+                    | Some(loadClosure) ->
                         loadClosure.PackageReferences
                         |> Array.tryFind (fun (m, _) -> rangeContainsPos m pos)
 
                 match matches with
                 | None -> emptyToolTip
-                | Some (_, lines) ->
+                | Some(_, lines) ->
                     let lines =
                         lines
                         |> List.filter (fun line -> not (line.StartsWith("//")) && not (String.IsNullOrEmpty line))
@@ -1967,7 +1965,7 @@ type internal TypeCheckInfo
 
                     match declItemsOpt with
                     | None -> emptyToolTip
-                    | Some (items, denv, _, m) ->
+                    | Some(items, denv, _, m) ->
                         match items with
                         | [ { Kind = CompletionItemKind.Property } as prop
                             { Kind = CompletionItemKind.Field }
@@ -2029,7 +2027,7 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None -> None
-                | Some (items: CompletionItem list, _, _, _) ->
+                | Some(items: CompletionItem list, _, _, _) ->
                     match items with
                     | [] -> None
                     | [ item ] -> GetF1Keyword g item.Item
@@ -2075,7 +2073,7 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None -> MethodGroup("", [||])
-                | Some (items, denv, _, m) ->
+                | Some(items, denv, _, m) ->
                     // GetDeclItemsForNamesAtPosition returns Items.Types and Item.CtorGroup for `new T(|)`,
                     // the Item.Types is not needed here as it duplicates (at best) parameterless ctor.
                     let ctors =
@@ -2116,8 +2114,8 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None
-                | Some ([], _, _, _) -> None
-                | Some (items, denv, _, m) ->
+                | Some([], _, _, _) -> None
+                | Some(items, denv, _, m) ->
                     let allItems =
                         items
                         |> List.collect (fun item -> SelectMethodGroupItems2 g m item.ItemWithInst)
@@ -2152,8 +2150,8 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None
-                | Some ([], _, _, _) -> FindDeclResult.DeclNotFound(FindDeclFailureReason.Unknown "")
-                | Some (item :: _, _, _, _) ->
+                | Some([], _, _, _) -> FindDeclResult.DeclNotFound(FindDeclFailureReason.Unknown "")
+                | Some(item :: _, _, _, _) ->
                     let getTypeVarNames (ilinfo: ILMethInfo) =
                         let classTypeParams =
                             ilinfo.DeclaringTyconRef.ILTyconRawMetadata.GenericParams
@@ -2166,7 +2164,7 @@ type internal TypeCheckInfo
                     // references from nuget packages are not labelled as external.
                     let result =
                         match item.Item with
-                        | Item.CtorGroup (_, ILMeth (_, ilinfo, _) :: _) ->
+                        | Item.CtorGroup(_, ILMeth(_, ilinfo, _) :: _) ->
                             match ilinfo.MetadataScope with
                             | ILScopeRef.Assembly assemblyRef ->
                                 let typeVarNames = getTypeVarNames ilinfo
@@ -2179,7 +2177,7 @@ type internal TypeCheckInfo
                                     FindDeclResult.ExternalDecl(assemblyRef.Name, externalSym))
                             | _ -> None
 
-                        | Item.MethodGroup (name, ILMeth (_, ilinfo, _) :: _, _) ->
+                        | Item.MethodGroup(name, ILMeth(_, ilinfo, _) :: _, _) ->
                             match ilinfo.MetadataScope with
                             | ILScopeRef.Assembly assemblyRef ->
                                 let typeVarNames = getTypeVarNames ilinfo
@@ -2197,7 +2195,7 @@ type internal TypeCheckInfo
                                     FindDeclResult.ExternalDecl(assemblyRef.Name, externalSym))
                             | _ -> None
 
-                        | Item.Property (name, ILProp propInfo :: _, _) ->
+                        | Item.Property(name, ILProp propInfo :: _, _) ->
                             let methInfo =
                                 if propInfo.HasGetter then Some propInfo.GetterMethod
                                 elif propInfo.HasSetter then Some propInfo.SetterMethod
@@ -2214,7 +2212,7 @@ type internal TypeCheckInfo
                                 | _ -> None
                             | None -> None
 
-                        | Item.ILField (ILFieldInfo (typeInfo, fieldDef)) when not typeInfo.TyconRefOfRawMetadata.IsLocalRef ->
+                        | Item.ILField(ILFieldInfo(typeInfo, fieldDef)) when not typeInfo.TyconRefOfRawMetadata.IsLocalRef ->
                             match typeInfo.ILScopeRef with
                             | ILScopeRef.Assembly assemblyRef ->
                                 let externalSym =
@@ -2223,7 +2221,7 @@ type internal TypeCheckInfo
                                 Some(FindDeclResult.ExternalDecl(assemblyRef.Name, externalSym))
                             | _ -> None
 
-                        | Item.Event (ILEvent (ILEventInfo (typeInfo, eventDef))) when not typeInfo.TyconRefOfRawMetadata.IsLocalRef ->
+                        | Item.Event(ILEvent(ILEventInfo(typeInfo, eventDef))) when not typeInfo.TyconRefOfRawMetadata.IsLocalRef ->
                             match typeInfo.ILScopeRef with
                             | ILScopeRef.Assembly assemblyRef ->
                                 let externalSym =
@@ -2232,14 +2230,14 @@ type internal TypeCheckInfo
                                 Some(FindDeclResult.ExternalDecl(assemblyRef.Name, externalSym))
                             | _ -> None
 
-                        | Item.Types (_, ty :: _) ->
+                        | Item.Types(_, ty :: _) ->
                             match stripTyparEqns ty with
-                            | TType_app (tr, _, _) ->
+                            | TType_app(tr, _, _) ->
                                 if tr.IsLocalRef then
                                     None
                                 else
                                     match tr.TypeReprInfo, tr.PublicPath with
-                                    | TILObjectRepr (TILObjectReprData (ILScopeRef.Assembly assemblyRef, _, _)), Some (PubPath parts) ->
+                                    | TILObjectRepr(TILObjectReprData(ILScopeRef.Assembly assemblyRef, _, _)), Some(PubPath parts) ->
                                         let fullName = parts |> String.concat "."
                                         Some(FindDeclResult.ExternalDecl(assemblyRef.Name, FindDeclExternalSymbol.Type fullName))
                                     | _ -> None
@@ -2266,11 +2264,11 @@ type internal TypeCheckInfo
                             match item.Item with
 #if !NO_TYPEPROVIDERS
                             // provided items may have TypeProviderDefinitionLocationAttribute that binds them to some location
-                            | Item.CtorGroup (name, ProvidedMeth _ :: _)
-                            | Item.MethodGroup (name, ProvidedMeth _ :: _, _)
-                            | Item.Property (name, ProvidedProp _ :: _, _) -> FindDeclFailureReason.ProvidedMember name
-                            | Item.Event (ProvidedEvent _ as e) -> FindDeclFailureReason.ProvidedMember e.EventName
-                            | Item.ILField (ProvidedField _ as f) -> FindDeclFailureReason.ProvidedMember f.FieldName
+                            | Item.CtorGroup(name, ProvidedMeth _ :: _)
+                            | Item.MethodGroup(name, ProvidedMeth _ :: _, _)
+                            | Item.Property(name, ProvidedProp _ :: _, _) -> FindDeclFailureReason.ProvidedMember name
+                            | Item.Event(ProvidedEvent _ as e) -> FindDeclFailureReason.ProvidedMember e.EventName
+                            | Item.ILField(ProvidedField _ as f) -> FindDeclFailureReason.ProvidedMember f.FieldName
                             | ItemIsProvidedType g tcref -> FindDeclFailureReason.ProvidedType tcref.DisplayName
 #endif
                             | _ -> FindDeclFailureReason.Unknown ""
@@ -2300,8 +2298,8 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None
-                | Some ([], _, _, _) -> None
-                | Some (item :: _, denv, _, m) ->
+                | Some([], _, _, _) -> None
+                | Some(item :: _, denv, _, m) ->
                     let symbol = FSharpSymbol.Create(cenv, item.Item)
                     Some(symbol, item.ItemWithInst, denv, m))
             (fun msg ->
@@ -2329,7 +2327,7 @@ type internal TypeCheckInfo
 
                 match declItemsOpt with
                 | None -> List.empty
-                | Some (items, denv, _, m) ->
+                | Some(items, denv, _, m) ->
                     items
                     |> List.map (fun item ->
                         let symbol = FSharpSymbol.Create(cenv, item.Item)
@@ -2468,7 +2466,7 @@ module internal ParseAndCheckFile =
             //    the formatting of types in it may change (for example, 'a to obj)
             //
             // So we'll create a diagnostic later, but cache the FormatCore message now
-            diagnostic.Exception.Data[ "CachedFormatCore" ] <- diagnostic.FormatCore(flatErrors, suggestNamesForErrors)
+            diagnostic.Exception.Data["CachedFormatCore"] <- diagnostic.FormatCore(flatErrors, suggestNamesForErrors)
             diagnosticsCollector.Add(struct (diagnostic, severity))
 
             if severity = FSharpDiagnosticSeverity.Error then
@@ -2674,7 +2672,7 @@ module internal ParseAndCheckFile =
                 | INTERP_STRING_BEGIN_PART _ | INTERP_STRING_PART _ as tok, _ ->
                     let braceOffset =
                         match tok with
-                        | INTERP_STRING_BEGIN_PART (_, SynStringKind.TripleQuote, (LexerContinuation.Token (_, (_, _, dl, _) :: _))) ->
+                        | INTERP_STRING_BEGIN_PART(_, SynStringKind.TripleQuote, (LexerContinuation.Token(_, (_, _, dl, _) :: _))) ->
                             dl - 1
                         | _ -> 0
 
@@ -3012,7 +3010,7 @@ type FSharpCheckFileResults
     member _.TryGetCurrentTcImports() =
         match details with
         | None -> None
-        | Some (scope, _builderOpt) -> Some scope.TcImports
+        | Some(scope, _builderOpt) -> Some scope.TcImports
 
     /// Intellisense autocompletions
     member _.GetDeclarationListInfo(parsedFileResults, line, lineText, partialName, ?getAllEntities, ?completionContextAtPos) =
@@ -3020,7 +3018,7 @@ type FSharpCheckFileResults
 
         match details with
         | None -> DeclarationListInfo.Empty
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             scope.GetDeclarations(parsedFileResults, line, lineText, partialName, completionContextAtPos, getAllEntities)
 
     member _.GetDeclarationListSymbols(parsedFileResults, line, lineText, partialName, ?getAllEntities) =
@@ -3028,7 +3026,7 @@ type FSharpCheckFileResults
 
         match details with
         | None -> []
-        | Some (scope, _builderOpt) -> scope.GetDeclarationListSymbols(parsedFileResults, line, lineText, partialName, getAllEntities)
+        | Some(scope, _builderOpt) -> scope.GetDeclarationListSymbols(parsedFileResults, line, lineText, partialName, getAllEntities)
 
     member _.GetKeywordTooltip(names: string list) =
         ToolTipText.ToolTipText
@@ -3047,34 +3045,34 @@ type FSharpCheckFileResults
         | TOKEN_IDENT ->
             match details with
             | None -> emptyToolTip
-            | Some (scope, _builderOpt) -> scope.GetStructuredToolTipText(line, lineText, colAtEndOfNames, names, width)
+            | Some(scope, _builderOpt) -> scope.GetStructuredToolTipText(line, lineText, colAtEndOfNames, names, width)
         | TOKEN_STRING
         | TOKEN_STRING_TEXT ->
             match details with
             | None -> emptyToolTip
-            | Some (scope, _builderOpt) -> scope.GetReferenceResolutionStructuredToolTipText(line, colAtEndOfNames, width)
+            | Some(scope, _builderOpt) -> scope.GetReferenceResolutionStructuredToolTipText(line, colAtEndOfNames, width)
         | _ -> emptyToolTip
 
     member _.GetDescription(symbol: FSharpSymbol, inst: (FSharpGenericParameter * FSharpType) list, displayFullName, range: range) =
         match details with
         | None -> emptyToolTip
-        | Some (scope, _builderOpt) -> scope.GetDescription(symbol, inst, displayFullName, range)
+        | Some(scope, _builderOpt) -> scope.GetDescription(symbol, inst, displayFullName, range)
 
     member _.GetF1Keyword(line, colAtEndOfNames, lineText, names) =
         match details with
         | None -> None
-        | Some (scope, _builderOpt) -> scope.GetF1Keyword(line, lineText, colAtEndOfNames, names)
+        | Some(scope, _builderOpt) -> scope.GetF1Keyword(line, lineText, colAtEndOfNames, names)
 
     // Resolve the names at the given location to a set of methods
     member _.GetMethods(line, colAtEndOfNames, lineText, names) =
         match details with
         | None -> MethodGroup.Empty
-        | Some (scope, _builderOpt) -> scope.GetMethods(line, lineText, colAtEndOfNames, names)
+        | Some(scope, _builderOpt) -> scope.GetMethods(line, lineText, colAtEndOfNames, names)
 
     member _.GetDeclarationLocation(line, colAtEndOfNames, lineText, names, ?preferFlag) =
         match details with
         | None -> emptyFindDeclResult
-        | Some (scope, _builderOpt) -> scope.GetDeclarationLocation(line, lineText, colAtEndOfNames, names, preferFlag)
+        | Some(scope, _builderOpt) -> scope.GetDeclarationLocation(line, lineText, colAtEndOfNames, names, preferFlag)
 
     member this.GetSymbolUseAtLocation(line, colAtEndOfNames, lineText, names) =
         this.GetSymbolUsesAtLocation(line, colAtEndOfNames, lineText, names)
@@ -3083,7 +3081,7 @@ type FSharpCheckFileResults
     member _.GetSymbolUsesAtLocation(line, colAtEndOfNames, lineText, names) =
         match details with
         | None -> List.empty
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             scope.GetSymbolUsesAtLocation(line, lineText, colAtEndOfNames, names)
             |> List.map (fun (sym, itemWithInst, denv, m) ->
                 FSharpSymbolUse(denv, sym, itemWithInst.TyparInstantiation, ItemOccurence.Use, m))
@@ -3091,7 +3089,7 @@ type FSharpCheckFileResults
     member _.GetMethodsAsSymbols(line, colAtEndOfNames, lineText, names) =
         match details with
         | None -> None
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             scope.GetMethodsAsSymbols(line, lineText, colAtEndOfNames, names)
             |> Option.map (fun (symbols, denv, m) ->
                 symbols
@@ -3100,7 +3098,7 @@ type FSharpCheckFileResults
     member _.GetSymbolAtLocation(line, colAtEndOfNames, lineStr, names) =
         match details with
         | None -> None
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             scope.GetSymbolUseAtLocation(line, lineStr, colAtEndOfNames, names)
             |> Option.map (fun (sym, _, _, _) -> sym)
 
@@ -3110,22 +3108,22 @@ type FSharpCheckFileResults
     member _.GetFormatSpecifierLocationsAndArity() =
         match details with
         | None -> [||]
-        | Some (scope, _builderOpt) -> scope.GetFormatSpecifierLocationsAndArity()
+        | Some(scope, _builderOpt) -> scope.GetFormatSpecifierLocationsAndArity()
 
     member _.GetSemanticClassification(range: range option) =
         match details with
         | None -> [||]
-        | Some (scope, _builderOpt) -> scope.GetSemanticClassification(range)
+        | Some(scope, _builderOpt) -> scope.GetSemanticClassification(range)
 
     member _.PartialAssemblySignature =
         match details with
         | None -> failwith "not available"
-        | Some (scope, _builderOpt) -> scope.PartialAssemblySignatureForFile
+        | Some(scope, _builderOpt) -> scope.PartialAssemblySignatureForFile
 
     member _.ProjectContext =
         match details with
         | None -> failwith "not available"
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             FSharpProjectContext(scope.ThisCcu, scope.GetReferencedAssemblies(), scope.AccessRights, scope.ProjectOptions)
 
     member _.DependencyFiles = dependencyFiles
@@ -3133,7 +3131,7 @@ type FSharpCheckFileResults
     member _.GetAllUsesOfAllSymbolsInFile(?cancellationToken: CancellationToken) =
         match details with
         | None -> Seq.empty
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             let cenv = scope.SymbolEnv
 
             seq {
@@ -3150,7 +3148,7 @@ type FSharpCheckFileResults
     member _.GetUsesOfSymbolInFile(symbol: FSharpSymbol, ?cancellationToken: CancellationToken) =
         match details with
         | None -> [||]
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             [|
                 for symbolUse in
                     scope.ScopeSymbolUses.GetUsesOfSymbol(symbol.Item)
@@ -3165,34 +3163,34 @@ type FSharpCheckFileResults
     member _.GetVisibleNamespacesAndModulesAtPoint(pos: pos) =
         match details with
         | None -> [||]
-        | Some (scope, _builderOpt) -> scope.GetVisibleNamespacesAndModulesAtPosition(pos) |> List.toArray
+        | Some(scope, _builderOpt) -> scope.GetVisibleNamespacesAndModulesAtPosition(pos) |> List.toArray
 
     member _.IsRelativeNameResolvable(cursorPos: pos, plid: string list, item: Item) =
         match details with
         | None -> true
-        | Some (scope, _builderOpt) -> scope.IsRelativeNameResolvable(cursorPos, plid, item)
+        | Some(scope, _builderOpt) -> scope.IsRelativeNameResolvable(cursorPos, plid, item)
 
     member _.IsRelativeNameResolvableFromSymbol(cursorPos: pos, plid: string list, symbol: FSharpSymbol) =
         match details with
         | None -> true
-        | Some (scope, _builderOpt) -> scope.IsRelativeNameResolvableFromSymbol(cursorPos, plid, symbol)
+        | Some(scope, _builderOpt) -> scope.IsRelativeNameResolvableFromSymbol(cursorPos, plid, symbol)
 
     member _.GetDisplayContextForPos(cursorPos: pos) =
         match details with
         | None -> None
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             let (nenv, _), _ = scope.GetBestDisplayEnvForPos cursorPos
             Some(FSharpDisplayContext(fun _ -> nenv.DisplayEnv))
 
     member _.GenerateSignature(?pageWidth: int) =
         match details with
         | None -> None
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             scope.ImplementationFile
             |> Option.map (fun implFile ->
                 let denv = DisplayEnv.InitialForSigFileGeneration scope.TcGlobals
                 let infoReader = InfoReader(scope.TcGlobals, scope.TcImports.GetImportMap())
-                let (CheckedImplFile (contents = mexpr)) = implFile
+                let (CheckedImplFile(contents = mexpr)) = implFile
 
                 let ad =
                     match scopeOptX with
@@ -3213,7 +3211,7 @@ type FSharpCheckFileResults
 
         match details with
         | None -> failwith "Typechecked details not available for CalculateSignatureHash() operation."
-        | Some (scope, _builderOpt) ->
+        | Some(scope, _builderOpt) ->
             scope.ImplementationFile
             |> Option.map (fun implFile ->
                 Fsharp.Compiler.SignatureHash.calculateSignatureHashOfFiles [ implFile ] scope.TcGlobals visibility)
@@ -3373,7 +3371,19 @@ type FSharpCheckProjectResults
         tcConfigOption: TcConfig option,
         keepAssemblyContents: bool,
         diagnostics: FSharpDiagnostic[],
-        details: (TcGlobals * TcImports * CcuThunk * ModuleOrNamespaceType * Choice<IncrementalBuilder, TcSymbolUses> * TopAttribs option * (unit -> IRawFSharpAssemblyData option) * ILAssemblyRef * AccessorDomain * CheckedImplFile list option * string[] * FSharpProjectOptions) option
+        details:
+            (TcGlobals *
+            TcImports *
+            CcuThunk *
+            ModuleOrNamespaceType *
+            Choice<IncrementalBuilder, TcSymbolUses> *
+            TopAttribs option *
+            (unit -> IRawFSharpAssemblyData option) *
+            ILAssemblyRef *
+            AccessorDomain *
+            CheckedImplFile list option *
+            string[] *
+            FSharpProjectOptions) option
     ) =
 
     let getDetails () =
@@ -3476,7 +3486,7 @@ type FSharpCheckProjectResults
                     match builder.GetCheckResultsForFileInProjectEvenIfStale x with
                     | Some partialCheckResults ->
                         match partialCheckResults.TryPeekTcInfoWithExtras() with
-                        | Some (_, tcInfoExtras) -> tcInfoExtras.TcSymbolUses.GetUsesOfSymbol symbol.Item
+                        | Some(_, tcInfoExtras) -> tcInfoExtras.TcSymbolUses.GetUsesOfSymbol symbol.Item
                         | _ -> [||]
                     | _ -> [||])
             | Choice2Of2 tcSymbolUses -> tcSymbolUses.GetUsesOfSymbol symbol.Item
@@ -3506,7 +3516,7 @@ type FSharpCheckProjectResults
                     match builder.GetCheckResultsForFileInProjectEvenIfStale x with
                     | Some partialCheckResults ->
                         match partialCheckResults.TryPeekTcInfoWithExtras() with
-                        | Some (_, tcInfoExtras) -> tcInfoExtras.TcSymbolUses
+                        | Some(_, tcInfoExtras) -> tcInfoExtras.TcSymbolUses
                         | _ -> TcSymbolUses.Empty
                     | _ -> TcSymbolUses.Empty)
             | Choice2Of2 tcSymbolUses -> [| tcSymbolUses |]

--- a/src/Compiler/Service/FSharpCheckerResults.fsi
+++ b/src/Compiler/Service/FSharpCheckerResults.fsi
@@ -532,7 +532,19 @@ type public FSharpCheckProjectResults =
         tcConfigOption: TcConfig option *
         keepAssemblyContents: bool *
         diagnostics: FSharpDiagnostic[] *
-        details: (TcGlobals * TcImports * CcuThunk * ModuleOrNamespaceType * Choice<IncrementalBuilder, TcSymbolUses> * TopAttribs option * (unit -> IRawFSharpAssemblyData option) * ILAssemblyRef * AccessorDomain * CheckedImplFile list option * string[] * FSharpProjectOptions) option ->
+        details:
+            (TcGlobals *
+            TcImports *
+            CcuThunk *
+            ModuleOrNamespaceType *
+            Choice<IncrementalBuilder, TcSymbolUses> *
+            TopAttribs option *
+            (unit -> IRawFSharpAssemblyData option) *
+            ILAssemblyRef *
+            AccessorDomain *
+            CheckedImplFile list option *
+            string[] *
+            FSharpProjectOptions) option ->
             FSharpCheckProjectResults
 
 module internal ParseAndCheckFile =

--- a/src/Compiler/Service/ItemKey.fs
+++ b/src/Compiler/Service/ItemKey.fs
@@ -216,7 +216,7 @@ type ItemKeyStore(mmf: MemoryMappedFile, length, tcGlobals, debugStore) =
 
         match builder.TryBuildAndReset() with
         | None -> Seq.empty
-        | Some (singleStore: ItemKeyStore) ->
+        | Some(singleStore: ItemKeyStore) ->
             let keyString1 = singleStore.ReadFirstKeyString()
             (singleStore :> IDisposable).Dispose()
 
@@ -281,9 +281,9 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             writeString "!"
             writeUInt16 n
 
-        | ILType.Modified (_, _, ty2) -> writeILType ty2
+        | ILType.Modified(_, _, ty2) -> writeILType ty2
 
-        | ILType.Array (ILArrayShape s, ty) ->
+        | ILType.Array(ILArrayShape s, ty) ->
             writeILType ty
             writeString "["
             writeInt32 (s.Length - 1)
@@ -319,23 +319,23 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
         debug.WriteType isStandalone ty
 
         match stripTyparEqns ty with
-        | TType_forall (_, ty) -> writeType false ty
+        | TType_forall(_, ty) -> writeType false ty
 
-        | TType_app (tcref, _, _) ->
+        | TType_app(tcref, _, _) ->
             match isStandalone, tcref.TypeAbbrev with
             | false, Some ty -> writeType false ty
             | _ -> writeEntityRef tcref
 
-        | TType_tuple (_, tinst) ->
+        | TType_tuple(_, tinst) ->
             writeString ItemKeyTags.typeTuple
             tinst |> List.iter (writeType false)
 
-        | TType_anon (anonInfo, tinst) ->
+        | TType_anon(anonInfo, tinst) ->
             writeString ItemKeyTags.typeAnonymousRecord
             writeString anonInfo.ILTypeRef.BasicQualifiedName
             tinst |> List.iter (writeType false)
 
-        | TType_fun (domainTy, rangeTy, _) ->
+        | TType_fun(domainTy, rangeTy, _) ->
             writeString ItemKeyTags.typeFunction
             writeType false domainTy
             writeType false rangeTy
@@ -345,11 +345,11 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
                 writeString ItemKeyTags.typeMeasure
                 writeMeasure isStandalone ms
 
-        | TType_var (tp, _) -> writeTypar isStandalone tp
+        | TType_var(tp, _) -> writeTypar isStandalone tp
 
-        | TType_ucase (uc, _) ->
+        | TType_ucase(uc, _) ->
             match uc with
-            | UnionCaseRef.UnionCaseRef (tcref, nm) ->
+            | UnionCaseRef.UnionCaseRef(tcref, nm) ->
                 writeString ItemKeyTags.typeUnionCase
                 writeEntityRef tcref
                 writeString nm
@@ -395,7 +395,7 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             match vref.IsInstanceMember, tryDestFunTy tcGlobals vref.Type with
             // In case of an instance member, we will skip the type of "this" because it will differ
             // between the definition and overrides. Also it's not needed to uniquely identify the reference.
-            | true, ValueSome (_thisTy, funTy) -> funTy
+            | true, ValueSome(_thisTy, funTy) -> funTy
             | _ -> vref.Type
             |> writeType false
 
@@ -406,7 +406,7 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             writeType false vref.Type
 
             match vref.Deref.ArgReprInfoForDisplay with
-            | Some ({ OtherRange = Some (r) }) -> writeRange r
+            | Some({ OtherRange = Some(r) }) -> writeRange r
             | _ -> ()
 
             match vref.TryDeclaringEntity with
@@ -455,12 +455,12 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
         match item with
         | Item.Value vref -> writeValue vref
 
-        | Item.UnionCase (info, _) ->
+        | Item.UnionCase(info, _) ->
             writeString ItemKeyTags.typeUnionCase
             writeEntityRef info.TyconRef
             writeString info.LogicalName
 
-        | Item.ActivePatternResult (info, _, index, _) -> writeActivePatternCase info index
+        | Item.ActivePatternResult(info, _, index, _) -> writeActivePatternCase info index
 
         | Item.ActivePatternCase elemRef -> writeActivePatternCase elemRef.ActivePatternInfo elemRef.CaseIndex
 
@@ -474,13 +474,13 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             writeString info.LogicalName
             writeType false info.FieldType
 
-        | Item.UnionCaseField (info, fieldIndex) ->
+        | Item.UnionCaseField(info, fieldIndex) ->
             writeString ItemKeyTags.typeUnionCase
             writeEntityRef info.TyconRef
             writeString info.LogicalName
             writeInt32 fieldIndex
 
-        | Item.AnonRecdField (info, tys, i, _) ->
+        | Item.AnonRecdField(info, tys, i, _) ->
             writeString ItemKeyTags.itemAnonymousRecordField
             writeString info.ILTypeRef.BasicQualifiedName
             tys |> List.iter (writeType false)
@@ -500,7 +500,7 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             writeString info.EventName
             writeEntityRef info.DeclaringTyconRef
 
-        | Item.Property (nm, infos, _) ->
+        | Item.Property(nm, infos, _) ->
             writeString ItemKeyTags.itemProperty
             writeString nm
 
@@ -508,26 +508,26 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             | Some info -> writeEntityRef info.DeclaringTyconRef
             | _ -> ()
 
-        | Item.Trait (info) ->
+        | Item.Trait(info) ->
             writeString ItemKeyTags.itemTrait
             writeString info.MemberLogicalName
             info.SupportTypes |> List.iter (writeType false)
             info.CompiledObjectAndArgumentTypes |> List.iter (writeType false)
             info.CompiledReturnType |> Option.iter (writeType false)
 
-        | Item.TypeVar (_, typar) -> writeTypar true typar
+        | Item.TypeVar(_, typar) -> writeTypar true typar
 
-        | Item.Types (_, [ ty ]) -> writeType true ty
+        | Item.Types(_, [ ty ]) -> writeType true ty
 
         | Item.UnqualifiedType [ tcref ] -> writeEntityRef tcref
 
-        | Item.MethodGroup (_, [ info ], _)
-        | Item.CtorGroup (_, [ info ]) ->
+        | Item.MethodGroup(_, [ info ], _)
+        | Item.CtorGroup(_, [ info ]) ->
             match info with
-            | FSMeth (_, ty, vref, _) when vref.IsConstructor -> writeType true ty
-            | FSMeth (_, _, vref, _) -> writeValue vref
-            | ILMeth (_, ilMethInfo, _) when info.IsConstructor -> writeType true ilMethInfo.ApparentEnclosingType
-            | ILMeth (_, ilMethInfo, _) ->
+            | FSMeth(_, ty, vref, _) when vref.IsConstructor -> writeType true ty
+            | FSMeth(_, _, vref, _) -> writeValue vref
+            | ILMeth(_, ilMethInfo, _) when info.IsConstructor -> writeType true ilMethInfo.ApparentEnclosingType
+            | ILMeth(_, ilMethInfo, _) ->
                 ilMethInfo.ILMethodRef.ArgTypes |> List.iter writeILType
                 writeILType ilMethInfo.ILMethodRef.ReturnType
                 writeString ilMethInfo.ILName
@@ -552,7 +552,7 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
             writeType false ty
 
         // Named argument in a signature
-        | Item.OtherName (ident = Some (ident); argType = ty; argInfo = Some _) ->
+        | Item.OtherName(ident = Some(ident); argType = ty; argInfo = Some _) ->
             writeString ItemKeyTags.itemValue
             writeString ident.idText
             writeString ItemKeyTags.parameters
@@ -569,18 +569,18 @@ and [<Sealed>] ItemKeyStoreBuilder(tcGlobals: TcGlobals) =
         | Item.SetterArg _ -> ()
 
         // Empty lists do not occur
-        | Item.Types (_, []) -> ()
+        | Item.Types(_, []) -> ()
         | Item.UnqualifiedType [] -> ()
-        | Item.MethodGroup (_, [], _) -> ()
-        | Item.CtorGroup (_, []) -> ()
+        | Item.MethodGroup(_, [], _) -> ()
+        | Item.CtorGroup(_, []) -> ()
         | Item.ModuleOrNamespaces [] -> ()
 
         // Items are flattened so multiples are not expected
-        | Item.Types (_, _ :: _ :: _) -> ()
-        | Item.UnqualifiedType (_ :: _ :: _) -> ()
-        | Item.MethodGroup (_, (_ :: _ :: _), _) -> ()
-        | Item.CtorGroup (_, (_ :: _ :: _)) -> ()
-        | Item.ModuleOrNamespaces (_ :: _ :: _) -> ()
+        | Item.Types(_, _ :: _ :: _) -> ()
+        | Item.UnqualifiedType(_ :: _ :: _) -> ()
+        | Item.MethodGroup(_, (_ :: _ :: _), _) -> ()
+        | Item.CtorGroup(_, (_ :: _ :: _)) -> ()
+        | Item.ModuleOrNamespaces(_ :: _ :: _) -> ()
 
         let postCount = b.Count
 

--- a/src/Compiler/Service/QuickParse.fs
+++ b/src/Compiler/Service/QuickParse.fs
@@ -153,7 +153,7 @@ module QuickParse =
                 walkOutsideBackticks 0
 
             match tickColsOpt with
-            | Some (prevTickTick, idxTickTick) ->
+            | Some(prevTickTick, idxTickTick) ->
                 // inside ``identifier`` (which can contain any characters!) so we try returning its location
                 let pos = idxTickTick + 1 + MagicalAdjustmentConstant
                 let ident = lineStr.Substring(prevTickTick, idxTickTick - prevTickTick + 2)
@@ -318,9 +318,9 @@ module QuickParse =
                     if nesting = 1 then
                         // all right, we are at the end of comment, jump outside
                         match callContext with
-                        | EatCommentCallContext.SkipWhiteSpaces (ident, current, throwAway) ->
+                        | EatCommentCallContext.SkipWhiteSpaces(ident, current, throwAway) ->
                             SkipWhitespaceBeforeDotIdentifier(pos + 2, ident, current, throwAway, lastDotPos)
-                        | EatCommentCallContext.StartIdentifier (current, throwAway) ->
+                        | EatCommentCallContext.StartIdentifier(current, throwAway) ->
                             AtStartOfIdentifier(pos + 2, current, throwAway, lastDotPos)
                     else
                         // reduce level of nesting and continue

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -114,7 +114,7 @@ module TcResolutionsExtensions =
             | TFSharpStruct -> SemanticClassificationType.ValueType
             | TFSharpDelegate _ -> SemanticClassificationType.Delegate
             | TFSharpEnum -> SemanticClassificationType.Enumeration
-        | TILObjectRepr (TILObjectReprData (_, _, td)) ->
+        | TILObjectRepr(TILObjectReprData(_, _, td)) ->
             if td.IsClass then
                 SemanticClassificationType.ReferenceType
             elif td.IsStruct then
@@ -257,7 +257,7 @@ module TcResolutionsExtensions =
                                 else
                                     add m SemanticClassificationType.RecordField
 
-                        | Item.AnonRecdField (_, tys, idx, m), _, _ ->
+                        | Item.AnonRecdField(_, tys, idx, m), _, _ ->
                             let ty = tys[idx]
 
                             // It's not currently possible for anon record fields to be mutable, but they can be ref cells
@@ -272,7 +272,7 @@ module TcResolutionsExtensions =
                             if not pinfo.IsIndexer then
                                 add m SemanticClassificationType.Property
 
-                        | Item.CtorGroup (_, minfos), _, m ->
+                        | Item.CtorGroup(_, minfos), _, m ->
                             match minfos with
                             | [] -> add m SemanticClassificationType.ConstructorForReferenceType
                             | _ ->
@@ -290,7 +290,7 @@ module TcResolutionsExtensions =
 
                         | Item.FakeInterfaceCtor _, _, m -> add m SemanticClassificationType.ConstructorForReferenceType
 
-                        | Item.MethodGroup (_, minfos, _), _, m ->
+                        | Item.MethodGroup(_, minfos, _), _, m ->
                             match minfos with
                             | [] -> add m SemanticClassificationType.Method
                             | _ ->
@@ -303,12 +303,12 @@ module TcResolutionsExtensions =
                                     add m SemanticClassificationType.Method
 
                         // Special case measures for struct types
-                        | Item.Types (_, AppTy g (tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurence, m when
+                        | Item.Types(_, AppTy g (tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurence, m when
                             isStructTyconRef g tyconRef
                             ->
                             add m SemanticClassificationType.ValueType
 
-                        | Item.Types (_, ty :: _), LegitTypeOccurence, m ->
+                        | Item.Types(_, ty :: _), LegitTypeOccurence, m ->
                             let ty = stripTyEqns g ty
 
                             if isDisposableTy g amap ty then
@@ -332,7 +332,7 @@ module TcResolutionsExtensions =
 
                         | Item.ExnCase _, LegitTypeOccurence, m -> add m SemanticClassificationType.Exception
 
-                        | Item.ModuleOrNamespaces (modref :: _), LegitTypeOccurence, m ->
+                        | Item.ModuleOrNamespaces(modref :: _), LegitTypeOccurence, m ->
                             if modref.IsNamespace then
                                 add m SemanticClassificationType.Namespace
                             else
@@ -356,7 +356,7 @@ module TcResolutionsExtensions =
 
                         | Item.SetterArg _, _, m -> add m SemanticClassificationType.NamedArgument
 
-                        | Item.UnqualifiedType (tcref :: _), LegitTypeOccurence, m ->
+                        | Item.UnqualifiedType(tcref :: _), LegitTypeOccurence, m ->
                             if tcref.IsEnumTycon || tcref.IsILEnumTycon then
                                 add m SemanticClassificationType.Enumeration
                             elif tcref.IsFSharpException then
@@ -377,7 +377,7 @@ module TcResolutionsExtensions =
                                 else
                                     add m SemanticClassificationType.UnionCase
                             elif tcref.IsILTycon then
-                                let (TILObjectReprData (_, _, tydef)) = tcref.ILTyconInfo
+                                let (TILObjectReprData(_, _, tydef)) = tcref.ILTyconInfo
 
                                 if tydef.IsInterface then
                                     add m SemanticClassificationType.Interface

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -719,9 +719,9 @@ module UnnecessaryParentheses =
         [<return: Struct>]
         let (|HighPrecedenceApp|_|) expr =
             match expr with
-            | SynExpr.App (isInfix = false; funcExpr = SynExpr.Ident _)
-            | SynExpr.App (isInfix = false; funcExpr = SynExpr.LongIdent _)
-            | SynExpr.App (isInfix = false; funcExpr = SynExpr.App(isInfix = false)) -> ValueSome HighPrecedenceApp
+            | SynExpr.App(isInfix = false; funcExpr = SynExpr.Ident _)
+            | SynExpr.App(isInfix = false; funcExpr = SynExpr.LongIdent _)
+            | SynExpr.App(isInfix = false; funcExpr = SynExpr.App(isInfix = false)) -> ValueSome HighPrecedenceApp
             | _ -> ValueNone
 
         module FuncExpr =
@@ -730,11 +730,11 @@ module UnnecessaryParentheses =
             [<return: Struct>]
             let (|SymbolicOperator|_|) funcExpr =
                 match funcExpr with
-                | SynExpr.LongIdent(longDotId = SynLongIdent (trivia = trivia)) ->
+                | SynExpr.LongIdent(longDotId = SynLongIdent(trivia = trivia)) ->
                     let rec tryPick =
                         function
                         | [] -> ValueNone
-                        | Some (IdentTrivia.OriginalNotation op) :: _ -> ValueSome op
+                        | Some(IdentTrivia.OriginalNotation op) :: _ -> ValueSome op
                         | _ :: rest -> tryPick rest
 
                     tryPick trivia
@@ -748,7 +748,7 @@ module UnnecessaryParentheses =
         [<return: Struct>]
         let (|PrefixApp|_|) expr : Precedence voption =
             match expr with
-            | SynExpr.App (isInfix = false; funcExpr = funcExpr & FuncExpr.SymbolicOperator op; argExpr = argExpr) ->
+            | SynExpr.App(isInfix = false; funcExpr = funcExpr & FuncExpr.SymbolicOperator op; argExpr = argExpr) ->
                 if funcExpr.Range.IsAdjacentTo argExpr.Range then
                     ValueSome High
                 else
@@ -759,7 +759,7 @@ module UnnecessaryParentheses =
                     | '~' -> ValueSome High
                     | _ -> ValueSome UnaryPrefix
 
-            | SynExpr.AddressOf (expr = expr; opRange = opRange) ->
+            | SynExpr.AddressOf(expr = expr; opRange = opRange) ->
                 if opRange.IsAdjacentTo expr.Range then
                     ValueSome High
                 else
@@ -811,13 +811,13 @@ module UnnecessaryParentheses =
             match synExpr with
             | SynExpr.Paren(expr = ConfusableWithTypeApp)
             | SynExpr.App(funcExpr = ConfusableWithTypeApp)
-            | SynExpr.App (isInfix = true; funcExpr = FuncExpr.SymbolicOperator (SymbolPrec Greater); argExpr = ConfusableWithTypeApp) ->
+            | SynExpr.App(isInfix = true; funcExpr = FuncExpr.SymbolicOperator(SymbolPrec Greater); argExpr = ConfusableWithTypeApp) ->
                 ValueSome ConfusableWithTypeApp
-            | SynExpr.App (isInfix = true; funcExpr = funcExpr & FuncExpr.SymbolicOperator (SymbolPrec Less); argExpr = argExpr) when
+            | SynExpr.App(isInfix = true; funcExpr = funcExpr & FuncExpr.SymbolicOperator(SymbolPrec Less); argExpr = argExpr) when
                 argExpr.Range.IsAdjacentTo funcExpr.Range
                 ->
                 ValueSome ConfusableWithTypeApp
-            | SynExpr.Tuple (exprs = exprs) ->
+            | SynExpr.Tuple(exprs = exprs) ->
                 let rec anyButLast =
                     function
                     | _ :: []
@@ -836,9 +836,9 @@ module UnnecessaryParentheses =
         [<return: Struct>]
         let (|InfixApp|_|) synExpr : struct (Precedence * Assoc) voption =
             match synExpr with
-            | SynExpr.App(funcExpr = SynExpr.App (isInfix = true; funcExpr = FuncExpr.SymbolicOperator (SymbolPrec prec))) ->
+            | SynExpr.App(funcExpr = SynExpr.App(isInfix = true; funcExpr = FuncExpr.SymbolicOperator(SymbolPrec prec))) ->
                 ValueSome(prec, Right)
-            | SynExpr.App (isInfix = true; funcExpr = FuncExpr.SymbolicOperator (SymbolPrec prec)) -> ValueSome(prec, Left)
+            | SynExpr.App(isInfix = true; funcExpr = FuncExpr.SymbolicOperator(SymbolPrec prec)) -> ValueSome(prec, Left)
             | SynExpr.Upcast _ -> ValueSome(Upcast, Left)
             | SynExpr.Downcast _ -> ValueSome(Downcast, Left)
             | SynExpr.TypeTest _ -> ValueSome(TypeTest, Left)
@@ -853,13 +853,13 @@ module UnnecessaryParentheses =
             | SynExpr.YieldOrReturnFrom _ -> ValueSome(Low, Right)
             | SynExpr.Tuple(exprs = SynExpr.Paren(expr = Is inner) :: _) -> ValueSome(Comma, Left)
             | SynExpr.Tuple _ -> ValueSome(Comma, Right)
-            | InfixApp (Cons, side) -> ValueSome(Cons, side)
+            | InfixApp(Cons, side) -> ValueSome(Cons, side)
             | SynExpr.Assert _
             | SynExpr.Lazy _
             | SynExpr.InferredUpcast _
             | SynExpr.InferredDowncast _ -> ValueSome(Apply, Non)
             | PrefixApp prec -> ValueSome(prec, Non)
-            | InfixApp (prec, side) -> ValueSome(prec, side)
+            | InfixApp(prec, side) -> ValueSome(prec, side)
             | SynExpr.App(argExpr = SynExpr.ComputationExpr _) -> ValueSome(UnaryPrefix, Left)
             | SynExpr.App(funcExpr = SynExpr.Paren(expr = SynExpr.App _)) -> ValueSome(Apply, Left)
             | SynExpr.App _ -> ValueSome(Apply, Non)
@@ -882,8 +882,8 @@ module UnnecessaryParentheses =
         let (|NestedApp|_|) expr =
             let rec loop =
                 function
-                | SynExpr.DotGet (expr = expr)
-                | SynExpr.DotIndexedGet (objectExpr = expr) -> loop expr
+                | SynExpr.DotGet(expr = expr)
+                | SynExpr.DotIndexedGet(objectExpr = expr) -> loop expr
                 | SynExpr.App _ -> ValueSome NestedApp
                 | _ -> ValueNone
 
@@ -899,7 +899,7 @@ module UnnecessaryParentheses =
             | SynExpr.DotGet _
             | SynExpr.DotIndexedGet _ -> ValueSome Dot
             | PrefixApp prec -> ValueSome prec
-            | InfixApp (prec, _) -> ValueSome prec
+            | InfixApp(prec, _) -> ValueSome prec
             | SynExpr.App _
             | SynExpr.Assert _
             | SynExpr.Lazy _
@@ -924,25 +924,25 @@ module UnnecessaryParentheses =
                 let rec loop expr =
                     match expr with
                     | Target expr -> ValueSome expr
-                    | SynExpr.Tuple (isStruct = false; exprs = Last expr)
-                    | SynExpr.App (argExpr = expr)
+                    | SynExpr.Tuple(isStruct = false; exprs = Last expr)
+                    | SynExpr.App(argExpr = expr)
                     | SynExpr.IfThenElse(elseExpr = Some expr)
-                    | SynExpr.IfThenElse (ifExpr = expr)
-                    | SynExpr.Sequential (expr2 = expr)
-                    | SynExpr.YieldOrReturn (expr = expr)
-                    | SynExpr.YieldOrReturnFrom (expr = expr)
-                    | SynExpr.Set (rhsExpr = expr)
-                    | SynExpr.DotSet (rhsExpr = expr)
-                    | SynExpr.DotNamedIndexedPropertySet (rhsExpr = expr)
-                    | SynExpr.DotIndexedSet (valueExpr = expr)
-                    | SynExpr.LongIdentSet (expr = expr)
-                    | SynExpr.LetOrUse (body = expr)
-                    | SynExpr.Lambda (body = expr)
-                    | SynExpr.Match(clauses = Last (SynMatchClause (resultExpr = expr)))
-                    | SynExpr.MatchLambda(matchClauses = Last (SynMatchClause (resultExpr = expr)))
-                    | SynExpr.MatchBang(clauses = Last (SynMatchClause (resultExpr = expr)))
-                    | SynExpr.TryWith(withCases = Last (SynMatchClause (resultExpr = expr)))
-                    | SynExpr.TryFinally (finallyExpr = expr) -> loop expr
+                    | SynExpr.IfThenElse(ifExpr = expr)
+                    | SynExpr.Sequential(expr2 = expr)
+                    | SynExpr.YieldOrReturn(expr = expr)
+                    | SynExpr.YieldOrReturnFrom(expr = expr)
+                    | SynExpr.Set(rhsExpr = expr)
+                    | SynExpr.DotSet(rhsExpr = expr)
+                    | SynExpr.DotNamedIndexedPropertySet(rhsExpr = expr)
+                    | SynExpr.DotIndexedSet(valueExpr = expr)
+                    | SynExpr.LongIdentSet(expr = expr)
+                    | SynExpr.LetOrUse(body = expr)
+                    | SynExpr.Lambda(body = expr)
+                    | SynExpr.Match(clauses = Last(SynMatchClause(resultExpr = expr)))
+                    | SynExpr.MatchLambda(matchClauses = Last(SynMatchClause(resultExpr = expr)))
+                    | SynExpr.MatchBang(clauses = Last(SynMatchClause(resultExpr = expr)))
+                    | SynExpr.TryWith(withCases = Last(SynMatchClause(resultExpr = expr)))
+                    | SynExpr.TryFinally(finallyExpr = expr) -> loop expr
                     | _ -> ValueNone
 
                 loop
@@ -1058,22 +1058,22 @@ module UnnecessaryParentheses =
                 function
                 | SynExpr.Quote _
                 | SynExpr.InterpolatedString _
-                | SynExpr.Const (SynConst.String(synStringKind = SynStringKind.Verbatim), _)
-                | SynExpr.Const (SynConst.Byte _, TextStartsWith '+')
-                | SynExpr.Const (SynConst.UInt16 _, TextStartsWith '+')
-                | SynExpr.Const (SynConst.UInt32 _, TextStartsWith '+')
-                | SynExpr.Const (SynConst.UInt64 _, TextStartsWith '+')
-                | SynExpr.Const (SynConst.UIntPtr _, TextStartsWith '+')
-                | SynExpr.Const (SynConst.SByte _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Int16 _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Int32 _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Int64 _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.IntPtr _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Decimal _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Double _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Single _, TextStartsWith ('-' | '+'))
-                | SynExpr.Const (SynConst.Measure (_, TextStartsWith ('-' | '+'), _, _), _)
-                | SynExpr.Const (SynConst.UserNum (StartsWith ('-' | '+'), _), _) -> Some StartsWithSymbol
+                | SynExpr.Const(SynConst.String(synStringKind = SynStringKind.Verbatim), _)
+                | SynExpr.Const(SynConst.Byte _, TextStartsWith '+')
+                | SynExpr.Const(SynConst.UInt16 _, TextStartsWith '+')
+                | SynExpr.Const(SynConst.UInt32 _, TextStartsWith '+')
+                | SynExpr.Const(SynConst.UInt64 _, TextStartsWith '+')
+                | SynExpr.Const(SynConst.UIntPtr _, TextStartsWith '+')
+                | SynExpr.Const(SynConst.SByte _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Int16 _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Int32 _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Int64 _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.IntPtr _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Decimal _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Double _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Single _, TextStartsWith('-' | '+'))
+                | SynExpr.Const(SynConst.Measure(_, TextStartsWith('-' | '+'), _, _), _)
+                | SynExpr.Const(SynConst.UserNum(StartsWith('-' | '+'), _), _) -> Some StartsWithSymbol
                 | _ -> None
 
             // Matches if the given expression is a numeric literal
@@ -1100,21 +1100,21 @@ module UnnecessaryParentheses =
                         None
 
                 function
-                | SynExpr.Const (SynConst.Byte _, _)
-                | SynExpr.Const (SynConst.UInt16 _, _)
-                | SynExpr.Const (SynConst.UInt32 _, _)
-                | SynExpr.Const (SynConst.UInt64 _, _)
-                | SynExpr.Const (SynConst.UIntPtr _, _)
-                | SynExpr.Const (SynConst.SByte _, _)
-                | SynExpr.Const (SynConst.Int16 _, _)
-                | SynExpr.Const (SynConst.Int32 _, TextContainsLetter)
-                | SynExpr.Const (SynConst.Int64 _, _)
-                | SynExpr.Const (SynConst.IntPtr _, _)
-                | SynExpr.Const (SynConst.Decimal _, _)
-                | SynExpr.Const (SynConst.Double _, (TextEndsWithNumber | TextContainsLetter))
-                | SynExpr.Const (SynConst.Single _, _)
-                | SynExpr.Const (SynConst.Measure _, _)
-                | SynExpr.Const (SynConst.UserNum _, _) -> Some DotSafeNumericLiteral
+                | SynExpr.Const(SynConst.Byte _, _)
+                | SynExpr.Const(SynConst.UInt16 _, _)
+                | SynExpr.Const(SynConst.UInt32 _, _)
+                | SynExpr.Const(SynConst.UInt64 _, _)
+                | SynExpr.Const(SynConst.UIntPtr _, _)
+                | SynExpr.Const(SynConst.SByte _, _)
+                | SynExpr.Const(SynConst.Int16 _, _)
+                | SynExpr.Const(SynConst.Int32 _, TextContainsLetter)
+                | SynExpr.Const(SynConst.Int64 _, _)
+                | SynExpr.Const(SynConst.IntPtr _, _)
+                | SynExpr.Const(SynConst.Decimal _, _)
+                | SynExpr.Const(SynConst.Double _, (TextEndsWithNumber | TextContainsLetter))
+                | SynExpr.Const(SynConst.Single _, _)
+                | SynExpr.Const(SynConst.Measure _, _)
+                | SynExpr.Const(SynConst.UserNum _, _) -> Some DotSafeNumericLiteral
                 | _ -> None
 
             match expr, path with
@@ -1141,8 +1141,8 @@ module UnnecessaryParentheses =
             //
             //     let x = (x
             //           + y)
-            | SynExpr.Paren (rightParenRange = Some _; range = parenRange),
-              SyntaxNode.SynBinding (SynBinding(trivia = { LeadingKeyword = leadingKeyword })) :: _ when
+            | SynExpr.Paren(rightParenRange = Some _; range = parenRange),
+              SyntaxNode.SynBinding(SynBinding(trivia = { LeadingKeyword = leadingKeyword })) :: _ when
                 containsSensitiveIndentation leadingKeyword.Range.StartColumn parenRange
                 ->
                 ValueNone
@@ -1152,8 +1152,8 @@ module UnnecessaryParentheses =
             //     let x = (…)
             //     _.member X = (…)
             //     (printfn "Hello, world.")
-            | SynExpr.Paren (rightParenRange = Some _; range = range), SyntaxNode.SynBinding _ :: _
-            | SynExpr.Paren (rightParenRange = Some _; range = range), SyntaxNode.SynModule _ :: _ -> ValueSome range
+            | SynExpr.Paren(rightParenRange = Some _; range = range), SyntaxNode.SynBinding _ :: _
+            | SynExpr.Paren(rightParenRange = Some _; range = range), SyntaxNode.SynModule _ :: _ -> ValueSome range
 
             // Parens must be kept when there is a high-precedence function application
             // before a prefix operator application before another expression that starts with a symbol, e.g.,
@@ -1165,7 +1165,7 @@ module UnnecessaryParentheses =
             //     id -(<@ ValueNone @>)
             //     let (~+) _ = true in assert +($"{true}")
             | SynExpr.Paren(expr = PrefixApp _ | StartsWithSymbol),
-              SyntaxNode.SynExpr (SynExpr.App _) :: SyntaxNode.SynExpr (HighPrecedenceApp | SynExpr.Assert _ | SynExpr.InferredUpcast _ | SynExpr.InferredDowncast _) :: _ ->
+              SyntaxNode.SynExpr(SynExpr.App _) :: SyntaxNode.SynExpr(HighPrecedenceApp | SynExpr.Assert _ | SynExpr.InferredUpcast _ | SynExpr.InferredDowncast _) :: _ ->
                 ValueNone
 
             // Parens are never required around suffixed or infixed numeric literals, e.g.,
@@ -1175,7 +1175,7 @@ module UnnecessaryParentheses =
             //     (0b1).ToString()
             //     (1e10).ToString()
             //     (1.0).ToString()
-            | SynExpr.Paren (expr = DotSafeNumericLiteral; rightParenRange = Some _; range = range), _ -> ValueSome range
+            | SynExpr.Paren(expr = DotSafeNumericLiteral; rightParenRange = Some _; range = range), _ -> ValueSome range
 
             // Parens are required around bare decimal ints or doubles ending
             // in dots when being dotted into, e.g.,
@@ -1183,12 +1183,12 @@ module UnnecessaryParentheses =
             //     (1).ToString()
             //     (1.).ToString()
             | SynExpr.Paren(expr = SynExpr.Const(constant = SynConst.Int32 _ | SynConst.Double _)),
-              SyntaxNode.SynExpr (SynExpr.DotGet _) :: _ -> ValueNone
+              SyntaxNode.SynExpr(SynExpr.DotGet _) :: _ -> ValueNone
 
             // Parens are required around join conditions:
             //
             //     join … on (… = …)
-            | SynExpr.Paren(expr = SynExpr.App _), SyntaxNode.SynExpr (SynExpr.App _) :: SyntaxNode.SynExpr (SynExpr.JoinIn _) :: _ ->
+            | SynExpr.Paren(expr = SynExpr.App _), SyntaxNode.SynExpr(SynExpr.App _) :: SyntaxNode.SynExpr(SynExpr.JoinIn _) :: _ ->
                 ValueNone
 
             // Parens are not required around a few anointed expressions after inherit:
@@ -1197,11 +1197,11 @@ module UnnecessaryParentheses =
             //     inherit T(null)
             //     inherit T("")
             //     …
-            | SynExpr.Paren (expr = AtomicExprAfterType; range = range), SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
+            | SynExpr.Paren(expr = AtomicExprAfterType; range = range), SyntaxNode.SynMemberDefn(SynMemberDefn.ImplicitInherit _) :: _ ->
                 ValueSome range
 
             // Parens are otherwise required in inherit T(x), etc.
-            | SynExpr.Paren _, SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ -> ValueNone
+            | SynExpr.Paren _, SyntaxNode.SynMemberDefn(SynMemberDefn.ImplicitInherit _) :: _ -> ValueNone
 
             // We can't remove parens when they're required for fluent calls:
             //
@@ -1210,11 +1210,11 @@ module UnnecessaryParentheses =
             //     (f x)[z]
             //     (f(x))[z]
             //     x.M(y)[z]
-            | SynExpr.Paren _, SyntaxNode.SynExpr (SynExpr.App _) :: SyntaxNode.SynExpr (SynExpr.DotGet _ | SynExpr.DotIndexedGet _) :: _
+            | SynExpr.Paren _, SyntaxNode.SynExpr(SynExpr.App _) :: SyntaxNode.SynExpr(SynExpr.DotGet _ | SynExpr.DotIndexedGet _) :: _
             | SynExpr.Paren(expr = SynExpr.App _),
-              SyntaxNode.SynExpr (SynExpr.App(argExpr = SynExpr.ArrayOrListComputed(isArray = false))) :: _
+              SyntaxNode.SynExpr(SynExpr.App(argExpr = SynExpr.ArrayOrListComputed(isArray = false))) :: _
             | SynExpr.Paren _,
-              SyntaxNode.SynExpr (SynExpr.App _) :: SyntaxNode.SynExpr (SynExpr.App(argExpr = SynExpr.ArrayOrListComputed(isArray = false))) :: _ ->
+              SyntaxNode.SynExpr(SynExpr.App _) :: SyntaxNode.SynExpr(SynExpr.App(argExpr = SynExpr.ArrayOrListComputed(isArray = false))) :: _ ->
                 ValueNone
 
             // Parens must stay around binary equals expressions in argument
@@ -1222,13 +1222,13 @@ module UnnecessaryParentheses =
             //
             //     o.M((x = y))
             //     o.N((x = y), z)
-            | SynExpr.Paren(expr = SynExpr.Paren(expr = InfixApp (Eq, _))),
-              SyntaxNode.SynExpr (SynExpr.App(funcExpr = SynExpr.LongIdent _)) :: _
-            | SynExpr.Paren(expr = InfixApp (Eq, _)),
-              SyntaxNode.SynExpr (SynExpr.Paren _) :: SyntaxNode.SynExpr (SynExpr.App(funcExpr = SynExpr.LongIdent _)) :: _
-            | SynExpr.Paren(expr = InfixApp (Eq, _)),
-              SyntaxNode.SynExpr (SynExpr.Tuple(isStruct = false)) :: SyntaxNode.SynExpr (SynExpr.Paren _) :: SyntaxNode.SynExpr (SynExpr.App(funcExpr = SynExpr.LongIdent _)) :: _ ->
-                ValueNone
+            | SynExpr.Paren(expr = SynExpr.Paren(expr = InfixApp(Eq, _))),
+              SyntaxNode.SynExpr(SynExpr.App(funcExpr = SynExpr.LongIdent _)) :: _
+            | SynExpr.Paren(expr = InfixApp(Eq, _)),
+              SyntaxNode.SynExpr(SynExpr.Paren _) :: SyntaxNode.SynExpr(SynExpr.App(funcExpr = SynExpr.LongIdent _)) :: _
+            | SynExpr.Paren(expr = InfixApp(Eq, _)),
+              SyntaxNode.SynExpr(SynExpr.Tuple(isStruct = false)) :: SyntaxNode.SynExpr(SynExpr.Paren _) :: SyntaxNode.SynExpr(SynExpr.App(
+                  funcExpr = SynExpr.LongIdent _)) :: _ -> ValueNone
 
             // The :: operator is parsed differently from other symbolic infix operators,
             // so we need to give it special treatment.
@@ -1239,8 +1239,8 @@ module UnnecessaryParentheses =
             //     (x * y) :: zs
             //     …
             | SynExpr.Paren(rightParenRange = Some _),
-              SyntaxNode.SynExpr (SynExpr.Tuple (isStruct = false; exprs = [ SynExpr.Paren _; _ ])) :: (SyntaxNode.SynExpr (SynExpr.App(isInfix = true)) :: _ as path) ->
-                unnecessaryParentheses expr path
+              SyntaxNode.SynExpr(SynExpr.Tuple(isStruct = false; exprs = [ SynExpr.Paren _; _ ])) :: (SyntaxNode.SynExpr(SynExpr.App(
+                  isInfix = true)) :: _ as path) -> unnecessaryParentheses expr path
 
             // Outer left:
             //
@@ -1248,14 +1248,15 @@ module UnnecessaryParentheses =
             //     x :: (ys @ zs)
             //     …
             | SynExpr.Paren(rightParenRange = Some _) as argExpr,
-              SyntaxNode.SynExpr (SynExpr.Tuple (isStruct = false; exprs = [ _; SynExpr.Paren _ ])) :: SyntaxNode.SynExpr (SynExpr.App(isInfix = true) as outer) :: path ->
+              SyntaxNode.SynExpr(SynExpr.Tuple(isStruct = false; exprs = [ _; SynExpr.Paren _ ])) :: SyntaxNode.SynExpr(SynExpr.App(
+                  isInfix = true) as outer) :: path ->
                 unnecessaryParentheses
                     expr
                     (SyntaxNode.SynExpr(SynExpr.App(ExprAtomicFlag.NonAtomic, false, outer, argExpr, outer.Range))
                      :: path)
 
             // Ordinary nested expressions.
-            | SynExpr.Paren (expr = inner; leftParenRange = leftParenRange; rightParenRange = Some _ as rightParenRange; range = range),
+            | SynExpr.Paren(expr = inner; leftParenRange = leftParenRange; rightParenRange = Some _ as rightParenRange; range = range),
               SyntaxNode.SynExpr outer :: outerPath when not (containsSensitiveIndentation outer.Range.StartColumn range) ->
                 let dangling expr =
                     match expr with
@@ -1263,8 +1264,8 @@ module UnnecessaryParentheses =
                         let parenzedSubExpr = SynExpr.Paren(subExpr, leftParenRange, rightParenRange, range)
 
                         match outer with
-                        | SynExpr.Tuple (exprs = exprs) -> not (obj.ReferenceEquals(subExpr, List.last exprs))
-                        | InfixApp (_, Left) -> true
+                        | SynExpr.Tuple(exprs = exprs) -> not (obj.ReferenceEquals(subExpr, List.last exprs))
+                        | InfixApp(_, Left) -> true
                         | _ -> unnecessaryParentheses parenzedSubExpr outerPath |> ValueOption.isNone
 
                     | _ -> false
@@ -1277,7 +1278,7 @@ module UnnecessaryParentheses =
                     let rec loop =
                         function
                         | [] -> false
-                        | SynMatchClause (trivia = trivia) :: clauses ->
+                        | SynMatchClause(trivia = trivia) :: clauses ->
                             trivia.BarRange |> Option.exists (problematic matchOrTryRange)
                             || trivia.ArrowRange |> Option.exists (problematic matchOrTryRange)
                             || loop clauses
@@ -1289,37 +1290,37 @@ module UnnecessaryParentheses =
 
                 | SynExpr.IfThenElse _, Dangling.Sequential _ -> ValueNone
 
-                | SynExpr.IfThenElse (trivia = trivia), Dangling.IfThen ifThenElse when
+                | SynExpr.IfThenElse(trivia = trivia), Dangling.IfThen ifThenElse when
                     problematic ifThenElse.Range trivia.ThenKeyword
                     || trivia.ElseKeyword |> Option.exists (problematic ifThenElse.Range)
                     ->
                     ValueNone
 
-                | SynExpr.TryFinally (trivia = trivia), Dangling.Try tryExpr when problematic tryExpr.Range trivia.FinallyKeyword ->
+                | SynExpr.TryFinally(trivia = trivia), Dangling.Try tryExpr when problematic tryExpr.Range trivia.FinallyKeyword ->
                     ValueNone
 
-                | SynExpr.Match (clauses = clauses; trivia = { WithKeyword = withKeyword }), Dangling.Match matchOrTry when
+                | SynExpr.Match(clauses = clauses; trivia = { WithKeyword = withKeyword }), Dangling.Match matchOrTry when
                     problematic matchOrTry.Range withKeyword
                     || anyProblematic matchOrTry.Range clauses
                     ->
                     ValueNone
 
-                | SynExpr.MatchBang (clauses = clauses; trivia = { WithKeyword = withKeyword }), Dangling.Match matchOrTry when
+                | SynExpr.MatchBang(clauses = clauses; trivia = { WithKeyword = withKeyword }), Dangling.Match matchOrTry when
                     problematic matchOrTry.Range withKeyword
                     || anyProblematic matchOrTry.Range clauses
                     ->
                     ValueNone
 
-                | SynExpr.MatchLambda (matchClauses = clauses), Dangling.Match matchOrTry when anyProblematic matchOrTry.Range clauses ->
+                | SynExpr.MatchLambda(matchClauses = clauses), Dangling.Match matchOrTry when anyProblematic matchOrTry.Range clauses ->
                     ValueNone
 
-                | SynExpr.TryWith (withCases = clauses; trivia = trivia), Dangling.Match matchOrTry when
+                | SynExpr.TryWith(withCases = clauses; trivia = trivia), Dangling.Match matchOrTry when
                     problematic matchOrTry.Range trivia.WithKeyword
                     || anyProblematic matchOrTry.Range clauses
                     ->
                     ValueNone
 
-                | SynExpr.Sequential (expr1 = SynExpr.Paren(expr = Is inner); expr2 = expr2), Dangling.Problematic _ when
+                | SynExpr.Sequential(expr1 = SynExpr.Paren(expr = Is inner); expr2 = expr2), Dangling.Problematic _ when
                     problematic inner.Range expr2.Range
                     ->
                     ValueNone
@@ -1372,8 +1373,8 @@ module UnnecessaryParentheses =
                 | SynExpr.New _, _ -> ValueNone
 
                 // { inherit T(expr); … }
-                | SynExpr.Record(baseInfo = Some (_, SynExpr.Paren(expr = Is inner), _, _, _)), AtomicExprAfterType -> ValueSome range
-                | SynExpr.Record(baseInfo = Some (_, SynExpr.Paren(expr = Is inner), _, _, _)), _ -> ValueNone
+                | SynExpr.Record(baseInfo = Some(_, SynExpr.Paren(expr = Is inner), _, _, _)), AtomicExprAfterType -> ValueSome range
+                | SynExpr.Record(baseInfo = Some(_, SynExpr.Paren(expr = Is inner), _, _, _)), _ -> ValueNone
 
                 | _, SynExpr.Paren _
                 | _, SynExpr.Quote _
@@ -1457,18 +1458,18 @@ module UnnecessaryParentheses =
             //     fun (x, y, …) -> …
             //     fun (x: …) -> …
             //     fun (Pattern …) -> …
-            | SynPat.Paren (SynPat.Typed _, _), SyntaxNode.SynExpr (SynExpr.LetOrUseBang _) :: _
-            | SynPat.Paren (SynPat.Typed _, _), SyntaxNode.SynPat (SynPat.Tuple _) :: SyntaxNode.SynExpr (SynExpr.LetOrUseBang _) :: _
-            | SynPat.Paren (SynPat.Tuple (isStruct = false; elementPats = AnyTyped), _), SyntaxNode.SynExpr (SynExpr.LetOrUseBang _) :: _
-            | SynPat.Paren (SynPat.Typed _, _), SyntaxNode.SynMatchClause _ :: _
-            | SynPat.Paren (SynPat.Typed _, _), SyntaxNode.SynPat (SynPat.Tuple _) :: SyntaxNode.SynMatchClause _ :: _
-            | SynPat.Paren (SynPat.Tuple (isStruct = false; elementPats = Last (SynPat.Typed _)), _), SyntaxNode.SynMatchClause _ :: _
-            | SynPat.Paren (SynPat.Typed _, _), SyntaxNode.SynPat (SynPat.Tuple _) :: SyntaxNode.SynBinding _ :: _
-            | SynPat.Paren (SynPat.Tuple (isStruct = false; elementPats = AnyTyped), _), SyntaxNode.SynBinding _ :: _
-            | SynPat.Paren (SynPat.LongIdent _, _), SyntaxNode.SynBinding _ :: _
-            | SynPat.Paren (SynPat.LongIdent _, _), SyntaxNode.SynExpr (SynExpr.Lambda _) :: _
-            | SynPat.Paren (SynPat.Tuple(isStruct = false), _), SyntaxNode.SynExpr (SynExpr.Lambda(parsedData = Some _)) :: _
-            | SynPat.Paren (SynPat.Typed _, _), SyntaxNode.SynExpr (SynExpr.Lambda(parsedData = Some _)) :: _ -> ValueNone
+            | SynPat.Paren(SynPat.Typed _, _), SyntaxNode.SynExpr(SynExpr.LetOrUseBang _) :: _
+            | SynPat.Paren(SynPat.Typed _, _), SyntaxNode.SynPat(SynPat.Tuple _) :: SyntaxNode.SynExpr(SynExpr.LetOrUseBang _) :: _
+            | SynPat.Paren(SynPat.Tuple(isStruct = false; elementPats = AnyTyped), _), SyntaxNode.SynExpr(SynExpr.LetOrUseBang _) :: _
+            | SynPat.Paren(SynPat.Typed _, _), SyntaxNode.SynMatchClause _ :: _
+            | SynPat.Paren(SynPat.Typed _, _), SyntaxNode.SynPat(SynPat.Tuple _) :: SyntaxNode.SynMatchClause _ :: _
+            | SynPat.Paren(SynPat.Tuple(isStruct = false; elementPats = Last(SynPat.Typed _)), _), SyntaxNode.SynMatchClause _ :: _
+            | SynPat.Paren(SynPat.Typed _, _), SyntaxNode.SynPat(SynPat.Tuple _) :: SyntaxNode.SynBinding _ :: _
+            | SynPat.Paren(SynPat.Tuple(isStruct = false; elementPats = AnyTyped), _), SyntaxNode.SynBinding _ :: _
+            | SynPat.Paren(SynPat.LongIdent _, _), SyntaxNode.SynBinding _ :: _
+            | SynPat.Paren(SynPat.LongIdent _, _), SyntaxNode.SynExpr(SynExpr.Lambda _) :: _
+            | SynPat.Paren(SynPat.Tuple(isStruct = false), _), SyntaxNode.SynExpr(SynExpr.Lambda(parsedData = Some _)) :: _
+            | SynPat.Paren(SynPat.Typed _, _), SyntaxNode.SynExpr(SynExpr.Lambda(parsedData = Some _)) :: _ -> ValueNone
 
             // () is parsed as this in certain cases…
             //
@@ -1478,20 +1479,20 @@ module UnnecessaryParentheses =
             //     and! () = …
             //     use! () = …
             //     match … with () -> …
-            | SynPat.Paren (SynPat.Const (SynConst.Unit, _), _), SyntaxNode.SynBinding _ :: _
-            | SynPat.Paren (SynPat.Const (SynConst.Unit, _), _), SyntaxNode.SynExpr (SynExpr.ForEach _) :: _
-            | SynPat.Paren (SynPat.Const (SynConst.Unit, _), _), SyntaxNode.SynExpr (SynExpr.LetOrUseBang _) :: _
-            | SynPat.Paren (SynPat.Const (SynConst.Unit, _), _), SyntaxNode.SynMatchClause _ :: _ -> ValueNone
+            | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _), SyntaxNode.SynBinding _ :: _
+            | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _), SyntaxNode.SynExpr(SynExpr.ForEach _) :: _
+            | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _), SyntaxNode.SynExpr(SynExpr.LetOrUseBang _) :: _
+            | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _), SyntaxNode.SynMatchClause _ :: _ -> ValueNone
 
             // (()) is required when overriding a generic member
             // where unit is the generic type argument:
             //
             //     type C<'T> = abstract M : 'T -> unit
             //     let _ = { new C<unit> with override _.M (()) = () }
-            | SynPat.Paren (SynPat.Paren (SynPat.Const (SynConst.Unit, _), _), _),
-              SyntaxNode.SynPat (SynPat.LongIdent _) :: SyntaxNode.SynBinding _ :: _
-            | SynPat.Paren (SynPat.Const (SynConst.Unit, _), _),
-              SyntaxNode.SynPat (SynPat.Paren _) :: SyntaxNode.SynPat (SynPat.LongIdent _) :: SyntaxNode.SynBinding _ :: _ -> ValueNone
+            | SynPat.Paren(SynPat.Paren(SynPat.Const(SynConst.Unit, _), _), _),
+              SyntaxNode.SynPat(SynPat.LongIdent _) :: SyntaxNode.SynBinding _ :: _
+            | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _),
+              SyntaxNode.SynPat(SynPat.Paren _) :: SyntaxNode.SynPat(SynPat.LongIdent _) :: SyntaxNode.SynBinding _ :: _ -> ValueNone
 
             // Parens are required for the first of multiple additional constructors.
             // We simply require them always.
@@ -1499,7 +1500,7 @@ module UnnecessaryParentheses =
             //     type T … =
             //         new (x) = …
             //         new (x, y) = …
-            | SynPat.Paren _, SyntaxNode.SynPat (SynPat.LongIdent(longDotId = SynLongIdent(id = [ Ident "new" ]))) :: _ -> ValueNone
+            | SynPat.Paren _, SyntaxNode.SynPat(SynPat.LongIdent(longDotId = SynLongIdent(id = [ Ident "new" ]))) :: _ -> ValueNone
 
             // Parens are otherwise never needed in these cases:
             //
@@ -1512,15 +1513,15 @@ module UnnecessaryParentheses =
             //     function (…) -> …
             //     function (Pattern …) -> …
             //     fun (x) -> …
-            | SynPat.Paren (_, range), SyntaxNode.SynBinding _ :: _
-            | SynPat.Paren (_, range), SyntaxNode.SynExpr (SynExpr.ForEach _) :: _
-            | SynPat.Paren (_, range), SyntaxNode.SynExpr (SynExpr.LetOrUseBang _) :: _
-            | SynPat.Paren (_, range), SyntaxNode.SynMatchClause _ :: _
-            | SynPat.Paren (_, range),
-              SyntaxNode.SynExpr (SynExpr.Lambda(args = SynSimplePats.SimplePats(pats = [ SynSimplePat.Id _ ]))) :: _ -> ValueSome range
+            | SynPat.Paren(_, range), SyntaxNode.SynBinding _ :: _
+            | SynPat.Paren(_, range), SyntaxNode.SynExpr(SynExpr.ForEach _) :: _
+            | SynPat.Paren(_, range), SyntaxNode.SynExpr(SynExpr.LetOrUseBang _) :: _
+            | SynPat.Paren(_, range), SyntaxNode.SynMatchClause _ :: _
+            | SynPat.Paren(_, range), SyntaxNode.SynExpr(SynExpr.Lambda(args = SynSimplePats.SimplePats(pats = [ SynSimplePat.Id _ ]))) :: _ ->
+                ValueSome range
 
             // Nested patterns.
-            | SynPat.Paren (inner, range), SyntaxNode.SynPat outer :: _ ->
+            | SynPat.Paren(inner, range), SyntaxNode.SynPat outer :: _ ->
                 match outer, inner with
                 // (x :: xs) :: ys
                 // (x, xs) :: ys
@@ -1560,7 +1561,7 @@ module UnnecessaryParentheses =
                 | SynPat.LongIdent _, SynPat.As _
                 | SynPat.LongIdent _, SynPat.Tuple(isStruct = false)
                 | SynPat.LongIdent _, SynPat.LongIdent(argPats = SynArgPats.NamePatPairs _)
-                | SynPat.LongIdent _, SynPat.LongIdent(argPats = SynArgPats.Pats (_ :: _))
+                | SynPat.LongIdent _, SynPat.LongIdent(argPats = SynArgPats.Pats(_ :: _))
 
                 // A | (B as C)
                 // A & (B as C)
@@ -1584,8 +1585,8 @@ module UnnecessaryParentheses =
 
                 // let () = …
                 // member _.M() = …
-                | SynPat.Paren _, SynPat.Const (SynConst.Unit, _)
-                | SynPat.LongIdent _, SynPat.Const (SynConst.Unit, _) -> ValueNone
+                | SynPat.Paren _, SynPat.Const(SynConst.Unit, _)
+                | SynPat.LongIdent _, SynPat.Const(SynConst.Unit, _) -> ValueNone
 
                 | _, SynPat.Const _
                 | _, SynPat.Wild _

--- a/src/Compiler/Service/ServiceInterfaceStubGenerator.fs
+++ b/src/Compiler/Service/ServiceInterfaceStubGenerator.fs
@@ -96,28 +96,28 @@ type InterfaceData =
 
     member x.Range =
         match x with
-        | InterfaceData.Interface (ty, _) -> ty.Range
-        | InterfaceData.ObjExpr (ty, _) -> ty.Range
+        | InterfaceData.Interface(ty, _) -> ty.Range
+        | InterfaceData.ObjExpr(ty, _) -> ty.Range
 
     member x.TypeParameters =
         match x with
-        | InterfaceData.Interface (StripParenTypes ty, _)
-        | InterfaceData.ObjExpr (StripParenTypes ty, _) ->
+        | InterfaceData.Interface(StripParenTypes ty, _)
+        | InterfaceData.ObjExpr(StripParenTypes ty, _) ->
             let rec (|RationalConst|) =
                 function
-                | SynRationalConst.Integer (value = i) -> string i
-                | SynRationalConst.Rational (numerator = numerator; denominator = denominator) -> sprintf "%i/%i" numerator denominator
-                | SynRationalConst.Negate (rationalConst = (RationalConst s)) -> sprintf "- %s" s
-                | SynRationalConst.Paren (rationalConst = (RationalConst s)) -> sprintf "(%s)" s
+                | SynRationalConst.Integer(value = i) -> string i
+                | SynRationalConst.Rational(numerator = numerator; denominator = denominator) -> sprintf "%i/%i" numerator denominator
+                | SynRationalConst.Negate(rationalConst = (RationalConst s)) -> sprintf "- %s" s
+                | SynRationalConst.Paren(rationalConst = (RationalConst s)) -> sprintf "(%s)" s
 
             let rec (|TypeIdent|_|) =
                 function
-                | SynType.Var (SynTypar (s, req, _), _) ->
+                | SynType.Var(SynTypar(s, req, _), _) ->
                     match req with
                     | TyparStaticReq.None -> Some("'" + s.idText)
                     | TyparStaticReq.HeadType -> Some("^" + s.idText)
-                | SynType.LongIdent (SynLongIdent (xs, _, _)) -> xs |> Seq.map (fun x -> x.idText) |> String.concat "." |> Some
-                | SynType.App (t, _, ts, _, _, isPostfix, _) ->
+                | SynType.LongIdent(SynLongIdent(xs, _, _)) -> xs |> Seq.map (fun x -> x.idText) |> String.concat "." |> Some
+                | SynType.App(t, _, ts, _, _, isPostfix, _) ->
                     match t, ts with
                     | TypeIdent typeName, [] -> Some typeName
                     | TypeIdent typeName, [ TypeIdent typeArg ] ->
@@ -136,15 +136,15 @@ type InterfaceData =
                         //debug "Unsupported case with %A and %A" t ts
                         None
                 | SynType.Anon _ -> Some "_"
-                | SynType.AnonRecd (_, ts, _) -> Some(ts |> Seq.choose (snd >> (|TypeIdent|_|)) |> String.concat "; ")
-                | SynType.Array (dimension, TypeIdent typeName, _) -> Some(sprintf "%s [%s]" typeName (String(',', dimension - 1)))
-                | SynType.MeasurePower (TypeIdent typeName, RationalConst power, _) -> Some(sprintf "%s^%s" typeName power)
-                | SynType.Paren (TypeIdent typeName, _) -> Some typeName
+                | SynType.AnonRecd(_, ts, _) -> Some(ts |> Seq.choose (snd >> (|TypeIdent|_|)) |> String.concat "; ")
+                | SynType.Array(dimension, TypeIdent typeName, _) -> Some(sprintf "%s [%s]" typeName (String(',', dimension - 1)))
+                | SynType.MeasurePower(TypeIdent typeName, RationalConst power, _) -> Some(sprintf "%s^%s" typeName power)
+                | SynType.Paren(TypeIdent typeName, _) -> Some typeName
                 | _ -> None
 
             match ty with
-            | SynType.App (_, _, ts, _, _, _, _)
-            | SynType.LongIdentApp (_, _, _, ts, _, _, _) -> ts |> Seq.choose (|TypeIdent|_|) |> Seq.toArray
+            | SynType.App(_, _, ts, _, _, _, _)
+            | SynType.LongIdentApp(_, _, _, ts, _, _, _) -> ts |> Seq.choose (|TypeIdent|_|) |> Seq.toArray
             | _ -> [||]
 
 module InterfaceStubGenerator =
@@ -266,7 +266,7 @@ module InterfaceStubGenerator =
 
         let argInfos, retType =
             match argInfos, v.IsPropertyGetterMethod, v.IsPropertySetterMethod with
-            | [ AllAndLast (args, last) ], _, true -> [ args ], Some last.Type
+            | [ AllAndLast(args, last) ], _, true -> [ args ], Some last.Type
             | [ [] ], true, _ -> [], Some retType
             | _, _, _ -> argInfos, Some retType
 
@@ -390,7 +390,7 @@ module InterfaceStubGenerator =
                 writer.Unindent ctx.Indentation
 
         match m with
-        | MemberInfo.PropertyGetSet (getter, setter) ->
+        | MemberInfo.PropertyGetSet(getter, setter) ->
             let usage, modifiers, getterArgInfos, retType = preprocess ctx getter
             let closeDeclaration = closeDeclaration retType
             let writeImplementation = writeImplementation ctx
@@ -513,7 +513,7 @@ module InterfaceStubGenerator =
 
     let internal (|TypeOfMember|_|) (m: FSharpMemberOrFunctionOrValue) =
         match m.FullTypeSafe with
-        | Some (MemberFunctionType ty) when m.IsProperty && m.DeclaringEntity.IsSome && m.DeclaringEntity.Value.IsFSharp -> Some ty
+        | Some(MemberFunctionType ty) when m.IsProperty && m.DeclaringEntity.IsSome && m.DeclaringEntity.Value.IsFSharp -> Some ty
         | Some ty -> Some ty
         | None -> None
 
@@ -549,7 +549,7 @@ module InterfaceStubGenerator =
 
     let internal (|LongIdentPattern|_|) =
         function
-        | SynPat.LongIdent(longDotId = SynLongIdent (xs, _, _)) ->
+        | SynPat.LongIdent(longDotId = SynLongIdent(xs, _, _)) ->
             //            let (name, range) = xs |> List.map (fun x -> x.idText, x.idRange) |> List.last
             let last = List.last xs
             Some(last.idText, last.idRange)
@@ -560,21 +560,21 @@ module InterfaceStubGenerator =
     // so we use 'get_' and 'set_' prefix to ensure corresponding symbols are retrieved correctly.
     let internal (|MemberNameAndRange|_|) =
         function
-        | SynBinding (valData = SynValData(memberFlags = Some mf); headPat = LongIdentPattern (name, range)) when
+        | SynBinding(valData = SynValData(memberFlags = Some mf); headPat = LongIdentPattern(name, range)) when
             mf.MemberKind = SynMemberKind.PropertyGet
             ->
             if name.StartsWithOrdinal("get_") then
                 Some(name, range)
             else
                 Some("get_" + name, range)
-        | SynBinding (valData = SynValData(memberFlags = Some mf); headPat = LongIdentPattern (name, range)) when
+        | SynBinding(valData = SynValData(memberFlags = Some mf); headPat = LongIdentPattern(name, range)) when
             mf.MemberKind = SynMemberKind.PropertySet
             ->
             if name.StartsWithOrdinal("set_") then
                 Some(name, range)
             else
                 Some("set_" + name, range)
-        | SynBinding(headPat = LongIdentPattern (name, range)) -> Some(name, range)
+        | SynBinding(headPat = LongIdentPattern(name, range)) -> Some(name, range)
         | _ -> None
 
     /// Get associated member names and ranges
@@ -582,18 +582,18 @@ module InterfaceStubGenerator =
     /// positions of 'member', which indicate the indentation for generating new members
     let GetMemberNameAndRanges interfaceData =
         match interfaceData with
-        | InterfaceData.Interface (_, None) -> []
-        | InterfaceData.Interface (_, Some memberDefns) ->
+        | InterfaceData.Interface(_, None) -> []
+        | InterfaceData.Interface(_, Some memberDefns) ->
             memberDefns
             |> Seq.collect (function
-                | SynMemberDefn.Member (binding, _) -> [ binding ]
-                | SynMemberDefn.GetSetMember (Some getBinding, Some setBinding, _, _) -> [ getBinding; setBinding ]
-                | SynMemberDefn.GetSetMember (Some binding, None, _, _)
-                | SynMemberDefn.GetSetMember (None, Some binding, _, _) -> [ binding ]
+                | SynMemberDefn.Member(binding, _) -> [ binding ]
+                | SynMemberDefn.GetSetMember(Some getBinding, Some setBinding, _, _) -> [ getBinding; setBinding ]
+                | SynMemberDefn.GetSetMember(Some binding, None, _, _)
+                | SynMemberDefn.GetSetMember(None, Some binding, _, _) -> [ binding ]
                 | _ -> [])
             |> Seq.choose (|MemberNameAndRange|_|)
             |> Seq.toList
-        | InterfaceData.ObjExpr (_, bindings) -> List.choose (|MemberNameAndRange|_|) bindings
+        | InterfaceData.ObjExpr(_, bindings) -> List.choose (|MemberNameAndRange|_|) bindings
 
     let internal normalizeEventName (m: FSharpMemberOrFunctionOrValue) =
         let name = m.DisplayName
@@ -762,7 +762,7 @@ module InterfaceStubGenerator =
         let rec walkImplFileInput (file: ParsedImplFileInput) =
             List.tryPick walkSynModuleOrNamespace file.Contents
 
-        and walkSynModuleOrNamespace (SynModuleOrNamespace (decls = decls; range = range)) =
+        and walkSynModuleOrNamespace (SynModuleOrNamespace(decls = decls; range = range)) =
             if not <| rangeContainsPos range pos then
                 None
             else
@@ -773,18 +773,18 @@ module InterfaceStubGenerator =
                 None
             else
                 match decl with
-                | SynModuleDecl.Exception (SynExceptionDefn (_, _, synMembers, _), _) -> List.tryPick walkSynMemberDefn synMembers
-                | SynModuleDecl.Let (_isRecursive, bindings, _range) -> List.tryPick walkBinding bindings
-                | SynModuleDecl.ModuleAbbrev (_lhs, _rhs, _range) -> None
-                | SynModuleDecl.NamespaceFragment (fragment) -> walkSynModuleOrNamespace fragment
-                | SynModuleDecl.NestedModule (decls = modules) -> List.tryPick walkSynModuleDecl modules
-                | SynModuleDecl.Types (typeDefs, _range) -> List.tryPick walkSynTypeDefn typeDefs
-                | SynModuleDecl.Expr (expr, _) -> walkExpr expr
+                | SynModuleDecl.Exception(SynExceptionDefn(_, _, synMembers, _), _) -> List.tryPick walkSynMemberDefn synMembers
+                | SynModuleDecl.Let(_isRecursive, bindings, _range) -> List.tryPick walkBinding bindings
+                | SynModuleDecl.ModuleAbbrev(_lhs, _rhs, _range) -> None
+                | SynModuleDecl.NamespaceFragment(fragment) -> walkSynModuleOrNamespace fragment
+                | SynModuleDecl.NestedModule(decls = modules) -> List.tryPick walkSynModuleDecl modules
+                | SynModuleDecl.Types(typeDefs, _range) -> List.tryPick walkSynTypeDefn typeDefs
+                | SynModuleDecl.Expr(expr, _) -> walkExpr expr
                 | SynModuleDecl.Attributes _
                 | SynModuleDecl.HashDirective _
                 | SynModuleDecl.Open _ -> None
 
-        and walkSynTypeDefn (SynTypeDefn (typeRepr = representation; members = members; range = range)) =
+        and walkSynTypeDefn (SynTypeDefn(typeRepr = representation; members = members; range = range)) =
             if not <| rangeContainsPos range pos then
                 None
             else
@@ -796,8 +796,8 @@ module InterfaceStubGenerator =
                 None
             else
                 match typeDefnRepr with
-                | SynTypeDefnRepr.ObjectModel (_kind, members, _range) -> List.tryPick walkSynMemberDefn members
-                | SynTypeDefnRepr.Simple (_repr, _range) -> None
+                | SynTypeDefnRepr.ObjectModel(_kind, members, _range) -> List.tryPick walkSynMemberDefn members
+                | SynTypeDefnRepr.Simple(_repr, _range) -> None
                 | SynTypeDefnRepr.Exception _ -> None
 
         and walkSynMemberDefn (memberDefn: SynMemberDefn) =
@@ -806,50 +806,50 @@ module InterfaceStubGenerator =
             else
                 match memberDefn with
                 | SynMemberDefn.AbstractSlot _ -> None
-                | SynMemberDefn.AutoProperty (synExpr = expr) -> walkExpr expr
-                | SynMemberDefn.Interface (interfaceType = interfaceType; members = members) ->
+                | SynMemberDefn.AutoProperty(synExpr = expr) -> walkExpr expr
+                | SynMemberDefn.Interface(interfaceType = interfaceType; members = members) ->
                     if rangeContainsPos interfaceType.Range pos then
                         Some(InterfaceData.Interface(interfaceType, members))
                     else
                         Option.bind (List.tryPick walkSynMemberDefn) members
-                | SynMemberDefn.Member (binding, _range) -> walkBinding binding
-                | SynMemberDefn.GetSetMember (getBinding, setBinding, _, _) ->
+                | SynMemberDefn.Member(binding, _range) -> walkBinding binding
+                | SynMemberDefn.GetSetMember(getBinding, setBinding, _, _) ->
                     match getBinding, setBinding with
                     | None, None -> None
                     | Some binding, None
                     | None, Some binding -> walkBinding binding
                     | Some getBinding, Some setBinding -> walkBinding getBinding |> Option.orElseWith (fun () -> walkBinding setBinding)
-                | SynMemberDefn.NestedType (typeDef, _access, _range) -> walkSynTypeDefn typeDef
+                | SynMemberDefn.NestedType(typeDef, _access, _range) -> walkSynTypeDefn typeDef
                 | SynMemberDefn.ValField _ -> None
-                | SynMemberDefn.LetBindings (bindings, _isStatic, _isRec, _range) -> List.tryPick walkBinding bindings
+                | SynMemberDefn.LetBindings(bindings, _isStatic, _isRec, _range) -> List.tryPick walkBinding bindings
                 | SynMemberDefn.Open _
                 | SynMemberDefn.ImplicitCtor _
                 | SynMemberDefn.Inherit _ -> None
-                | SynMemberDefn.ImplicitInherit (_, expr, _, _) -> walkExpr expr
+                | SynMemberDefn.ImplicitInherit(_, expr, _, _) -> walkExpr expr
 
-        and walkBinding (SynBinding (expr = expr)) = walkExpr expr
+        and walkBinding (SynBinding(expr = expr)) = walkExpr expr
 
         and walkExpr expr =
             if not <| rangeContainsPos expr.Range pos then
                 None
             else
                 match expr with
-                | SynExpr.Quote (synExpr1, _, synExpr2, _, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.Quote(synExpr1, _, synExpr2, _, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.Const (_synConst, _range) -> None
+                | SynExpr.Const(_synConst, _range) -> None
 
-                | SynExpr.Paren (synExpr, _, _, _parenRange) -> walkExpr synExpr
-                | SynExpr.Typed (synExpr, _synType, _range) -> walkExpr synExpr
+                | SynExpr.Paren(synExpr, _, _, _parenRange) -> walkExpr synExpr
+                | SynExpr.Typed(synExpr, _synType, _range) -> walkExpr synExpr
 
-                | SynExpr.Tuple (_, synExprList, _, _range)
-                | SynExpr.ArrayOrList (_, synExprList, _range) -> List.tryPick walkExpr synExprList
+                | SynExpr.Tuple(_, synExprList, _, _range)
+                | SynExpr.ArrayOrList(_, synExprList, _range) -> List.tryPick walkExpr synExprList
 
-                | SynExpr.Record (_inheritOpt, _copyOpt, fields, _range) ->
-                    List.tryPick (fun (SynExprRecordField (expr = e)) -> Option.bind walkExpr e) fields
+                | SynExpr.Record(_inheritOpt, _copyOpt, fields, _range) ->
+                    List.tryPick (fun (SynExprRecordField(expr = e)) -> Option.bind walkExpr e) fields
 
-                | SynExpr.New (_, _synType, synExpr, _range) -> walkExpr synExpr
+                | SynExpr.New(_, _synType, synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.ObjExpr (objType = ty; argOptions = baseCallOpt; bindings = binds; members = ms; extraImpls = ifaces) ->
+                | SynExpr.ObjExpr(objType = ty; argOptions = baseCallOpt; bindings = binds; members = ms; extraImpls = ifaces) ->
                     let binds = unionBindingAndMembers binds ms
 
                     match baseCallOpt with
@@ -858,7 +858,7 @@ module InterfaceStubGenerator =
                             Some(InterfaceData.ObjExpr(ty, binds))
                         else
                             ifaces
-                            |> List.tryPick (fun (SynInterfaceImpl (interfaceTy = ty; bindings = binds; range = range)) ->
+                            |> List.tryPick (fun (SynInterfaceImpl(interfaceTy = ty; bindings = binds; range = range)) ->
                                 if rangeContainsPos range pos then
                                     Some(InterfaceData.ObjExpr(ty, binds))
                                 else
@@ -867,99 +867,99 @@ module InterfaceStubGenerator =
                         // Ignore object expressions of normal objects
                         None
 
-                | SynExpr.While (_spWhile, synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.While(_spWhile, synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.ForEach (_spFor, _spIn, _seqExprOnly, _isFromSource, _synPat, synExpr1, synExpr2, _range) ->
+                | SynExpr.ForEach(_spFor, _spIn, _seqExprOnly, _isFromSource, _synPat, synExpr1, synExpr2, _range) ->
                     List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.For (identBody = synExpr1; toBody = synExpr2; doBody = synExpr3) ->
+                | SynExpr.For(identBody = synExpr1; toBody = synExpr2; doBody = synExpr3) ->
                     List.tryPick walkExpr [ synExpr1; synExpr2; synExpr3 ]
 
-                | SynExpr.ArrayOrListComputed (_, synExpr, _range) -> walkExpr synExpr
+                | SynExpr.ArrayOrListComputed(_, synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.ComputationExpr (_, synExpr, _range) -> walkExpr synExpr
+                | SynExpr.ComputationExpr(_, synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.Lambda (body = synExpr) -> walkExpr synExpr
+                | SynExpr.Lambda(body = synExpr) -> walkExpr synExpr
 
-                | SynExpr.DotLambda (expr = synExpr) -> walkExpr synExpr
+                | SynExpr.DotLambda(expr = synExpr) -> walkExpr synExpr
 
-                | SynExpr.MatchLambda (_isExnMatch, _argm, synMatchClauseList, _spBind, _wholem) ->
+                | SynExpr.MatchLambda(_isExnMatch, _argm, synMatchClauseList, _spBind, _wholem) ->
                     synMatchClauseList
-                    |> List.tryPick (fun (SynMatchClause (resultExpr = e)) -> walkExpr e)
+                    |> List.tryPick (fun (SynMatchClause(resultExpr = e)) -> walkExpr e)
 
-                | SynExpr.Match (expr = synExpr; clauses = synMatchClauseList) ->
+                | SynExpr.Match(expr = synExpr; clauses = synMatchClauseList) ->
                     walkExpr synExpr
                     |> Option.orElse (
                         synMatchClauseList
-                        |> List.tryPick (fun (SynMatchClause (resultExpr = e)) -> walkExpr e)
+                        |> List.tryPick (fun (SynMatchClause(resultExpr = e)) -> walkExpr e)
                     )
 
-                | SynExpr.Lazy (synExpr, _range) -> walkExpr synExpr
+                | SynExpr.Lazy(synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.Do (synExpr, _range) -> walkExpr synExpr
+                | SynExpr.Do(synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.Assert (synExpr, _range) -> walkExpr synExpr
+                | SynExpr.Assert(synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.App (_exprAtomicFlag, _isInfix, synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.App(_exprAtomicFlag, _isInfix, synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> walkExpr synExpr
+                | SynExpr.TypeApp(synExpr, _, _synTypeList, _commas, _, _, _range) -> walkExpr synExpr
 
-                | SynExpr.LetOrUse (bindings = synBindingList; body = synExpr) ->
+                | SynExpr.LetOrUse(bindings = synBindingList; body = synExpr) ->
                     Option.orElse (List.tryPick walkBinding synBindingList) (walkExpr synExpr)
 
-                | SynExpr.TryWith (tryExpr = synExpr) -> walkExpr synExpr
+                | SynExpr.TryWith(tryExpr = synExpr) -> walkExpr synExpr
 
-                | SynExpr.TryFinally (tryExpr = synExpr1; finallyExpr = synExpr2) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.TryFinally(tryExpr = synExpr1; finallyExpr = synExpr2) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
                 | Sequentials exprs -> List.tryPick walkExpr exprs
 
-                | SynExpr.IfThenElse (ifExpr = synExpr1; thenExpr = synExpr2; elseExpr = synExprOpt) ->
+                | SynExpr.IfThenElse(ifExpr = synExpr1; thenExpr = synExpr2; elseExpr = synExprOpt) ->
                     match synExprOpt with
                     | Some synExpr3 -> List.tryPick walkExpr [ synExpr1; synExpr2; synExpr3 ]
                     | None -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
                 | SynExpr.Ident _ident -> None
 
-                | SynExpr.LongIdent (_, _longIdent, _altNameRefCell, _range) -> None
+                | SynExpr.LongIdent(_, _longIdent, _altNameRefCell, _range) -> None
 
-                | SynExpr.LongIdentSet (_longIdent, synExpr, _range) -> walkExpr synExpr
+                | SynExpr.LongIdentSet(_longIdent, synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.DotGet (synExpr, _dotm, _longIdent, _range) -> walkExpr synExpr
+                | SynExpr.DotGet(synExpr, _dotm, _longIdent, _range) -> walkExpr synExpr
 
-                | SynExpr.DotSet (synExpr1, _longIdent, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.DotSet(synExpr1, _longIdent, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.Set (synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.Set(synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.DotIndexedGet (synExpr, indexArgs, _range, _range2) -> Option.orElse (walkExpr synExpr) (walkExpr indexArgs)
+                | SynExpr.DotIndexedGet(synExpr, indexArgs, _range, _range2) -> Option.orElse (walkExpr synExpr) (walkExpr indexArgs)
 
-                | SynExpr.DotIndexedSet (synExpr1, indexArgs, synExpr2, _, _range, _range2) ->
+                | SynExpr.DotIndexedSet(synExpr1, indexArgs, synExpr2, _, _range, _range2) ->
                     [ synExpr1; indexArgs; synExpr2 ] |> List.tryPick walkExpr
 
-                | SynExpr.JoinIn (synExpr1, _range, synExpr2, _range2) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
-                | SynExpr.NamedIndexedPropertySet (_longIdent, synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.JoinIn(synExpr1, _range, synExpr2, _range2) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
+                | SynExpr.NamedIndexedPropertySet(_longIdent, synExpr1, synExpr2, _range) -> List.tryPick walkExpr [ synExpr1; synExpr2 ]
 
-                | SynExpr.DotNamedIndexedPropertySet (synExpr1, _longIdent, synExpr2, synExpr3, _range) ->
+                | SynExpr.DotNamedIndexedPropertySet(synExpr1, _longIdent, synExpr2, synExpr3, _range) ->
                     List.tryPick walkExpr [ synExpr1; synExpr2; synExpr3 ]
 
-                | SynExpr.TypeTest (synExpr, _synType, _range)
-                | SynExpr.Upcast (synExpr, _synType, _range)
-                | SynExpr.Downcast (synExpr, _synType, _range) -> walkExpr synExpr
-                | SynExpr.InferredUpcast (synExpr, _range)
-                | SynExpr.InferredDowncast (synExpr, _range) -> walkExpr synExpr
-                | SynExpr.AddressOf (_, synExpr, _range, _range2) -> walkExpr synExpr
-                | SynExpr.TraitCall (_synTyparList, _synMemberSig, synExpr, _range) -> walkExpr synExpr
+                | SynExpr.TypeTest(synExpr, _synType, _range)
+                | SynExpr.Upcast(synExpr, _synType, _range)
+                | SynExpr.Downcast(synExpr, _synType, _range) -> walkExpr synExpr
+                | SynExpr.InferredUpcast(synExpr, _range)
+                | SynExpr.InferredDowncast(synExpr, _range) -> walkExpr synExpr
+                | SynExpr.AddressOf(_, synExpr, _range, _range2) -> walkExpr synExpr
+                | SynExpr.TraitCall(_synTyparList, _synMemberSig, synExpr, _range) -> walkExpr synExpr
 
                 | SynExpr.Null _range
                 | SynExpr.ImplicitZero _range -> None
 
-                | SynExpr.YieldOrReturn (_, synExpr, _range)
-                | SynExpr.YieldOrReturnFrom (_, synExpr, _range)
-                | SynExpr.DoBang (synExpr, _range) -> walkExpr synExpr
+                | SynExpr.YieldOrReturn(_, synExpr, _range)
+                | SynExpr.YieldOrReturnFrom(_, synExpr, _range)
+                | SynExpr.DoBang(synExpr, _range) -> walkExpr synExpr
 
-                | SynExpr.LetOrUseBang (rhs = synExpr1; andBangs = synExprAndBangs; body = synExpr2) ->
+                | SynExpr.LetOrUseBang(rhs = synExpr1; andBangs = synExprAndBangs; body = synExpr2) ->
                     [
                         yield synExpr1
-                        for SynExprAndBang (body = eAndBang) in synExprAndBangs do
+                        for SynExprAndBang(body = eAndBang) in synExprAndBangs do
                             yield eAndBang
                         yield synExpr2
                     ]
@@ -969,10 +969,10 @@ module InterfaceStubGenerator =
                 | SynExpr.LibraryOnlyStaticOptimization _
                 | SynExpr.LibraryOnlyUnionCaseFieldGet _
                 | SynExpr.LibraryOnlyUnionCaseFieldSet _ -> None
-                | SynExpr.ArbitraryAfterError (_debugStr, _range) -> None
+                | SynExpr.ArbitraryAfterError(_debugStr, _range) -> None
 
-                | SynExpr.FromParseError (synExpr, _range)
-                | SynExpr.DiscardAfterMissingQualificationAfterDot (synExpr, _, _range) -> walkExpr synExpr
+                | SynExpr.FromParseError(synExpr, _range)
+                | SynExpr.DiscardAfterMissingQualificationAfterDot(synExpr, _, _range) -> walkExpr synExpr
 
                 | _ -> None
 

--- a/src/Compiler/Service/ServiceLexing.fs
+++ b/src/Compiler/Service/ServiceLexing.fs
@@ -200,8 +200,8 @@ module internal TokenClassifications =
             // (this isn't entirely correct, but it'll work for now - see bug 3727)
             (FSharpTokenColorKind.Number, FSharpTokenCharKind.Operator, FSharpTokenTriggerClass.None)
 
-        | INFIX_STAR_DIV_MOD_OP ("mod" | "land" | "lor" | "lxor")
-        | INFIX_STAR_STAR_OP ("lsl" | "lsr" | "asr") ->
+        | INFIX_STAR_DIV_MOD_OP("mod" | "land" | "lor" | "lxor")
+        | INFIX_STAR_STAR_OP("lsl" | "lsr" | "asr") ->
             (FSharpTokenColorKind.Keyword, FSharpTokenCharKind.Keyword, FSharpTokenTriggerClass.None)
 
         | LPAREN_STAR_RPAREN
@@ -481,23 +481,23 @@ module internal LexerStateEncoding =
         match token with
         | HASH_LINE cont
         | HASH_LIGHT cont
-        | HASH_IF (_, _, cont)
-        | HASH_ELSE (_, _, cont)
-        | HASH_ENDIF (_, _, cont)
+        | HASH_IF(_, _, cont)
+        | HASH_ELSE(_, _, cont)
+        | HASH_ENDIF(_, _, cont)
         | INACTIVECODE cont
         | WHITESPACE cont
         | COMMENT cont
         | LINE_COMMENT cont
         | STRING_TEXT cont
         | EOF cont
-        | INTERP_STRING_BEGIN_PART (_, _, cont)
-        | INTERP_STRING_PART (_, cont)
-        | INTERP_STRING_BEGIN_END (_, _, cont)
-        | INTERP_STRING_END (_, cont)
+        | INTERP_STRING_BEGIN_PART(_, _, cont)
+        | INTERP_STRING_PART(_, cont)
+        | INTERP_STRING_BEGIN_END(_, _, cont)
+        | INTERP_STRING_END(_, cont)
         | LBRACE cont
         | RBRACE cont
-        | BYTEARRAY (_, _, cont)
-        | STRING (_, _, cont) -> cont
+        | BYTEARRAY(_, _, cont)
+        | STRING(_, _, cont) -> cont
         | _ -> prevLexcont
 
     // Note that this will discard all lexcont state, including the ifdefStack.
@@ -709,7 +709,7 @@ module internal LexerStateEncoding =
 
     let encodeLexInt indentationSyntaxStatus (lexcont: LexerContinuation) =
         match lexcont with
-        | LexCont.Token (ifdefs, stringNest) ->
+        | LexCont.Token(ifdefs, stringNest) ->
             encodeLexCont (
                 FSharpTokenizerColorState.Token,
                 0L,
@@ -720,7 +720,7 @@ module internal LexerStateEncoding =
                 stringNest,
                 0
             )
-        | LexCont.IfDefSkip (ifdefs, stringNest, n, m) ->
+        | LexCont.IfDefSkip(ifdefs, stringNest, n, m) ->
             encodeLexCont (
                 FSharpTokenizerColorState.IfDefSkip,
                 int64 n,
@@ -731,9 +731,9 @@ module internal LexerStateEncoding =
                 stringNest,
                 0
             )
-        | LexCont.EndLine (ifdefs, stringNest, econt) ->
+        | LexCont.EndLine(ifdefs, stringNest, econt) ->
             match econt with
-            | LexerEndlineContinuation.Skip (n, m) ->
+            | LexerEndlineContinuation.Skip(n, m) ->
                 encodeLexCont (
                     FSharpTokenizerColorState.EndLineThenSkip,
                     int64 n,
@@ -755,7 +755,7 @@ module internal LexerStateEncoding =
                     stringNest,
                     0
                 )
-        | LexCont.String (ifdefs, stringNest, style, kind, delimLen, m) ->
+        | LexCont.String(ifdefs, stringNest, style, kind, delimLen, m) ->
             let state =
                 match style with
                 | LexerStringStyle.SingleQuote -> FSharpTokenizerColorState.String
@@ -764,7 +764,7 @@ module internal LexerStateEncoding =
                 | LexerStringStyle.ExtendedInterpolated -> FSharpTokenizerColorState.ExtendedInterpolatedString
 
             encodeLexCont (state, 0L, m.Start, ifdefs, indentationSyntaxStatus, kind, stringNest, delimLen)
-        | LexCont.Comment (ifdefs, stringNest, n, m) ->
+        | LexCont.Comment(ifdefs, stringNest, n, m) ->
             encodeLexCont (
                 FSharpTokenizerColorState.Comment,
                 int64 n,
@@ -775,7 +775,7 @@ module internal LexerStateEncoding =
                 stringNest,
                 0
             )
-        | LexCont.SingleLineComment (ifdefs, stringNest, n, m) ->
+        | LexCont.SingleLineComment(ifdefs, stringNest, n, m) ->
             encodeLexCont (
                 FSharpTokenizerColorState.SingleLineComment,
                 int64 n,
@@ -786,7 +786,7 @@ module internal LexerStateEncoding =
                 stringNest,
                 0
             )
-        | LexCont.StringInComment (ifdefs, stringNest, style, n, m) ->
+        | LexCont.StringInComment(ifdefs, stringNest, style, n, m) ->
             let state =
                 match style with
                 | LexerStringStyle.SingleQuote -> FSharpTokenizerColorState.StringInComment
@@ -795,7 +795,7 @@ module internal LexerStateEncoding =
                 | LexerStringStyle.ExtendedInterpolated -> FSharpTokenizerColorState.TripleQuoteStringInComment
 
             encodeLexCont (state, int64 n, m.Start, ifdefs, indentationSyntaxStatus, LexerStringKind.String, stringNest, 0)
-        | LexCont.MLOnly (ifdefs, stringNest, m) ->
+        | LexCont.MLOnly(ifdefs, stringNest, m) ->
             encodeLexCont (
                 FSharpTokenizerColorState.CamlOnly,
                 0L,
@@ -948,22 +948,22 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf, maxLength: int option, fi
         lexargs.indentationSyntaxStatus <- indentationSyntaxStatus
 
         match lexcont with
-        | LexCont.EndLine (ifdefs, stringNest, cont) ->
+        | LexCont.EndLine(ifdefs, stringNest, cont) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             Lexer.endline cont lexargs skip lexbuf
 
-        | LexCont.Token (ifdefs, stringNest) ->
+        | LexCont.Token(ifdefs, stringNest) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             Lexer.token lexargs skip lexbuf
 
-        | LexCont.IfDefSkip (ifdefs, stringNest, n, m) ->
+        | LexCont.IfDefSkip(ifdefs, stringNest, n, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             Lexer.ifdefSkip n m lexargs skip lexbuf
 
-        | LexCont.String (ifdefs, stringNest, style, kind, delimLen, m) ->
+        | LexCont.String(ifdefs, stringNest, style, kind, delimLen, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             lexargs.interpolationDelimiterLength <- delimLen
@@ -976,18 +976,18 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf, maxLength: int option, fi
             | LexerStringStyle.TripleQuote -> Lexer.tripleQuoteString args skip lexbuf
             | LexerStringStyle.ExtendedInterpolated -> Lexer.extendedInterpolatedString args skip lexbuf
 
-        | LexCont.Comment (ifdefs, stringNest, n, m) ->
+        | LexCont.Comment(ifdefs, stringNest, n, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             Lexer.comment (n, m, lexargs) skip lexbuf
 
-        | LexCont.SingleLineComment (ifdefs, stringNest, n, m) ->
+        | LexCont.SingleLineComment(ifdefs, stringNest, n, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             // The first argument is 'None' because we don't need XML comments when called from VS tokenizer
             Lexer.singleLineComment (None, n, m, m, lexargs) skip lexbuf
 
-        | LexCont.StringInComment (ifdefs, stringNest, style, n, m) ->
+        | LexCont.StringInComment(ifdefs, stringNest, style, n, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
 
@@ -997,7 +997,7 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf, maxLength: int option, fi
             | LexerStringStyle.TripleQuote
             | LexerStringStyle.ExtendedInterpolated -> Lexer.tripleQuoteStringInComment n m lexargs skip lexbuf
 
-        | LexCont.MLOnly (ifdefs, stringNest, m) ->
+        | LexCont.MLOnly(ifdefs, stringNest, m) ->
             lexargs.ifdefStack <- ifdefs
             lexargs.stringNest <- stringNest
             Lexer.mlOnly m lexargs skip lexbuf
@@ -1031,16 +1031,16 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf, maxLength: int option, fi
                 // because sometimes token shouldn't be split. However it is just for colorization &
                 // for VS (which needs to recognize when user types ".").
                 match token with
-                | HASH_IF (m, lineStr, cont) when lineStr <> "" -> false, processHashIfLine m.StartColumn lineStr cont
-                | HASH_ELSE (m, lineStr, cont) when lineStr <> "" -> false, processHashEndElse m.StartColumn lineStr 4 cont
-                | HASH_ENDIF (m, lineStr, cont) when lineStr <> "" -> false, processHashEndElse m.StartColumn lineStr 5 cont
-                | HASH_IDENT (ident) ->
+                | HASH_IF(m, lineStr, cont) when lineStr <> "" -> false, processHashIfLine m.StartColumn lineStr cont
+                | HASH_ELSE(m, lineStr, cont) when lineStr <> "" -> false, processHashEndElse m.StartColumn lineStr 4 cont
+                | HASH_ENDIF(m, lineStr, cont) when lineStr <> "" -> false, processHashEndElse m.StartColumn lineStr 5 cont
+                | HASH_IDENT(ident) ->
                     delayToken (IDENT ident, leftc + 1, rightc)
                     false, (HASH, leftc, leftc)
-                | RQUOTE_DOT (s, raw) ->
+                | RQUOTE_DOT(s, raw) ->
                     delayToken (DOT, rightc, rightc)
                     false, (RQUOTE(s, raw), leftc, rightc - 1)
-                | INFIX_COMPARE_OP (LexFilter.TyparsCloseOp (greaters, afterOp) as opstr) ->
+                | INFIX_COMPARE_OP(LexFilter.TyparsCloseOp(greaters, afterOp) as opstr) ->
                     match afterOp with
                     | None -> ()
                     | Some tok -> delayToken (tok, leftc + greaters.Length, rightc)
@@ -1216,12 +1216,7 @@ type FSharpLineTokenizer(lexbuf: UnicodeLexing.Lexbuf, maxLength: int option, fi
 
 [<Sealed>]
 type FSharpSourceTokenizer
-    (
-        conditionalDefines: string list,
-        fileName: string option,
-        langVersion: string option,
-        strictIndentation: bool option
-    ) =
+    (conditionalDefines: string list, fileName: string option, langVersion: string option, strictIndentation: bool option) =
 
     let langVersion =
         langVersion

--- a/src/Compiler/Service/ServiceParamInfoLocations.fs
+++ b/src/Compiler/Service/ServiceParamInfoLocations.fs
@@ -72,11 +72,11 @@ module internal ParameterLocationsImpl =
         // we found it, dig out ident
         match synExpr with
         | SynExpr.Ident id -> Some([ id.idText ], id.idRange)
-        | SynExpr.LongIdent (_, SynLongIdent ([ id ], [], [ Some _ ]), _, _) -> Some([ id.idText ], id.idRange)
-        | SynExpr.LongIdent (_, SynLongIdent (lid, _, _), _, mLongId)
-        | SynExpr.DotGet (_, _, SynLongIdent (lid, _, _), mLongId) -> Some(pathOfLid lid, mLongId)
-        | SynExpr.TypeApp (synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr
-        | SynExpr.Paren (expr = expr) -> digOutIdentFromFuncExpr expr
+        | SynExpr.LongIdent(_, SynLongIdent([ id ], [], [ Some _ ]), _, _) -> Some([ id.idText ], id.idRange)
+        | SynExpr.LongIdent(_, SynLongIdent(lid, _, _), _, mLongId)
+        | SynExpr.DotGet(_, _, SynLongIdent(lid, _, _), mLongId) -> Some(pathOfLid lid, mLongId)
+        | SynExpr.TypeApp(synExpr, _, _synTypeList, _commas, _, _, _range) -> digOutIdentFromFuncExpr synExpr
+        | SynExpr.Paren(expr = expr) -> digOutIdentFromFuncExpr expr
         | _ -> None
 
     type FindResult =
@@ -89,37 +89,37 @@ module internal ParameterLocationsImpl =
 
     let digOutIdentFromStaticArg (StripParenTypes synType) =
         match synType with
-        | SynType.StaticConstantNamed (SynType.LongIdent (SynLongIdent ([ id ], _, _)), _, _) -> Some id.idText
-        | SynType.LongIdent (SynLongIdent ([ id ], _, _)) -> Some id.idText // NOTE: again, not a static constant, but may be a prefix of a Named in incomplete code
+        | SynType.StaticConstantNamed(SynType.LongIdent(SynLongIdent([ id ], _, _)), _, _) -> Some id.idText
+        | SynType.LongIdent(SynLongIdent([ id ], _, _)) -> Some id.idText // NOTE: again, not a static constant, but may be a prefix of a Named in incomplete code
         | _ -> None
 
     let getNamedParamName e =
         match e with
         // f(x=4)
-        | SynExpr.App (ExprAtomicFlag.NonAtomic,
-                       _,
-                       SynExpr.App (ExprAtomicFlag.NonAtomic,
-                                    true,
-                                    SynExpr.LongIdent(longDotId = SynLongIdent(id = [ op ])),
-                                    SynExpr.Ident n,
-                                    _range),
-                       _,
-                       _) when op.idText = "op_Equality" -> Some n.idText
+        | SynExpr.App(ExprAtomicFlag.NonAtomic,
+                      _,
+                      SynExpr.App(ExprAtomicFlag.NonAtomic,
+                                  true,
+                                  SynExpr.LongIdent(longDotId = SynLongIdent(id = [ op ])),
+                                  SynExpr.Ident n,
+                                  _range),
+                      _,
+                      _) when op.idText = "op_Equality" -> Some n.idText
         // f(?x=4)
-        | SynExpr.App (ExprAtomicFlag.NonAtomic,
-                       _,
-                       SynExpr.App (ExprAtomicFlag.NonAtomic,
-                                    true,
-                                    SynExpr.LongIdent(longDotId = SynLongIdent(id = [ op ])),
-                                    SynExpr.LongIdent (true, SynLongIdent ([ n ], _, _), _ref, _lidrange),
-                                    _range),
-                       _,
-                       _) when op.idText = "op_Equality" -> Some n.idText
+        | SynExpr.App(ExprAtomicFlag.NonAtomic,
+                      _,
+                      SynExpr.App(ExprAtomicFlag.NonAtomic,
+                                  true,
+                                  SynExpr.LongIdent(longDotId = SynLongIdent(id = [ op ])),
+                                  SynExpr.LongIdent(true, SynLongIdent([ n ], _, _), _ref, _lidrange),
+                                  _range),
+                      _,
+                      _) when op.idText = "op_Equality" -> Some n.idText
         | _ -> None
 
     let getTypeName synType =
         match synType with
-        | SynType.LongIdent (SynLongIdent (ids, _, _)) -> ids |> pathOfLid
+        | SynType.LongIdent(SynLongIdent(ids, _, _)) -> ids |> pathOfLid
         | _ -> [ "" ] // TODO type name for other cases, see also unit test named "ParameterInfo.LocationOfParams.AfterQuicklyTyping.CallConstructorViaLongId.Bug94333"
 
     let handleSingleArg traverseSynExpr (pos, synExpr, parenRange, rpRangeOpt: _ option) =
@@ -148,7 +148,7 @@ module internal ParameterLocationsImpl =
     // see bug 345385.
     let rec searchSynArgExpr traverseSynExpr pos expr =
         match expr with
-        | SynExprParen (SynExpr.Tuple (false, synExprList, commaRanges, _tupleRange) as synExpr, _lpRange, rpRangeOpt, parenRange) -> // tuple argument
+        | SynExprParen(SynExpr.Tuple(false, synExprList, commaRanges, _tupleRange) as synExpr, _lpRange, rpRangeOpt, parenRange) -> // tuple argument
             let inner = traverseSynExpr synExpr
 
             match inner with
@@ -173,25 +173,25 @@ module internal ParameterLocationsImpl =
                     NotFound, None
             | _ -> NotFound, None
 
-        | SynExprParen (SynExprParen (SynExpr.Tuple (false, _, _, _), _, _, _) as synExpr, _, rpRangeOpt, parenRange) -> // f((x, y)) is special, single tuple arg
+        | SynExprParen(SynExprParen(SynExpr.Tuple(false, _, _, _), _, _, _) as synExpr, _, rpRangeOpt, parenRange) -> // f((x, y)) is special, single tuple arg
             handleSingleArg traverseSynExpr (pos, synExpr, parenRange, rpRangeOpt)
 
         // dig into multiple parens
-        | SynExprParen (SynExprParen (_, _, _, _) as synExpr, _, _, _parenRange) ->
+        | SynExprParen(SynExprParen(_, _, _, _) as synExpr, _, _, _parenRange) ->
             let r, _cacheOpt = searchSynArgExpr traverseSynExpr pos synExpr
             r, None
 
-        | SynExprParen (synExpr, _lpRange, rpRangeOpt, parenRange) -> // single argument
+        | SynExprParen(synExpr, _lpRange, rpRangeOpt, parenRange) -> // single argument
             handleSingleArg traverseSynExpr (pos, synExpr, parenRange, rpRangeOpt)
 
-        | SynExpr.ArbitraryAfterError (_debugStr, range) -> // single argument when e.g. after open paren you hit EOF
+        | SynExpr.ArbitraryAfterError(_debugStr, range) -> // single argument when e.g. after open paren you hit EOF
             if SyntaxTraversal.rangeContainsPosEdgesExclusive range pos then
                 let r = Found(range.Start, [], [ (range.End, None) ], false)
                 r, None
             else
                 NotFound, None
 
-        | SynExpr.Const (SynConst.Unit, unitRange) ->
+        | SynExpr.Const(SynConst.Unit, unitRange) ->
             if SyntaxTraversal.rangeContainsPosEdgesExclusive unitRange pos then
                 let r = Found(unitRange.Start, [], [ (unitRange.End, None) ], true)
                 r, None
@@ -212,13 +212,13 @@ module internal ParameterLocationsImpl =
 
     let (|StaticParameters|_|) pos (StripParenTypes synType) =
         match synType with
-        | SynType.App (StripParenTypes (SynType.LongIdent (SynLongIdent (lid, _, _) as lidwd)),
-                       Some mLess,
-                       args,
-                       commas,
-                       mGreaterOpt,
-                       _pf,
-                       wholem) ->
+        | SynType.App(StripParenTypes(SynType.LongIdent(SynLongIdent(lid, _, _) as lidwd)),
+                      Some mLess,
+                      args,
+                      commas,
+                      mGreaterOpt,
+                      _pf,
+                      wholem) ->
             let lidm = lidwd.Range
             let betweenTheBrackets = withStart mLess.Start wholem
 
@@ -254,11 +254,11 @@ module internal ParameterLocationsImpl =
                     match expr with
 
                     // new LID<tyarg1, ...., tyargN>(...)  and error recovery of these
-                    | SynExpr.New (_, synType, synExpr, _) ->
+                    | SynExpr.New(_, synType, synExpr, _) ->
                         let constrArgsResult, cacheOpt = searchSynArgExpr traverseSynExpr pos synExpr
 
                         match constrArgsResult, cacheOpt with
-                        | Found (parenLoc, argRanges, commasAndCloseParen, isThereACloseParen), _ ->
+                        | Found(parenLoc, argRanges, commasAndCloseParen, isThereACloseParen), _ ->
                             let typeName = getTypeName synType
 
                             Some(
@@ -279,11 +279,11 @@ module internal ParameterLocationsImpl =
                             | _ -> traverseSynExpr synExpr
 
                     // EXPR<  = error recovery of a form of half-written TypeApp
-                    | SynExpr.App (_,
-                                   _,
-                                   SynExpr.App (_, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ op ])), synExpr, mLess),
-                                   SynExpr.ArbitraryAfterError _,
-                                   wholem) when op.idText = "op_LessThan" ->
+                    | SynExpr.App(_,
+                                  _,
+                                  SynExpr.App(_, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ op ])), synExpr, mLess),
+                                  SynExpr.ArbitraryAfterError _,
+                                  wholem) when op.idText = "op_LessThan" ->
                         // Look in the function expression
                         let fResult = traverseSynExpr synExpr
 
@@ -295,14 +295,14 @@ module internal ParameterLocationsImpl =
                             if SyntaxTraversal.rangeContainsPosEdgesExclusive typeArgsm pos then
                                 // We found it, dig out ident
                                 match digOutIdentFromFuncExpr synExpr with
-                                | Some (lid, mLongId) ->
+                                | Some(lid, mLongId) ->
                                     Some(ParameterLocations(lid, mLongId, op.idRange.Start, [], [ wholem.End ], false, []))
                                 | None -> None
                             else
                                 None
 
                     // EXPR EXPR2
-                    | SynExpr.App (_exprAtomicFlag, isInfix, synExpr, synExpr2, _range) ->
+                    | SynExpr.App(_exprAtomicFlag, isInfix, synExpr, synExpr2, _range) ->
                         // Look in the function expression
                         let fResult = traverseSynExpr synExpr
 
@@ -313,10 +313,10 @@ module internal ParameterLocationsImpl =
                             let xResult, cacheOpt = searchSynArgExpr traverseSynExpr pos synExpr2
 
                             match xResult, cacheOpt with
-                            | Found (parenLoc, argRanges, commasAndCloseParen, isThereACloseParen), _ ->
+                            | Found(parenLoc, argRanges, commasAndCloseParen, isThereACloseParen), _ ->
                                 // We found it, dig out ident
                                 match digOutIdentFromFuncExpr synExpr with
-                                | Some (lid, mLongId) ->
+                                | Some(lid, mLongId) ->
                                     assert (isInfix = (posLt parenLoc mLongId.End))
 
                                     if isInfix then
@@ -340,7 +340,7 @@ module internal ParameterLocationsImpl =
                             | _ -> traverseSynExpr synExpr2
 
                     // ID<tyarg1, ...., tyargN>  and error recovery of these
-                    | SynExpr.TypeApp (synExpr, mLess, tyArgs, commas, mGreaterOpt, _, wholem) ->
+                    | SynExpr.TypeApp(synExpr, mLess, tyArgs, commas, mGreaterOpt, _, wholem) ->
                         match traverseSynExpr synExpr with
                         | Some _ as r -> r
                         | None ->
@@ -393,7 +393,7 @@ module internal ParameterLocationsImpl =
                             let xResult, _cacheOpt = searchSynArgExpr defaultTraverse pos expr
 
                             match xResult with
-                            | Found (parenLoc, argRanges, commasAndCloseParen, isThereACloseParen) ->
+                            | Found(parenLoc, argRanges, commasAndCloseParen, isThereACloseParen) ->
                                 // we found it, dig out ident
                                 let typeName = getTypeName ty
 
@@ -424,7 +424,8 @@ type ParameterLocations with
             let ranges =
                 nwpl.LongIdStartLocation
                 :: nwpl.LongIdEndLocation
-                   :: nwpl.OpenParenLocation :: (nwpl.TupleEndLocations |> Array.toList)
+                :: nwpl.OpenParenLocation
+                :: (nwpl.TupleEndLocations |> Array.toList)
 
             let sorted =
                 ranges |> List.sortWith (fun a b -> posOrder.Compare(a, b)) |> Seq.toList
@@ -439,9 +440,9 @@ type ParameterLocations with
 module internal SynExprAppLocationsImpl =
     let rec private searchSynArgExpr traverseSynExpr expr ranges =
         match expr with
-        | SynExpr.Const (SynConst.Unit, _) -> None, None
+        | SynExpr.Const(SynConst.Unit, _) -> None, None
 
-        | SynExpr.Paren (SynExpr.Tuple (_, exprs, _commas, _tupRange), _, _, _parenRange) ->
+        | SynExpr.Paren(SynExpr.Tuple(_, exprs, _commas, _tupRange), _, _, _parenRange) ->
             let rec loop (exprs: SynExpr list) ranges =
                 match exprs with
                 | [] -> ranges
@@ -450,11 +451,11 @@ module internal SynExprAppLocationsImpl =
             let res = loop exprs ranges
             Some res, None
 
-        | SynExpr.Paren (SynExpr.Paren _ as synExpr, _, _, _parenRange) ->
+        | SynExpr.Paren(SynExpr.Paren _ as synExpr, _, _, _parenRange) ->
             let r, _cacheOpt = searchSynArgExpr traverseSynExpr synExpr ranges
             r, None
 
-        | SynExpr.Paren (SynExpr.App (_, _isInfix, _, _, _range), _, _, parenRange) -> Some(parenRange :: ranges), None
+        | SynExpr.Paren(SynExpr.App(_, _isInfix, _, _, _range), _, _, parenRange) -> Some(parenRange :: ranges), None
 
         | e ->
             let inner = traverseSynExpr e
@@ -470,10 +471,10 @@ module internal SynExprAppLocationsImpl =
             { new SyntaxVisitorBase<_>() with
                 member _.VisitExpr(_path, traverseSynExpr, defaultTraverse, expr) =
                     match expr with
-                    | SynExpr.App (_exprAtomicFlag, _isInfix, funcExpr, argExpr, range) when posEq pos range.Start ->
+                    | SynExpr.App(_exprAtomicFlag, _isInfix, funcExpr, argExpr, range) when posEq pos range.Start ->
                         let isInfixFuncExpr =
                             match funcExpr with
-                            | SynExpr.App (_, isInfix, _, _, _) -> isInfix
+                            | SynExpr.App(_, isInfix, _, _, _) -> isInfix
                             | _ -> false
 
                         if isInfixFuncExpr then

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -315,33 +315,33 @@ module SyntaxTraversal =
                 let path = SyntaxNode.SynModule m :: origPath
 
                 match m with
-                | SynModuleDecl.ModuleAbbrev (_ident, _longIdent, _range) -> None
-                | SynModuleDecl.NestedModule (decls = synModuleDecls; moduleInfo = SynComponentInfo (attributes = attributes)) ->
+                | SynModuleDecl.ModuleAbbrev(_ident, _longIdent, _range) -> None
+                | SynModuleDecl.NestedModule(decls = synModuleDecls; moduleInfo = SynComponentInfo(attributes = attributes)) ->
                     synModuleDecls
                     |> List.map (fun x -> dive x x.Range (traverseSynModuleDecl path))
                     |> List.append (attributeApplicationDives path attributes)
                     |> pick decl
-                | SynModuleDecl.Let (isRecursive, synBindingList, range) ->
+                | SynModuleDecl.Let(isRecursive, synBindingList, range) ->
                     match visitor.VisitLetOrUse(path, isRecursive, traverseSynBinding path, synBindingList, range) with
                     | Some x -> Some x
                     | None ->
                         synBindingList
                         |> List.map (fun x -> dive x x.RangeOfBindingWithRhs (traverseSynBinding path))
                         |> pick decl
-                | SynModuleDecl.Expr (synExpr, _range) -> traverseSynExpr path synExpr
-                | SynModuleDecl.Types (synTypeDefnList, _range) ->
+                | SynModuleDecl.Expr(synExpr, _range) -> traverseSynExpr path synExpr
+                | SynModuleDecl.Types(synTypeDefnList, _range) ->
                     synTypeDefnList
                     |> List.map (fun x -> dive x x.Range (traverseSynTypeDefn path))
                     |> pick decl
-                | SynModuleDecl.Exception (_synExceptionDefn, _range) -> None
-                | SynModuleDecl.Open (_target, _range) -> None
-                | SynModuleDecl.Attributes (attributes, _) -> attributeApplicationDives path attributes |> pick decl
-                | SynModuleDecl.HashDirective (parsedHashDirective, range) -> visitor.VisitHashDirective(path, parsedHashDirective, range)
-                | SynModuleDecl.NamespaceFragment (synModuleOrNamespace) -> traverseSynModuleOrNamespace path synModuleOrNamespace
+                | SynModuleDecl.Exception(_synExceptionDefn, _range) -> None
+                | SynModuleDecl.Open(_target, _range) -> None
+                | SynModuleDecl.Attributes(attributes, _) -> attributeApplicationDives path attributes |> pick decl
+                | SynModuleDecl.HashDirective(parsedHashDirective, range) -> visitor.VisitHashDirective(path, parsedHashDirective, range)
+                | SynModuleDecl.NamespaceFragment(synModuleOrNamespace) -> traverseSynModuleOrNamespace path synModuleOrNamespace
 
             visitor.VisitModuleDecl(origPath, defaultTraverse, decl)
 
-        and traverseSynModuleOrNamespace origPath (SynModuleOrNamespace (decls = synModuleDecls; range = range) as mors) =
+        and traverseSynModuleOrNamespace origPath (SynModuleOrNamespace(decls = synModuleDecls; range = range) as mors) =
             match visitor.VisitModuleOrNamespace(origPath, mors) with
             | Some x -> Some x
             | None ->
@@ -361,52 +361,51 @@ module SyntaxTraversal =
                 let traversePat = traversePat path
 
                 match e with
-                | SynExpr.LongIdentSet (expr = synExpr)
-                | SynExpr.DotGet (expr = synExpr)
-                | SynExpr.Do (expr = synExpr)
-                | SynExpr.DoBang (expr = synExpr)
-                | SynExpr.Assert (expr = synExpr)
-                | SynExpr.Fixed (expr = synExpr)
-                | SynExpr.DebugPoint (innerExpr = synExpr)
-                | SynExpr.AddressOf (expr = synExpr)
-                | SynExpr.TraitCall (argExpr = synExpr)
-                | SynExpr.Lazy (expr = synExpr)
-                | SynExpr.InferredUpcast (expr = synExpr)
-                | SynExpr.InferredDowncast (expr = synExpr)
-                | SynExpr.YieldOrReturn (expr = synExpr)
-                | SynExpr.YieldOrReturnFrom (expr = synExpr)
-                | SynExpr.FromParseError (expr = synExpr)
-                | SynExpr.DiscardAfterMissingQualificationAfterDot (expr = synExpr)
-                | SynExpr.IndexFromEnd (expr = synExpr)
-                | SynExpr.New (expr = synExpr)
-                | SynExpr.ArrayOrListComputed (expr = synExpr)
-                | SynExpr.TypeApp (expr = synExpr)
-                | SynExpr.DotLambda (expr = synExpr)
-                | SynExpr.Quote (quotedExpr = synExpr)
-                | SynExpr.Paren (expr = synExpr) -> traverseSynExpr synExpr
+                | SynExpr.LongIdentSet(expr = synExpr)
+                | SynExpr.DotGet(expr = synExpr)
+                | SynExpr.Do(expr = synExpr)
+                | SynExpr.DoBang(expr = synExpr)
+                | SynExpr.Assert(expr = synExpr)
+                | SynExpr.Fixed(expr = synExpr)
+                | SynExpr.DebugPoint(innerExpr = synExpr)
+                | SynExpr.AddressOf(expr = synExpr)
+                | SynExpr.TraitCall(argExpr = synExpr)
+                | SynExpr.Lazy(expr = synExpr)
+                | SynExpr.InferredUpcast(expr = synExpr)
+                | SynExpr.InferredDowncast(expr = synExpr)
+                | SynExpr.YieldOrReturn(expr = synExpr)
+                | SynExpr.YieldOrReturnFrom(expr = synExpr)
+                | SynExpr.FromParseError(expr = synExpr)
+                | SynExpr.DiscardAfterMissingQualificationAfterDot(expr = synExpr)
+                | SynExpr.IndexFromEnd(expr = synExpr)
+                | SynExpr.New(expr = synExpr)
+                | SynExpr.ArrayOrListComputed(expr = synExpr)
+                | SynExpr.TypeApp(expr = synExpr)
+                | SynExpr.DotLambda(expr = synExpr)
+                | SynExpr.Quote(quotedExpr = synExpr)
+                | SynExpr.Paren(expr = synExpr) -> traverseSynExpr synExpr
 
-                | SynExpr.InterpolatedString (contents = parts) ->
+                | SynExpr.InterpolatedString(contents = parts) ->
                     [
                         for part in parts do
                             match part with
                             | SynInterpolatedStringPart.String _ -> ()
-                            | SynInterpolatedStringPart.FillExpr (fillExpr, _) -> yield dive fillExpr fillExpr.Range traverseSynExpr
+                            | SynInterpolatedStringPart.FillExpr(fillExpr, _) -> yield dive fillExpr fillExpr.Range traverseSynExpr
                     ]
                     |> pick expr
 
-                | SynExpr.Typed (expr = synExpr; targetType = synType) ->
+                | SynExpr.Typed(expr = synExpr; targetType = synType) ->
                     match traverseSynExpr synExpr with
                     | None -> traverseSynType synType
                     | x -> x
 
-                | SynExpr.Tuple (exprs = synExprList)
-                | SynExpr.ArrayOrList (exprs = synExprList) ->
-                    synExprList |> List.map (fun x -> dive x x.Range traverseSynExpr) |> pick expr
+                | SynExpr.Tuple(exprs = synExprList)
+                | SynExpr.ArrayOrList(exprs = synExprList) -> synExprList |> List.map (fun x -> dive x x.Range traverseSynExpr) |> pick expr
 
-                | SynExpr.AnonRecd (copyInfo = copyOpt; recordFields = fields) ->
+                | SynExpr.AnonRecd(copyInfo = copyOpt; recordFields = fields) ->
                     [
                         match copyOpt with
-                        | Some (expr, (withRange, _)) ->
+                        | Some(expr, (withRange, _)) ->
                             yield dive expr expr.Range traverseSynExpr
 
                             yield
@@ -425,7 +424,7 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.Record (baseInfo = inheritOpt; copyInfo = copyOpt; recordFields = fields) ->
+                | SynExpr.Record(baseInfo = inheritOpt; copyInfo = copyOpt; recordFields = fields) ->
                     [
                         let diveIntoSeparator offsideColumn scPosOpt copyOpt =
                             match scPosOpt with
@@ -442,7 +441,7 @@ module SyntaxTraversal =
                                     None
 
                         match inheritOpt with
-                        | Some (_ty, expr, _range, sepOpt, inheritRange) ->
+                        | Some(_ty, expr, _range, sepOpt, inheritRange) ->
                             // dive into argument
                             yield
                                 dive expr expr.Range (fun expr ->
@@ -459,7 +458,7 @@ module SyntaxTraversal =
                                         traverseSynExpr expr)
 
                             match sepOpt with
-                            | Some (sep, scPosOpt) ->
+                            | Some(sep, scPosOpt) ->
                                 yield
                                     dive () sep (fun () ->
                                         // special case: caret is below 'inherit' + one or more fields are already defined
@@ -471,7 +470,7 @@ module SyntaxTraversal =
                         | _ -> ()
 
                         match copyOpt with
-                        | Some (expr, (withRange, _)) ->
+                        | Some(expr, (withRange, _)) ->
                             yield dive expr expr.Range traverseSynExpr
 
                             yield
@@ -486,7 +485,7 @@ module SyntaxTraversal =
 
                         let copyOpt = Option.map fst copyOpt
 
-                        for SynExprRecordField (fieldName = (field, _); expr = e; blockSeparator = sepOpt) in fields do
+                        for SynExprRecordField(fieldName = (field, _); expr = e; blockSeparator = sepOpt) in fields do
                             yield
                                 dive (path, copyOpt, Some field) field.Range (fun r ->
                                     if rangeContainsPos field.Range pos then
@@ -496,7 +495,7 @@ module SyntaxTraversal =
 
                             let offsideColumn =
                                 match inheritOpt with
-                                | Some (_, _, _, _, inheritRange) -> inheritRange.StartColumn
+                                | Some(_, _, _, _, inheritRange) -> inheritRange.StartColumn
                                 | None -> field.Range.StartColumn
 
                             match e with
@@ -517,7 +516,7 @@ module SyntaxTraversal =
                             | None -> ()
 
                             match sepOpt with
-                            | Some (sep, scPosOpt) ->
+                            | Some(sep, scPosOpt) ->
                                 yield
                                     dive () sep (fun () ->
                                         // special case: caret is between field bindings
@@ -530,12 +529,12 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.ObjExpr (objType = ty; argOptions = baseCallOpt; bindings = binds; members = ms; extraImpls = ifaces) ->
+                | SynExpr.ObjExpr(objType = ty; argOptions = baseCallOpt; bindings = binds; members = ms; extraImpls = ifaces) ->
                     let binds = unionBindingAndMembers binds ms
 
                     let result =
                         ifaces
-                        |> Seq.map (fun (SynInterfaceImpl (interfaceTy = ty)) -> ty)
+                        |> Seq.map (fun (SynInterfaceImpl(interfaceTy = ty)) -> ty)
                         |> Seq.tryPick (fun ty -> visitor.VisitInterfaceSynMemberDefnType(path, ty))
 
                     if result.IsSome then
@@ -543,20 +542,20 @@ module SyntaxTraversal =
                     else
                         [
                             match baseCallOpt with
-                            | Some (expr, _) ->
+                            | Some(expr, _) ->
                                 // this is like a call to 'new', so mock up a 'new' so we can recurse and use that existing logic
                                 let newCall = SynExpr.New(false, ty, expr, unionRanges ty.Range expr.Range)
                                 yield dive newCall newCall.Range traverseSynExpr
                             | _ -> ()
                             for b in binds do
                                 yield dive b b.RangeOfBindingWithRhs (traverseSynBinding path)
-                            for SynInterfaceImpl (bindings = binds) in ifaces do
+                            for SynInterfaceImpl(bindings = binds) in ifaces do
                                 for b in binds do
                                     yield dive b b.RangeOfBindingWithRhs (traverseSynBinding path)
                         ]
                         |> pick expr
 
-                | SynExpr.ForEach (pat = synPat; enumExpr = synExpr; bodyExpr = synExpr2) ->
+                | SynExpr.ForEach(pat = synPat; enumExpr = synExpr; bodyExpr = synExpr2) ->
                     [
                         dive synPat synPat.Range traversePat
                         dive synExpr synExpr.Range traverseSynExpr
@@ -564,27 +563,27 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.ComputationExpr (expr = synExpr) ->
+                | SynExpr.ComputationExpr(expr = synExpr) ->
                     // now parser treats this syntactic expression as computation expression
                     // { identifier }
                     // here we detect this situation and treat ComputationExpr  { Identifier } as attempt to create record
                     // note: sequence expressions use SynExpr.ComputationExpr too - they need to be filtered out
                     let isPartOfArrayOrList =
                         match origPath with
-                        | SyntaxNode.SynExpr (SynExpr.ArrayOrListComputed _) :: _ -> true
+                        | SyntaxNode.SynExpr(SynExpr.ArrayOrListComputed _) :: _ -> true
                         | _ -> false
 
                     let ok =
                         match isPartOfArrayOrList, synExpr with
-                        | false, LongOrSingleIdent (_, lid, _, _) -> visitor.VisitRecordField(path, None, Some lid)
+                        | false, LongOrSingleIdent(_, lid, _, _) -> visitor.VisitRecordField(path, None, Some lid)
                         | _ -> None
 
                     if ok.IsSome then ok else traverseSynExpr synExpr
 
-                | SynExpr.Lambda (parsedData = parsedData) ->
+                | SynExpr.Lambda(parsedData = parsedData) ->
                     [
                         match parsedData with
-                        | Some (pats, body) ->
+                        | Some(pats, body) ->
                             for pat in pats do
                                 yield dive pat pat.Range traversePat
 
@@ -593,14 +592,14 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.MatchLambda (matchClauses = synMatchClauseList) ->
+                | SynExpr.MatchLambda(matchClauses = synMatchClauseList) ->
                     synMatchClauseList
                     |> List.map (fun x -> dive x x.Range (traverseSynMatchClause path))
                     |> pick expr
 
-                | SynExpr.TryWith (tryExpr = synExpr; withCases = synMatchClauseList)
-                | SynExpr.Match (expr = synExpr; clauses = synMatchClauseList)
-                | SynExpr.MatchBang (expr = synExpr; clauses = synMatchClauseList) ->
+                | SynExpr.TryWith(tryExpr = synExpr; withCases = synMatchClauseList)
+                | SynExpr.Match(expr = synExpr; clauses = synMatchClauseList)
+                | SynExpr.MatchBang(expr = synExpr; clauses = synMatchClauseList) ->
                     [
                         yield dive synExpr synExpr.Range traverseSynExpr
                         yield!
@@ -609,7 +608,7 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.App (isInfix = isInfix; funcExpr = synExpr; argExpr = synExpr2) ->
+                | SynExpr.App(isInfix = isInfix; funcExpr = synExpr; argExpr = synExpr2) ->
                     if isInfix then
                         [
                             dive synExpr2 synExpr2.Range traverseSynExpr
@@ -623,7 +622,7 @@ module SyntaxTraversal =
                         ]
                         |> pick expr
 
-                | SynExpr.LetOrUse (isRecursive = isRecursive; bindings = synBindingList; body = synExpr; range = range) ->
+                | SynExpr.LetOrUse(isRecursive = isRecursive; bindings = synBindingList; body = synExpr; range = range) ->
                     match visitor.VisitLetOrUse(path, isRecursive, traverseSynBinding path, synBindingList, range) with
                     | None ->
                         [
@@ -635,7 +634,7 @@ module SyntaxTraversal =
                         |> pick expr
                     | x -> x
 
-                | SynExpr.IfThenElse (ifExpr = synExpr; thenExpr = synExpr2; elseExpr = synExprOpt) ->
+                | SynExpr.IfThenElse(ifExpr = synExpr; thenExpr = synExpr2; elseExpr = synExprOpt) ->
                     [
                         yield dive synExpr synExpr.Range traverseSynExpr
                         yield dive synExpr2 synExpr2.Range traverseSynExpr
@@ -645,7 +644,7 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.IndexRange (expr1 = expr1; expr2 = expr2) ->
+                | SynExpr.IndexRange(expr1 = expr1; expr2 = expr2) ->
                     [
                         match expr1 with
                         | Some e -> dive e e.Range traverseSynExpr
@@ -656,25 +655,25 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.Set (targetExpr = synExpr1; rhsExpr = synExpr2)
-                | SynExpr.DotSet (targetExpr = synExpr1; rhsExpr = synExpr2)
-                | SynExpr.TryFinally (tryExpr = synExpr1; finallyExpr = synExpr2)
-                | SynExpr.SequentialOrImplicitYield (expr1 = synExpr1; expr2 = synExpr2)
-                | SynExpr.Sequential (expr1 = synExpr1; expr2 = synExpr2)
-                | SynExpr.While (whileExpr = synExpr1; doExpr = synExpr2)
-                | SynExpr.WhileBang (whileExpr = synExpr1; doExpr = synExpr2)
-                | SynExpr.DotIndexedGet (objectExpr = synExpr1; indexArgs = synExpr2)
-                | SynExpr.JoinIn (lhsExpr = synExpr1; rhsExpr = synExpr2)
-                | SynExpr.NamedIndexedPropertySet (expr1 = synExpr1; expr2 = synExpr2) ->
+                | SynExpr.Set(targetExpr = synExpr1; rhsExpr = synExpr2)
+                | SynExpr.DotSet(targetExpr = synExpr1; rhsExpr = synExpr2)
+                | SynExpr.TryFinally(tryExpr = synExpr1; finallyExpr = synExpr2)
+                | SynExpr.SequentialOrImplicitYield(expr1 = synExpr1; expr2 = synExpr2)
+                | SynExpr.Sequential(expr1 = synExpr1; expr2 = synExpr2)
+                | SynExpr.While(whileExpr = synExpr1; doExpr = synExpr2)
+                | SynExpr.WhileBang(whileExpr = synExpr1; doExpr = synExpr2)
+                | SynExpr.DotIndexedGet(objectExpr = synExpr1; indexArgs = synExpr2)
+                | SynExpr.JoinIn(lhsExpr = synExpr1; rhsExpr = synExpr2)
+                | SynExpr.NamedIndexedPropertySet(expr1 = synExpr1; expr2 = synExpr2) ->
                     [
                         dive synExpr1 synExpr1.Range traverseSynExpr
                         dive synExpr2 synExpr2.Range traverseSynExpr
                     ]
                     |> pick expr
 
-                | SynExpr.For (identBody = synExpr1; toBody = synExpr2; doBody = synExpr3)
-                | SynExpr.DotIndexedSet (objectExpr = synExpr1; indexArgs = synExpr2; valueExpr = synExpr3)
-                | SynExpr.DotNamedIndexedPropertySet (targetExpr = synExpr1; argExpr = synExpr2; rhsExpr = synExpr3) ->
+                | SynExpr.For(identBody = synExpr1; toBody = synExpr2; doBody = synExpr3)
+                | SynExpr.DotIndexedSet(objectExpr = synExpr1; indexArgs = synExpr2; valueExpr = synExpr3)
+                | SynExpr.DotNamedIndexedPropertySet(targetExpr = synExpr1; argExpr = synExpr2; rhsExpr = synExpr3) ->
                     [
                         dive synExpr1 synExpr1.Range traverseSynExpr
                         dive synExpr2 synExpr2.Range traverseSynExpr
@@ -682,22 +681,22 @@ module SyntaxTraversal =
                     ]
                     |> pick expr
 
-                | SynExpr.TypeTest (expr = synExpr; targetType = synType)
-                | SynExpr.Upcast (expr = synExpr; targetType = synType)
-                | SynExpr.Downcast (expr = synExpr; targetType = synType) ->
+                | SynExpr.TypeTest(expr = synExpr; targetType = synType)
+                | SynExpr.Upcast(expr = synExpr; targetType = synType)
+                | SynExpr.Downcast(expr = synExpr; targetType = synType) ->
                     [
                         dive synExpr synExpr.Range traverseSynExpr
                         dive synType synType.Range traverseSynType
                     ]
                     |> pick expr
 
-                | SynExpr.LetOrUseBang (pat = synPat; rhs = synExpr; andBangs = andBangSynExprs; body = synExpr2) ->
+                | SynExpr.LetOrUseBang(pat = synPat; rhs = synExpr; andBangs = andBangSynExprs; body = synExpr2) ->
                     [
                         yield dive synPat synPat.Range traversePat
                         yield dive synExpr synExpr.Range traverseSynExpr
                         yield!
                             [
-                                for SynExprAndBang (pat = andBangSynPat; body = andBangSynExpr) in andBangSynExprs do
+                                for SynExprAndBang(pat = andBangSynPat; body = andBangSynExpr) in andBangSynExprs do
                                     yield (dive andBangSynPat andBangSynPat.Range traversePat)
                                     yield (dive andBangSynExpr andBangSynExpr.Range traverseSynExpr)
                             ]
@@ -725,27 +724,27 @@ module SyntaxTraversal =
                 let path = SyntaxNode.SynPat p :: origPath
 
                 match p with
-                | SynPat.Paren (p, _) -> traversePat path p
-                | SynPat.As (p1, p2, _)
-                | SynPat.Or (p1, p2, _, _)
-                | SynPat.ListCons (p1, p2, _, _) -> [ p1; p2 ] |> List.tryPick (traversePat path)
-                | SynPat.Ands (ps, _)
-                | SynPat.Tuple (elementPats = ps)
-                | SynPat.ArrayOrList (_, ps, _) -> ps |> List.tryPick (traversePat path)
-                | SynPat.Record (fieldPats = fieldPats) -> fieldPats |> List.tryPick (fun (_, _, p) -> traversePat path p)
-                | SynPat.Attrib (p, attributes, m) ->
+                | SynPat.Paren(p, _) -> traversePat path p
+                | SynPat.As(p1, p2, _)
+                | SynPat.Or(p1, p2, _, _)
+                | SynPat.ListCons(p1, p2, _, _) -> [ p1; p2 ] |> List.tryPick (traversePat path)
+                | SynPat.Ands(ps, _)
+                | SynPat.Tuple(elementPats = ps)
+                | SynPat.ArrayOrList(_, ps, _) -> ps |> List.tryPick (traversePat path)
+                | SynPat.Record(fieldPats = fieldPats) -> fieldPats |> List.tryPick (fun (_, _, p) -> traversePat path p)
+                | SynPat.Attrib(p, attributes, m) ->
                     match traversePat path p with
                     | None -> attributeApplicationDives path attributes |> pick m attributes
                     | x -> x
-                | SynPat.LongIdent (argPats = args) ->
+                | SynPat.LongIdent(argPats = args) ->
                     match args with
                     | SynArgPats.Pats ps -> ps |> List.tryPick (traversePat path)
-                    | SynArgPats.NamePatPairs (pats = ps) -> ps |> List.map (fun (_, _, pat) -> pat) |> List.tryPick (traversePat path)
-                | SynPat.Typed (p, ty, _) ->
+                    | SynArgPats.NamePatPairs(pats = ps) -> ps |> List.map (fun (_, _, pat) -> pat) |> List.tryPick (traversePat path)
+                | SynPat.Typed(p, ty, _) ->
                     match traversePat path p with
                     | None -> traverseSynType path ty
                     | x -> x
-                | SynPat.QuoteExpr (expr, _) -> traverseSynExpr path expr
+                | SynPat.QuoteExpr(expr, _) -> traverseSynExpr path expr
                 | _ -> None
 
             visitor.VisitPat(origPath, defaultTraverse, pat)
@@ -756,7 +755,7 @@ module SyntaxTraversal =
                 pats
                 |> List.tryPick (fun pat ->
                     match pat with
-                    | SynSimplePat.Attrib (attributes = attributes; range = m) ->
+                    | SynSimplePat.Attrib(attributes = attributes; range = m) ->
                         attributeApplicationDives origPath attributes |> pick m attributes
                     | _ -> None)
             | x -> x
@@ -766,20 +765,20 @@ module SyntaxTraversal =
                 let path = SyntaxNode.SynType ty :: origPath
 
                 match ty with
-                | SynType.App (typeName, _, typeArgs, _, _, _, _)
-                | SynType.LongIdentApp (typeName, _, _, typeArgs, _, _, _) -> typeName :: typeArgs |> List.tryPick (traverseSynType path)
-                | SynType.Fun (argType = ty1; returnType = ty2) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
-                | SynType.MeasurePower (ty, _, _)
-                | SynType.HashConstraint (ty, _)
-                | SynType.WithGlobalConstraints (ty, _, _)
-                | SynType.Array (_, ty, _) -> traverseSynType path ty
-                | SynType.StaticConstantNamed (ty1, ty2, _)
-                | SynType.Or (ty1, ty2, _, _) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
-                | SynType.Tuple (path = segments) -> getTypeFromTuplePath segments |> List.tryPick (traverseSynType path)
-                | SynType.StaticConstantExpr (expr, _) -> traverseSynExpr [] expr
-                | SynType.Paren (innerType = t)
-                | SynType.SignatureParameter (usedType = t) -> traverseSynType path t
-                | SynType.Intersection (types = types) -> List.tryPick (traverseSynType path) types
+                | SynType.App(typeName, _, typeArgs, _, _, _, _)
+                | SynType.LongIdentApp(typeName, _, _, typeArgs, _, _, _) -> typeName :: typeArgs |> List.tryPick (traverseSynType path)
+                | SynType.Fun(argType = ty1; returnType = ty2) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
+                | SynType.MeasurePower(ty, _, _)
+                | SynType.HashConstraint(ty, _)
+                | SynType.WithGlobalConstraints(ty, _, _)
+                | SynType.Array(_, ty, _) -> traverseSynType path ty
+                | SynType.StaticConstantNamed(ty1, ty2, _)
+                | SynType.Or(ty1, ty2, _, _) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
+                | SynType.Tuple(path = segments) -> getTypeFromTuplePath segments |> List.tryPick (traverseSynType path)
+                | SynType.StaticConstantExpr(expr, _) -> traverseSynExpr [] expr
+                | SynType.Paren(innerType = t)
+                | SynType.SignatureParameter(usedType = t) -> traverseSynType path t
+                | SynType.Intersection(types = types) -> List.tryPick (traverseSynType path) types
                 | SynType.Anon _
                 | SynType.AnonRecd _
                 | SynType.LongIdent _
@@ -794,10 +793,10 @@ module SyntaxTraversal =
             // property getters are setters are two members that can have the same range, so do some somersaults to deal with this
             |> Seq.map (fun mb ->
                 match mb with
-                | SynMemberDefn.GetSetMember (Some binding, None, m, _)
-                | SynMemberDefn.GetSetMember (None, Some binding, m, _) ->
+                | SynMemberDefn.GetSetMember(Some binding, None, m, _)
+                | SynMemberDefn.GetSetMember(None, Some binding, m, _) ->
                     dive (SynMemberDefn.Member(binding, m)) m (traverseSynMemberDefn path traverseInherit)
-                | SynMemberDefn.GetSetMember (Some getBinding, Some setBinding, m, _) ->
+                | SynMemberDefn.GetSetMember(Some getBinding, Some setBinding, m, _) ->
                     let traverse () =
                         match traverseSynMemberDefn path (fun _ -> None) (SynMemberDefn.Member(getBinding, m)) with
                         | Some _ as x -> x
@@ -806,14 +805,14 @@ module SyntaxTraversal =
                     m, traverse
                 | mem -> dive mem mem.Range (traverseSynMemberDefn path traverseInherit))
 
-        and traverseSynTypeDefn origPath (SynTypeDefn (synComponentInfo, synTypeDefnRepr, synMemberDefns, _, tRange, _) as tydef) =
+        and traverseSynTypeDefn origPath (SynTypeDefn(synComponentInfo, synTypeDefnRepr, synMemberDefns, _, tRange, _) as tydef) =
             let path = SyntaxNode.SynTypeDefn tydef :: origPath
 
             match visitor.VisitComponentInfo(origPath, synComponentInfo) with
             | Some x -> Some x
             | None ->
                 match synComponentInfo with
-                | SynComponentInfo (attributes = attributes) ->
+                | SynComponentInfo(attributes = attributes) ->
                     [
                         yield! attributeApplicationDives path attributes
 
@@ -822,7 +821,7 @@ module SyntaxTraversal =
                             // This node is generated in CheckExpressions.fs, not in the AST.
                             // But note exception declarations are missing from this tree walk.
                             ()
-                        | SynTypeDefnRepr.ObjectModel (synTypeDefnKind, synMemberDefns, _oRange) ->
+                        | SynTypeDefnRepr.ObjectModel(synTypeDefnKind, synMemberDefns, _oRange) ->
                             // traverse inherit function is used to capture type specific data required for processing Inherit part
                             let traverseInherit (synType: SynType, range: range) =
                                 visitor.VisitInheritSynMemberDefn(path, synComponentInfo, synTypeDefnKind, synType, synMemberDefns, range)
@@ -830,15 +829,15 @@ module SyntaxTraversal =
                             yield!
                                 synMemberDefns
                                 |> normalizeMembersToDealWithPeculiaritiesOfGettersAndSetters path traverseInherit
-                        | SynTypeDefnRepr.Simple (synTypeDefnSimpleRepr, _range) ->
+                        | SynTypeDefnRepr.Simple(synTypeDefnSimpleRepr, _range) ->
                             match synTypeDefnSimpleRepr with
-                            | SynTypeDefnSimpleRepr.Record (_synAccessOption, fields, m) ->
+                            | SynTypeDefnSimpleRepr.Record(_synAccessOption, fields, m) ->
                                 yield dive () synTypeDefnRepr.Range (fun () -> traverseRecordDefn path fields m)
-                            | SynTypeDefnSimpleRepr.Union (_synAccessOption, cases, m) ->
+                            | SynTypeDefnSimpleRepr.Union(_synAccessOption, cases, m) ->
                                 yield dive () synTypeDefnRepr.Range (fun () -> traverseUnionDefn path cases m)
-                            | SynTypeDefnSimpleRepr.Enum (cases, m) ->
+                            | SynTypeDefnSimpleRepr.Enum(cases, m) ->
                                 yield dive () synTypeDefnRepr.Range (fun () -> traverseEnumDefn path cases m)
-                            | SynTypeDefnSimpleRepr.TypeAbbrev (_, synType, m) ->
+                            | SynTypeDefnSimpleRepr.TypeAbbrev(_, synType, m) ->
                                 yield dive synTypeDefnRepr synTypeDefnRepr.Range (fun _ -> visitor.VisitTypeAbbrev(path, synType, m))
                             | _ -> ()
                         yield!
@@ -849,23 +848,23 @@ module SyntaxTraversal =
 
         and traverseRecordDefn path fields m =
             fields
-            |> List.tryPick (fun (SynField (attributes = attributes)) -> attributeApplicationDives path attributes |> pick m attributes)
+            |> List.tryPick (fun (SynField(attributes = attributes)) -> attributeApplicationDives path attributes |> pick m attributes)
             |> Option.orElseWith (fun () -> visitor.VisitRecordDefn(path, fields, m))
 
         and traverseEnumDefn path cases m =
             cases
-            |> List.tryPick (fun (SynEnumCase (attributes = attributes)) -> attributeApplicationDives path attributes |> pick m attributes)
+            |> List.tryPick (fun (SynEnumCase(attributes = attributes)) -> attributeApplicationDives path attributes |> pick m attributes)
             |> Option.orElseWith (fun () -> visitor.VisitEnumDefn(path, cases, m))
 
         and traverseUnionDefn path cases m =
             cases
-            |> List.tryPick (fun (SynUnionCase (attributes = attributes; caseType = caseType)) ->
+            |> List.tryPick (fun (SynUnionCase(attributes = attributes; caseType = caseType)) ->
                 match attributeApplicationDives path attributes |> pick m attributes with
                 | None ->
                     match caseType with
                     | SynUnionCaseKind.Fields fields ->
                         fields
-                        |> List.tryPick (fun (SynField (attributes = attributes)) ->
+                        |> List.tryPick (fun (SynField(attributes = attributes)) ->
                             attributeApplicationDives path attributes |> pick m attributes)
                     | _ -> None
                 | x -> x)
@@ -876,9 +875,9 @@ module SyntaxTraversal =
             let path = SyntaxNode.SynMemberDefn m :: path
 
             match m with
-            | SynMemberDefn.Open (_longIdent, _range) -> None
-            | SynMemberDefn.Member (synBinding, _range) -> traverseSynBinding path synBinding
-            | SynMemberDefn.GetSetMember (getBinding, setBinding, _, _) ->
+            | SynMemberDefn.Open(_longIdent, _range) -> None
+            | SynMemberDefn.Member(synBinding, _range) -> traverseSynBinding path synBinding
+            | SynMemberDefn.GetSetMember(getBinding, setBinding, _, _) ->
                 match getBinding, setBinding with
                 | None, None -> None
                 | Some binding, None
@@ -887,10 +886,10 @@ module SyntaxTraversal =
                     traverseSynBinding path getBinding
                     |> Option.orElseWith (fun () -> traverseSynBinding path setBinding)
 
-            | SynMemberDefn.ImplicitCtor (ctorArgs = simplePats) ->
+            | SynMemberDefn.ImplicitCtor(ctorArgs = simplePats) ->
                 match simplePats with
-                | SynSimplePats.SimplePats (pats = simplePats) -> traverseSynSimplePats path simplePats
-            | SynMemberDefn.ImplicitInherit (synType, synExpr, _identOption, range) ->
+                | SynSimplePats.SimplePats(pats = simplePats) -> traverseSynSimplePats path simplePats
+            | SynMemberDefn.ImplicitInherit(synType, synExpr, _identOption, range) ->
                 [
                     dive () synType.Range (fun () ->
                         match traverseInherit (synType, range) with
@@ -899,27 +898,27 @@ module SyntaxTraversal =
                     dive () synExpr.Range (fun () -> visitor.VisitImplicitInherit(path, traverseSynExpr path, synType, synExpr, range))
                 ]
                 |> pick m
-            | SynMemberDefn.AutoProperty (synExpr = synExpr; attributes = attributes) ->
+            | SynMemberDefn.AutoProperty(synExpr = synExpr; attributes = attributes) ->
                 match traverseSynExpr path synExpr with
                 | None -> attributeApplicationDives path attributes |> pick attributes
                 | x -> x
-            | SynMemberDefn.LetBindings (synBindingList, isRecursive, _, range) ->
+            | SynMemberDefn.LetBindings(synBindingList, isRecursive, _, range) ->
                 match visitor.VisitLetOrUse(path, isRecursive, traverseSynBinding path, synBindingList, range) with
                 | None ->
                     synBindingList
                     |> List.map (fun x -> dive x x.RangeOfBindingWithRhs (traverseSynBinding path))
                     |> pick m
                 | x -> x
-            | SynMemberDefn.AbstractSlot(slotSig = SynValSig (synType = synType; attributes = attributes)) ->
+            | SynMemberDefn.AbstractSlot(slotSig = SynValSig(synType = synType; attributes = attributes)) ->
                 match traverseSynType path synType with
                 | None -> attributeApplicationDives path attributes |> pick attributes
                 | x -> x
-            | SynMemberDefn.Interface (interfaceType = synType; members = synMemberDefnsOption) ->
+            | SynMemberDefn.Interface(interfaceType = synType; members = synMemberDefnsOption) ->
                 match visitor.VisitInterfaceSynMemberDefnType(path, synType) with
                 | None ->
                     match synMemberDefnsOption with
                     | None -> None
-                    | Some (x) ->
+                    | Some(x) ->
                         [
                             yield!
                                 x
@@ -927,16 +926,16 @@ module SyntaxTraversal =
                         ]
                         |> pick x
                 | ok -> ok
-            | SynMemberDefn.Inherit (synType, _identOption, range) -> traverseInherit (synType, range)
+            | SynMemberDefn.Inherit(synType, _identOption, range) -> traverseInherit (synType, range)
             | SynMemberDefn.ValField _ -> None
-            | SynMemberDefn.NestedType (synTypeDefn, _synAccessOption, _range) -> traverseSynTypeDefn path synTypeDefn
+            | SynMemberDefn.NestedType(synTypeDefn, _synAccessOption, _range) -> traverseSynTypeDefn path synTypeDefn
 
         and traverseSynMatchClause origPath mc =
             let defaultTraverse mc =
                 let path = SyntaxNode.SynMatchClause mc :: origPath
 
                 match mc with
-                | SynMatchClause (pat = synPat; whenExpr = synExprOption; resultExpr = synExpr) as all ->
+                | SynMatchClause(pat = synPat; whenExpr = synExprOption; resultExpr = synExpr) as all ->
                     [ dive synPat synPat.Range (traversePat path) ]
                     @ ([
                         match synExprOption with
@@ -954,7 +953,7 @@ module SyntaxTraversal =
                 let path = SyntaxNode.SynBinding b :: origPath
 
                 match b with
-                | SynBinding (headPat = synPat; expr = synExpr; attributes = attributes; range = m) ->
+                | SynBinding(headPat = synPat; expr = synExpr; attributes = attributes; range = m) ->
                     [
                         yield! attributeApplicationDives path attributes
                         dive synPat synPat.Range (traversePat path)
@@ -968,7 +967,7 @@ module SyntaxTraversal =
             attributes
             |> List.map (fun attributes -> dive () attributes.Range (fun () -> visitor.VisitAttributeApplication(origPath, attributes)))
 
-        and traverseSynModuleOrNamespaceSig origPath (SynModuleOrNamespaceSig (decls = synModuleSigDecls; range = range) as mors) =
+        and traverseSynModuleOrNamespaceSig origPath (SynModuleOrNamespaceSig(decls = synModuleSigDecls; range = range) as mors) =
             match visitor.VisitModuleOrNamespaceSig(origPath, mors) with
             | Some x -> Some x
             | None ->
@@ -985,27 +984,26 @@ module SyntaxTraversal =
                 let path = SyntaxNode.SynModuleSigDecl m :: origPath
 
                 match m with
-                | SynModuleSigDecl.ModuleAbbrev (_ident, _longIdent, _range) -> None
-                | SynModuleSigDecl.NestedModule (moduleDecls = synModuleDecls; moduleInfo = SynComponentInfo (attributes = attributes)) ->
+                | SynModuleSigDecl.ModuleAbbrev(_ident, _longIdent, _range) -> None
+                | SynModuleSigDecl.NestedModule(moduleDecls = synModuleDecls; moduleInfo = SynComponentInfo(attributes = attributes)) ->
                     synModuleDecls
                     |> List.map (fun x -> dive x x.Range (traverseSynModuleSigDecl path))
                     |> List.append (attributeApplicationDives path attributes)
                     |> pick decl
-                | SynModuleSigDecl.Val (synValSig, range) -> [ dive synValSig range (traverseSynValSig path) ] |> pick decl
-                | SynModuleSigDecl.Types (types = types; range = range) ->
+                | SynModuleSigDecl.Val(synValSig, range) -> [ dive synValSig range (traverseSynValSig path) ] |> pick decl
+                | SynModuleSigDecl.Types(types = types; range = range) ->
                     types
                     |> List.map (fun t -> dive t range (traverseSynTypeDefnSig path))
                     |> pick decl
-                | SynModuleSigDecl.Exception (_synExceptionDefn, _range) -> None
-                | SynModuleSigDecl.Open (_target, _range) -> None
-                | SynModuleSigDecl.HashDirective (parsedHashDirective, range) ->
-                    visitor.VisitHashDirective(path, parsedHashDirective, range)
+                | SynModuleSigDecl.Exception(_synExceptionDefn, _range) -> None
+                | SynModuleSigDecl.Open(_target, _range) -> None
+                | SynModuleSigDecl.HashDirective(parsedHashDirective, range) -> visitor.VisitHashDirective(path, parsedHashDirective, range)
                 | SynModuleSigDecl.NamespaceFragment synModuleOrNamespaceSig -> traverseSynModuleOrNamespaceSig path synModuleOrNamespaceSig
 
             visitor.VisitModuleSigDecl(origPath, defaultTraverse, decl)
 
         and traverseSynValSig origPath (valSig: SynValSig) =
-            let defaultTraverse (SynValSig (synType = t; attributes = attributes; synExpr = expr; range = m)) =
+            let defaultTraverse (SynValSig(synType = t; attributes = attributes; synExpr = expr; range = m)) =
                 let path = SyntaxNode.SynValSig valSig :: origPath
 
                 [
@@ -1019,14 +1017,14 @@ module SyntaxTraversal =
 
             visitor.VisitValSig(origPath, defaultTraverse, valSig)
 
-        and traverseSynTypeDefnSig origPath (SynTypeDefnSig (synComponentInfo, typeRepr, members, tRange, _) as tydef) =
+        and traverseSynTypeDefnSig origPath (SynTypeDefnSig(synComponentInfo, typeRepr, members, tRange, _) as tydef) =
             let path = SyntaxNode.SynTypeDefnSig tydef :: origPath
 
             match visitor.VisitComponentInfo(origPath, synComponentInfo) with
             | Some x -> Some x
             | None ->
                 match synComponentInfo with
-                | SynComponentInfo (attributes = attributes) ->
+                | SynComponentInfo(attributes = attributes) ->
                     [
                         yield! attributeApplicationDives path attributes
 
@@ -1035,17 +1033,16 @@ module SyntaxTraversal =
                             // This node is generated in CheckExpressions.fs, not in the AST.
                             // But note exception declarations are missing from this tree walk.
                             ()
-                        | SynTypeDefnSigRepr.ObjectModel (memberSigs = memberSigs) ->
+                        | SynTypeDefnSigRepr.ObjectModel(memberSigs = memberSigs) ->
                             yield! memberSigs |> List.map (fun ms -> dive ms ms.Range (traverseSynMemberSig path))
-                        | SynTypeDefnSigRepr.Simple (synTypeDefnSimpleRepr, _range) ->
+                        | SynTypeDefnSigRepr.Simple(synTypeDefnSimpleRepr, _range) ->
                             match synTypeDefnSimpleRepr with
-                            | SynTypeDefnSimpleRepr.Record (_synAccessOption, fields, m) ->
+                            | SynTypeDefnSimpleRepr.Record(_synAccessOption, fields, m) ->
                                 yield dive () typeRepr.Range (fun () -> traverseRecordDefn path fields m)
-                            | SynTypeDefnSimpleRepr.Union (_synAccessOption, cases, m) ->
+                            | SynTypeDefnSimpleRepr.Union(_synAccessOption, cases, m) ->
                                 yield dive () typeRepr.Range (fun () -> traverseUnionDefn path cases m)
-                            | SynTypeDefnSimpleRepr.Enum (cases, m) ->
-                                yield dive () typeRepr.Range (fun () -> traverseEnumDefn path cases m)
-                            | SynTypeDefnSimpleRepr.TypeAbbrev (_, synType, m) ->
+                            | SynTypeDefnSimpleRepr.Enum(cases, m) -> yield dive () typeRepr.Range (fun () -> traverseEnumDefn path cases m)
+                            | SynTypeDefnSimpleRepr.TypeAbbrev(_, synType, m) ->
                                 yield dive typeRepr typeRepr.Range (fun _ -> visitor.VisitTypeAbbrev(path, synType, m))
                             | _ -> ()
                         yield! members |> List.map (fun ms -> dive ms ms.Range (traverseSynMemberSig path))
@@ -1056,12 +1053,12 @@ module SyntaxTraversal =
             let path = SyntaxNode.SynMemberSig m :: path
 
             match m with
-            | SynMemberSig.Member (memberSig = memberSig) -> traverseSynValSig path memberSig
-            | SynMemberSig.Interface (interfaceType = synType) -> traverseSynType path synType
-            | SynMemberSig.Inherit (inheritedType = synType) -> traverseSynType path synType
-            | SynMemberSig.ValField(field = SynField (attributes = attributes)) ->
+            | SynMemberSig.Member(memberSig = memberSig) -> traverseSynValSig path memberSig
+            | SynMemberSig.Interface(interfaceType = synType) -> traverseSynType path synType
+            | SynMemberSig.Inherit(inheritedType = synType) -> traverseSynType path synType
+            | SynMemberSig.ValField(field = SynField(attributes = attributes)) ->
                 attributeApplicationDives path attributes |> pick m.Range attributes
-            | SynMemberSig.NestedType (nestedType = nestedType) -> traverseSynTypeDefnSig path nestedType
+            | SynMemberSig.NestedType(nestedType = nestedType) -> traverseSynTypeDefnSig path nestedType
 
         match parseTree with
         | ParsedInput.ImplFile file ->

--- a/src/Compiler/Service/ServiceParseTreeWalk.fsi
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fsi
@@ -31,6 +31,7 @@ type SyntaxVisitorBase<'T> =
 
     default VisitBinding:
         path: SyntaxVisitorPath * defaultTraverse: (SynBinding -> 'T option) * synBinding: SynBinding -> 'T option
+
     abstract VisitBinding:
         path: SyntaxVisitorPath * defaultTraverse: (SynBinding -> 'T option) * synBinding: SynBinding -> 'T option
 
@@ -48,6 +49,7 @@ type SyntaxVisitorBase<'T> =
         defaultTraverse: (SynExpr -> 'T option) *
         synExpr: SynExpr ->
             'T option
+
     default VisitExpr:
         path: SyntaxVisitorPath *
         traverseSynExpr: (SynExpr -> 'T option) *
@@ -57,6 +59,7 @@ type SyntaxVisitorBase<'T> =
 
     abstract VisitHashDirective:
         path: SyntaxVisitorPath * hashDirective: ParsedHashDirective * range: range -> 'T option
+
     default VisitHashDirective: path: SyntaxVisitorPath * hashDirective: ParsedHashDirective * range: range -> 'T option
 
     abstract VisitImplicitInherit:
@@ -66,6 +69,7 @@ type SyntaxVisitorBase<'T> =
         synArgs: SynExpr *
         range: range ->
             'T option
+
     default VisitImplicitInherit:
         path: SyntaxVisitorPath *
         defaultTraverse: (SynExpr -> 'T option) *
@@ -82,6 +86,7 @@ type SyntaxVisitorBase<'T> =
         members: SynMemberDefns *
         range: range ->
             'T option
+
     default VisitInheritSynMemberDefn:
         path: SyntaxVisitorPath *
         componentInfo: SynComponentInfo *
@@ -110,6 +115,7 @@ type SyntaxVisitorBase<'T> =
         bindings: SynBinding list *
         range: range ->
             'T option
+
     default VisitLetOrUse:
         path: SyntaxVisitorPath *
         isRecursive: bool *
@@ -121,6 +127,7 @@ type SyntaxVisitorBase<'T> =
     abstract VisitMatchClause:
         path: SyntaxVisitorPath * defaultTraverse: (SynMatchClause -> 'T option) * matchClause: SynMatchClause ->
             'T option
+
     default VisitMatchClause:
         path: SyntaxVisitorPath * defaultTraverse: (SynMatchClause -> 'T option) * matchClause: SynMatchClause ->
             'T option
@@ -128,6 +135,7 @@ type SyntaxVisitorBase<'T> =
     abstract VisitModuleDecl:
         path: SyntaxVisitorPath * defaultTraverse: (SynModuleDecl -> 'T option) * synModuleDecl: SynModuleDecl ->
             'T option
+
     default VisitModuleDecl:
         path: SyntaxVisitorPath * defaultTraverse: (SynModuleDecl -> 'T option) * synModuleDecl: SynModuleDecl ->
             'T option
@@ -140,6 +148,7 @@ type SyntaxVisitorBase<'T> =
 
     abstract VisitRecordField:
         path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: SynLongIdent option -> 'T option
+
     default VisitRecordField:
         path: SyntaxVisitorPath * copyOpt: SynExpr option * recordField: SynLongIdent option -> 'T option
 
@@ -148,6 +157,7 @@ type SyntaxVisitorBase<'T> =
 
     abstract VisitType:
         path: SyntaxVisitorPath * defaultTraverse: (SynType -> 'T option) * synType: SynType -> 'T option
+
     default VisitType: path: SyntaxVisitorPath * defaultTraverse: (SynType -> 'T option) * synType: SynType -> 'T option
 
     abstract VisitTypeAbbrev: path: SyntaxVisitorPath * synType: SynType * range: range -> 'T option
@@ -158,12 +168,14 @@ type SyntaxVisitorBase<'T> =
 
     abstract VisitModuleOrNamespaceSig:
         path: SyntaxVisitorPath * synModuleOrNamespaceSig: SynModuleOrNamespaceSig -> 'T option
+
     default VisitModuleOrNamespaceSig:
         path: SyntaxVisitorPath * synModuleOrNamespaceSig: SynModuleOrNamespaceSig -> 'T option
 
     abstract VisitModuleSigDecl:
         path: SyntaxVisitorPath * defaultTraverse: (SynModuleSigDecl -> 'T option) * synModuleSigDecl: SynModuleSigDecl ->
             'T option
+
     default VisitModuleSigDecl:
         path: SyntaxVisitorPath * defaultTraverse: (SynModuleSigDecl -> 'T option) * synModuleSigDecl: SynModuleSigDecl ->
             'T option

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -162,15 +162,11 @@ type OpenStatementInsertionPoint =
 module Entity =
     let getRelativeNamespace (targetNs: ShortIdents) (sourceNs: ShortIdents) =
         let rec loop index =
-            if index > targetNs.Length - 1 then
-                sourceNs[index..]
+            if index > targetNs.Length - 1 then sourceNs[index..]
             // target namespace is not a full parent of source namespace, keep the source ns as is
-            elif index > sourceNs.Length - 1 then
-                sourceNs
-            elif targetNs[index] = sourceNs[index] then
-                loop (index + 1)
-            else
-                sourceNs[index..]
+            elif index > sourceNs.Length - 1 then sourceNs
+            elif targetNs[index] = sourceNs[index] then loop (index + 1)
+            else sourceNs[index..]
 
         if sourceNs.Length = 0 || targetNs.Length = 0 then
             sourceNs
@@ -267,8 +263,8 @@ module ParsedInput =
 
         let rec collect expr acc =
             match expr with
-            | SynExpr.Sequential (_, _, e1, (SynExpr.Sequential _ as e2), _) -> collect e2 (e1 :: acc)
-            | SynExpr.Sequential (_, _, e1, e2, _) -> e2 :: e1 :: acc
+            | SynExpr.Sequential(_, _, e1, (SynExpr.Sequential _ as e2), _) -> collect e2 (e1 :: acc)
+            | SynExpr.Sequential(_, _, e1, e2, _) -> e2 :: e1 :: acc
             | _ -> acc
 
         match collect expr [] with
@@ -296,15 +292,15 @@ module ParsedInput =
                     let expr = expr // fix debugger locals
 
                     match expr with
-                    | SynExpr.LongIdent(longDotId = SynLongIdent ([ id ], [], [ Some _ ])) -> defaultTraverse (SynExpr.Ident(id))
+                    | SynExpr.LongIdent(longDotId = SynLongIdent([ id ], [], [ Some _ ])) -> defaultTraverse (SynExpr.Ident(id))
 
-                    | SynExpr.LongIdent (_, lid, _altNameRefCell, _) ->
-                        let (SynLongIdent (longIdent, _, _)) = lid
+                    | SynExpr.LongIdent(_, lid, _altNameRefCell, _) ->
+                        let (SynLongIdent(longIdent, _, _)) = lid
                         let _, r = CheckLongIdent longIdent
                         Some r
 
-                    | SynExpr.LongIdentSet (lid, synExpr, _) ->
-                        let (SynLongIdent (longIdent, _, _)) = lid
+                    | SynExpr.LongIdentSet(lid, synExpr, _) ->
+                        let (SynLongIdent(longIdent, _, _)) = lid
 
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
@@ -312,8 +308,8 @@ module ParsedInput =
                             let _, r = CheckLongIdent longIdent
                             Some r
 
-                    | SynExpr.DotGet (synExpr, _dotm, lid, _) ->
-                        let (SynLongIdent (longIdent, _, _)) = lid
+                    | SynExpr.DotGet(synExpr, _dotm, lid, _) ->
+                        let (SynLongIdent(longIdent, _, _)) = lid
 
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
@@ -326,7 +322,7 @@ module ParsedInput =
                                 // see comment below for SynExpr.DotSet
                                 Some(unionRanges synExpr.Range r)
 
-                    | SynExpr.Set (synExpr, synExpr2, range) ->
+                    | SynExpr.Set(synExpr, synExpr2, range) ->
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
                         elif SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr2.Range pos then
@@ -334,8 +330,8 @@ module ParsedInput =
                         else
                             Some range
 
-                    | SynExpr.DotSet (synExpr, lid, synExpr2, _) ->
-                        let (SynLongIdent (longIdent, _, _)) = lid
+                    | SynExpr.DotSet(synExpr, lid, synExpr2, _) ->
+                        let (SynLongIdent(longIdent, _, _)) = lid
 
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
@@ -354,8 +350,8 @@ module ParsedInput =
                                 // ------   we want this value
                                 Some(unionRanges synExpr.Range r)
 
-                    | SynExpr.DotNamedIndexedPropertySet (synExpr, lid, synExpr2, synExpr3, _) ->
-                        let (SynLongIdent (longIdent, _, _)) = lid
+                    | SynExpr.DotNamedIndexedPropertySet(synExpr, lid, synExpr2, synExpr3, _) ->
+                        let (SynLongIdent(longIdent, _, _)) = lid
 
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
@@ -372,19 +368,19 @@ module ParsedInput =
                                 Some(unionRanges synExpr.Range r)
 
                     // get this for e.g. "bar()."
-                    | SynExpr.DiscardAfterMissingQualificationAfterDot (synExpr, _, _) ->
+                    | SynExpr.DiscardAfterMissingQualificationAfterDot(synExpr, _, _) ->
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
                         else
                             Some synExpr.Range
 
-                    | SynExpr.FromParseError (synExpr, range) ->
+                    | SynExpr.FromParseError(synExpr, range) ->
                         if SyntaxTraversal.rangeContainsPosLeftEdgeInclusive synExpr.Range pos then
                             traverseSynExpr synExpr
                         else
                             Some range
 
-                    | SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ])), rhs, _) when
+                    | SynExpr.App(ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ])), rhs, _) when
                         ident.idText = "op_ArrayLookup"
                         && not (SyntaxTraversal.rangeContainsPosLeftEdgeInclusive rhs.Range pos)
                         ->
@@ -396,7 +392,7 @@ module ParsedInput =
                             Some expr.Range
                         | x -> x // we found the answer deeper somewhere in the lhs
 
-                    | SynExpr.Const (SynConst.Double _, range) -> Some range
+                    | SynExpr.Const(SynConst.Double _, range) -> Some range
 
                     | _ -> defaultTraverse expr
             }
@@ -416,11 +412,11 @@ module ParsedInput =
         // foundCandidate = true - we found candidate (DotGet) and now drill down to the left part
         let rec TryGetExpression foundCandidate expr =
             match expr with
-            | SynExpr.Paren (e, _, _, _) when foundCandidate -> TryGetExpression foundCandidate e
+            | SynExpr.Paren(e, _, _, _) when foundCandidate -> TryGetExpression foundCandidate e
 
-            | SynExpr.LongIdent (_isOptional, SynLongIdent (lid, _, _), _altNameRefCell, _m) -> getLidParts lid |> Some
+            | SynExpr.LongIdent(_isOptional, SynLongIdent(lid, _, _), _altNameRefCell, _m) -> getLidParts lid |> Some
 
-            | SynExpr.DotGet (leftPart, _, SynLongIdent (lid, _, _), _) when (rangeContainsPos (rangeOfLid lid) pos) || foundCandidate ->
+            | SynExpr.DotGet(leftPart, _, SynLongIdent(lid, _, _), _) when (rangeContainsPos (rangeOfLid lid) pos) || foundCandidate ->
                 // requested position is at the lid part of the DotGet
                 // process left part and append result to the result of processing lid
                 let leftPartResult = TryGetExpression true leftPart
@@ -429,7 +425,7 @@ module ParsedInput =
                 | Some leftPartResult -> [ yield! leftPartResult; yield! getLidParts lid ] |> Some
                 | None -> None
 
-            | SynExpr.FromParseError (synExpr, _) -> TryGetExpression foundCandidate synExpr
+            | SynExpr.FromParseError(synExpr, _) -> TryGetExpression foundCandidate synExpr
 
             | _ -> None
 
@@ -446,7 +442,7 @@ module ParsedInput =
 
         SyntaxTraversal.Traverse(pos, parsedInput, visitor)
 
-    let traverseLidOrElse pos (optExprIfLeftOfLongId: SynExpr option) (SynLongIdent (lid, dots, _) as lidwd) =
+    let traverseLidOrElse pos (optExprIfLeftOfLongId: SynExpr option) (SynLongIdent(lid, dots, _) as lidwd) =
         let resultIfLeftOfLongId =
             match optExprIfLeftOfLongId with
             | None -> None
@@ -460,7 +456,7 @@ module ParsedInput =
 
         match dotSearch with
         | None -> resultIfLeftOfLongId
-        | Some (n, _) ->
+        | Some(n, _) ->
             let flag =
                 // foo.$
                 (lid.Length = n + 1)
@@ -494,7 +490,7 @@ module ParsedInput =
 
                     if not (rangeContainsPos expr.Range pos) then
                         match expr with
-                        | SynExpr.DiscardAfterMissingQualificationAfterDot (e, _, _m) ->
+                        | SynExpr.DiscardAfterMissingQualificationAfterDot(e, _, _m) ->
                             // This happens with e.g. "f(x)  .   $" when you bring up a completion list a few spaces after a dot.  The cursor is not 'in the parse tree',
                             // but the dive algorithm will dive down into this node, and this is the one case where we do want to give a result despite the cursor
                             // not properly being in a node.
@@ -508,17 +504,17 @@ module ParsedInput =
                             None
                     else
                         match expr with
-                        | SynExpr.LongIdent(longDotId = SynLongIdent ([ id ], [], [ Some _ ])) -> defaultTraverse (SynExpr.Ident(id))
-                        | SynExpr.LongIdent (_isOptional, lidwd, _altNameRefCell, _m) -> traverseLidOrElse pos None lidwd
+                        | SynExpr.LongIdent(longDotId = SynLongIdent([ id ], [], [ Some _ ])) -> defaultTraverse (SynExpr.Ident(id))
+                        | SynExpr.LongIdent(_isOptional, lidwd, _altNameRefCell, _m) -> traverseLidOrElse pos None lidwd
 
-                        | SynExpr.LongIdentSet (lidwd, exprRhs, _m) ->
+                        | SynExpr.LongIdentSet(lidwd, exprRhs, _m) ->
                             [
                                 dive lidwd lidwd.Range (traverseLidOrElse pos None)
                                 dive exprRhs exprRhs.Range traverseSynExpr
                             ]
                             |> pick expr
 
-                        | SynExpr.DotGet (exprLeft, mDot, lidwd, _m) ->
+                        | SynExpr.DotGet(exprLeft, mDot, lidwd, _m) ->
                             let afterDotBeforeLid = withStartEnd mDot.End lidwd.Range.Start mDot
 
                             [
@@ -528,7 +524,7 @@ module ParsedInput =
                             ]
                             |> pick expr
 
-                        | SynExpr.DotSet (exprLeft, lidwd, exprRhs, _m) ->
+                        | SynExpr.DotSet(exprLeft, lidwd, exprRhs, _m) ->
                             [
                                 dive exprLeft exprLeft.Range traverseSynExpr
                                 dive lidwd lidwd.Range (traverseLidOrElse pos (Some exprLeft))
@@ -536,14 +532,14 @@ module ParsedInput =
                             ]
                             |> pick expr
 
-                        | SynExpr.Set (exprLeft, exprRhs, _m) ->
+                        | SynExpr.Set(exprLeft, exprRhs, _m) ->
                             [
                                 dive exprLeft exprLeft.Range traverseSynExpr
                                 dive exprRhs exprRhs.Range traverseSynExpr
                             ]
                             |> pick expr
 
-                        | SynExpr.NamedIndexedPropertySet (lidwd, exprIndexer, exprRhs, _m) ->
+                        | SynExpr.NamedIndexedPropertySet(lidwd, exprIndexer, exprRhs, _m) ->
                             [
                                 dive lidwd lidwd.Range (traverseLidOrElse pos None)
                                 dive exprIndexer exprIndexer.Range traverseSynExpr
@@ -551,7 +547,7 @@ module ParsedInput =
                             ]
                             |> pick expr
 
-                        | SynExpr.DotNamedIndexedPropertySet (exprLeft, lidwd, exprIndexer, exprRhs, _m) ->
+                        | SynExpr.DotNamedIndexedPropertySet(exprLeft, lidwd, exprIndexer, exprRhs, _m) ->
                             [
                                 dive exprLeft exprLeft.Range traverseSynExpr
                                 dive lidwd lidwd.Range (traverseLidOrElse pos (Some exprLeft))
@@ -560,7 +556,7 @@ module ParsedInput =
                             ]
                             |> pick expr
 
-                        | SynExpr.Const (SynConst.Double _, m) ->
+                        | SynExpr.Const(SynConst.Double _, m) ->
                             if posEq m.End pos then
                                 // the cursor is at the dot
                                 Some(m.End, false)
@@ -568,7 +564,7 @@ module ParsedInput =
                                 // the cursor is left of the dot
                                 None
 
-                        | SynExpr.DiscardAfterMissingQualificationAfterDot (e, _, m) ->
+                        | SynExpr.DiscardAfterMissingQualificationAfterDot(e, _, m) ->
                             match traverseSynExpr e with
                             | None ->
                                 if posEq m.End pos then
@@ -579,7 +575,7 @@ module ParsedInput =
                                     None
                             | r -> r
 
-                        | SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ])), lhs, _m) when
+                        | SynExpr.App(ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ])), lhs, _m) when
                             ident.idText = "op_ArrayLookup"
                             && not (SyntaxTraversal.rangeContainsPosLeftEdgeInclusive lhs.Range pos)
                             ->
@@ -598,7 +594,7 @@ module ParsedInput =
         let (|ConstructorPats|) pats =
             match pats with
             | SynArgPats.Pats ps -> ps
-            | SynArgPats.NamePatPairs (pats = xs) -> List.map (fun (_, _, pat) -> pat) xs
+            | SynArgPats.NamePatPairs(pats = xs) -> List.map (fun (_, _, pat) -> pat) xs
 
         let inline isPosInRange range = rangeContainsPos range pos
 
@@ -609,7 +605,7 @@ module ParsedInput =
             List.tryPick (walkSynModuleOrNamespace true) file.Contents
 
         and walkSynModuleOrNamespace isTopLevel inp =
-            let (SynModuleOrNamespace (decls = decls; attribs = Attributes attrs; range = r)) =
+            let (SynModuleOrNamespace(decls = decls; attribs = Attributes attrs; range = r)) =
                 inp
 
             List.tryPick walkAttribute attrs
@@ -623,11 +619,11 @@ module ParsedInput =
             |> Option.orElseWith (fun () -> walkExprWithKind (Some EntityKind.Type) attr.ArgExpr)
 
         and walkTypar typar =
-            let (SynTypar (ident, _, _)) = typar
+            let (SynTypar(ident, _, _)) = typar
             ifPosInRange ident.idRange (fun _ -> Some EntityKind.Type)
 
         and walkTyparDecl typarDecl =
-            let (SynTyparDecl (Attributes attrs, typar, intersectionContraints, _)) = typarDecl
+            let (SynTyparDecl(Attributes attrs, typar, intersectionContraints, _)) = typarDecl
 
             List.tryPick walkAttribute attrs
             |> Option.orElseWith (fun () -> walkTypar typar)
@@ -635,47 +631,47 @@ module ParsedInput =
 
         and walkTypeConstraint cx =
             match cx with
-            | SynTypeConstraint.WhereTyparDefaultsToType (t1, t2, _) -> walkTypar t1 |> Option.orElseWith (fun () -> walkType t2)
-            | SynTypeConstraint.WhereTyparIsValueType (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparIsReferenceType (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparIsUnmanaged (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparSupportsNull (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparIsComparable (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparIsEquatable (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparSubtypeOfType (t, ty, _) -> walkTypar t |> Option.orElseWith (fun () -> walkType ty)
-            | SynTypeConstraint.WhereTyparSupportsMember (TypesForTypar ts, sign, _) ->
+            | SynTypeConstraint.WhereTyparDefaultsToType(t1, t2, _) -> walkTypar t1 |> Option.orElseWith (fun () -> walkType t2)
+            | SynTypeConstraint.WhereTyparIsValueType(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparIsReferenceType(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparIsUnmanaged(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparSupportsNull(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparIsComparable(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparIsEquatable(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparSubtypeOfType(t, ty, _) -> walkTypar t |> Option.orElseWith (fun () -> walkType ty)
+            | SynTypeConstraint.WhereTyparSupportsMember(TypesForTypar ts, sign, _) ->
                 List.tryPick walkType ts |> Option.orElseWith (fun () -> walkMemberSig sign)
-            | SynTypeConstraint.WhereTyparIsEnum (t, ts, _) -> walkTypar t |> Option.orElseWith (fun () -> List.tryPick walkType ts)
-            | SynTypeConstraint.WhereTyparIsDelegate (t, ts, _) -> walkTypar t |> Option.orElseWith (fun () -> List.tryPick walkType ts)
-            | SynTypeConstraint.WhereSelfConstrained (ts, _) -> walkType ts
+            | SynTypeConstraint.WhereTyparIsEnum(t, ts, _) -> walkTypar t |> Option.orElseWith (fun () -> List.tryPick walkType ts)
+            | SynTypeConstraint.WhereTyparIsDelegate(t, ts, _) -> walkTypar t |> Option.orElseWith (fun () -> List.tryPick walkType ts)
+            | SynTypeConstraint.WhereSelfConstrained(ts, _) -> walkType ts
 
         and walkPatWithKind (kind: EntityKind option) pat =
             match pat with
-            | SynPat.Ands (pats, _) -> List.tryPick walkPat pats
-            | SynPat.As (pat1, pat2, _) -> List.tryPick walkPat [ pat1; pat2 ]
-            | SynPat.Typed (pat, t, _) -> walkPat pat |> Option.orElseWith (fun () -> walkType t)
-            | SynPat.Attrib (pat, Attributes attrs, _) -> walkPat pat |> Option.orElseWith (fun () -> List.tryPick walkAttribute attrs)
-            | SynPat.Or (pat1, pat2, _, _)
-            | SynPat.ListCons (pat1, pat2, _, _) -> List.tryPick walkPat [ pat1; pat2 ]
-            | SynPat.LongIdent (typarDecls = typars; argPats = ConstructorPats pats; range = r) ->
+            | SynPat.Ands(pats, _) -> List.tryPick walkPat pats
+            | SynPat.As(pat1, pat2, _) -> List.tryPick walkPat [ pat1; pat2 ]
+            | SynPat.Typed(pat, t, _) -> walkPat pat |> Option.orElseWith (fun () -> walkType t)
+            | SynPat.Attrib(pat, Attributes attrs, _) -> walkPat pat |> Option.orElseWith (fun () -> List.tryPick walkAttribute attrs)
+            | SynPat.Or(pat1, pat2, _, _)
+            | SynPat.ListCons(pat1, pat2, _, _) -> List.tryPick walkPat [ pat1; pat2 ]
+            | SynPat.LongIdent(typarDecls = typars; argPats = ConstructorPats pats; range = r) ->
                 ifPosInRange r (fun _ -> kind)
                 |> Option.orElseWith (fun () ->
                     typars
-                    |> Option.bind (fun (ValTyparDecls (typars, constraints, _)) ->
+                    |> Option.bind (fun (ValTyparDecls(typars, constraints, _)) ->
                         List.tryPick walkTyparDecl typars
                         |> Option.orElseWith (fun () -> List.tryPick walkTypeConstraint constraints)))
                 |> Option.orElseWith (fun () -> List.tryPick walkPat pats)
-            | SynPat.Tuple (elementPats = pats) -> List.tryPick walkPat pats
-            | SynPat.Paren (pat, _) -> walkPat pat
-            | SynPat.ArrayOrList (_, pats, _) -> List.tryPick walkPat pats
-            | SynPat.IsInst (t, _) -> walkType t
-            | SynPat.QuoteExpr (e, _) -> walkExpr e
+            | SynPat.Tuple(elementPats = pats) -> List.tryPick walkPat pats
+            | SynPat.Paren(pat, _) -> walkPat pat
+            | SynPat.ArrayOrList(_, pats, _) -> List.tryPick walkPat pats
+            | SynPat.IsInst(t, _) -> walkType t
+            | SynPat.QuoteExpr(e, _) -> walkExpr e
             | _ -> None
 
         and walkPat = walkPatWithKind None
 
         and walkBinding bind =
-            let (SynBinding (attributes = Attributes attrs; headPat = pat; returnInfo = returnInfo; expr = e)) =
+            let (SynBinding(attributes = Attributes attrs; headPat = pat; returnInfo = returnInfo; expr = e)) =
                 bind
 
             List.tryPick walkAttribute attrs
@@ -683,10 +679,10 @@ module ParsedInput =
             |> Option.orElseWith (fun () -> walkExpr e)
             |> Option.orElseWith (fun () ->
                 match returnInfo with
-                | Some (SynBindingReturnInfo (typeName = t)) -> walkType t
+                | Some(SynBindingReturnInfo(typeName = t)) -> walkType t
                 | None -> None)
 
-        and walkInterfaceImpl (SynInterfaceImpl (bindings = bindings)) = List.tryPick walkBinding bindings
+        and walkInterfaceImpl (SynInterfaceImpl(bindings = bindings)) = List.tryPick walkBinding bindings
 
         and walkType ty =
             match ty with
@@ -697,20 +693,20 @@ module ParsedInput =
                     ifPosInRange ident.Range (fun _ -> Some EntityKind.Type)
                 with _ ->
                     None
-            | SynType.App (ty, _, types, _, _, _, _) -> walkType ty |> Option.orElseWith (fun () -> List.tryPick walkType types)
-            | SynType.LongIdentApp (_, _, _, types, _, _, _) -> List.tryPick walkType types
-            | SynType.Tuple (path = segments) -> getTypeFromTuplePath segments |> List.tryPick walkType
-            | SynType.Array (_, t, _) -> walkType t
-            | SynType.Fun (argType = t1; returnType = t2) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
-            | SynType.WithGlobalConstraints (t, _, _) -> walkType t
-            | SynType.HashConstraint (t, _) -> walkType t
-            | SynType.Or (t1, t2, _, _) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
-            | SynType.MeasurePower (t, _, _) -> walkType t
-            | SynType.Paren (t, _)
-            | SynType.SignatureParameter (usedType = t) -> walkType t
-            | SynType.StaticConstantExpr (e, _) -> walkExpr e
-            | SynType.StaticConstantNamed (ident, value, _) -> List.tryPick walkType [ ident; value ]
-            | SynType.Intersection (types = types) -> List.tryPick walkType types
+            | SynType.App(ty, _, types, _, _, _, _) -> walkType ty |> Option.orElseWith (fun () -> List.tryPick walkType types)
+            | SynType.LongIdentApp(_, _, _, types, _, _, _) -> List.tryPick walkType types
+            | SynType.Tuple(path = segments) -> getTypeFromTuplePath segments |> List.tryPick walkType
+            | SynType.Array(_, t, _) -> walkType t
+            | SynType.Fun(argType = t1; returnType = t2) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
+            | SynType.WithGlobalConstraints(t, _, _) -> walkType t
+            | SynType.HashConstraint(t, _) -> walkType t
+            | SynType.Or(t1, t2, _, _) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
+            | SynType.MeasurePower(t, _, _) -> walkType t
+            | SynType.Paren(t, _)
+            | SynType.SignatureParameter(usedType = t) -> walkType t
+            | SynType.StaticConstantExpr(e, _) -> walkExpr e
+            | SynType.StaticConstantNamed(ident, value, _) -> List.tryPick walkType [ ident; value ]
+            | SynType.Intersection(types = types) -> List.tryPick walkType types
             | SynType.Anon _
             | SynType.AnonRecd _
             | SynType.LongIdent _
@@ -719,7 +715,7 @@ module ParsedInput =
             | SynType.FromParseError _ -> None
 
         and walkClause clause =
-            let (SynMatchClause (pat = pat; whenExpr = e1; resultExpr = e2)) = clause
+            let (SynMatchClause(pat = pat; whenExpr = e1; resultExpr = e2)) = clause
 
             walkPatWithKind (Some EntityKind.Type) pat
             |> Option.orElseWith (fun () -> walkExpr e2)
@@ -727,10 +723,10 @@ module ParsedInput =
 
         and walkExprWithKind parentKind expr =
             match expr with
-            | SynExpr.LongIdent(longDotId = SynLongIdent (id = [ ident ]; trivia = [ Some _ ])) ->
+            | SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ]; trivia = [ Some _ ])) ->
                 ifPosInRange ident.idRange (fun _ -> Some(EntityKind.FunctionOrValue false))
 
-            | SynExpr.LongIdent (longDotId = SynLongIdent (dotRanges = dotRanges); range = r) ->
+            | SynExpr.LongIdent(longDotId = SynLongIdent(dotRanges = dotRanges); range = r) ->
                 match dotRanges with
                 | [] when isPosInRange r ->
                     parentKind
@@ -746,81 +742,81 @@ module ParsedInput =
                         None
                 | _ -> None
 
-            | SynExpr.LongIdentSet (expr = e)
-            | SynExpr.DotGet (expr = e)
-            | SynExpr.DotSet (targetExpr = e)
-            | SynExpr.Set (targetExpr = e)
-            | SynExpr.Lazy (expr = e)
-            | SynExpr.DoBang (expr = e)
-            | SynExpr.Do (expr = e)
-            | SynExpr.Assert (expr = e)
-            | SynExpr.ArrayOrListComputed (expr = e)
-            | SynExpr.ComputationExpr (expr = e)
-            | SynExpr.Lambda (body = e)
-            | SynExpr.DotLambda (expr = e)
-            | SynExpr.InferredUpcast (expr = e)
-            | SynExpr.InferredDowncast (expr = e)
-            | SynExpr.AddressOf (expr = e)
-            | SynExpr.YieldOrReturn (expr = e)
-            | SynExpr.YieldOrReturnFrom (expr = e)
-            | SynExpr.Paren (expr = e)
-            | SynExpr.Quote (quotedExpr = e)
-            | SynExpr.Typed (expr = e) -> walkExprWithKind parentKind e
+            | SynExpr.LongIdentSet(expr = e)
+            | SynExpr.DotGet(expr = e)
+            | SynExpr.DotSet(targetExpr = e)
+            | SynExpr.Set(targetExpr = e)
+            | SynExpr.Lazy(expr = e)
+            | SynExpr.DoBang(expr = e)
+            | SynExpr.Do(expr = e)
+            | SynExpr.Assert(expr = e)
+            | SynExpr.ArrayOrListComputed(expr = e)
+            | SynExpr.ComputationExpr(expr = e)
+            | SynExpr.Lambda(body = e)
+            | SynExpr.DotLambda(expr = e)
+            | SynExpr.InferredUpcast(expr = e)
+            | SynExpr.InferredDowncast(expr = e)
+            | SynExpr.AddressOf(expr = e)
+            | SynExpr.YieldOrReturn(expr = e)
+            | SynExpr.YieldOrReturnFrom(expr = e)
+            | SynExpr.Paren(expr = e)
+            | SynExpr.Quote(quotedExpr = e)
+            | SynExpr.Typed(expr = e) -> walkExprWithKind parentKind e
 
-            | SynExpr.NamedIndexedPropertySet (expr1 = e1; expr2 = e2)
-            | SynExpr.TryFinally (tryExpr = e1; finallyExpr = e2)
-            | SynExpr.App (funcExpr = e1; argExpr = e2)
-            | SynExpr.WhileBang (whileExpr = e1; doExpr = e2)
-            | SynExpr.While (whileExpr = e1; doExpr = e2)
-            | SynExpr.ForEach (enumExpr = e1; bodyExpr = e2)
-            | SynExpr.DotIndexedGet (objectExpr = e1; indexArgs = e2)
-            | SynExpr.DotIndexedSet (objectExpr = e1; indexArgs = e2)
-            | SynExpr.JoinIn (lhsExpr = e1; rhsExpr = e2) ->
+            | SynExpr.NamedIndexedPropertySet(expr1 = e1; expr2 = e2)
+            | SynExpr.TryFinally(tryExpr = e1; finallyExpr = e2)
+            | SynExpr.App(funcExpr = e1; argExpr = e2)
+            | SynExpr.WhileBang(whileExpr = e1; doExpr = e2)
+            | SynExpr.While(whileExpr = e1; doExpr = e2)
+            | SynExpr.ForEach(enumExpr = e1; bodyExpr = e2)
+            | SynExpr.DotIndexedGet(objectExpr = e1; indexArgs = e2)
+            | SynExpr.DotIndexedSet(objectExpr = e1; indexArgs = e2)
+            | SynExpr.JoinIn(lhsExpr = e1; rhsExpr = e2) ->
                 walkExprWithKind parentKind e1
                 |> Option.orElseWith (fun () -> walkExprWithKind parentKind e2)
 
-            | SynExpr.New (expr = e; targetType = t)
-            | SynExpr.TypeTest (expr = e; targetType = t)
-            | SynExpr.Upcast (expr = e; targetType = t)
-            | SynExpr.Downcast (expr = e; targetType = t) -> walkExprWithKind parentKind e |> Option.orElseWith (fun () -> walkType t)
+            | SynExpr.New(expr = e; targetType = t)
+            | SynExpr.TypeTest(expr = e; targetType = t)
+            | SynExpr.Upcast(expr = e; targetType = t)
+            | SynExpr.Downcast(expr = e; targetType = t) -> walkExprWithKind parentKind e |> Option.orElseWith (fun () -> walkType t)
 
             | Sequentials es
-            | SynExpr.Tuple (exprs = es)
-            | SynExpr.ArrayOrList (exprs = es) -> List.tryPick (walkExprWithKind parentKind) es
+            | SynExpr.Tuple(exprs = es)
+            | SynExpr.ArrayOrList(exprs = es) -> List.tryPick (walkExprWithKind parentKind) es
 
-            | SynExpr.For (identBody = e1; toBody = e2; doBody = e3)
-            | SynExpr.DotNamedIndexedPropertySet (targetExpr = e1; argExpr = e2; rhsExpr = e3) ->
+            | SynExpr.For(identBody = e1; toBody = e2; doBody = e3)
+            | SynExpr.DotNamedIndexedPropertySet(targetExpr = e1; argExpr = e2; rhsExpr = e3) ->
                 List.tryPick (walkExprWithKind parentKind) [ e1; e2; e3 ]
 
-            | SynExpr.TryWith (tryExpr = e; withCases = clauses)
-            | SynExpr.MatchBang (expr = e; clauses = clauses)
-            | SynExpr.Match (expr = e; clauses = clauses) ->
+            | SynExpr.TryWith(tryExpr = e; withCases = clauses)
+            | SynExpr.MatchBang(expr = e; clauses = clauses)
+            | SynExpr.Match(expr = e; clauses = clauses) ->
                 walkExprWithKind parentKind e
                 |> Option.orElseWith (fun () -> List.tryPick walkClause clauses)
 
-            | SynExpr.MatchLambda (matchClauses = clauses) -> List.tryPick walkClause clauses
+            | SynExpr.MatchLambda(matchClauses = clauses) -> List.tryPick walkClause clauses
 
-            | SynExpr.Record (_, _, fields, r) ->
+            | SynExpr.Record(_, _, fields, r) ->
                 ifPosInRange r (fun _ ->
                     fields
-                    |> List.tryPick (fun (SynExprRecordField (expr = e)) -> e |> Option.bind (walkExprWithKind parentKind)))
+                    |> List.tryPick (fun (SynExprRecordField(expr = e)) -> e |> Option.bind (walkExprWithKind parentKind)))
 
-            | SynExpr.ObjExpr (objType = ty; bindings = bindings; members = ms; extraImpls = ifaces) ->
+            | SynExpr.ObjExpr(objType = ty; bindings = bindings; members = ms; extraImpls = ifaces) ->
                 let bindings = unionBindingAndMembers bindings ms
 
                 walkType ty
                 |> Option.orElseWith (fun () -> List.tryPick walkBinding bindings)
                 |> Option.orElseWith (fun () -> List.tryPick walkInterfaceImpl ifaces)
 
-            | SynExpr.TypeApp (expr = e; typeArgs = tys) ->
+            | SynExpr.TypeApp(expr = e; typeArgs = tys) ->
                 walkExprWithKind (Some EntityKind.Type) e
                 |> Option.orElseWith (fun () -> List.tryPick walkType tys)
 
-            | SynExpr.LetOrUse (bindings = bindings; body = e) ->
+            | SynExpr.LetOrUse(bindings = bindings; body = e) ->
                 List.tryPick walkBinding bindings
                 |> Option.orElseWith (fun () -> walkExprWithKind parentKind e)
 
-            | SynExpr.IfThenElse (ifExpr = e1; thenExpr = e2; elseExpr = e3) ->
+            | SynExpr.IfThenElse(ifExpr = e1; thenExpr = e2; elseExpr = e3) ->
                 walkExprWithKind parentKind e1
                 |> Option.orElseWith (fun () -> walkExprWithKind parentKind e2)
                 |> Option.orElseWith (fun () ->
@@ -830,16 +826,16 @@ module ParsedInput =
 
             | SynExpr.Ident ident -> ifPosInRange ident.idRange (fun _ -> Some(EntityKind.FunctionOrValue false))
 
-            | SynExpr.LetOrUseBang (rhs = e1; andBangs = es; body = e2) ->
+            | SynExpr.LetOrUseBang(rhs = e1; andBangs = es; body = e2) ->
                 [
                     yield e1
-                    for SynExprAndBang (body = eAndBang) in es do
+                    for SynExprAndBang(body = eAndBang) in es do
                         yield eAndBang
                     yield e2
                 ]
                 |> List.tryPick (walkExprWithKind parentKind)
 
-            | SynExpr.TraitCall (TypesForTypar ts, sign, e, _) ->
+            | SynExpr.TraitCall(TypesForTypar ts, sign, e, _) ->
                 List.tryPick walkType ts
                 |> Option.orElseWith (fun () -> walkMemberSig sign)
                 |> Option.orElseWith (fun () -> walkExprWithKind parentKind e)
@@ -850,67 +846,67 @@ module ParsedInput =
 
         and walkSimplePat pat =
             match pat with
-            | SynSimplePat.Attrib (pat, Attributes attrs, _) ->
+            | SynSimplePat.Attrib(pat, Attributes attrs, _) ->
                 walkSimplePat pat
                 |> Option.orElseWith (fun () -> List.tryPick walkAttribute attrs)
-            | SynSimplePat.Typed (pat, t, _) -> walkSimplePat pat |> Option.orElseWith (fun () -> walkType t)
+            | SynSimplePat.Typed(pat, t, _) -> walkSimplePat pat |> Option.orElseWith (fun () -> walkType t)
             | _ -> None
 
         and walkField synField =
-            let (SynField (attributes = Attributes attrs; fieldType = t)) = synField
+            let (SynField(attributes = Attributes attrs; fieldType = t)) = synField
             List.tryPick walkAttribute attrs |> Option.orElseWith (fun () -> walkType t)
 
         and walkValSig synValSig =
-            let (SynValSig (attributes = Attributes attrs; synType = t)) = synValSig
+            let (SynValSig(attributes = Attributes attrs; synType = t)) = synValSig
             List.tryPick walkAttribute attrs |> Option.orElseWith (fun () -> walkType t)
 
         and walkMemberSig membSig =
             match membSig with
-            | SynMemberSig.Inherit (t, _) -> walkType t
+            | SynMemberSig.Inherit(t, _) -> walkType t
 
-            | SynMemberSig.Member (memberSig = vs) -> walkValSig vs
+            | SynMemberSig.Member(memberSig = vs) -> walkValSig vs
 
-            | SynMemberSig.Interface (t, _) -> walkType t
+            | SynMemberSig.Interface(t, _) -> walkType t
 
-            | SynMemberSig.ValField (f, _) -> walkField f
+            | SynMemberSig.ValField(f, _) -> walkField f
 
-            | SynMemberSig.NestedType(nestedType = SynTypeDefnSig.SynTypeDefnSig (typeInfo = info; typeRepr = repr; members = memberSigs)) ->
+            | SynMemberSig.NestedType(nestedType = SynTypeDefnSig.SynTypeDefnSig(typeInfo = info; typeRepr = repr; members = memberSigs)) ->
                 walkComponentInfo false info
                 |> Option.orElseWith (fun () -> walkTypeDefnSigRepr repr)
                 |> Option.orElseWith (fun () -> List.tryPick walkMemberSig memberSigs)
 
         and walkMember memb =
             match memb with
-            | SynMemberDefn.AbstractSlot (slotSig = valSig) -> walkValSig valSig
+            | SynMemberDefn.AbstractSlot(slotSig = valSig) -> walkValSig valSig
 
-            | SynMemberDefn.Member (binding, _) -> walkBinding binding
+            | SynMemberDefn.Member(binding, _) -> walkBinding binding
 
-            | SynMemberDefn.GetSetMember (getBinding, setBinding, _, _) ->
+            | SynMemberDefn.GetSetMember(getBinding, setBinding, _, _) ->
                 match getBinding, setBinding with
                 | None, None -> None
                 | Some binding, None
                 | None, Some binding -> walkBinding binding
                 | Some getBinding, Some setBinding -> walkBinding getBinding |> Option.orElseWith (fun () -> walkBinding setBinding)
 
-            | SynMemberDefn.ImplicitCtor (attributes = Attributes attrs; ctorArgs = SynSimplePats.SimplePats (pats = simplePats)) ->
+            | SynMemberDefn.ImplicitCtor(attributes = Attributes attrs; ctorArgs = SynSimplePats.SimplePats(pats = simplePats)) ->
                 List.tryPick walkAttribute attrs
                 |> Option.orElseWith (fun () -> List.tryPick walkSimplePat simplePats)
 
-            | SynMemberDefn.ImplicitInherit (t, e, _, _) -> walkType t |> Option.orElseWith (fun () -> walkExpr e)
+            | SynMemberDefn.ImplicitInherit(t, e, _, _) -> walkType t |> Option.orElseWith (fun () -> walkExpr e)
 
-            | SynMemberDefn.LetBindings (bindings, _, _, _) -> List.tryPick walkBinding bindings
+            | SynMemberDefn.LetBindings(bindings, _, _, _) -> List.tryPick walkBinding bindings
 
-            | SynMemberDefn.Interface (interfaceType = t; members = members) ->
+            | SynMemberDefn.Interface(interfaceType = t; members = members) ->
                 walkType t
                 |> Option.orElseWith (fun () -> members |> Option.bind (List.tryPick walkMember))
 
-            | SynMemberDefn.Inherit (t, _, _) -> walkType t
+            | SynMemberDefn.Inherit(t, _, _) -> walkType t
 
-            | SynMemberDefn.ValField (fieldInfo = field) -> walkField field
+            | SynMemberDefn.ValField(fieldInfo = field) -> walkField field
 
-            | SynMemberDefn.NestedType (tdef, _, _) -> walkTypeDefn tdef
+            | SynMemberDefn.NestedType(tdef, _, _) -> walkTypeDefn tdef
 
-            | SynMemberDefn.AutoProperty (attributes = Attributes attrs; typeOpt = t; synExpr = e) ->
+            | SynMemberDefn.AutoProperty(attributes = Attributes attrs; typeOpt = t; synExpr = e) ->
                 List.tryPick walkAttribute attrs
                 |> Option.orElseWith (fun () -> Option.bind walkType t)
                 |> Option.orElseWith (fun () -> walkExpr e)
@@ -922,24 +918,24 @@ module ParsedInput =
         and walkUnionCaseType inp =
             match inp with
             | SynUnionCaseKind.Fields fields -> List.tryPick walkField fields
-            | SynUnionCaseKind.FullType (t, _) -> walkType t
+            | SynUnionCaseKind.FullType(t, _) -> walkType t
 
         and walkUnionCase synUnionCase =
-            let (SynUnionCase (attributes = Attributes attrs; caseType = t)) = synUnionCase
+            let (SynUnionCase(attributes = Attributes attrs; caseType = t)) = synUnionCase
 
             List.tryPick walkAttribute attrs
             |> Option.orElseWith (fun () -> walkUnionCaseType t)
 
         and walkTypeDefnSimple synTypeDefn =
             match synTypeDefn with
-            | SynTypeDefnSimpleRepr.Enum (cases, _) -> List.tryPick walkEnumCase cases
-            | SynTypeDefnSimpleRepr.Union (_, cases, _) -> List.tryPick walkUnionCase cases
-            | SynTypeDefnSimpleRepr.Record (_, fields, _) -> List.tryPick walkField fields
-            | SynTypeDefnSimpleRepr.TypeAbbrev (_, t, _) -> walkType t
+            | SynTypeDefnSimpleRepr.Enum(cases, _) -> List.tryPick walkEnumCase cases
+            | SynTypeDefnSimpleRepr.Union(_, cases, _) -> List.tryPick walkUnionCase cases
+            | SynTypeDefnSimpleRepr.Record(_, fields, _) -> List.tryPick walkField fields
+            | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, _) -> walkType t
             | _ -> None
 
         and walkComponentInfo isModule compInfo =
-            let (SynComponentInfo (Attributes attrs, TyparsAndConstraints (typars, cs1), cs2, _, _, _, _, r)) =
+            let (SynComponentInfo(Attributes attrs, TyparsAndConstraints(typars, cs1), cs2, _, _, _, _, r)) =
                 compInfo
 
             let constraints = cs1 @ cs2
@@ -955,18 +951,18 @@ module ParsedInput =
 
         and walkTypeDefnRepr inp =
             match inp with
-            | SynTypeDefnRepr.ObjectModel (_, defns, _) -> List.tryPick walkMember defns
-            | SynTypeDefnRepr.Simple (defn, _) -> walkTypeDefnSimple defn
+            | SynTypeDefnRepr.ObjectModel(_, defns, _) -> List.tryPick walkMember defns
+            | SynTypeDefnRepr.Simple(defn, _) -> walkTypeDefnSimple defn
             | SynTypeDefnRepr.Exception _ -> None
 
         and walkTypeDefnSigRepr inp =
             match inp with
-            | SynTypeDefnSigRepr.ObjectModel (_, defns, _) -> List.tryPick walkMemberSig defns
-            | SynTypeDefnSigRepr.Simple (defn, _) -> walkTypeDefnSimple defn
+            | SynTypeDefnSigRepr.ObjectModel(_, defns, _) -> List.tryPick walkMemberSig defns
+            | SynTypeDefnSigRepr.Simple(defn, _) -> walkTypeDefnSimple defn
             | SynTypeDefnSigRepr.Exception _ -> None
 
         and walkTypeDefn typeDefn =
-            let (SynTypeDefn (typeInfo = info; typeRepr = repr; members = members)) = typeDefn
+            let (SynTypeDefn(typeInfo = info; typeRepr = repr; members = members)) = typeDefn
 
             walkComponentInfo false info
             |> Option.orElseWith (fun () -> walkTypeDefnRepr repr)
@@ -976,17 +972,17 @@ module ParsedInput =
             match decl with
             | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace isTopLevel fragment
 
-            | SynModuleDecl.NestedModule (moduleInfo = info; decls = modules; range = range) ->
+            | SynModuleDecl.NestedModule(moduleInfo = info; decls = modules; range = range) ->
                 walkComponentInfo true info
                 |> Option.orElseWith (fun () -> ifPosInRange range (fun _ -> List.tryPick (walkSynModuleDecl false) modules))
 
             | SynModuleDecl.Open _ -> None
 
-            | SynModuleDecl.Let (_, bindings, _) -> List.tryPick walkBinding bindings
+            | SynModuleDecl.Let(_, bindings, _) -> List.tryPick walkBinding bindings
 
-            | SynModuleDecl.Expr (expr, _) -> walkExpr expr
+            | SynModuleDecl.Expr(expr, _) -> walkExpr expr
 
-            | SynModuleDecl.Types (types, _) -> List.tryPick walkTypeDefn types
+            | SynModuleDecl.Types(types, _) -> List.tryPick walkTypeDefn types
 
             | _ -> None
 
@@ -1005,9 +1001,7 @@ module ParsedInput =
     let (|Class|Interface|Struct|Unknown|Invalid|) synAttributes =
         let (|SynAttr|_|) name (attr: SynAttribute) =
             match attr with
-            | {
-                  TypeName = SynLongIdent ([ x ], _, _)
-              } when x.idText = name -> Some()
+            | { TypeName = SynLongIdent([ x ], _, _) } when x.idText = name -> Some()
             | _ -> None
 
         let rec getKind isClass isInterface isStruct attrs =
@@ -1065,17 +1059,17 @@ module ParsedInput =
 
     let (|Operator|_|) name e =
         match e with
-        | SynExpr.App (ExprAtomicFlag.NonAtomic,
-                       false,
-                       SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ])), lhs, _),
-                       rhs,
-                       _) when ident.idText = name -> Some(lhs, rhs)
+        | SynExpr.App(ExprAtomicFlag.NonAtomic,
+                      false,
+                      SynExpr.App(ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ ident ])), lhs, _),
+                      rhs,
+                      _) when ident.idText = name -> Some(lhs, rhs)
         | _ -> None
 
     // checks if we are in a range operator
     let isAtRangeOp (p: SyntaxVisitorPath) =
         match p with
-        | SyntaxNode.SynExpr (SynExpr.IndexRange _) :: _ -> true
+        | SyntaxNode.SynExpr(SynExpr.IndexRange _) :: _ -> true
         | _ -> false
 
     let (|Setter|_|) e =
@@ -1085,7 +1079,7 @@ module ParsedInput =
 
     let findSetters argList =
         match argList with
-        | SynExpr.Paren (SynExpr.Tuple (false, parameters, _, _), _, _, _) ->
+        | SynExpr.Paren(SynExpr.Tuple(false, parameters, _, _), _, _, _) ->
             let setters = HashSet()
 
             for p in parameters do
@@ -1112,27 +1106,27 @@ module ParsedInput =
 
     let (|NewObjectOrMethodCall|_|) e =
         match e with
-        | SynExpr.New (_, SynType.LongIdent typeName, arg, _) ->
+        | SynExpr.New(_, SynType.LongIdent typeName, arg, _) ->
             // new A()
             Some(endOfLastIdent typeName, findSetters arg)
 
-        | SynExpr.New (_, SynType.App (StripParenTypes (SynType.LongIdent typeName), _, _, _, mGreaterThan, _, _), arg, _) ->
+        | SynExpr.New(_, SynType.App(StripParenTypes(SynType.LongIdent typeName), _, _, _, mGreaterThan, _, _), arg, _) ->
             // new A<_>()
             Some(endOfClosingTokenOrLastIdent mGreaterThan typeName, findSetters arg)
 
-        | SynExpr.App (_, false, SynExpr.Ident id, arg, _) ->
+        | SynExpr.App(_, false, SynExpr.Ident id, arg, _) ->
             // A()
             Some(id.idRange.End, findSetters arg)
 
-        | SynExpr.App (_, false, SynExpr.TypeApp (SynExpr.Ident id, _, _, _, mGreaterThan, _, _), arg, _) ->
+        | SynExpr.App(_, false, SynExpr.TypeApp(SynExpr.Ident id, _, _, _, mGreaterThan, _, _), arg, _) ->
             // A<_>()
             Some(endOfClosingTokenOrIdent mGreaterThan id, findSetters arg)
 
-        | SynExpr.App (_, false, SynExpr.LongIdent (_, lid, _, _), arg, _) ->
+        | SynExpr.App(_, false, SynExpr.LongIdent(_, lid, _, _), arg, _) ->
             // A.B()
             Some(endOfLastIdent lid, findSetters arg)
 
-        | SynExpr.App (_, false, SynExpr.TypeApp (SynExpr.LongIdent (_, lid, _, _), _, _, _, mGreaterThan, _, _), arg, _) ->
+        | SynExpr.App(_, false, SynExpr.TypeApp(SynExpr.LongIdent(_, lid, _, _), _, _, _, mGreaterThan, _, _), arg, _) ->
             // A.B<_>()
             Some(endOfClosingTokenOrLastIdent mGreaterThan lid, findSetters arg)
         | _ -> None
@@ -1154,9 +1148,9 @@ module ParsedInput =
 
     let (|PartOfParameterList|_|) pos precedingArgument path =
         match path with
-        | SyntaxNode.SynExpr (SynExpr.Paren _) :: SyntaxNode.SynExpr (NewObjectOrMethodCall args) :: _ ->
+        | SyntaxNode.SynExpr(SynExpr.Paren _) :: SyntaxNode.SynExpr(NewObjectOrMethodCall args) :: _ ->
             if Option.isSome precedingArgument then None else Some args
-        | SyntaxNode.SynExpr (SynExpr.Tuple (false, elements, commas, _)) :: SyntaxNode.SynExpr (SynExpr.Paren _) :: SyntaxNode.SynExpr (NewObjectOrMethodCall args) :: _ ->
+        | SyntaxNode.SynExpr(SynExpr.Tuple(false, elements, commas, _)) :: SyntaxNode.SynExpr(SynExpr.Paren _) :: SyntaxNode.SynExpr(NewObjectOrMethodCall args) :: _ ->
             match precedingArgument with
             | None -> Some args
             | Some e ->
@@ -1199,9 +1193,9 @@ module ParsedInput =
                         // A $.B - return nothing
                         None
 
-    let parseLid pos (SynLongIdent (lid, dots, _)) =
+    let parseLid pos (SynLongIdent(lid, dots, _)) =
         match parseLidAux pos [] lid dots with
-        | Some (parts, residue) -> Some((List.rev parts), residue)
+        | Some(parts, residue) -> Some((List.rev parts), residue)
         | None -> None
 
     /// Try to determine completion context at the given position within in an attribute using approximate analysis based on line text matching
@@ -1211,7 +1205,7 @@ module ParsedInput =
             // cut off leading attributes, i.e. we cut "[<A1; A2; >]" to " >]"
             match str.LastIndexOf ';' with
             | -1 -> str
-            | idx when idx < str.Length -> str[ idx + 1 .. ].TrimStart()
+            | idx when idx < str.Length -> str[idx + 1 ..].TrimStart()
             | _ -> ""
 
         let isLongIdent (lid: string) =
@@ -1245,7 +1239,7 @@ module ParsedInput =
             match lineStr.LastIndexOf("[<", StringComparison.Ordinal) with
             | -1 -> None
             | openParenIndex when pos.Column >= openParenIndex + 2 ->
-                let str = lineStr[ openParenIndex + 2 .. pos.Column - 1 ].TrimStart()
+                let str = lineStr[openParenIndex + 2 .. pos.Column - 1].TrimStart()
                 let str = cutLeadingAttributes str
 
                 if isLongIdent str then
@@ -1268,8 +1262,8 @@ module ParsedInput =
     //
     let rec TryGetCompletionContextInPattern suppressIdentifierCompletions (pat: SynPat) previousContext pos =
         match pat with
-        | SynPat.LongIdent (longDotId = id) when rangeContainsPos id.Range pos -> Some(CompletionContext.Pattern PatternContext.Other)
-        | SynPat.LongIdent (argPats = SynArgPats.NamePatPairs (pats = pats; range = mPairs); longDotId = caseId; range = m) when
+        | SynPat.LongIdent(longDotId = id) when rangeContainsPos id.Range pos -> Some(CompletionContext.Pattern PatternContext.Other)
+        | SynPat.LongIdent(argPats = SynArgPats.NamePatPairs(pats = pats; range = mPairs); longDotId = caseId; range = m) when
             rangeContainsPos m pos
             ->
             pats
@@ -1288,23 +1282,23 @@ module ParsedInput =
                     Some(CompletionContext.Pattern(PatternContext.UnionCaseFieldIdentifier(referencedFields, caseId.Range)))
                 else
                     None)
-        | SynPat.LongIdent (argPats = SynArgPats.Pats pats; longDotId = id; range = m) when rangeContainsPos m pos ->
+        | SynPat.LongIdent(argPats = SynArgPats.Pats pats; longDotId = id; range = m) when rangeContainsPos m pos ->
             match pats with
 
             // fun (Some v| ) ->
             | [ SynPat.Named _ ] -> Some(CompletionContext.Pattern(PatternContext.PositionalUnionCaseField(None, true, id.Range)))
 
             // fun (Case (| )) ->
-            | [ SynPat.Paren (SynPat.Const (SynConst.Unit, _), m) ] when rangeContainsPos m pos ->
+            | [ SynPat.Paren(SynPat.Const(SynConst.Unit, _), m) ] when rangeContainsPos m pos ->
                 Some(CompletionContext.Pattern(PatternContext.PositionalUnionCaseField(Some 0, true, id.Range)))
 
             // fun (Case (a| )) ->
             // This could either be the first positional field pattern or the user might want to use named pairs
-            | [ SynPat.Paren (SynPat.Named _, _) ] ->
+            | [ SynPat.Paren(SynPat.Named _, _) ] ->
                 Some(CompletionContext.Pattern(PatternContext.PositionalUnionCaseField(Some 0, true, id.Range)))
 
             // fun (Case (a| , b)) ->
-            | [ SynPat.Paren (SynPat.Tuple (elementPats = pats) as pat, _) ] ->
+            | [ SynPat.Paren(SynPat.Tuple(elementPats = pats) as pat, _) ] ->
                 let context =
                     Some(PatternContext.PositionalUnionCaseField(Some 0, pats.Length = 1, id.Range))
 
@@ -1313,7 +1307,7 @@ module ParsedInput =
             | _ ->
                 pats
                 |> List.tryPick (fun pat -> TryGetCompletionContextInPattern false pat None pos)
-        | SynPat.Record (fieldPats = pats; range = m) when rangeContainsPos m pos ->
+        | SynPat.Record(fieldPats = pats; range = m) when rangeContainsPos m pos ->
             pats
             |> List.tryPick (fun ((_, fieldId), _, pat) ->
                 if rangeContainsPos fieldId.idRange pos then
@@ -1338,17 +1332,17 @@ module ParsedInput =
                     Some(CompletionContext.Pattern(PatternContext.RecordFieldIdentifier referencedFields))
                 else
                     Some(CompletionContext.Pattern PatternContext.Other))
-        | SynPat.Ands (pats = pats)
-        | SynPat.ArrayOrList (elementPats = pats) ->
+        | SynPat.Ands(pats = pats)
+        | SynPat.ArrayOrList(elementPats = pats) ->
             pats
             |> List.tryPick (fun pat -> TryGetCompletionContextInPattern false pat None pos)
-        | SynPat.Tuple (elementPats = pats; commaRanges = commas; range = m) ->
+        | SynPat.Tuple(elementPats = pats; commaRanges = commas; range = m) ->
             pats
             |> List.indexed
             |> List.tryPick (fun (i, pat) ->
                 let context =
                     match previousContext with
-                    | Some (PatternContext.PositionalUnionCaseField (_, isTheOnlyField, caseIdRange)) ->
+                    | Some(PatternContext.PositionalUnionCaseField(_, isTheOnlyField, caseIdRange)) ->
                         Some(PatternContext.PositionalUnionCaseField(Some i, isTheOnlyField, caseIdRange))
                     | _ ->
                         // No preceding LongIdent => this is a tuple deconstruction
@@ -1359,7 +1353,7 @@ module ParsedInput =
                 // Last resort - check for fun (Case (item1 = a, | )) ->
                 // That is, pos is after the last comma and before the end of the tuple
                 match previousContext, List.tryLast commas with
-                | Some (PatternContext.PositionalUnionCaseField (_, isTheOnlyField, caseIdRange)), Some mComma when
+                | Some(PatternContext.PositionalUnionCaseField(_, isTheOnlyField, caseIdRange)), Some mComma when
                     rangeBeforePos mComma pos && rangeContainsPos m pos
                     ->
                     Some(
@@ -1368,7 +1362,7 @@ module ParsedInput =
                         )
                     )
                 | _ -> None)
-        | SynPat.Named (range = m) when rangeContainsPos m pos ->
+        | SynPat.Named(range = m) when rangeContainsPos m pos ->
             if suppressIdentifierCompletions then
                 Some CompletionContext.Invalid
             else
@@ -1376,17 +1370,17 @@ module ParsedInput =
                 |> Option.defaultValue PatternContext.Other
                 |> CompletionContext.Pattern
                 |> Some
-        | SynPat.FromParseError (pat = pat)
-        | SynPat.Attrib (pat = pat) -> TryGetCompletionContextInPattern suppressIdentifierCompletions pat previousContext pos
-        | SynPat.Paren (pat, _) -> TryGetCompletionContextInPattern suppressIdentifierCompletions pat None pos
-        | SynPat.ListCons (lhsPat = pat1; rhsPat = pat2)
-        | SynPat.As (lhsPat = pat1; rhsPat = pat2)
-        | SynPat.Or (lhsPat = pat1; rhsPat = pat2) ->
+        | SynPat.FromParseError(pat = pat)
+        | SynPat.Attrib(pat = pat) -> TryGetCompletionContextInPattern suppressIdentifierCompletions pat previousContext pos
+        | SynPat.Paren(pat, _) -> TryGetCompletionContextInPattern suppressIdentifierCompletions pat None pos
+        | SynPat.ListCons(lhsPat = pat1; rhsPat = pat2)
+        | SynPat.As(lhsPat = pat1; rhsPat = pat2)
+        | SynPat.Or(lhsPat = pat1; rhsPat = pat2) ->
             TryGetCompletionContextInPattern suppressIdentifierCompletions pat1 None pos
             |> Option.orElseWith (fun () -> TryGetCompletionContextInPattern suppressIdentifierCompletions pat2 None pos)
-        | SynPat.IsInst (_, m) when rangeContainsPos m pos -> Some CompletionContext.Type
+        | SynPat.IsInst(_, m) when rangeContainsPos m pos -> Some CompletionContext.Type
         | SynPat.Wild m when rangeContainsPos m pos && m.StartColumn <> m.EndColumn -> Some CompletionContext.Invalid
-        | SynPat.Typed (pat = pat; targetType = synType) ->
+        | SynPat.Typed(pat = pat; targetType = synType) ->
             if rangeContainsPos pat.Range pos then
                 TryGetCompletionContextInPattern suppressIdentifierCompletions pat previousContext pos
             elif rangeContainsPos synType.Range pos then
@@ -1409,14 +1403,14 @@ module ParsedInput =
                     else
                         match expr with
                         // new A($)
-                        | SynExpr.Const (SynConst.Unit, m) when rangeContainsPos m pos ->
+                        | SynExpr.Const(SynConst.Unit, m) when rangeContainsPos m pos ->
                             match path with
-                            | SyntaxNode.SynExpr (NewObjectOrMethodCall args) :: _ -> Some(CompletionContext.ParameterList args)
+                            | SyntaxNode.SynExpr(NewObjectOrMethodCall args) :: _ -> Some(CompletionContext.ParameterList args)
                             | _ -> defaultTraverse expr
 
                         // new (... A$)
                         | SynExpr.Ident id
-                        | SynExpr.LongIdent(longDotId = SynLongIdent ([ id ], [], [ Some _ ])) when id.idRange.End = pos ->
+                        | SynExpr.LongIdent(longDotId = SynLongIdent([ id ], [], [ Some _ ])) when id.idRange.End = pos ->
                             match path with
                             | PartOfParameterList pos None args -> Some(CompletionContext.ParameterList args)
                             | _ -> defaultTraverse expr
@@ -1430,13 +1424,13 @@ module ParsedInput =
                             | PartOfParameterList pos precedingArgument args -> Some(CompletionContext.ParameterList args)
                             | _ -> defaultTraverse expr
 
-                        | SynExpr.Record (None, None, [], _) -> Some(CompletionContext.RecordField RecordContext.Empty)
+                        | SynExpr.Record(None, None, [], _) -> Some(CompletionContext.RecordField RecordContext.Empty)
 
                         // Unchecked.defaultof<str$>
-                        | SynExpr.TypeApp (typeArgsRange = range) when rangeContainsPos range pos -> Some CompletionContext.Type
+                        | SynExpr.TypeApp(typeArgsRange = range) when rangeContainsPos range pos -> Some CompletionContext.Type
 
                         // fun (Some v$ ) ->
-                        | SynExpr.Lambda(parsedData = Some (pats, _)) ->
+                        | SynExpr.Lambda(parsedData = Some(pats, _)) ->
                             pats
                             |> List.tryPick (fun pat -> TryGetCompletionContextInPattern true pat None pos)
                             |> Option.orElseWith (fun () -> defaultTraverse expr)
@@ -1447,10 +1441,10 @@ module ParsedInput =
                     let contextFromTreePath completionPath =
                         // detect records usage in constructor
                         match path with
-                        | SyntaxNode.SynExpr _ :: SyntaxNode.SynBinding _ :: SyntaxNode.SynMemberDefn _ :: SyntaxNode.SynTypeDefn (SynTypeDefn(typeInfo = SynComponentInfo(longId = [ id ]))) :: _ ->
-                            RecordContext.Constructor(id.idText)
+                        | SyntaxNode.SynExpr _ :: SyntaxNode.SynBinding _ :: SyntaxNode.SynMemberDefn _ :: SyntaxNode.SynTypeDefn(SynTypeDefn(
+                            typeInfo = SynComponentInfo(longId = [ id ]))) :: _ -> RecordContext.Constructor(id.idText)
 
-                        | SyntaxNode.SynExpr (SynExpr.Record (None, _, fields, _)) :: _ ->
+                        | SyntaxNode.SynExpr(SynExpr.Record(None, _, fields, _)) :: _ ->
                             let isFirstField =
                                 match field, fields with
                                 | Some contextLid, SynExprRecordField(fieldName = lid, _) :: _ -> contextLid.Range = lid.Range
@@ -1459,7 +1453,7 @@ module ParsedInput =
                             RecordContext.New(completionPath, isFirstField)
 
                         // Unfinished `{ xxx }` expression considered a record field by the tree visitor.
-                        | SyntaxNode.SynExpr (SynExpr.ComputationExpr _) :: _ -> RecordContext.New(completionPath, true)
+                        | SyntaxNode.SynExpr(SynExpr.ComputationExpr _) :: _ -> RecordContext.New(completionPath, true)
 
                         | _ -> RecordContext.New(completionPath, false)
 
@@ -1469,7 +1463,7 @@ module ParsedInput =
                         | Some completionPath ->
                             let recordContext =
                                 match copyOpt with
-                                | Some (s: SynExpr) -> RecordContext.CopyOnUpdate(s.Range, completionPath)
+                                | Some(s: SynExpr) -> RecordContext.CopyOnUpdate(s.Range, completionPath)
                                 | None -> contextFromTreePath completionPath
 
                             Some(CompletionContext.RecordField recordContext)
@@ -1495,7 +1489,7 @@ module ParsedInput =
                     (
                         path,
                         defaultTraverse,
-                        (SynBinding (headPat = headPat; trivia = trivia; returnInfo = returnInfo) as synBinding)
+                        (SynBinding(headPat = headPat; trivia = trivia; returnInfo = returnInfo) as synBinding)
                     ) =
 
                     let isOverride leadingKeyword =
@@ -1505,12 +1499,12 @@ module ParsedInput =
 
                     let overrideContext path =
                         match path with
-                        | _ :: SyntaxNode.SynTypeDefn (SynTypeDefn(typeInfo = SynComponentInfo(longId = [ enclosingType ]))) :: _ ->
+                        | _ :: SyntaxNode.SynTypeDefn(SynTypeDefn(typeInfo = SynComponentInfo(longId = [ enclosingType ]))) :: _ ->
                             Some(CompletionContext.MethodOverride enclosingType.idRange)
                         | _ -> Some CompletionContext.Invalid
 
                     match returnInfo with
-                    | Some (SynBindingReturnInfo (range = m)) when rangeContainsPos m pos -> Some CompletionContext.Type
+                    | Some(SynBindingReturnInfo(range = m)) when rangeContainsPos m pos -> Some CompletionContext.Type
                     | _ ->
                         match headPat with
 
@@ -1518,7 +1512,7 @@ module ParsedInput =
                         | SynPat.FromParseError _ when isOverride trivia.LeadingKeyword -> overrideContext path
 
                         // override this.|
-                        | SynPat.Named(ident = SynIdent (ident = selfId)) when
+                        | SynPat.Named(ident = SynIdent(ident = selfId)) when
                             isOverride trivia.LeadingKeyword && selfId.idRange.End.IsAdjacentTo pos
                             ->
                             overrideContext path
@@ -1529,7 +1523,7 @@ module ParsedInput =
                             ->
                             overrideContext path
 
-                        | SynPat.LongIdent (longDotId = lidwd; argPats = SynArgPats.Pats pats; range = m) when rangeContainsPos m pos ->
+                        | SynPat.LongIdent(longDotId = lidwd; argPats = SynArgPats.Pats pats; range = m) when rangeContainsPos m pos ->
                             if rangeContainsPos lidwd.Range pos then
                                 // let fo|o x = ()
                                 Some CompletionContext.Invalid
@@ -1538,8 +1532,8 @@ module ParsedInput =
                                 |> List.tryPick (fun pat -> TryGetCompletionContextInPattern true pat None pos)
                                 |> Option.orElseWith (fun () -> defaultTraverse synBinding)
 
-                        | SynPat.Named (range = range)
-                        | SynPat.As (_, SynPat.Named (range = range), _) when rangeContainsPos range pos ->
+                        | SynPat.Named(range = range)
+                        | SynPat.As(_, SynPat.Named(range = range), _) when rangeContainsPos range pos ->
                             // let fo|o = 1
                             Some CompletionContext.Invalid
 
@@ -1552,7 +1546,7 @@ module ParsedInput =
                     else
                         None
 
-                member _.VisitModuleOrNamespace(_, SynModuleOrNamespace (longId = idents)) =
+                member _.VisitModuleOrNamespace(_, SynModuleOrNamespace(longId = idents)) =
                     match List.tryLast idents with
                     | Some lastIdent when
                         pos.Line = lastIdent.idRange.EndLine
@@ -1569,7 +1563,7 @@ module ParsedInput =
                             None
                     | _ -> None
 
-                member _.VisitComponentInfo(_, SynComponentInfo (range = range)) =
+                member _.VisitComponentInfo(_, SynComponentInfo(range = range)) =
                     // No completions in component info (unless it's within an attribute)
                     // /// XmlDo|
                     // type R = class end
@@ -1591,8 +1585,8 @@ module ParsedInput =
                     |> List.tryPick (fun pat ->
                         match pat with
                         // type C (x| )
-                        | SynSimplePat.Id (range = range) when rangeContainsPos range pos -> Some CompletionContext.Invalid
-                        | SynSimplePat.Typed (pat = SynSimplePat.Id (range = idRange); targetType = synType) ->
+                        | SynSimplePat.Id(range = range) when rangeContainsPos range pos -> Some CompletionContext.Invalid
+                        | SynSimplePat.Typed(pat = SynSimplePat.Id(range = idRange); targetType = synType) ->
                             // type C (x|: int) ->
                             if rangeContainsPos idRange pos then
                                 Some CompletionContext.Invalid
@@ -1609,7 +1603,7 @@ module ParsedInput =
 
                 member _.VisitModuleDecl(_, defaultTraverse, decl) =
                     match decl with
-                    | SynModuleDecl.Open (target, m) ->
+                    | SynModuleDecl.Open(target, m) ->
                         // in theory, this means we're "in an open"
                         // in practice, because the parse tree/visitors do not handle attributes well yet, need extra check below to ensure not e.g. $here$
                         //     open System
@@ -1642,7 +1636,7 @@ module ParsedInput =
 
                 member _.VisitRecordDefn(_, fields, _) =
                     fields
-                    |> List.tryPick (fun (SynField (idOpt = idOpt; range = fieldRange)) ->
+                    |> List.tryPick (fun (SynField(idOpt = idOpt; range = fieldRange)) ->
                         match idOpt with
                         | Some id when rangeContainsPos id.idRange pos ->
                             Some(CompletionContext.RecordField(RecordContext.Declaration true))
@@ -1653,7 +1647,7 @@ module ParsedInput =
 
                 member _.VisitUnionDefn(_, cases, _) =
                     cases
-                    |> List.tryPick (fun (SynUnionCase (ident = SynIdent (id, _); caseType = caseType)) ->
+                    |> List.tryPick (fun (SynUnionCase(ident = SynIdent(id, _); caseType = caseType)) ->
                         if rangeContainsPos id.idRange pos then
                             // No completions in a union case identifier
                             Some CompletionContext.Invalid
@@ -1661,7 +1655,7 @@ module ParsedInput =
                             match caseType with
                             | SynUnionCaseKind.Fields fieldCases ->
                                 fieldCases
-                                |> List.tryPick (fun (SynField (idOpt = fieldIdOpt; range = fieldRange)) ->
+                                |> List.tryPick (fun (SynField(idOpt = fieldIdOpt; range = fieldRange)) ->
                                     match fieldIdOpt with
                                     // No completions in a union case field identifier
                                     | Some id when rangeContainsPos id.idRange pos -> Some CompletionContext.Invalid
@@ -1674,7 +1668,7 @@ module ParsedInput =
 
                 member _.VisitEnumDefn(_, cases, _) =
                     cases
-                    |> List.tryPick (fun (SynEnumCase(ident = SynIdent (ident = id))) ->
+                    |> List.tryPick (fun (SynEnumCase(ident = SynIdent(ident = id))) ->
                         if rangeContainsPos id.idRange pos then
                             // No completions in an enum case identifier
                             Some CompletionContext.Invalid
@@ -1720,7 +1714,7 @@ module ParsedInput =
                     // don't need to keep going, namespaces and modules never appear inside Exprs
                     None
 
-                override this.VisitModuleOrNamespace(_, SynModuleOrNamespace (longId = longId; range = range)) =
+                override this.VisitModuleOrNamespace(_, SynModuleOrNamespace(longId = longId; range = range)) =
                     if rangeContainsPos range pos then
                         path <- path @ longId
 
@@ -1733,7 +1727,7 @@ module ParsedInput =
     let (|ConstructorPats|) pats =
         match pats with
         | SynArgPats.Pats ps -> ps
-        | SynArgPats.NamePatPairs (pats = xs) -> List.map (fun (_, _, pat) -> pat) xs
+        | SynArgPats.NamePatPairs(pats = xs) -> List.map (fun (_, _, pat) -> pat) xs
 
     /// Returns all `Ident`s and `LongIdent`s found in an untyped AST.
     let getLongIdents (parsedInput: ParsedInput) : IDictionary<pos, LongIdent> =
@@ -1743,7 +1737,7 @@ module ParsedInput =
             for ident in longIdent do
                 identsByEndPos[ident.idRange.End] <- longIdent
 
-        let addLongIdentWithDots (SynLongIdent (longIdent, lids, _) as value) =
+        let addLongIdentWithDots (SynLongIdent(longIdent, lids, _) as value) =
             match longIdent with
             | [] -> ()
             | [ _ ] as idents -> identsByEndPos[value.Range.End] <- idents
@@ -1759,7 +1753,7 @@ module ParsedInput =
         let rec walkImplFileInput (file: ParsedImplFileInput) =
             List.iter walkSynModuleOrNamespace file.Contents
 
-        and walkSynModuleOrNamespace (SynModuleOrNamespace (decls = decls; attribs = Attributes attrs)) =
+        and walkSynModuleOrNamespace (SynModuleOrNamespace(decls = decls; attribs = Attributes attrs)) =
             List.iter walkAttribute attrs
             List.iter walkSynModuleDecl decls
 
@@ -1767,166 +1761,166 @@ module ParsedInput =
             addLongIdentWithDots attr.TypeName
             walkExpr attr.ArgExpr
 
-        and walkTyparDecl (SynTyparDecl.SynTyparDecl (Attributes attrs, typar, intersectionConstraints, _)) =
+        and walkTyparDecl (SynTyparDecl.SynTyparDecl(Attributes attrs, typar, intersectionConstraints, _)) =
             List.iter walkAttribute attrs
             walkTypar typar
             List.iter walkType intersectionConstraints
 
         and walkTypeConstraint cx =
             match cx with
-            | SynTypeConstraint.WhereTyparIsValueType (t, _)
-            | SynTypeConstraint.WhereTyparIsReferenceType (t, _)
-            | SynTypeConstraint.WhereTyparIsUnmanaged (t, _)
-            | SynTypeConstraint.WhereTyparSupportsNull (t, _)
-            | SynTypeConstraint.WhereTyparIsComparable (t, _)
-            | SynTypeConstraint.WhereTyparIsEquatable (t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparDefaultsToType (t, ty, _)
-            | SynTypeConstraint.WhereTyparSubtypeOfType (t, ty, _) ->
+            | SynTypeConstraint.WhereTyparIsValueType(t, _)
+            | SynTypeConstraint.WhereTyparIsReferenceType(t, _)
+            | SynTypeConstraint.WhereTyparIsUnmanaged(t, _)
+            | SynTypeConstraint.WhereTyparSupportsNull(t, _)
+            | SynTypeConstraint.WhereTyparIsComparable(t, _)
+            | SynTypeConstraint.WhereTyparIsEquatable(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparDefaultsToType(t, ty, _)
+            | SynTypeConstraint.WhereTyparSubtypeOfType(t, ty, _) ->
                 walkTypar t
                 walkType ty
-            | SynTypeConstraint.WhereTyparIsEnum (t, ts, _)
-            | SynTypeConstraint.WhereTyparIsDelegate (t, ts, _) ->
+            | SynTypeConstraint.WhereTyparIsEnum(t, ts, _)
+            | SynTypeConstraint.WhereTyparIsDelegate(t, ts, _) ->
                 walkTypar t
                 List.iter walkType ts
-            | SynTypeConstraint.WhereTyparSupportsMember (TypesForTypar ts, sign, _) ->
+            | SynTypeConstraint.WhereTyparSupportsMember(TypesForTypar ts, sign, _) ->
                 List.iter walkType ts
                 walkMemberSig sign
-            | SynTypeConstraint.WhereSelfConstrained (ty, _) -> walkType ty
+            | SynTypeConstraint.WhereSelfConstrained(ty, _) -> walkType ty
 
         and walkPat pat =
             match pat with
-            | SynPat.Tuple (elementPats = pats)
-            | SynPat.ArrayOrList (_, pats, _)
-            | SynPat.Ands (pats, _) -> List.iter walkPat pats
-            | SynPat.Named (SynIdent (ident, _), _, _, _) -> addIdent ident
-            | SynPat.Typed (pat, t, _) ->
+            | SynPat.Tuple(elementPats = pats)
+            | SynPat.ArrayOrList(_, pats, _)
+            | SynPat.Ands(pats, _) -> List.iter walkPat pats
+            | SynPat.Named(SynIdent(ident, _), _, _, _) -> addIdent ident
+            | SynPat.Typed(pat, t, _) ->
                 walkPat pat
                 walkType t
-            | SynPat.Attrib (pat, Attributes attrs, _) ->
+            | SynPat.Attrib(pat, Attributes attrs, _) ->
                 walkPat pat
                 List.iter walkAttribute attrs
-            | SynPat.As (pat1, pat2, _)
-            | SynPat.Or (pat1, pat2, _, _)
-            | SynPat.ListCons (pat1, pat2, _, _) -> List.iter walkPat [ pat1; pat2 ]
-            | SynPat.LongIdent (longDotId = ident; typarDecls = typars; argPats = ConstructorPats pats) ->
+            | SynPat.As(pat1, pat2, _)
+            | SynPat.Or(pat1, pat2, _, _)
+            | SynPat.ListCons(pat1, pat2, _, _) -> List.iter walkPat [ pat1; pat2 ]
+            | SynPat.LongIdent(longDotId = ident; typarDecls = typars; argPats = ConstructorPats pats) ->
                 addLongIdentWithDots ident
 
                 typars
-                |> Option.iter (fun (ValTyparDecls (typars, constraints, _)) ->
+                |> Option.iter (fun (ValTyparDecls(typars, constraints, _)) ->
                     List.iter walkTyparDecl typars
                     List.iter walkTypeConstraint constraints)
 
                 List.iter walkPat pats
-            | SynPat.Paren (pat, _) -> walkPat pat
-            | SynPat.IsInst (t, _) -> walkType t
-            | SynPat.QuoteExpr (e, _) -> walkExpr e
+            | SynPat.Paren(pat, _) -> walkPat pat
+            | SynPat.IsInst(t, _) -> walkType t
+            | SynPat.QuoteExpr(e, _) -> walkExpr e
             | _ -> ()
 
         and walkTypar (SynTypar _) = ()
 
-        and walkBinding (SynBinding (attributes = Attributes attrs; headPat = pat; returnInfo = returnInfo; expr = e)) =
+        and walkBinding (SynBinding(attributes = Attributes attrs; headPat = pat; returnInfo = returnInfo; expr = e)) =
             List.iter walkAttribute attrs
             walkPat pat
             walkExpr e
 
             returnInfo
-            |> Option.iter (fun (SynBindingReturnInfo (typeName = t)) -> walkType t)
+            |> Option.iter (fun (SynBindingReturnInfo(typeName = t)) -> walkType t)
 
-        and walkInterfaceImpl (SynInterfaceImpl (bindings = bindings)) = List.iter walkBinding bindings
+        and walkInterfaceImpl (SynInterfaceImpl(bindings = bindings)) = List.iter walkBinding bindings
 
         and walkType synType =
             match synType with
-            | SynType.Array (_, t, _)
-            | SynType.HashConstraint (t, _)
-            | SynType.MeasurePower (t, _, _)
-            | SynType.Paren (t, _)
-            | SynType.SignatureParameter (usedType = t) -> walkType t
-            | SynType.Fun (argType = t1; returnType = t2)
-            | SynType.Or (t1, t2, _, _) ->
+            | SynType.Array(_, t, _)
+            | SynType.HashConstraint(t, _)
+            | SynType.MeasurePower(t, _, _)
+            | SynType.Paren(t, _)
+            | SynType.SignatureParameter(usedType = t) -> walkType t
+            | SynType.Fun(argType = t1; returnType = t2)
+            | SynType.Or(t1, t2, _, _) ->
                 walkType t1
                 walkType t2
             | SynType.LongIdent ident -> addLongIdentWithDots ident
-            | SynType.App (ty, _, types, _, _, _, _) ->
+            | SynType.App(ty, _, types, _, _, _, _) ->
                 walkType ty
                 List.iter walkType types
-            | SynType.LongIdentApp (_, _, _, types, _, _, _) -> List.iter walkType types
-            | SynType.Tuple (path = segment) -> getTypeFromTuplePath segment |> List.iter walkType
-            | SynType.WithGlobalConstraints (t, typeConstraints, _) ->
+            | SynType.LongIdentApp(_, _, _, types, _, _, _) -> List.iter walkType types
+            | SynType.Tuple(path = segment) -> getTypeFromTuplePath segment |> List.iter walkType
+            | SynType.WithGlobalConstraints(t, typeConstraints, _) ->
                 walkType t
                 List.iter walkTypeConstraint typeConstraints
-            | SynType.StaticConstantExpr (e, _) -> walkExpr e
-            | SynType.StaticConstantNamed (ident, value, _) ->
+            | SynType.StaticConstantExpr(e, _) -> walkExpr e
+            | SynType.StaticConstantNamed(ident, value, _) ->
                 walkType ident
                 walkType value
-            | SynType.Intersection (types = types) -> List.iter walkType types
+            | SynType.Intersection(types = types) -> List.iter walkType types
             | SynType.Anon _
             | SynType.AnonRecd _
             | SynType.Var _
             | SynType.StaticConstant _
             | SynType.FromParseError _ -> ()
 
-        and walkClause (SynMatchClause (pat = pat; whenExpr = e1; resultExpr = e2)) =
+        and walkClause (SynMatchClause(pat = pat; whenExpr = e1; resultExpr = e2)) =
             walkPat pat
             walkExpr e2
             e1 |> Option.iter walkExpr
 
         and walkSimplePats spats =
             match spats with
-            | SynSimplePats.SimplePats (pats = pats) -> List.iter walkSimplePat pats
+            | SynSimplePats.SimplePats(pats = pats) -> List.iter walkSimplePat pats
 
         and walkExpr expr =
             match expr with
-            | SynExpr.Paren (expr = e)
-            | SynExpr.Quote (quotedExpr = e)
-            | SynExpr.Typed (expr = e)
-            | SynExpr.InferredUpcast (expr = e)
-            | SynExpr.InferredDowncast (expr = e)
-            | SynExpr.AddressOf (expr = e)
-            | SynExpr.DoBang (expr = e)
-            | SynExpr.YieldOrReturn (expr = e)
-            | SynExpr.ArrayOrListComputed (expr = e)
-            | SynExpr.ComputationExpr (expr = e)
-            | SynExpr.Do (expr = e)
-            | SynExpr.Assert (expr = e)
-            | SynExpr.Lazy (expr = e)
-            | SynExpr.DotLambda (expr = e)
-            | SynExpr.IndexFromEnd (expr = e)
-            | SynExpr.YieldOrReturnFrom (expr = e) -> walkExpr e
+            | SynExpr.Paren(expr = e)
+            | SynExpr.Quote(quotedExpr = e)
+            | SynExpr.Typed(expr = e)
+            | SynExpr.InferredUpcast(expr = e)
+            | SynExpr.InferredDowncast(expr = e)
+            | SynExpr.AddressOf(expr = e)
+            | SynExpr.DoBang(expr = e)
+            | SynExpr.YieldOrReturn(expr = e)
+            | SynExpr.ArrayOrListComputed(expr = e)
+            | SynExpr.ComputationExpr(expr = e)
+            | SynExpr.Do(expr = e)
+            | SynExpr.Assert(expr = e)
+            | SynExpr.Lazy(expr = e)
+            | SynExpr.DotLambda(expr = e)
+            | SynExpr.IndexFromEnd(expr = e)
+            | SynExpr.YieldOrReturnFrom(expr = e) -> walkExpr e
 
-            | SynExpr.Lambda (args = pats; body = e) ->
+            | SynExpr.Lambda(args = pats; body = e) ->
                 walkSimplePats pats
                 walkExpr e
 
-            | SynExpr.New (expr = e; targetType = t)
-            | SynExpr.TypeTest (expr = e; targetType = t)
-            | SynExpr.Upcast (expr = e; targetType = t)
-            | SynExpr.Downcast (expr = e; targetType = t) ->
+            | SynExpr.New(expr = e; targetType = t)
+            | SynExpr.TypeTest(expr = e; targetType = t)
+            | SynExpr.Upcast(expr = e; targetType = t)
+            | SynExpr.Downcast(expr = e; targetType = t) ->
                 walkExpr e
                 walkType t
 
-            | SynExpr.Tuple (exprs = es)
+            | SynExpr.Tuple(exprs = es)
             | Sequentials es
-            | SynExpr.ArrayOrList (exprs = es) -> List.iter walkExpr es
+            | SynExpr.ArrayOrList(exprs = es) -> List.iter walkExpr es
 
-            | SynExpr.JoinIn (lhsExpr = e1; rhsExpr = e2)
-            | SynExpr.DotIndexedGet (objectExpr = e1; indexArgs = e2)
-            | SynExpr.Set (targetExpr = e1; rhsExpr = e2)
-            | SynExpr.App (funcExpr = e1; argExpr = e2)
-            | SynExpr.TryFinally (tryExpr = e1; finallyExpr = e2)
-            | SynExpr.WhileBang (whileExpr = e1; doExpr = e2)
-            | SynExpr.While (whileExpr = e1; doExpr = e2) ->
+            | SynExpr.JoinIn(lhsExpr = e1; rhsExpr = e2)
+            | SynExpr.DotIndexedGet(objectExpr = e1; indexArgs = e2)
+            | SynExpr.Set(targetExpr = e1; rhsExpr = e2)
+            | SynExpr.App(funcExpr = e1; argExpr = e2)
+            | SynExpr.TryFinally(tryExpr = e1; finallyExpr = e2)
+            | SynExpr.WhileBang(whileExpr = e1; doExpr = e2)
+            | SynExpr.While(whileExpr = e1; doExpr = e2) ->
                 walkExpr e1
                 walkExpr e2
 
-            | SynExpr.Record (recordFields = fields) ->
+            | SynExpr.Record(recordFields = fields) ->
                 fields
-                |> List.iter (fun (SynExprRecordField (fieldName = (ident, _); expr = e)) ->
+                |> List.iter (fun (SynExprRecordField(fieldName = (ident, _); expr = e)) ->
                     addLongIdentWithDots ident
                     e |> Option.iter walkExpr)
 
             | SynExpr.Ident ident -> addIdent ident
 
-            | SynExpr.ObjExpr (objType = ty; argOptions = argOpt; bindings = bindings; members = ms; extraImpls = ifaces) ->
+            | SynExpr.ObjExpr(objType = ty; argOptions = argOpt; bindings = bindings; members = ms; extraImpls = ifaces) ->
                 let bindings = unionBindingAndMembers bindings ms
 
                 argOpt
@@ -1938,55 +1932,55 @@ module ParsedInput =
                 List.iter walkBinding bindings
                 List.iter walkInterfaceImpl ifaces
 
-            | SynExpr.LongIdent (longDotId = ident) -> addLongIdentWithDots ident
+            | SynExpr.LongIdent(longDotId = ident) -> addLongIdentWithDots ident
 
-            | SynExpr.For (ident = ident; identBody = e1; toBody = e2; doBody = e3) ->
+            | SynExpr.For(ident = ident; identBody = e1; toBody = e2; doBody = e3) ->
                 addIdent ident
                 walkExpr e1
                 walkExpr e2
                 walkExpr e3
 
-            | SynExpr.ForEach (pat = pat; enumExpr = e1; bodyExpr = e2) ->
+            | SynExpr.ForEach(pat = pat; enumExpr = e1; bodyExpr = e2) ->
                 walkPat pat
                 walkExpr e1
                 walkExpr e2
 
-            | SynExpr.MatchLambda (matchClauses = clauses) -> List.iter walkClause clauses
+            | SynExpr.MatchLambda(matchClauses = clauses) -> List.iter walkClause clauses
 
-            | SynExpr.MatchBang (expr = e; clauses = clauses)
-            | SynExpr.Match (expr = e; clauses = clauses) ->
+            | SynExpr.MatchBang(expr = e; clauses = clauses)
+            | SynExpr.Match(expr = e; clauses = clauses) ->
                 walkExpr e
                 List.iter walkClause clauses
 
-            | SynExpr.TypeApp (expr = e; typeArgs = tys) ->
+            | SynExpr.TypeApp(expr = e; typeArgs = tys) ->
                 List.iter walkType tys
                 walkExpr e
 
-            | SynExpr.LetOrUse (bindings = bindings; body = e) ->
+            | SynExpr.LetOrUse(bindings = bindings; body = e) ->
                 List.iter walkBinding bindings
                 walkExpr e
 
-            | SynExpr.TryWith (tryExpr = e; withCases = clauses) ->
+            | SynExpr.TryWith(tryExpr = e; withCases = clauses) ->
                 List.iter walkClause clauses
                 walkExpr e
 
-            | SynExpr.IfThenElse (ifExpr = e1; thenExpr = e2; elseExpr = e3) ->
+            | SynExpr.IfThenElse(ifExpr = e1; thenExpr = e2; elseExpr = e3) ->
                 walkExpr e1
                 walkExpr e2
                 e3 |> Option.iter walkExpr
 
-            | SynExpr.LongIdentSet (longDotId = ident; expr = e)
-            | SynExpr.DotGet (longDotId = ident; expr = e) ->
+            | SynExpr.LongIdentSet(longDotId = ident; expr = e)
+            | SynExpr.DotGet(longDotId = ident; expr = e) ->
                 addLongIdentWithDots ident
                 walkExpr e
 
-            | SynExpr.NamedIndexedPropertySet (longDotId = ident; expr1 = e1; expr2 = e2)
-            | SynExpr.DotSet (targetExpr = e1; longDotId = ident; rhsExpr = e2) ->
+            | SynExpr.NamedIndexedPropertySet(longDotId = ident; expr1 = e1; expr2 = e2)
+            | SynExpr.DotSet(targetExpr = e1; longDotId = ident; rhsExpr = e2) ->
                 addLongIdentWithDots ident
                 walkExpr e1
                 walkExpr e2
 
-            | SynExpr.IndexRange (expr1 = expr1; expr2 = expr2) ->
+            | SynExpr.IndexRange(expr1 = expr1; expr2 = expr2) ->
                 match expr1 with
                 | Some e -> walkExpr e
                 | None -> ()
@@ -1995,88 +1989,88 @@ module ParsedInput =
                 | Some e -> walkExpr e
                 | None -> ()
 
-            | SynExpr.DotIndexedSet (objectExpr = e1; indexArgs = args; valueExpr = e2) ->
+            | SynExpr.DotIndexedSet(objectExpr = e1; indexArgs = args; valueExpr = e2) ->
                 walkExpr e1
                 walkExpr args
                 walkExpr e2
 
-            | SynExpr.DotNamedIndexedPropertySet (targetExpr = e1; longDotId = ident; argExpr = e2; rhsExpr = e3) ->
+            | SynExpr.DotNamedIndexedPropertySet(targetExpr = e1; longDotId = ident; argExpr = e2; rhsExpr = e3) ->
                 addLongIdentWithDots ident
                 walkExpr e1
                 walkExpr e2
                 walkExpr e3
 
-            | SynExpr.LetOrUseBang (pat = pat; rhs = e1; andBangs = es; body = e2) ->
+            | SynExpr.LetOrUseBang(pat = pat; rhs = e1; andBangs = es; body = e2) ->
                 walkPat pat
                 walkExpr e1
 
-                for SynExprAndBang (pat = patAndBang; body = eAndBang) in es do
+                for SynExprAndBang(pat = patAndBang; body = eAndBang) in es do
                     walkPat patAndBang
                     walkExpr eAndBang
 
                 walkExpr e2
 
-            | SynExpr.TraitCall (TypesForTypar ts, sign, e, _) ->
+            | SynExpr.TraitCall(TypesForTypar ts, sign, e, _) ->
                 List.iter walkType ts
                 walkMemberSig sign
                 walkExpr e
 
-            | SynExpr.Const(constant = SynConst.Measure (synMeasure = m)) -> walkMeasure m
+            | SynExpr.Const(constant = SynConst.Measure(synMeasure = m)) -> walkMeasure m
 
             | _ -> ()
 
         and walkMeasure measure =
             match measure with
-            | SynMeasure.Product (measure1 = m1; measure2 = m2) ->
+            | SynMeasure.Product(measure1 = m1; measure2 = m2) ->
                 walkMeasure m1
                 walkMeasure m2
-            | SynMeasure.Divide (measure1 = m1; measure2 = m2) ->
+            | SynMeasure.Divide(measure1 = m1; measure2 = m2) ->
                 m1 |> Option.iter walkMeasure
                 walkMeasure m2
-            | SynMeasure.Named (longIdent, _) -> addLongIdent longIdent
-            | SynMeasure.Seq (ms, _) -> List.iter walkMeasure ms
-            | SynMeasure.Paren (m, _)
-            | SynMeasure.Power (measure = m) -> walkMeasure m
-            | SynMeasure.Var (ty, _) -> walkTypar ty
+            | SynMeasure.Named(longIdent, _) -> addLongIdent longIdent
+            | SynMeasure.Seq(ms, _) -> List.iter walkMeasure ms
+            | SynMeasure.Paren(m, _)
+            | SynMeasure.Power(measure = m) -> walkMeasure m
+            | SynMeasure.Var(ty, _) -> walkTypar ty
             | SynMeasure.One _
             | SynMeasure.Anon _ -> ()
 
         and walkSimplePat spat =
             match spat with
-            | SynSimplePat.Attrib (pat, Attributes attrs, _) ->
+            | SynSimplePat.Attrib(pat, Attributes attrs, _) ->
                 walkSimplePat pat
                 List.iter walkAttribute attrs
-            | SynSimplePat.Typed (pat, t, _) ->
+            | SynSimplePat.Typed(pat, t, _) ->
                 walkSimplePat pat
                 walkType t
             | _ -> ()
 
-        and walkField (SynField (attributes = Attributes attrs; fieldType = t)) =
+        and walkField (SynField(attributes = Attributes attrs; fieldType = t)) =
             List.iter walkAttribute attrs
             walkType t
 
-        and walkValSig (SynValSig (attributes = Attributes attrs; synType = t; arity = SynValInfo (argInfos, argInfo))) =
+        and walkValSig (SynValSig(attributes = Attributes attrs; synType = t; arity = SynValInfo(argInfos, argInfo))) =
             List.iter walkAttribute attrs
             walkType t
 
             argInfo :: (argInfos |> List.concat)
-            |> List.collect (fun (SynArgInfo (Attributes attrs, _, _)) -> attrs)
+            |> List.collect (fun (SynArgInfo(Attributes attrs, _, _)) -> attrs)
             |> List.iter walkAttribute
 
         and walkMemberSig membSig =
             match membSig with
-            | SynMemberSig.Inherit (t, _)
-            | SynMemberSig.Interface (t, _) -> walkType t
-            | SynMemberSig.Member (memberSig = vs) -> walkValSig vs
-            | SynMemberSig.ValField (f, _) -> walkField f
-            | SynMemberSig.NestedType (nestedType = typeDefn) ->
-                let (SynTypeDefnSig (typeInfo = info; typeRepr = repr; members = memberSigs)) =
+            | SynMemberSig.Inherit(t, _)
+            | SynMemberSig.Interface(t, _) -> walkType t
+            | SynMemberSig.Member(memberSig = vs) -> walkValSig vs
+            | SynMemberSig.ValField(f, _) -> walkField f
+            | SynMemberSig.NestedType(nestedType = typeDefn) ->
+                let (SynTypeDefnSig(typeInfo = info; typeRepr = repr; members = memberSigs)) =
                     typeDefn
 
                 let isTypeExtensionOrAlias =
                     match repr with
-                    | SynTypeDefnSigRepr.Simple (SynTypeDefnSimpleRepr.TypeAbbrev _, _)
-                    | SynTypeDefnSigRepr.ObjectModel (SynTypeDefnKind.Abbrev, _, _)
+                    | SynTypeDefnSigRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev _, _)
+                    | SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Abbrev, _, _)
                     | SynTypeDefnSigRepr.ObjectModel(kind = SynTypeDefnKind.Augmentation _) -> true
                     | _ -> false
 
@@ -2086,25 +2080,25 @@ module ParsedInput =
 
         and walkMember memb =
             match memb with
-            | SynMemberDefn.AbstractSlot (slotSig = valSig) -> walkValSig valSig
-            | SynMemberDefn.Member (binding, _) -> walkBinding binding
-            | SynMemberDefn.GetSetMember (getBinding, setBinding, _, _) ->
+            | SynMemberDefn.AbstractSlot(slotSig = valSig) -> walkValSig valSig
+            | SynMemberDefn.Member(binding, _) -> walkBinding binding
+            | SynMemberDefn.GetSetMember(getBinding, setBinding, _, _) ->
                 Option.iter walkBinding getBinding
                 Option.iter walkBinding setBinding
-            | SynMemberDefn.ImplicitCtor (attributes = Attributes attrs; ctorArgs = SynSimplePats.SimplePats (pats = simplePats)) ->
+            | SynMemberDefn.ImplicitCtor(attributes = Attributes attrs; ctorArgs = SynSimplePats.SimplePats(pats = simplePats)) ->
                 List.iter walkAttribute attrs
                 List.iter walkSimplePat simplePats
-            | SynMemberDefn.ImplicitInherit (t, e, _, _) ->
+            | SynMemberDefn.ImplicitInherit(t, e, _, _) ->
                 walkType t
                 walkExpr e
-            | SynMemberDefn.LetBindings (bindings, _, _, _) -> List.iter walkBinding bindings
-            | SynMemberDefn.Interface (interfaceType = t; members = members) ->
+            | SynMemberDefn.LetBindings(bindings, _, _, _) -> List.iter walkBinding bindings
+            | SynMemberDefn.Interface(interfaceType = t; members = members) ->
                 walkType t
                 members |> Option.iter (List.iter walkMember)
-            | SynMemberDefn.Inherit (t, _, _) -> walkType t
-            | SynMemberDefn.ValField (fieldInfo = field) -> walkField field
-            | SynMemberDefn.NestedType (tdef, _, _) -> walkTypeDefn tdef
-            | SynMemberDefn.AutoProperty (attributes = Attributes attrs; typeOpt = t; synExpr = e) ->
+            | SynMemberDefn.Inherit(t, _, _) -> walkType t
+            | SynMemberDefn.ValField(fieldInfo = field) -> walkField field
+            | SynMemberDefn.NestedType(tdef, _, _) -> walkTypeDefn tdef
+            | SynMemberDefn.AutoProperty(attributes = Attributes attrs; typeOpt = t; synExpr = e) ->
                 List.iter walkAttribute attrs
                 Option.iter walkType t
                 walkExpr e
@@ -2115,22 +2109,22 @@ module ParsedInput =
         and walkUnionCaseType kind =
             match kind with
             | SynUnionCaseKind.Fields fields -> List.iter walkField fields
-            | SynUnionCaseKind.FullType (t, _) -> walkType t
+            | SynUnionCaseKind.FullType(t, _) -> walkType t
 
-        and walkUnionCase (SynUnionCase (attributes = Attributes attrs; caseType = t)) =
+        and walkUnionCase (SynUnionCase(attributes = Attributes attrs; caseType = t)) =
             List.iter walkAttribute attrs
             walkUnionCaseType t
 
         and walkTypeDefnSimple typeDefn =
             match typeDefn with
-            | SynTypeDefnSimpleRepr.Enum (cases, _) -> List.iter walkEnumCase cases
-            | SynTypeDefnSimpleRepr.Union (_, cases, _) -> List.iter walkUnionCase cases
-            | SynTypeDefnSimpleRepr.Record (_, fields, _) -> List.iter walkField fields
-            | SynTypeDefnSimpleRepr.TypeAbbrev (_, t, _) -> walkType t
+            | SynTypeDefnSimpleRepr.Enum(cases, _) -> List.iter walkEnumCase cases
+            | SynTypeDefnSimpleRepr.Union(_, cases, _) -> List.iter walkUnionCase cases
+            | SynTypeDefnSimpleRepr.Record(_, fields, _) -> List.iter walkField fields
+            | SynTypeDefnSimpleRepr.TypeAbbrev(_, t, _) -> walkType t
             | _ -> ()
 
         and walkComponentInfo isTypeExtensionOrAlias compInfo =
-            let (SynComponentInfo (Attributes attrs, TyparsAndConstraints (typars, cs1), cs2, longIdent, _, _, _, _)) =
+            let (SynComponentInfo(Attributes attrs, TyparsAndConstraints(typars, cs1), cs2, longIdent, _, _, _, _)) =
                 compInfo
 
             let constraints = cs1 @ cs2
@@ -2143,25 +2137,25 @@ module ParsedInput =
 
         and walkTypeDefnRepr inp =
             match inp with
-            | SynTypeDefnRepr.ObjectModel (_, defns, _) -> List.iter walkMember defns
-            | SynTypeDefnRepr.Simple (defn, _) -> walkTypeDefnSimple defn
+            | SynTypeDefnRepr.ObjectModel(_, defns, _) -> List.iter walkMember defns
+            | SynTypeDefnRepr.Simple(defn, _) -> walkTypeDefnSimple defn
             | SynTypeDefnRepr.Exception _ -> ()
 
         and walkTypeDefnSigRepr inp =
             match inp with
-            | SynTypeDefnSigRepr.ObjectModel (_, defns, _) -> List.iter walkMemberSig defns
-            | SynTypeDefnSigRepr.Simple (defn, _) -> walkTypeDefnSimple defn
+            | SynTypeDefnSigRepr.ObjectModel(_, defns, _) -> List.iter walkMemberSig defns
+            | SynTypeDefnSigRepr.Simple(defn, _) -> walkTypeDefnSimple defn
             | SynTypeDefnSigRepr.Exception _ -> ()
 
         and walkTypeDefn typeDefn =
-            let (SynTypeDefn (typeInfo = info; typeRepr = repr; members = members; implicitConstructor = implicitCtor)) =
+            let (SynTypeDefn(typeInfo = info; typeRepr = repr; members = members; implicitConstructor = implicitCtor)) =
                 typeDefn
 
             let isTypeExtensionOrAlias =
                 match repr with
                 | SynTypeDefnRepr.ObjectModel(kind = SynTypeDefnKind.Augmentation _)
-                | SynTypeDefnRepr.ObjectModel (SynTypeDefnKind.Abbrev, _, _)
-                | SynTypeDefnRepr.Simple (SynTypeDefnSimpleRepr.TypeAbbrev _, _) -> true
+                | SynTypeDefnRepr.ObjectModel(SynTypeDefnKind.Abbrev, _, _)
+                | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev _, _) -> true
                 | _ -> false
 
             walkComponentInfo isTypeExtensionOrAlias info
@@ -2172,13 +2166,13 @@ module ParsedInput =
         and walkSynModuleDecl (decl: SynModuleDecl) =
             match decl with
             | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace fragment
-            | SynModuleDecl.NestedModule (moduleInfo = info; decls = modules) ->
+            | SynModuleDecl.NestedModule(moduleInfo = info; decls = modules) ->
                 walkComponentInfo false info
                 List.iter walkSynModuleDecl modules
-            | SynModuleDecl.Let (_, bindings, _) -> List.iter walkBinding bindings
-            | SynModuleDecl.Expr (expr, _) -> walkExpr expr
-            | SynModuleDecl.Types (types, _) -> List.iter walkTypeDefn types
-            | SynModuleDecl.Attributes (Attributes attrs, _) -> List.iter walkAttribute attrs
+            | SynModuleDecl.Let(_, bindings, _) -> List.iter walkBinding bindings
+            | SynModuleDecl.Expr(expr, _) -> walkExpr expr
+            | SynModuleDecl.Types(types, _) -> List.iter walkTypeDefn types
+            | SynModuleDecl.Attributes(Attributes attrs, _) -> List.iter walkAttribute attrs
             | _ -> ()
 
         match parsedInput with
@@ -2232,10 +2226,10 @@ module ParsedInput =
                             mkPos line col,
                             false
                         )
-                | Some (_, _, true), _ -> ()
-                | Some (oldScope, oldPos, false), OpenStatementInsertionPoint.TopLevel when kind <> OpenDeclaration ->
+                | Some(_, _, true), _ -> ()
+                | Some(oldScope, oldPos, false), OpenStatementInsertionPoint.TopLevel when kind <> OpenDeclaration ->
                     result <- Some(oldScope, oldPos, true)
-                | Some (oldScope, oldPos, _), _ ->
+                | Some(oldScope, oldPos, _), _ ->
                     match kind, oldScope.Kind with
                     | (Namespace | NestedModule | TopModule), OpenDeclaration
                     | _ when oldPos.Line <= line ->
@@ -2258,13 +2252,13 @@ module ParsedInput =
             | [] -> None
             | firstDecl :: _ ->
                 match firstDecl with
-                | SynModuleDecl.NestedModule (range = r)
-                | SynModuleDecl.Let (range = r)
-                | SynModuleDecl.Expr (range = r)
-                | SynModuleDecl.Types (range = r)
-                | SynModuleDecl.Exception (range = r)
-                | SynModuleDecl.Open (range = r)
-                | SynModuleDecl.HashDirective (range = r) -> Some r
+                | SynModuleDecl.NestedModule(range = r)
+                | SynModuleDecl.Let(range = r)
+                | SynModuleDecl.Expr(range = r)
+                | SynModuleDecl.Types(range = r)
+                | SynModuleDecl.Exception(range = r)
+                | SynModuleDecl.Open(range = r)
+                | SynModuleDecl.HashDirective(range = r) -> Some r
                 | _ -> None
                 |> Option.map (fun r -> r.StartColumn)
 
@@ -2272,7 +2266,7 @@ module ParsedInput =
             List.iter (walkSynModuleOrNamespace []) file.Contents
 
         and walkSynModuleOrNamespace (parent: LongIdent) modul =
-            let (SynModuleOrNamespace (longId = ident; kind = kind; decls = decls; range = range)) =
+            let (SynModuleOrNamespace(longId = ident; kind = kind; decls = decls; range = range)) =
                 modul
 
             if range.EndLine >= currentLine then
@@ -2303,7 +2297,7 @@ module ParsedInput =
         and walkSynModuleDecl (parent: LongIdent) (decl: SynModuleDecl) =
             match decl with
             | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace parent fragment
-            | SynModuleDecl.NestedModule (moduleInfo = SynComponentInfo (longId = ident); decls = decls; range = range) ->
+            | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = ident); decls = decls; range = range) ->
                 let fullIdent = parent @ ident
                 addModule (fullIdent, range)
 
@@ -2313,8 +2307,8 @@ module ParsedInput =
 
                     doRange NestedModule fullIdent range.StartLine moduleBodyIndentation
                     List.iter (walkSynModuleDecl fullIdent) decls
-            | SynModuleDecl.Open (_, range) -> doRange OpenDeclaration [] range.EndLine (range.StartColumn - 5)
-            | SynModuleDecl.HashDirective (_, range) -> doRange HashDirective [] range.EndLine range.StartColumn
+            | SynModuleDecl.Open(_, range) -> doRange OpenDeclaration [] range.EndLine (range.StartColumn - 5)
+            | SynModuleDecl.HashDirective(_, range) -> doRange HashDirective [] range.EndLine range.StartColumn
             | _ -> ()
 
         match ast with
@@ -2359,7 +2353,8 @@ module ParsedInput =
         let res, modules =
             tryFindNearestPointAndModules currentLine parsedInput insertionPoint
 
-        fun (requiresQualifiedAccessParent: ShortIdents option,
+        fun
+            (requiresQualifiedAccessParent: ShortIdents option,
              autoOpenParent: ShortIdents option,
              entityNamespace: ShortIdents option,
              entity: ShortIdents) ->
@@ -2371,7 +2366,7 @@ module ParsedInput =
 
             match res with
             | None -> [||]
-            | Some (scope, ns, pos) ->
+            | Some(scope, ns, pos) ->
                 let entities =
                     Entity.tryCreate (
                         ns,
@@ -2438,7 +2433,7 @@ module ParsedInput =
         (insertionPoint: OpenStatementInsertionPoint)
         =
         match tryFindNearestPointAndModules currentLine parsedInput insertionPoint with
-        | Some (scope, _, point), modules -> findBestPositionToInsertOpenDeclaration modules scope point entity
+        | Some(scope, _, point), modules -> findBestPositionToInsertOpenDeclaration modules scope point entity
         | _ ->
             // we failed to find insertion point because ast is empty for some reason, return top left point in this case
             {

--- a/src/Compiler/Service/ServiceParsedInputOps.fsi
+++ b/src/Compiler/Service/ServiceParsedInputOps.fsi
@@ -169,7 +169,11 @@ module public ParsedInput =
         parsedInput: ParsedInput ->
         partiallyQualifiedName: MaybeUnresolvedIdent[] ->
         insertionPoint: OpenStatementInsertionPoint ->
-            (( (* requiresQualifiedAccessParent: *) ShortIdents option (* autoOpenParent: *) * ShortIdents option (*  entityNamespace *) * ShortIdents option (* entity: *) * ShortIdents) -> (InsertionContextEntity * InsertionContext)[])
+            (( (* requiresQualifiedAccessParent: *) ShortIdents option (* autoOpenParent: *) *
+            ShortIdents option (*  entityNamespace *) *
+            ShortIdents option (* entity: *) *
+            ShortIdents)
+                -> (InsertionContextEntity * InsertionContext)[])
 
     /// Returns `InsertContext` based on current position and symbol idents.
     val FindNearestPointToInsertOpenDeclaration:

--- a/src/Compiler/Service/ServiceStructure.fs
+++ b/src/Compiler/Service/ServiceStructure.fs
@@ -62,7 +62,7 @@ module Structure =
         | [] -> other
         | ls ->
             ls
-            |> List.map (fun (SynTyparDecl (typar = typarg)) -> typarg.Range)
+            |> List.map (fun (SynTyparDecl(typar = typarg)) -> typarg.Range)
             |> List.reduce unionRanges
 
     /// Collapse indicates the way a range/snapshot should be collapsed. `Same` is for a scope inside
@@ -226,43 +226,43 @@ module Structure =
 
         let rec parseExpr expr =
             match expr with
-            | SynExpr.Upcast (e, _, _)
-            | SynExpr.Downcast (e, _, _)
-            | SynExpr.AddressOf (_, e, _, _)
-            | SynExpr.InferredDowncast (e, _)
-            | SynExpr.InferredUpcast (e, _)
-            | SynExpr.DotGet (e, _, _, _)
-            | SynExpr.Do (e, _)
-            | SynExpr.Typed (e, _, _)
-            | SynExpr.DotIndexedGet (e, _, _, _) -> parseExpr e
+            | SynExpr.Upcast(e, _, _)
+            | SynExpr.Downcast(e, _, _)
+            | SynExpr.AddressOf(_, e, _, _)
+            | SynExpr.InferredDowncast(e, _)
+            | SynExpr.InferredUpcast(e, _)
+            | SynExpr.DotGet(e, _, _, _)
+            | SynExpr.Do(e, _)
+            | SynExpr.Typed(e, _, _)
+            | SynExpr.DotIndexedGet(e, _, _, _) -> parseExpr e
 
-            | SynExpr.Set (e1, e2, _)
-            | SynExpr.DotSet (e1, _, e2, _)
-            | SynExpr.DotIndexedSet (e1, _, e2, _, _, _) ->
+            | SynExpr.Set(e1, e2, _)
+            | SynExpr.DotSet(e1, _, e2, _)
+            | SynExpr.DotIndexedSet(e1, _, e2, _, _, _) ->
                 parseExpr e1
                 parseExpr e2
 
-            | SynExpr.New (_, _, e, r) ->
+            | SynExpr.New(_, _, e, r) ->
                 rcheck Scope.New Collapse.Below r e.Range
                 parseExpr e
 
-            | SynExpr.YieldOrReturn (_, e, r) ->
+            | SynExpr.YieldOrReturn(_, e, r) ->
                 rcheck Scope.YieldOrReturn Collapse.Below r r
                 parseExpr e
 
-            | SynExpr.YieldOrReturnFrom (_, e, r) ->
+            | SynExpr.YieldOrReturnFrom(_, e, r) ->
                 rcheck Scope.YieldOrReturnBang Collapse.Below r r
                 parseExpr e
 
-            | SynExpr.DoBang (e, r) ->
+            | SynExpr.DoBang(e, r) ->
                 rcheck Scope.Do Collapse.Below r <| Range.modStart 3 r
                 parseExpr e
 
-            | SynExpr.LetOrUseBang (pat = pat; rhs = eLet; andBangs = es; body = eBody) ->
+            | SynExpr.LetOrUseBang(pat = pat; rhs = eLet; andBangs = es; body = eBody) ->
                 let exprs =
                     [
                         eLet
-                        for SynExprAndBang (body = eAndBang) in es do
+                        for SynExprAndBang(body = eAndBang) in es do
                             eAndBang
                     ]
 
@@ -277,17 +277,17 @@ module Structure =
 
                 parseExpr eBody
 
-            | SynExpr.For (doBody = e; range = r)
-            | SynExpr.ForEach (_, _, _, _, _, _, e, r) ->
+            | SynExpr.For(doBody = e; range = r)
+            | SynExpr.ForEach(_, _, _, _, _, _, e, r) ->
                 rcheck Scope.For Collapse.Below r r
                 parseExpr e
 
-            | SynExpr.LetOrUse (bindings = bindings; body = body) ->
+            | SynExpr.LetOrUse(bindings = bindings; body = body) ->
                 parseBindings bindings
                 parseExpr body
 
-            | SynExpr.Match (matchDebugPoint = seqPointAtBinding; clauses = clauses; range = r)
-            | SynExpr.MatchBang (matchDebugPoint = seqPointAtBinding; clauses = clauses; range = r) ->
+            | SynExpr.Match(matchDebugPoint = seqPointAtBinding; clauses = clauses; range = r)
+            | SynExpr.MatchBang(matchDebugPoint = seqPointAtBinding; clauses = clauses; range = r) ->
                 match seqPointAtBinding with
                 | DebugPointAtBinding.Yes sr ->
                     let collapse = Range.endToEnd sr r
@@ -296,7 +296,7 @@ module Structure =
 
                 List.iter parseMatchClause clauses
 
-            | SynExpr.MatchLambda (_, caseRange, clauses, matchSeqPoint, r) ->
+            | SynExpr.MatchLambda(_, caseRange, clauses, matchSeqPoint, r) ->
                 let caseRange =
                     match matchSeqPoint with
                     | DebugPointAtBinding.Yes r -> r
@@ -306,7 +306,7 @@ module Structure =
                 rcheck Scope.MatchLambda Collapse.Same r collapse
                 List.iter parseMatchClause clauses
 
-            | SynExpr.App (atomicFlag, isInfix, funcExpr, argExpr, r) ->
+            | SynExpr.App(atomicFlag, isInfix, funcExpr, argExpr, r) ->
                 // seq exprs, custom operators, etc
                 if
                     ExprAtomicFlag.NonAtomic = atomicFlag
@@ -337,27 +337,23 @@ module Structure =
                 parseExpr argExpr
                 parseExpr funcExpr
 
-            | SynExpr.Sequential (_, _, e1, e2, _) ->
+            | SynExpr.Sequential(_, _, e1, e2, _) ->
                 parseExpr e1
                 parseExpr e2
 
-            | SynExpr.ArrayOrListComputed (isArray, e, r) ->
+            | SynExpr.ArrayOrListComputed(isArray, e, r) ->
                 let collapse = Range.modBoth (if isArray then 2 else 1) (if isArray then 2 else 1) r
                 rcheck Scope.ArrayOrList Collapse.Same r collapse
                 parseExpr e
 
-            | SynExpr.ComputationExpr (_, e, _r) as _c -> parseExpr e
+            | SynExpr.ComputationExpr(_, e, _r) as _c -> parseExpr e
 
-            | SynExpr.ObjExpr (argOptions = argOpt
-                               bindings = bindings
-                               members = ms
-                               extraImpls = extraImpls
-                               newExprRange = newRange
-                               range = mWhole) ->
+            | SynExpr.ObjExpr(
+                argOptions = argOpt; bindings = bindings; members = ms; extraImpls = extraImpls; newExprRange = newRange; range = mWhole) ->
                 let bindings = unionBindingAndMembers bindings ms
 
                 match argOpt with
-                | Some (args, _) ->
+                | Some(args, _) ->
                     let collapse = Range.endToEnd args.Range mWhole
                     rcheck Scope.ObjExpr Collapse.Below mWhole collapse
                 | None ->
@@ -367,7 +363,7 @@ module Structure =
                 parseBindings bindings
                 parseExprInterfaces extraImpls
 
-            | SynExpr.TryWith (e, matchClauses, mWhole, tryPoint, withPoint, _trivia) ->
+            | SynExpr.TryWith(e, matchClauses, mWhole, tryPoint, withPoint, _trivia) ->
                 match tryPoint, withPoint with
                 | DebugPointAtTry.Yes tryRange, DebugPointAtWith.Yes withRange ->
                     let mFull = Range.startToEnd tryRange mWhole
@@ -384,7 +380,7 @@ module Structure =
                 parseExpr e
                 List.iter parseMatchClause matchClauses
 
-            | SynExpr.TryFinally (tryExpr, finallyExpr, r, tryPoint, finallyPoint, _trivia) ->
+            | SynExpr.TryFinally(tryExpr, finallyExpr, r, tryPoint, finallyPoint, _trivia) ->
                 match tryPoint, finallyPoint with
                 | DebugPointAtTry.Yes tryRange, DebugPointAtFinally.Yes finallyRange ->
                     let collapse = Range.endToEnd tryRange finallyExpr.Range
@@ -398,12 +394,8 @@ module Structure =
                 parseExpr tryExpr
                 parseExpr finallyExpr
 
-            | SynExpr.IfThenElse (ifExpr = ifExpr
-                                  thenExpr = thenExpr
-                                  elseExpr = elseExprOpt
-                                  spIfToThen = spIfToThen
-                                  range = r
-                                  trivia = trivia) ->
+            | SynExpr.IfThenElse(
+                ifExpr = ifExpr; thenExpr = thenExpr; elseExpr = elseExprOpt; spIfToThen = spIfToThen; range = r; trivia = trivia) ->
                 match spIfToThen with
                 | DebugPointAtBinding.Yes rt ->
                     // Outline the entire IfThenElse
@@ -431,53 +423,53 @@ module Structure =
                         parseExpr elseExpr
                 | None -> ()
 
-            | SynExpr.While (_, _, e, r)
-            | SynExpr.WhileBang (_, _, e, r) ->
+            | SynExpr.While(_, _, e, r)
+            | SynExpr.WhileBang(_, _, e, r) ->
                 rcheck Scope.While Collapse.Below r r
                 parseExpr e
 
-            | SynExpr.Lambda (args = pats; body = e; range = r) ->
+            | SynExpr.Lambda(args = pats; body = e; range = r) ->
                 rcheck Scope.Lambda Collapse.Below r (Range.endToEnd pats.Range r)
 
                 parseExpr e
 
-            | SynExpr.Lazy (e, r) ->
+            | SynExpr.Lazy(e, r) ->
                 rcheck Scope.SpecialFunc Collapse.Below r r
                 parseExpr e
 
-            | SynExpr.Quote (_, isRaw, e, _, r) ->
+            | SynExpr.Quote(_, isRaw, e, _, r) ->
                 // subtract columns so the @@> or @> is not collapsed
                 let collapse = Range.modBoth (if isRaw then 3 else 2) (if isRaw then 3 else 2) r
                 rcheck Scope.Quote Collapse.Same r collapse
                 parseExpr e
 
-            | SynExpr.Tuple (_, es, _, r) ->
+            | SynExpr.Tuple(_, es, _, r) ->
                 rcheck Scope.Tuple Collapse.Same r r
                 List.iter parseExpr es
 
-            | SynExpr.Paren (e, _, _, _) -> parseExpr e
+            | SynExpr.Paren(e, _, _, _) -> parseExpr e
 
-            | SynExpr.Record (recCtor, recCopy, recordFields, r) ->
+            | SynExpr.Record(recCtor, recCopy, recordFields, r) ->
                 match recCtor with
-                | Some (_, ctorArgs, _, _, _) -> parseExpr ctorArgs
+                | Some(_, ctorArgs, _, _, _) -> parseExpr ctorArgs
                 | _ -> ()
 
                 match recCopy with
-                | Some (e, _) -> parseExpr e
+                | Some(e, _) -> parseExpr e
                 | _ -> ()
 
                 recordFields
-                |> List.choose (fun (SynExprRecordField (expr = e)) -> e)
+                |> List.choose (fun (SynExprRecordField(expr = e)) -> e)
                 |> List.iter parseExpr
                 // exclude the opening `{` and closing `}` of the record from collapsing
                 let m = Range.modBoth 1 1 r
                 rcheck Scope.Record Collapse.Same r m
             | _ -> ()
 
-        and parseMatchClause (SynMatchClause (pat = synPat; resultExpr = e) as clause) =
+        and parseMatchClause (SynMatchClause(pat = synPat; resultExpr = e) as clause) =
             let rec getLastPat =
                 function
-                | SynPat.Or (rhsPat = pat) -> getLastPat pat
+                | SynPat.Or(rhsPat = pat) -> getLastPat pat
                 | x -> x
 
             let synPat = getLastPat synPat
@@ -521,8 +513,8 @@ module Structure =
                     parseExpr attr.ArgExpr
 
         and parseBinding binding =
-            let (SynBinding (kind = kind; attributes = attrs; valData = valData; expr = expr; range = br)) = binding
-            let (SynValData (memberFlags = memberFlags)) = valData
+            let (SynBinding(kind = kind; attributes = attrs; valData = valData; expr = expr; range = br)) = binding
+            let (SynValData(memberFlags = memberFlags)) = valData
 
             match kind with
             | SynBindingKind.Normal ->
@@ -547,7 +539,7 @@ module Structure =
                 parseBinding bind
 
         and parseExprInterface intf =
-            let (SynInterfaceImpl (interfaceTy = synType; bindings = bindings; range = range)) = intf
+            let (SynInterfaceImpl(interfaceTy = synType; bindings = bindings; range = range)) = intf
             let collapse = Range.endToEnd synType.Range range |> Range.modEnd -1
             rcheck Scope.Interface Collapse.Below range collapse
             parseBindings bindings
@@ -558,25 +550,27 @@ module Structure =
 
         and parseSynMemberDefn (objectModelRange: range) d =
             match d with
-            | SynMemberDefn.Member (binding, _) ->
-                let (SynBinding (attributes = attrs; valData = valData; headPat = synPat; range = bindingRange)) =
+            | SynMemberDefn.Member(binding, _) ->
+                let (SynBinding(attributes = attrs; valData = valData; headPat = synPat; range = bindingRange)) =
                     binding
 
                 match valData with
-                | SynValData(memberFlags = Some {
-                                                    MemberKind = SynMemberKind.Constructor
-                                                }) ->
+                | SynValData(
+                    memberFlags = Some {
+                                           MemberKind = SynMemberKind.Constructor
+                                       }) ->
                     let collapse = Range.endToEnd synPat.Range d.Range
                     rcheck Scope.New Collapse.Below d.Range collapse
 
-                | SynValData(memberFlags = Some {
-                                                    MemberKind = SynMemberKind.PropertyGet | SynMemberKind.PropertySet
-                                                }) ->
+                | SynValData(
+                    memberFlags = Some {
+                                           MemberKind = SynMemberKind.PropertyGet | SynMemberKind.PropertySet
+                                       }) ->
                     let range = withStart (mkPos d.Range.StartLine objectModelRange.StartColumn) d.Range
 
                     let collapse =
                         match synPat with
-                        | SynPat.LongIdent (longDotId = longIdent) -> Range.endToEnd longIdent.Range d.Range
+                        | SynPat.LongIdent(longDotId = longIdent) -> Range.endToEnd longIdent.Range d.Range
                         | _ -> Range.endToEnd bindingRange d.Range
 
                     rcheck Scope.Member Collapse.Below range collapse
@@ -587,7 +581,7 @@ module Structure =
                 parseAttributes attrs
                 parseBinding binding
 
-            | SynMemberDefn.GetSetMember (getBinding, setBinding, m, _) ->
+            | SynMemberDefn.GetSetMember(getBinding, setBinding, m, _) ->
                 getBinding
                 |> Option.map (fun b -> SynMemberDefn.Member(b, m))
                 |> Option.iter (parseSynMemberDefn objectModelRange)
@@ -596,21 +590,21 @@ module Structure =
                 |> Option.map (fun b -> SynMemberDefn.Member(b, m))
                 |> Option.iter (parseSynMemberDefn objectModelRange)
 
-            | SynMemberDefn.LetBindings (bindings, _, _, _) -> parseBindings bindings
+            | SynMemberDefn.LetBindings(bindings, _, _, _) -> parseBindings bindings
 
-            | SynMemberDefn.Interface (interfaceType = tp; members = iMembers; range = r) ->
+            | SynMemberDefn.Interface(interfaceType = tp; members = iMembers; range = r) ->
                 rcheck Scope.Interface Collapse.Below d.Range (Range.endToEnd tp.Range d.Range)
 
                 match iMembers with
                 | Some members -> List.iter (parseSynMemberDefn r) members
                 | None -> ()
 
-            | SynMemberDefn.NestedType (td, _, _) -> parseTypeDefn td
+            | SynMemberDefn.NestedType(td, _, _) -> parseTypeDefn td
 
-            | SynMemberDefn.AbstractSlot (slotSig = SynValSig (synType = synt); range = r) ->
+            | SynMemberDefn.AbstractSlot(slotSig = SynValSig(synType = synt); range = r) ->
                 rcheck Scope.Member Collapse.Below d.Range (Range.startToEnd synt.Range r)
 
-            | SynMemberDefn.AutoProperty (synExpr = e; range = r) ->
+            | SynMemberDefn.AutoProperty(synExpr = e; range = r) ->
                 rcheck Scope.Member Collapse.Below d.Range r
                 parseExpr e
             | _ -> ()
@@ -627,37 +621,37 @@ module Structure =
         *)
         and parseSimpleRepr simple =
             match simple with
-            | SynTypeDefnSimpleRepr.Enum (cases, _er) ->
-                for SynEnumCase (attributes = attrs; range = cr) in cases do
+            | SynTypeDefnSimpleRepr.Enum(cases, _er) ->
+                for SynEnumCase(attributes = attrs; range = cr) in cases do
                     rcheck Scope.EnumCase Collapse.Below cr cr
                     parseAttributes attrs
 
-            | SynTypeDefnSimpleRepr.Record (_, fields, rr) ->
+            | SynTypeDefnSimpleRepr.Record(_, fields, rr) ->
                 rcheck Scope.RecordDefn Collapse.Same rr rr
 
-                for SynField (attributes = attrs; range = fr) in fields do
+                for SynField(attributes = attrs; range = fr) in fields do
                     rcheck Scope.RecordField Collapse.Below fr fr
                     parseAttributes attrs
 
-            | SynTypeDefnSimpleRepr.Union (_, cases, ur) ->
+            | SynTypeDefnSimpleRepr.Union(_, cases, ur) ->
                 rcheck Scope.UnionDefn Collapse.Same ur ur
 
-                for SynUnionCase (attributes = attrs; range = cr) in cases do
+                for SynUnionCase(attributes = attrs; range = cr) in cases do
                     rcheck Scope.UnionCase Collapse.Below cr cr
                     parseAttributes attrs
 
             | _ -> ()
 
         and parseTypeDefn typeDefn =
-            let (SynTypeDefn (typeInfo = typeInfo; typeRepr = objectModel; members = members; range = mFull)) =
+            let (SynTypeDefn(typeInfo = typeInfo; typeRepr = objectModel; members = members; range = mFull)) =
                 typeDefn
 
-            let (SynComponentInfo (typeParams = TyparDecls typeArgs; range = r)) = typeInfo
+            let (SynComponentInfo(typeParams = TyparDecls typeArgs; range = r)) = typeInfo
             let typeArgsRange = rangeOfTypeArgsElse r typeArgs
             let collapse = Range.endToEnd (Range.modEnd 1 typeArgsRange) mFull
 
             match objectModel with
-            | SynTypeDefnRepr.ObjectModel (defnKind, objMembers, r) ->
+            | SynTypeDefnRepr.ObjectModel(defnKind, objMembers, r) ->
                 match defnKind with
                 | SynTypeDefnKind.Augmentation _ -> rcheck Scope.TypeExtension Collapse.Below mFull collapse
                 | _ -> rcheck Scope.Type Collapse.Below mFull collapse
@@ -665,7 +659,7 @@ module Structure =
                 List.iter (parseSynMemberDefn r) objMembers
                 // visit the members of a type extension
                 List.iter (parseSynMemberDefn r) members
-            | SynTypeDefnRepr.Simple (simpleRepr, r) ->
+            | SynTypeDefnRepr.Simple(simpleRepr, r) ->
                 rcheck Scope.Type Collapse.Below mFull collapse
                 parseSimpleRepr simpleRepr
                 List.iter (parseSynMemberDefn r) members
@@ -726,13 +720,13 @@ module Structure =
 
         let collectOpens =
             getConsecutiveModuleDecls Scope.Open (function
-                | SynModuleDecl.Open (_, r) -> Some r
+                | SynModuleDecl.Open(_, r) -> Some r
                 | _ -> None)
 
         let collectHashDirectives =
             getConsecutiveModuleDecls Scope.HashDirective (fun decl ->
                 match decl with
-                | SynModuleDecl.HashDirective (ParsedHashDirective (directive, _, _), r) ->
+                | SynModuleDecl.HashDirective(ParsedHashDirective(directive, _, _), r) ->
                     let prefixLength = "#".Length + directive.Length + " ".Length
                     Some(mkRange "" (mkPos r.StartLine prefixLength) r.End)
                 | _ -> None)
@@ -744,7 +738,7 @@ module Structure =
                 | ConditionalDirectiveTrivia.If _ as ifDirective :: directives -> group directives (ifDirective :: stack) sourceLines
                 | ConditionalDirectiveTrivia.Else elseRange as elseDirective :: directives ->
                     match stack with
-                    | ConditionalDirectiveTrivia.If (_, ifRange) :: stack ->
+                    | ConditionalDirectiveTrivia.If(_, ifRange) :: stack ->
                         let startLineIndex = elseRange.StartLine - 2
 
                         if startLineIndex >= 0 then
@@ -767,7 +761,7 @@ module Structure =
                     | _ -> group directives stack sourceLines
                 | ConditionalDirectiveTrivia.EndIf endIfRange :: directives ->
                     match stack with
-                    | ConditionalDirectiveTrivia.If (_, ifRange) :: stack ->
+                    | ConditionalDirectiveTrivia.If(_, ifRange) :: stack ->
                         let range = Range.startToEnd ifRange endIfRange
 
                         {
@@ -797,20 +791,20 @@ module Structure =
 
         let rec parseDeclaration (decl: SynModuleDecl) =
             match decl with
-            | SynModuleDecl.Let (_, bindings, r) ->
+            | SynModuleDecl.Let(_, bindings, r) ->
                 for binding in bindings do
                     let collapse = Range.endToEnd binding.RangeOfBindingWithoutRhs r
                     rcheck Scope.LetOrUse Collapse.Below r collapse
 
                 parseBindings bindings
 
-            | SynModuleDecl.Types (types, _r) ->
+            | SynModuleDecl.Types(types, _r) ->
                 for t in types do
                     parseTypeDefn t
 
             // Fold the attributes above a module
-            | SynModuleDecl.NestedModule (moduleInfo = moduleInfo; decls = decls) ->
-                let (SynComponentInfo (attributes = attrs; range = cmpRange)) = moduleInfo
+            | SynModuleDecl.NestedModule(moduleInfo = moduleInfo; decls = decls) ->
+                let (SynComponentInfo(attributes = attrs; range = cmpRange)) = moduleInfo
                 // Outline the full scope of the module
                 let r = Range.endToEnd cmpRange decl.Range
                 rcheck Scope.Module Collapse.Below decl.Range r
@@ -819,13 +813,13 @@ module Structure =
                 collectOpens decls
                 List.iter parseDeclaration decls
 
-            | SynModuleDecl.Expr (e, _) -> parseExpr e
+            | SynModuleDecl.Expr(e, _) -> parseExpr e
 
-            | SynModuleDecl.Attributes (attrs, _) -> parseAttributes attrs
+            | SynModuleDecl.Attributes(attrs, _) -> parseAttributes attrs
 
             | _ -> ()
 
-        let parseModuleOrNamespace (SynModuleOrNamespace (longId, _, kind, decls, _, attribs, _, r, _)) =
+        let parseModuleOrNamespace (SynModuleOrNamespace(longId, _, kind, decls, _, attribs, _, r, _)) =
             parseAttributes attribs
             let idRange = longIdentRange longId
             let mFull = Range.startToEnd idRange r
@@ -929,17 +923,17 @@ module Structure =
             | [] -> r
             | ls ->
                 match List.last ls with
-                | SynMemberSig.Inherit (range = r)
-                | SynMemberSig.Interface (range = r)
-                | SynMemberSig.Member (range = r)
-                | SynMemberSig.NestedType (range = r)
-                | SynMemberSig.ValField (range = r) -> r
+                | SynMemberSig.Inherit(range = r)
+                | SynMemberSig.Interface(range = r)
+                | SynMemberSig.Member(range = r)
+                | SynMemberSig.NestedType(range = r)
+                | SynMemberSig.ValField(range = r) -> r
 
         let lastTypeDefnSigRangeElse range (typeSigs: SynTypeDefnSig list) =
             match typeSigs with
             | [] -> range
             | ls ->
-                let (SynTypeDefnSig (members = memberSigs; range = r)) = List.last ls
+                let (SynTypeDefnSig(members = memberSigs; range = r)) = List.last ls
                 lastMemberSigRangeElse r memberSigs
 
         let lastModuleSigDeclRangeElse range (sigDecls: SynModuleSigDecl list) =
@@ -947,30 +941,30 @@ module Structure =
             | [] -> range
             | ls ->
                 match List.last ls with
-                | SynModuleSigDecl.Types (typeSigs, r) -> lastTypeDefnSigRangeElse r typeSigs
-                | SynModuleSigDecl.Val (SynValSig (range = r), _) -> r
-                | SynModuleSigDecl.Exception (_, r) -> r
-                | SynModuleSigDecl.Open (_, r) -> r
-                | SynModuleSigDecl.ModuleAbbrev (_, _, r) -> r
+                | SynModuleSigDecl.Types(typeSigs, r) -> lastTypeDefnSigRangeElse r typeSigs
+                | SynModuleSigDecl.Val(SynValSig(range = r), _) -> r
+                | SynModuleSigDecl.Exception(_, r) -> r
+                | SynModuleSigDecl.Open(_, r) -> r
+                | SynModuleSigDecl.ModuleAbbrev(_, _, r) -> r
                 | _ -> range
 
         let rec parseSynMemberDefnSig inp =
             match inp with
-            | SynMemberSig.Member (memberSig = valSigs; range = r) ->
+            | SynMemberSig.Member(memberSig = valSigs; range = r) ->
                 let collapse = Range.endToEnd valSigs.RangeOfId r
                 rcheck Scope.Member Collapse.Below r collapse
-            | SynMemberSig.ValField (SynField (attributes = attrs; range = fr), mFull) ->
+            | SynMemberSig.ValField(SynField(attributes = attrs; range = fr), mFull) ->
                 let collapse = Range.endToEnd fr mFull
                 rcheck Scope.Val Collapse.Below mFull collapse
                 parseAttributes attrs
-            | SynMemberSig.Interface (tp, r) -> rcheck Scope.Interface Collapse.Below r (Range.endToEnd tp.Range r)
-            | SynMemberSig.NestedType (typeDefSig, _r) -> parseTypeDefnSig typeDefSig
+            | SynMemberSig.Interface(tp, r) -> rcheck Scope.Interface Collapse.Below r (Range.endToEnd tp.Range r)
+            | SynMemberSig.NestedType(typeDefSig, _r) -> parseTypeDefnSig typeDefSig
             | _ -> ()
 
         and parseTypeDefnSig typeDefn =
-            let (SynTypeDefnSig (typeInfo = typeInfo; typeRepr = objectModel; members = memberSigs)) = typeDefn
+            let (SynTypeDefnSig(typeInfo = typeInfo; typeRepr = objectModel; members = memberSigs)) = typeDefn
 
-            let (SynComponentInfo (attributes = attribs; typeParams = TyparDecls typeArgs; longId = longId; range = r)) =
+            let (SynComponentInfo(attributes = attribs; typeParams = TyparDecls typeArgs; longId = longId; range = r)) =
                 typeInfo
 
             parseAttributes attribs
@@ -986,23 +980,23 @@ module Structure =
 
             match objectModel with
             // matches against a type declaration with <'T, ...> and (args, ...)
-            | SynTypeDefnSigRepr.ObjectModel (SynTypeDefnKind.Unspecified, objMembers, _) ->
+            | SynTypeDefnSigRepr.ObjectModel(SynTypeDefnKind.Unspecified, objMembers, _) ->
                 List.iter parseSynMemberDefnSig objMembers
                 let mFull, collapse = makeRanges objMembers
                 rcheck Scope.Type Collapse.Below mFull collapse
 
-            | SynTypeDefnSigRepr.ObjectModel (kind = SynTypeDefnKind.Augmentation _; memberSigs = objMembers) ->
+            | SynTypeDefnSigRepr.ObjectModel(kind = SynTypeDefnKind.Augmentation _; memberSigs = objMembers) ->
                 let mFull, collapse = makeRanges objMembers
                 rcheck Scope.TypeExtension Collapse.Below mFull collapse
                 List.iter parseSynMemberDefnSig objMembers
 
-            | SynTypeDefnSigRepr.ObjectModel (_, objMembers, _) ->
+            | SynTypeDefnSigRepr.ObjectModel(_, objMembers, _) ->
                 let mFull, collapse = makeRanges objMembers
                 rcheck Scope.Type Collapse.Below mFull collapse
                 List.iter parseSynMemberDefnSig objMembers
             // visit the members of a type extension
 
-            | SynTypeDefnSigRepr.Simple (simpleRepr, _) ->
+            | SynTypeDefnSigRepr.Simple(simpleRepr, _) ->
                 let mFull, collapse = makeRanges memberSigs
                 rcheck Scope.Type Collapse.Below mFull collapse
                 parseSimpleRepr simpleRepr
@@ -1061,29 +1055,29 @@ module Structure =
             decls
             |> getConsecutiveSigModuleDecls Scope.HashDirective (fun decl ->
                 match decl with
-                | SynModuleSigDecl.HashDirective (ParsedHashDirective (directive, _, _), r) ->
+                | SynModuleSigDecl.HashDirective(ParsedHashDirective(directive, _, _), r) ->
                     let prefixLength = "#".Length + directive.Length + " ".Length
                     Some(mkRange "" (mkPos r.StartLine prefixLength) r.End)
                 | _ -> None)
 
         let collectSigOpens =
             getConsecutiveSigModuleDecls Scope.Open (function
-                | SynModuleSigDecl.Open (_, r) -> Some r
+                | SynModuleSigDecl.Open(_, r) -> Some r
                 | _ -> None)
 
         let rec parseModuleSigDeclaration (decl: SynModuleSigDecl) =
             match decl with
-            | SynModuleSigDecl.Val (valSig, r) ->
-                let (SynValSig (attributes = attrs; ident = SynIdent (ident, _); range = valrange)) = valSig
+            | SynModuleSigDecl.Val(valSig, r) ->
+                let (SynValSig(attributes = attrs; ident = SynIdent(ident, _); range = valrange)) = valSig
                 let collapse = Range.endToEnd ident.idRange valrange
                 rcheck Scope.Val Collapse.Below r collapse
                 parseAttributes attrs
 
-            | SynModuleSigDecl.Types (typeSigs, _) -> List.iter parseTypeDefnSig typeSigs
+            | SynModuleSigDecl.Types(typeSigs, _) -> List.iter parseTypeDefnSig typeSigs
 
             // Fold the attributes above a module
-            | SynModuleSigDecl.NestedModule (moduleInfo = moduleInfo; moduleDecls = decls; range = moduleRange) ->
-                let (SynComponentInfo (attributes = attrs; range = cmpRange)) = moduleInfo
+            | SynModuleSigDecl.NestedModule(moduleInfo = moduleInfo; moduleDecls = decls; range = moduleRange) ->
+                let (SynComponentInfo(attributes = attrs; range = cmpRange)) = moduleInfo
                 let rangeEnd = lastModuleSigDeclRangeElse moduleRange decls
                 // Outline the full scope of the module
                 let collapse = Range.endToEnd cmpRange rangeEnd
@@ -1096,7 +1090,7 @@ module Structure =
             | _ -> ()
 
         let parseModuleOrNamespaceSigs moduleSig =
-            let (SynModuleOrNamespaceSig (longId, _, kind, decls, _, attribs, _, r, _)) = moduleSig
+            let (SynModuleOrNamespaceSig(longId, _, kind, decls, _, attribs, _, r, _)) = moduleSig
             parseAttributes attribs
             let rangeEnd = lastModuleSigDeclRangeElse r decls
             let idrange = longIdentRange longId

--- a/src/Compiler/Service/ServiceXmlDocParser.fs
+++ b/src/Compiler/Service/ServiceXmlDocParser.fs
@@ -16,19 +16,19 @@ module XmlDocParsing =
     let (|ConstructorPats|) =
         function
         | SynArgPats.Pats ps -> ps
-        | SynArgPats.NamePatPairs (pats = xs) -> List.map (fun (_, _, pat) -> pat) xs
+        | SynArgPats.NamePatPairs(pats = xs) -> List.map (fun (_, _, pat) -> pat) xs
 
     let rec digNamesFrom pat =
         match pat with
-        | SynPat.As (_, SynPat.Named (SynIdent (id, _), _isTheThisVar, _access, _range), _)
-        | SynPat.Named (SynIdent (id, _), _isTheThisVar, _access, _range) -> [ id.idText ]
-        | SynPat.Typed (pat, _type, _range) -> digNamesFrom pat
-        | SynPat.Attrib (pat, _attrs, _range) -> digNamesFrom pat
+        | SynPat.As(_, SynPat.Named(SynIdent(id, _), _isTheThisVar, _access, _range), _)
+        | SynPat.Named(SynIdent(id, _), _isTheThisVar, _access, _range) -> [ id.idText ]
+        | SynPat.Typed(pat, _type, _range) -> digNamesFrom pat
+        | SynPat.Attrib(pat, _attrs, _range) -> digNamesFrom pat
         | SynPat.LongIdent(argPats = ConstructorPats pats) -> pats |> List.collect digNamesFrom
-        | SynPat.ListCons (p1, p2, _, _) -> List.collect digNamesFrom [ p1; p2 ]
-        | SynPat.Tuple (elementPats = pats) -> pats |> List.collect digNamesFrom
-        | SynPat.Paren (pat, _range) -> digNamesFrom pat
-        | SynPat.OptionalVal (id, _) -> [ id.idText ]
+        | SynPat.ListCons(p1, p2, _, _) -> List.collect digNamesFrom [ p1; p2 ]
+        | SynPat.Tuple(elementPats = pats) -> pats |> List.collect digNamesFrom
+        | SynPat.Paren(pat, _range) -> digNamesFrom pat
+        | SynPat.OptionalVal(id, _) -> [ id.idText ]
         | SynPat.As _ // no one uses as in fun decls
         | SynPat.Or _ // no one uses ors in fun decls
         | SynPat.Ands _ // no one uses ands in fun decls
@@ -43,14 +43,14 @@ module XmlDocParsing =
         | SynPat.FromParseError _ -> []
 
     let getParamNames binding =
-        let (SynBinding (valData = synValData; headPat = synPat)) = binding
+        let (SynBinding(valData = synValData; headPat = synPat)) = binding
 
         match synValData with
-        | SynValData(valInfo = SynValInfo (curriedArgInfos = curriedArgs)) when not curriedArgs.IsEmpty ->
+        | SynValData(valInfo = SynValInfo(curriedArgInfos = curriedArgs)) when not curriedArgs.IsEmpty ->
             let parameters =
                 [
                     for args in curriedArgs do
-                        for (SynArgInfo (ident = ident)) in args do
+                        for (SynArgInfo(ident = ident)) in args do
                             match ident with
                             | Some ident -> ident.idText
                             | None -> ()
@@ -79,17 +79,17 @@ module XmlDocParsing =
         let rec getXmlDocablesSynModuleDecl decl =
             [
                 match decl with
-                | SynModuleDecl.NestedModule (decls = decls) ->
+                | SynModuleDecl.NestedModule(decls = decls) ->
                     for decl in decls do
                         yield! getXmlDocablesSynModuleDecl decl
-                | SynModuleDecl.Let (_, synBindingList, range) ->
+                | SynModuleDecl.Let(_, synBindingList, range) ->
                     let anyXmlDoc =
                         synBindingList
-                        |> List.exists (fun (SynBinding (xmlDoc = preXmlDoc)) -> not (isEmptyXmlDoc preXmlDoc))
+                        |> List.exists (fun (SynBinding(xmlDoc = preXmlDoc)) -> not (isEmptyXmlDoc preXmlDoc))
 
                     if not anyXmlDoc then
                         let synAttributes =
-                            synBindingList |> List.collect (fun (SynBinding (attributes = a)) -> a)
+                            synBindingList |> List.collect (fun (SynBinding(attributes = a)) -> a)
 
                         let fullRange = synAttributes |> List.fold (fun r a -> unionRanges r a.Range) range
                         let line = fullRange.StartLine
@@ -102,10 +102,10 @@ module XmlDocParsing =
                             ]
 
                         yield XmlDocable(line, indent, paramNames)
-                | SynModuleDecl.Types (typeDefns, _) ->
+                | SynModuleDecl.Types(typeDefns, _) ->
                     for typeDefn in typeDefns do
                         yield! getXmlDocablesSynTypeDefn typeDefn
-                | SynModuleDecl.NamespaceFragment (synModuleOrNamespace) -> yield! getXmlDocablesSynModuleOrNamespace synModuleOrNamespace
+                | SynModuleDecl.NamespaceFragment(synModuleOrNamespace) -> yield! getXmlDocablesSynModuleOrNamespace synModuleOrNamespace
                 | SynModuleDecl.ModuleAbbrev _
                 | SynModuleDecl.Expr _
                 | SynModuleDecl.Exception _
@@ -115,19 +115,19 @@ module XmlDocParsing =
             ]
 
         and getXmlDocablesSynModuleOrNamespace inp =
-            let (SynModuleOrNamespace (decls = decls)) = inp
+            let (SynModuleOrNamespace(decls = decls)) = inp
             decls |> List.collect getXmlDocablesSynModuleDecl
 
         and getXmlDocablesSynTypeDefn typeDefn =
-            let (SynTypeDefn (typeInfo = typeInfo; typeRepr = synTypeDefnRepr; members = synMemberDefns; range = tRange)) =
+            let (SynTypeDefn(typeInfo = typeInfo; typeRepr = synTypeDefnRepr; members = synMemberDefns; range = tRange)) =
                 typeDefn
 
-            let (SynComponentInfo (attributes = synAttributes; xmlDoc = preXmlDoc; range = compRange)) =
+            let (SynComponentInfo(attributes = synAttributes; xmlDoc = preXmlDoc; range = compRange)) =
                 typeInfo
 
             [
                 match synTypeDefnRepr with
-                | SynTypeDefnRepr.ObjectModel (_, extraMemberDefns, _) ->
+                | SynTypeDefnRepr.ObjectModel(_, extraMemberDefns, _) ->
                     for extraMemberDefn in extraMemberDefns do
                         yield! getXmlDocablesSynMemberDefn extraMemberDefn
                 | SynTypeDefnRepr.Simple _ -> ()
@@ -148,8 +148,8 @@ module XmlDocParsing =
         and getXmlDocablesSynMemberDefn inp =
             [
                 match inp with
-                | SynMemberDefn.Member (memberBinding, memRange) ->
-                    let (SynBinding (attributes = synAttributes; xmlDoc = preXmlDoc; headPat = synPat)) =
+                | SynMemberDefn.Member(memberBinding, memRange) ->
+                    let (SynBinding(attributes = synAttributes; xmlDoc = preXmlDoc; headPat = synPat)) =
                         memberBinding
 
                     if isEmptyXmlDoc preXmlDoc then
@@ -161,7 +161,7 @@ module XmlDocParsing =
                         let paramNames = digNamesFrom synPat
                         XmlDocable(line, indent, paramNames)
 
-                | SynMemberDefn.GetSetMember (getBinding, setBinding, m, _) ->
+                | SynMemberDefn.GetSetMember(getBinding, setBinding, m, _) ->
                     yield!
                         getBinding
                         |> Option.map (fun b -> SynMemberDefn.Member(b, m))
@@ -174,8 +174,8 @@ module XmlDocParsing =
                         |> Option.toList
                         |> List.collect getXmlDocablesSynMemberDefn
 
-                | SynMemberDefn.AbstractSlot (slotSig = valSig; range = range) ->
-                    let (SynValSig (attributes = synAttributes; arity = synValInfo; xmlDoc = preXmlDoc)) =
+                | SynMemberDefn.AbstractSlot(slotSig = valSig; range = range) ->
+                    let (SynValSig(attributes = synAttributes; arity = synValInfo; xmlDoc = preXmlDoc)) =
                         valSig
 
                     if isEmptyXmlDoc preXmlDoc then
@@ -185,16 +185,16 @@ module XmlDocParsing =
                         let paramNames = synValInfo.ArgNames
                         XmlDocable(line, indent, paramNames)
 
-                | SynMemberDefn.Interface (members = synMemberDefnsOption) ->
+                | SynMemberDefn.Interface(members = synMemberDefnsOption) ->
                     match synMemberDefnsOption with
                     | None -> ()
-                    | Some (xs) ->
+                    | Some(xs) ->
                         for x in xs do
                             yield! getXmlDocablesSynMemberDefn x
 
-                | SynMemberDefn.NestedType (synTypeDefn, _, _) -> yield! getXmlDocablesSynTypeDefn synTypeDefn
+                | SynMemberDefn.NestedType(synTypeDefn, _, _) -> yield! getXmlDocablesSynTypeDefn synTypeDefn
 
-                | SynMemberDefn.AutoProperty (attributes = synAttributes; range = range) ->
+                | SynMemberDefn.AutoProperty(attributes = synAttributes; range = range) ->
                     let fullRange = synAttributes |> List.fold (fun r a -> unionRanges r a.Range) range
                     let line = fullRange.StartLine
                     let indent = indentOf line

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -160,7 +160,7 @@ module CompileHelpers =
     let setOutputStreams execute =
         // Set the output streams, if requested
         match execute with
-        | Some (writer, error) ->
+        | Some(writer, error) ->
             Console.SetOut writer
             Console.SetError error
         | None -> ()
@@ -229,7 +229,7 @@ type BackgroundCompiler
             for r in options.ReferencedProjects do
 
                 match r with
-                | FSharpReferencedProject.FSharpReference (nm, opts) ->
+                | FSharpReferencedProject.FSharpReference(nm, opts) ->
                     // Don't use cross-project references for FSharp.Core, since various bits of code
                     // require a concrete FSharp.Core to exist on-disk. The only solutions that have
                     // these cross-project references to FSharp.Core are VisualFSharp.sln and FSharp.sln. The ramification
@@ -255,7 +255,7 @@ type BackgroundCompiler
                             member x.FileName = nm
                         }
 
-                | FSharpReferencedProject.PEReference (getStamp, delayedReader) ->
+                | FSharpReferencedProject.PEReference(getStamp, delayedReader) ->
                     { new IProjectReference with
                         member x.EvaluateRawContents() =
                             node {
@@ -276,7 +276,7 @@ type BackgroundCompiler
                         member x.FileName = delayedReader.OutputFile
                     }
 
-                | FSharpReferencedProject.ILModuleReference (nm, getStamp, getReader) ->
+                | FSharpReferencedProject.ILModuleReference(nm, getStamp, getReader) ->
                     { new IProjectReference with
                         member x.EvaluateRawContents() =
                             node {
@@ -588,7 +588,7 @@ type BackgroundCompiler
                 | parseResults, checkResults, _, priorTimeStamp when
                     (match builder.GetCheckResultsBeforeFileInProjectEvenIfStale fileName with
                      | None -> false
-                     | Some (tcPrior) ->
+                     | Some(tcPrior) ->
                          tcPrior.ProjectTimeStamp = priorTimeStamp
                          && builder.AreCheckResultsBeforeFileInProjectReady(fileName))
                     ->
@@ -660,7 +660,7 @@ type BackgroundCompiler
 
         node {
             match! bc.GetCachedCheckFileResult(builder, fileName, sourceText, options) with
-            | Some (_, results) -> return FSharpCheckFileAnswer.Succeeded results
+            | Some(_, results) -> return FSharpCheckFileAnswer.Succeeded results
             | _ ->
                 let lazyCheckFile =
                     getCheckFileNode (parseResults, sourceText, fileName, options, fileVersion, builder, tcPrior, tcInfo, creationDiags)
@@ -696,15 +696,15 @@ type BackgroundCompiler
                     match builderOpt with
                     | Some builder ->
                         match! bc.GetCachedCheckFileResult(builder, fileName, sourceText, options) with
-                        | Some (_, checkResults) -> return Some(builder, creationDiags, Some(FSharpCheckFileAnswer.Succeeded checkResults))
+                        | Some(_, checkResults) -> return Some(builder, creationDiags, Some(FSharpCheckFileAnswer.Succeeded checkResults))
                         | _ -> return Some(builder, creationDiags, None)
                     | _ -> return None // the builder wasn't ready
                 }
 
             match cachedResults with
             | None -> return None
-            | Some (_, _, Some x) -> return Some x
-            | Some (builder, creationDiags, None) ->
+            | Some(_, _, Some x) -> return Some x
+            | Some(builder, creationDiags, None) ->
                 Trace.TraceInformation("FCS: {0}.{1} ({2})", userOpName, "CheckFileInProjectAllowingStaleCachedResults.CacheMiss", fileName)
 
                 match builder.GetCheckResultsBeforeFileInProjectEvenIfStale fileName with
@@ -740,7 +740,7 @@ type BackgroundCompiler
                 let! cachedResults = bc.GetCachedCheckFileResult(builder, fileName, sourceText, options)
 
                 match cachedResults with
-                | Some (_, checkResults) -> return FSharpCheckFileAnswer.Succeeded checkResults
+                | Some(_, checkResults) -> return FSharpCheckFileAnswer.Succeeded checkResults
                 | _ ->
                     let! tcPrior = builder.GetCheckResultsBeforeFileInProject fileName
                     let! tcInfo = tcPrior.GetOrComputeTcInfo()
@@ -771,7 +771,7 @@ type BackgroundCompiler
                 let! cachedResults = bc.GetCachedCheckFileResult(builder, fileName, sourceText, options)
 
                 match cachedResults with
-                | Some (parseResults, checkResults) -> return (parseResults, FSharpCheckFileAnswer.Succeeded checkResults)
+                | Some(parseResults, checkResults) -> return (parseResults, FSharpCheckFileAnswer.Succeeded checkResults)
                 | _ ->
                     let! tcPrior = builder.GetCheckResultsBeforeFileInProject fileName
                     let! tcInfo = tcPrior.GetOrComputeTcInfo()
@@ -1007,7 +1007,7 @@ type BackgroundCompiler
             match resOpt with
             | Some res ->
                 match res.TryPeekValue() with
-                | ValueSome (a, b, c, _) -> Some(a, b, c)
+                | ValueSome(a, b, c, _) -> Some(a, b, c)
                 | ValueNone -> None
             | None -> None
         | None -> None
@@ -1103,7 +1103,7 @@ type BackgroundCompiler
         match tryGetBuilderNode options with
         | Some lazyWork ->
             match lazyWork.TryPeekValue() with
-            | ValueSome (Some builder, _) -> Some(builder.GetLogicalTimeStampForProject(cache))
+            | ValueSome(Some builder, _) -> Some(builder.GetLogicalTimeStampForProject(cache))
             | _ -> None
         | _ -> None
 
@@ -1216,7 +1216,14 @@ type BackgroundCompiler
             let diags =
                 loadClosure.LoadClosureRootFileDiagnostics
                 |> List.map (fun (exn, isError) ->
-                    FSharpDiagnostic.CreateFromException(exn, isError, range.Zero, false, options.OtherOptions |> Array.contains "--flaterrors", None))
+                    FSharpDiagnostic.CreateFromException(
+                        exn,
+                        isError,
+                        range.Zero,
+                        false,
+                        options.OtherOptions |> Array.contains "--flaterrors",
+                        None
+                    ))
 
             return options, (diags @ diagnostics.Diagnostics)
         }
@@ -1413,7 +1420,7 @@ type FSharpChecker
 
         let useChangeNotifications =
             match documentSource with
-            | Some (DocumentSource.Custom _) -> true
+            | Some(DocumentSource.Custom _) -> true
             | _ -> false
 
         let useSyntaxTreeCache = defaultArg useSyntaxTreeCache true
@@ -1436,7 +1443,7 @@ type FSharpChecker
             parallelReferenceResolution,
             captureIdentifiersWhenParsing,
             (match documentSource with
-             | Some (DocumentSource.Custom f) -> Some f
+             | Some(DocumentSource.Custom f) -> Some f
              | _ -> None),
             useChangeNotifications,
             useSyntaxTreeCache

--- a/src/Compiler/Service/service.fsi
+++ b/src/Compiler/Service/service.fsi
@@ -54,8 +54,10 @@ type public FSharpChecker =
         ?enablePartialTypeChecking: bool *
         ?parallelReferenceResolution: bool *
         ?captureIdentifiersWhenParsing: bool *
-        [<Experimental "This parameter is experimental and likely to be removed in the future.">] ?documentSource: DocumentSource *
-        [<Experimental "This parameter is experimental and likely to be removed in the future.">] ?useSyntaxTreeCache: bool ->
+        [<Experimental "This parameter is experimental and likely to be removed in the future.">] ?documentSource:
+            DocumentSource *
+        [<Experimental "This parameter is experimental and likely to be removed in the future.">] ?useSyntaxTreeCache:
+            bool ->
             FSharpChecker
 
     /// <summary>
@@ -421,6 +423,7 @@ type public FSharpChecker =
 
     [<Obsolete("Please create an instance of FSharpChecker using FSharpChecker.Create")>]
     static member Instance: FSharpChecker
+
     member internal FrameworkImportsCache: FrameworkImportsCache
     member internal ReferenceResolver: LegacyReferenceResolver
 

--- a/src/Compiler/Symbols/Exprs.fsi
+++ b/src/Compiler/Symbols/Exprs.fsi
@@ -126,7 +126,12 @@ module public FSharpExprPatterns =
     /// Like Call but also indicates witness arguments
     val (|CallWithWitnesses|_|):
         FSharpExpr ->
-            (FSharpExpr option * FSharpMemberOrFunctionOrValue * FSharpType list * FSharpType list * FSharpExpr list * FSharpExpr list) option
+            (FSharpExpr option *
+            FSharpMemberOrFunctionOrValue *
+            FSharpType list *
+            FSharpType list *
+            FSharpExpr list *
+            FSharpExpr list) option
 
     /// Matches expressions which are calls to object constructors
     val (|NewObject|_|): FSharpExpr -> (FSharpMemberOrFunctionOrValue * FSharpType list * FSharpExpr list) option
@@ -225,7 +230,13 @@ module public FSharpExprPatterns =
     /// Matches try/with expressions
     val (|TryWith|_|):
         FSharpExpr ->
-            (FSharpExpr * FSharpMemberOrFunctionOrValue * FSharpExpr * FSharpMemberOrFunctionOrValue * FSharpExpr * DebugPointAtTry * DebugPointAtWith) option
+            (FSharpExpr *
+            FSharpMemberOrFunctionOrValue *
+            FSharpExpr *
+            FSharpMemberOrFunctionOrValue *
+            FSharpExpr *
+            DebugPointAtTry *
+            DebugPointAtWith) option
 
     /// Matches expressions which create an instance of a delegate type
     val (|NewDelegate|_|): FSharpExpr -> (FSharpType * FSharpExpr) option

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -84,6 +84,7 @@ type FSharpSymbol =
     static member internal Create:
         g: TcGlobals * thisCcu: CcuThunk * thisCcuTyp: ModuleOrNamespaceType * tcImports: TcImports * item: Item ->
             FSharpSymbol
+
     static member internal Create: cenv: SymbolEnv * item: Item -> FSharpSymbol
 
     /// Computes if the symbol is accessible for the given accessibility rights
@@ -1062,6 +1063,7 @@ type FSharpType =
     internal new:
         g: TcGlobals * thisCcu: CcuThunk * thisCcuTyp: ModuleOrNamespaceType * tcImports: TcImports * ty: TType ->
             FSharpType
+
     internal new: SymbolEnv * ty: TType -> FSharpType
 
     /// Indicates this is a named type in an unresolved assembly

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -98,13 +98,13 @@ module LexbufLocalXmlDocStore =
         | true, collector -> collector
         | _ ->
             let collector = box (XmlDocCollector())
-            lexbuf.BufferLocalStore[ xmlDocKey ] <- collector
+            lexbuf.BufferLocalStore[xmlDocKey] <- collector
             collector
 
         |> unbox<XmlDocCollector>
 
     let ClearXmlDoc (lexbuf: Lexbuf) =
-        lexbuf.BufferLocalStore[ xmlDocKey ] <- box (XmlDocCollector())
+        lexbuf.BufferLocalStore[xmlDocKey] <- box (XmlDocCollector())
 
     /// Called from the lexer to save a single line of XML doc comment.
     let SaveXmlDocLine (lexbuf: Lexbuf, lineText, range: range) =
@@ -173,8 +173,8 @@ type LexerIfdefExpression =
 
 let rec LexerIfdefEval (lookup: string -> bool) =
     function
-    | IfdefAnd (l, r) -> (LexerIfdefEval lookup l) && (LexerIfdefEval lookup r)
-    | IfdefOr (l, r) -> (LexerIfdefEval lookup l) || (LexerIfdefEval lookup r)
+    | IfdefAnd(l, r) -> (LexerIfdefEval lookup l) && (LexerIfdefEval lookup r)
+    | IfdefOr(l, r) -> (LexerIfdefEval lookup l) || (LexerIfdefEval lookup r)
     | IfdefNot e -> not (LexerIfdefEval lookup e)
     | IfdefId id -> lookup id
 
@@ -189,7 +189,7 @@ module LexbufIfdefStore =
         | true, store -> store
         | _ ->
             let store = box (ResizeArray<ConditionalDirectiveTrivia>())
-            lexbuf.BufferLocalStore[ ifDefKey ] <- store
+            lexbuf.BufferLocalStore[ifDefKey] <- store
             store
         |> unbox<ResizeArray<ConditionalDirectiveTrivia>>
 
@@ -203,8 +203,8 @@ module LexbufIfdefStore =
         let expr =
             let rec visit (expr: LexerIfdefExpression) : IfDirectiveExpression =
                 match expr with
-                | LexerIfdefExpression.IfdefAnd (l, r) -> IfDirectiveExpression.And(visit l, visit r)
-                | LexerIfdefExpression.IfdefOr (l, r) -> IfDirectiveExpression.Or(visit l, visit r)
+                | LexerIfdefExpression.IfdefAnd(l, r) -> IfDirectiveExpression.And(visit l, visit r)
+                | LexerIfdefExpression.IfdefOr(l, r) -> IfDirectiveExpression.Or(visit l, visit r)
                 | LexerIfdefExpression.IfdefNot e -> IfDirectiveExpression.Not(visit e)
                 | LexerIfdefExpression.IfdefId id -> IfDirectiveExpression.Ident id
 
@@ -238,7 +238,7 @@ module LexbufCommentStore =
         | true, store -> store
         | _ ->
             let store = box (ResizeArray<CommentTrivia>())
-            lexbuf.BufferLocalStore[ commentKey ] <- store
+            lexbuf.BufferLocalStore[commentKey] <- store
             store
         |> unbox<ResizeArray<CommentTrivia>>
 
@@ -341,25 +341,25 @@ type LexerContinuation =
 
     member x.LexerIfdefStack =
         match x with
-        | LexCont.Token (ifdef = ifd)
-        | LexCont.IfDefSkip (ifdef = ifd)
-        | LexCont.String (ifdef = ifd)
-        | LexCont.Comment (ifdef = ifd)
-        | LexCont.SingleLineComment (ifdef = ifd)
-        | LexCont.StringInComment (ifdef = ifd)
-        | LexCont.EndLine (ifdef = ifd)
-        | LexCont.MLOnly (ifdef = ifd) -> ifd
+        | LexCont.Token(ifdef = ifd)
+        | LexCont.IfDefSkip(ifdef = ifd)
+        | LexCont.String(ifdef = ifd)
+        | LexCont.Comment(ifdef = ifd)
+        | LexCont.SingleLineComment(ifdef = ifd)
+        | LexCont.StringInComment(ifdef = ifd)
+        | LexCont.EndLine(ifdef = ifd)
+        | LexCont.MLOnly(ifdef = ifd) -> ifd
 
     member x.LexerInterpStringNesting =
         match x with
-        | LexCont.Token (nesting = nesting)
-        | LexCont.IfDefSkip (nesting = nesting)
-        | LexCont.String (nesting = nesting)
-        | LexCont.Comment (nesting = nesting)
-        | LexCont.SingleLineComment (nesting = nesting)
-        | LexCont.StringInComment (nesting = nesting)
-        | LexCont.EndLine (nesting = nesting)
-        | LexCont.MLOnly (nesting = nesting) -> nesting
+        | LexCont.Token(nesting = nesting)
+        | LexCont.IfDefSkip(nesting = nesting)
+        | LexCont.String(nesting = nesting)
+        | LexCont.Comment(nesting = nesting)
+        | LexCont.SingleLineComment(nesting = nesting)
+        | LexCont.StringInComment(nesting = nesting)
+        | LexCont.EndLine(nesting = nesting)
+        | LexCont.MLOnly(nesting = nesting) -> nesting
 
 and LexCont = LexerContinuation
 
@@ -424,7 +424,8 @@ let mkSynMemberDefnGetSet
     (parseState: IParseState)
     (opt_inline: range option)
     (mWith: range)
-    (classDefnMemberGetSetElements: (range option * SynAttributeList list * (SynPat * range) * (range option * SynReturnInfo) option * range option * SynExpr * range) list)
+    (classDefnMemberGetSetElements:
+        (range option * SynAttributeList list * (SynPat * range) * (range option * SynReturnInfo) option * range option * SynExpr * range) list)
     (mAnd: range option)
     (mWhole: range)
     (propertyNameBindingPat: SynPat)
@@ -491,18 +492,18 @@ let mkSynMemberDefnGetSet
                  Some(memFlagsBuilder SynMemberKind.Member),
                  trivia)
 
-        let (SynBinding (accessibility = vis; isInline = isInline; attributes = attrs; headPat = pv; range = mBindLhs)) =
+        let (SynBinding(accessibility = vis; isInline = isInline; attributes = attrs; headPat = pv; range = mBindLhs)) =
             binding
 
         let memberKind =
             let getset =
                 let rec go p =
                     match p with
-                    | SynPat.LongIdent(longDotId = SynLongIdent ([ id ], _, _)) -> id.idText
-                    | SynPat.Named (SynIdent (nm, _), _, _, _)
-                    | SynPat.As (_, SynPat.Named (SynIdent (nm, _), _, _, _), _) -> nm.idText
-                    | SynPat.Typed (p, _, _) -> go p
-                    | SynPat.Attrib (p, _, _) -> go p
+                    | SynPat.LongIdent(longDotId = SynLongIdent([ id ], _, _)) -> id.idText
+                    | SynPat.Named(SynIdent(nm, _), _, _, _)
+                    | SynPat.As(_, SynPat.Named(SynIdent(nm, _), _, _, _), _) -> nm.idText
+                    | SynPat.Typed(p, _, _) -> go p
+                    | SynPat.Attrib(p, _, _) -> go p
                     | _ -> raiseParseErrorAt mBindLhs (FSComp.SR.parsInvalidDeclarationSyntax ())
 
                 go pv
@@ -559,14 +560,14 @@ let mkSynMemberDefnGetSet
                      Some(memFlagsBuilder memberKind),
                      trivia)
 
-            let (SynBinding (vis, _, isInline, _, attrs, doc, valSynData, pv, rhsRetInfo, rhsExpr, mBindLhs, spBind, trivia)) =
+            let (SynBinding(vis, _, isInline, _, attrs, doc, valSynData, pv, rhsRetInfo, rhsExpr, mBindLhs, spBind, trivia)) =
                 binding
 
             let mWholeBindLhs =
                 (mBindLhs, attrs)
                 ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
 
-            let (SynValData (valInfo = valSynInfo)) = valSynData
+            let (SynValData(valInfo = valSynInfo)) = valSynData
 
             // Setters have all arguments tupled in their internal TAST form, though they don't appear to be
             // tupled from the syntax
@@ -579,34 +580,34 @@ let mkSynMemberDefnGetSet
                     | _ -> SynInfo.unnamedTopArg
 
                 match memberKind, valSynInfo, memFlags.IsInstance with
-                | SynMemberKind.PropertyGet, SynValInfo ([], _ret), false
-                | SynMemberKind.PropertyGet, SynValInfo ([ _ ], _ret), true ->
+                | SynMemberKind.PropertyGet, SynValInfo([], _ret), false
+                | SynMemberKind.PropertyGet, SynValInfo([ _ ], _ret), true ->
                     raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsGetterMustHaveAtLeastOneArgument ())
 
-                | SynMemberKind.PropertyGet, SynValInfo (thisArg :: indexOrUnitArgs :: rest, ret), true ->
+                | SynMemberKind.PropertyGet, SynValInfo(thisArg :: indexOrUnitArgs :: rest, ret), true ->
                     if not rest.IsEmpty then
                         reportParseErrorAt mWholeBindLhs (FSComp.SR.parsGetterAtMostOneArgument ())
 
                     SynValInfo([ thisArg; indexOrUnitArgs ], ret)
 
-                | SynMemberKind.PropertyGet, SynValInfo (indexOrUnitArgs :: rest, ret), false ->
+                | SynMemberKind.PropertyGet, SynValInfo(indexOrUnitArgs :: rest, ret), false ->
                     if not rest.IsEmpty then
                         reportParseErrorAt mWholeBindLhs (FSComp.SR.parsGetterAtMostOneArgument ())
 
                     SynValInfo([ indexOrUnitArgs ], ret)
 
-                | SynMemberKind.PropertySet, SynValInfo ([ thisArg; valueArg ], ret), true ->
+                | SynMemberKind.PropertySet, SynValInfo([ thisArg; valueArg ], ret), true ->
                     SynValInfo([ thisArg; adjustValueArg valueArg ], ret)
 
-                | SynMemberKind.PropertySet, SynValInfo (thisArg :: indexArgs :: valueArg :: rest, ret), true ->
+                | SynMemberKind.PropertySet, SynValInfo(thisArg :: indexArgs :: valueArg :: rest, ret), true ->
                     if not rest.IsEmpty then
                         reportParseErrorAt mWholeBindLhs (FSComp.SR.parsSetterAtMostTwoArguments ())
 
                     SynValInfo([ thisArg; indexArgs @ adjustValueArg valueArg ], ret)
 
-                | SynMemberKind.PropertySet, SynValInfo ([ valueArg ], ret), false -> SynValInfo([ adjustValueArg valueArg ], ret)
+                | SynMemberKind.PropertySet, SynValInfo([ valueArg ], ret), false -> SynValInfo([ adjustValueArg valueArg ], ret)
 
-                | SynMemberKind.PropertySet, SynValInfo (indexArgs :: valueArg :: rest, ret), _ ->
+                | SynMemberKind.PropertySet, SynValInfo(indexArgs :: valueArg :: rest, ret), _ ->
                     if not rest.IsEmpty then
                         reportParseErrorAt mWholeBindLhs (FSComp.SR.parsSetterAtMostTwoArguments ())
 
@@ -639,14 +640,14 @@ let mkSynMemberDefnGetSet
                          Some(memFlagsBuilder SynMemberKind.Member),
                          trivia)
 
-                let (SynBinding (_, _, _, _, _, doc2, _, bindingPatOuter, _, _, _, _, _)) =
+                let (SynBinding(_, _, _, _, _, doc2, _, bindingPatOuter, _, _, _, _, _)) =
                     bindingOuter
 
                 let lidOuter, lidVisOuter =
                     match bindingPatOuter with
-                    | SynPat.LongIdent (lid, _, None, SynArgPats.Pats [], lidVisOuter, _m) -> lid, lidVisOuter
-                    | SynPat.Named (SynIdent (id, _), _, visOuter, _m)
-                    | SynPat.As (_, SynPat.Named (SynIdent (id, _), _, visOuter, _m), _) -> SynLongIdent([ id ], [], [ None ]), visOuter
+                    | SynPat.LongIdent(lid, _, None, SynArgPats.Pats [], lidVisOuter, _m) -> lid, lidVisOuter
+                    | SynPat.Named(SynIdent(id, _), _, visOuter, _m)
+                    | SynPat.As(_, SynPat.Named(SynIdent(id, _), _, visOuter, _m), _) -> SynLongIdent([ id ], [], [ None ]), visOuter
                     | _ -> raiseParseErrorAt mWholeBindLhs (FSComp.SR.parsInvalidDeclarationSyntax ())
 
                 // Merge the visibility from the outer point with the inner point, e.g.
@@ -664,17 +665,18 @@ let mkSynMemberDefnGetSet
                 // Replace the "get" or the "set" with the right name
                 let rec go p =
                     match p with
-                    | SynPat.LongIdent (longDotId = SynLongIdent ([ id ], _, _)
-                                        typarDecls = tyargs
-                                        argPats = SynArgPats.Pats args
-                                        accessibility = lidVisInner
-                                        range = m) ->
+                    | SynPat.LongIdent(
+                        longDotId = SynLongIdent([ id ], _, _)
+                        typarDecls = tyargs
+                        argPats = SynArgPats.Pats args
+                        accessibility = lidVisInner
+                        range = m) ->
                         // Setters have all arguments tupled in their internal form, though they don't
                         // appear to be tupled from the syntax. Somewhat unfortunate
                         let args =
                             if id.idText = "set" then
                                 match args with
-                                | [ SynPat.Paren (SynPat.Tuple (false, indexPats, commas, _), indexPatRange); valuePat ] when
+                                | [ SynPat.Paren(SynPat.Tuple(false, indexPats, commas, _), indexPatRange); valuePat ] when
                                     id.idText = "set"
                                     ->
                                     [
@@ -687,13 +689,13 @@ let mkSynMemberDefnGetSet
                                 args
 
                         SynPat.LongIdent(lidOuter, Some id, tyargs, SynArgPats.Pats args, mergeLidVisOuter lidVisInner, m), Some id
-                    | SynPat.Named (_, _, lidVisInner, m)
-                    | SynPat.As (_, SynPat.Named (_, _, lidVisInner, m), _) ->
+                    | SynPat.Named(_, _, lidVisInner, m)
+                    | SynPat.As(_, SynPat.Named(_, _, lidVisInner, m), _) ->
                         SynPat.LongIdent(lidOuter, None, None, SynArgPats.Pats [], mergeLidVisOuter lidVisInner, m), None
-                    | SynPat.Typed (p, ty, m) ->
+                    | SynPat.Typed(p, ty, m) ->
                         let p, id = go p
                         SynPat.Typed(p, ty, m), id
-                    | SynPat.Attrib (p, attribs, m) ->
+                    | SynPat.Attrib(p, attribs, m) ->
                         let p, id = go p
                         SynPat.Attrib(p, attribs, m), id
                     | SynPat.Wild m -> SynPat.Wild(m), None
@@ -727,10 +729,10 @@ let mkSynMemberDefnGetSet
     match classDefnMemberGetSetElements with
     | [ h ] ->
         match tryMkSynMemberDefnMember h with
-        | Some (memberDefn, getSetIdentOpt) ->
+        | Some(memberDefn, getSetIdentOpt) ->
             match memberDefn, getSetIdentOpt with
             | SynMemberDefn.Member _, None -> [ memberDefn ]
-            | SynMemberDefn.Member (binding, m), Some getOrSet ->
+            | SynMemberDefn.Member(binding, m), Some getOrSet ->
                 if getOrSet.idText = "get" then
                     let trivia =
                         {
@@ -760,8 +762,8 @@ let mkSynMemberDefnGetSet
         let setter = tryMkSynMemberDefnMember s
 
         match getter, setter with
-        | Some (SynMemberDefn.Member (getBinding, m1), GetIdent mGet), Some (SynMemberDefn.Member (setBinding, m2), SetIdent mSet)
-        | Some (SynMemberDefn.Member (setBinding, m1), SetIdent mSet), Some (SynMemberDefn.Member (getBinding, m2), GetIdent mGet) ->
+        | Some(SynMemberDefn.Member(getBinding, m1), GetIdent mGet), Some(SynMemberDefn.Member(setBinding, m2), SetIdent mSet)
+        | Some(SynMemberDefn.Member(setBinding, m1), SetIdent mSet), Some(SynMemberDefn.Member(getBinding, m2), GetIdent mGet) ->
             let range = unionRanges m1 m2
 
             let trivia =
@@ -774,8 +776,8 @@ let mkSynMemberDefnGetSet
                 }
 
             [ SynMemberDefn.GetSetMember(Some getBinding, Some setBinding, range, trivia) ]
-        | Some (SynMemberDefn.Member (binding, m), getOrSet), None
-        | None, Some (SynMemberDefn.Member (binding, m), getOrSet) ->
+        | Some(SynMemberDefn.Member(binding, m), getOrSet), None
+        | None, Some(SynMemberDefn.Member(binding, m), getOrSet) ->
             let trivia =
                 match getOrSet with
                 | GetIdent mGet ->
@@ -823,21 +825,21 @@ let mkSynMemberDefnGetSet
 let adjustHatPrefixToTyparLookup mFull rightExpr =
     let rec take inp =
         match inp with
-        | SynExpr.Ident (typarIdent)
-        | SynExpr.LongIdent (false, SynLongIdent ([ typarIdent ], _, _), None, _) ->
+        | SynExpr.Ident(typarIdent)
+        | SynExpr.LongIdent(false, SynLongIdent([ typarIdent ], _, _), None, _) ->
             let typar = SynTypar(typarIdent, TyparStaticReq.HeadType, false)
             SynExpr.Typar(typar, mFull)
-        | SynExpr.LongIdent (false, SynLongIdent ((typarIdent :: items), (dotm :: dots), (_ :: itemTrivias)), None, _) ->
+        | SynExpr.LongIdent(false, SynLongIdent((typarIdent :: items), (dotm :: dots), (_ :: itemTrivias)), None, _) ->
             let typar = SynTypar(typarIdent, TyparStaticReq.HeadType, false)
             let lookup = SynLongIdent(items, dots, itemTrivias)
             SynExpr.DotGet(SynExpr.Typar(typar, mFull), dotm, lookup, mFull)
-        | SynExpr.App (isAtomic, false, funcExpr, argExpr, m) ->
+        | SynExpr.App(isAtomic, false, funcExpr, argExpr, m) ->
             let funcExpr2 = take funcExpr
             SynExpr.App(isAtomic, false, funcExpr2, argExpr, unionRanges funcExpr2.Range m)
-        | SynExpr.DotGet (leftExpr, dotm, lookup, m) ->
+        | SynExpr.DotGet(leftExpr, dotm, lookup, m) ->
             let leftExpr2 = take leftExpr
             SynExpr.DotGet(leftExpr2, dotm, lookup, m)
-        | SynExpr.DotIndexedGet (leftExpr, indexArg, dotm, m) ->
+        | SynExpr.DotIndexedGet(leftExpr, indexArg, dotm, m) ->
             let leftExpr2 = take leftExpr
             SynExpr.DotIndexedGet(leftExpr2, indexArg, dotm, m)
         | _ ->
@@ -926,46 +928,45 @@ let unionRangeWithPos (r: range) p =
 /// Report a good error at the end of file, e.g. for non-terminated strings
 let checkEndOfFileError t =
     match t with
-    | LexCont.IfDefSkip (_, _, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInHashIf ())
+    | LexCont.IfDefSkip(_, _, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInHashIf ())
 
-    | LexCont.String (_, _, LexerStringStyle.SingleQuote, kind, _, m) ->
+    | LexCont.String(_, _, LexerStringStyle.SingleQuote, kind, _, m) ->
         if kind.IsInterpolated then
             reportParseErrorAt m (FSComp.SR.parsEofInInterpolatedString ())
         else
             reportParseErrorAt m (FSComp.SR.parsEofInString ())
 
-    | LexCont.String (_, _, LexerStringStyle.ExtendedInterpolated, kind, _, m)
-    | LexCont.String (_, _, LexerStringStyle.TripleQuote, kind, _, m) ->
+    | LexCont.String(_, _, LexerStringStyle.ExtendedInterpolated, kind, _, m)
+    | LexCont.String(_, _, LexerStringStyle.TripleQuote, kind, _, m) ->
         if kind.IsInterpolated then
             reportParseErrorAt m (FSComp.SR.parsEofInInterpolatedTripleQuoteString ())
         else
             reportParseErrorAt m (FSComp.SR.parsEofInTripleQuoteString ())
 
-    | LexCont.String (_, _, LexerStringStyle.Verbatim, kind, _, m) ->
+    | LexCont.String(_, _, LexerStringStyle.Verbatim, kind, _, m) ->
         if kind.IsInterpolated then
             reportParseErrorAt m (FSComp.SR.parsEofInInterpolatedVerbatimString ())
         else
             reportParseErrorAt m (FSComp.SR.parsEofInVerbatimString ())
 
-    | LexCont.Comment (_, _, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInComment ())
+    | LexCont.Comment(_, _, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInComment ())
 
-    | LexCont.SingleLineComment (_, _, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInComment ())
+    | LexCont.SingleLineComment(_, _, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInComment ())
 
-    | LexCont.StringInComment (_, _, LexerStringStyle.SingleQuote, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInStringInComment ())
+    | LexCont.StringInComment(_, _, LexerStringStyle.SingleQuote, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInStringInComment ())
 
-    | LexCont.StringInComment (_, _, LexerStringStyle.Verbatim, _, m) ->
-        reportParseErrorAt m (FSComp.SR.parsEofInVerbatimStringInComment ())
+    | LexCont.StringInComment(_, _, LexerStringStyle.Verbatim, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInVerbatimStringInComment ())
 
-    | LexCont.StringInComment (_, _, LexerStringStyle.ExtendedInterpolated, _, m)
-    | LexCont.StringInComment (_, _, LexerStringStyle.TripleQuote, _, m) ->
+    | LexCont.StringInComment(_, _, LexerStringStyle.ExtendedInterpolated, _, m)
+    | LexCont.StringInComment(_, _, LexerStringStyle.TripleQuote, _, m) ->
         reportParseErrorAt m (FSComp.SR.parsEofInTripleQuoteStringInComment ())
 
-    | LexCont.MLOnly (_, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInIfOcaml ())
+    | LexCont.MLOnly(_, _, m) -> reportParseErrorAt m (FSComp.SR.parsEofInIfOcaml ())
 
-    | LexCont.EndLine (_, _, LexerEndlineContinuation.Skip (_, m)) -> reportParseErrorAt m (FSComp.SR.parsEofInDirective ())
+    | LexCont.EndLine(_, _, LexerEndlineContinuation.Skip(_, m)) -> reportParseErrorAt m (FSComp.SR.parsEofInDirective ())
 
-    | LexCont.EndLine (endifs, nesting, LexerEndlineContinuation.Token)
-    | LexCont.Token (endifs, nesting) ->
+    | LexCont.EndLine(endifs, nesting, LexerEndlineContinuation.Token)
+    | LexCont.Token(endifs, nesting) ->
         match endifs with
         | [] -> ()
         | (_, m) :: _ -> reportParseErrorAt m (FSComp.SR.parsNoHashEndIfFound ())
@@ -982,7 +983,7 @@ let mkClassMemberLocalBindings
         initialRangeOpt,
         attrs,
         vis,
-        BindingSetPreAttrs (_, isRec, isUse, declsPreAttrs, bindingSetRange)
+        BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, bindingSetRange)
     ) =
     let ignoredFreeAttrs, decls = declsPreAttrs attrs vis
 
@@ -991,7 +992,7 @@ let mkClassMemberLocalBindings
         | None -> bindingSetRange
         | Some m -> unionRanges m bindingSetRange
         // decls could have a leading attribute
-        |> fun m -> (m, decls) ||> unionRangeWithListBy (fun (SynBinding (range = m)) -> m)
+        |> fun m -> (m, decls) ||> unionRangeWithListBy (fun (SynBinding(range = m)) -> m)
 
     if not (isNil ignoredFreeAttrs) then
         warning (Error(FSComp.SR.parsAttributesIgnored (), mWhole))
@@ -1002,11 +1003,11 @@ let mkClassMemberLocalBindings
     let decls =
         match initialRangeOpt, decls with
         | _, [] -> []
-        | Some mStatic, SynBinding (a0, k, il, im, a, x, v, h, ri, e, m, dp, trivia) :: rest ->
+        | Some mStatic, SynBinding(a0, k, il, im, a, x, v, h, ri, e, m, dp, trivia) :: rest ->
             // prepend static keyword to existing leading keyword.
             let trivia =
                 match trivia.LeadingKeyword with
-                | SynLeadingKeyword.LetRec (mLet, mRec) ->
+                | SynLeadingKeyword.LetRec(mLet, mRec) ->
                     { trivia with
                         LeadingKeyword = SynLeadingKeyword.StaticLetRec(mStatic, mLet, mRec)
                     }
@@ -1025,12 +1026,12 @@ let mkClassMemberLocalBindings
 
     SynMemberDefn.LetBindings(decls, isStatic, isRec, mWhole)
 
-let mkLocalBindings (mWhole, BindingSetPreAttrs (_, isRec, isUse, declsPreAttrs, _), mIn, body: SynExpr) =
+let mkLocalBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _), mIn, body: SynExpr) =
     let ignoredFreeAttrs, decls = declsPreAttrs [] None
 
     let mWhole =
         match decls with
-        | SynBinding (xmlDoc = xmlDoc) :: _ -> unionRangeWithXmlDoc xmlDoc mWhole
+        | SynBinding(xmlDoc = xmlDoc) :: _ -> unionRangeWithXmlDoc xmlDoc mWhole
         | _ -> mWhole
 
     if not (isNil ignoredFreeAttrs) then
@@ -1046,14 +1047,14 @@ let mkLocalBindings (mWhole, BindingSetPreAttrs (_, isRec, isUse, declsPreAttrs,
 
     SynExpr.LetOrUse(isRec, isUse, decls, body, mWhole, { InKeyword = mIn })
 
-let mkDefnBindings (mWhole, BindingSetPreAttrs (_, isRec, isUse, declsPreAttrs, _bindingSetRange), attrs, vis, attrsm) =
+let mkDefnBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _bindingSetRange), attrs, vis, attrsm) =
     if isUse then
         warning (Error(FSComp.SR.parsUseBindingsIllegalInModules (), mWhole))
 
     let freeAttrs, decls = declsPreAttrs attrs vis
     // decls might have an extended range due to leading attributes
     let mWhole =
-        (mWhole, decls) ||> unionRangeWithListBy (fun (SynBinding (range = m)) -> m)
+        (mWhole, decls) ||> unionRangeWithListBy (fun (SynBinding(range = m)) -> m)
 
     let letDecls = [ SynModuleDecl.Let(isRec, decls, mWhole) ]
 
@@ -1068,9 +1069,8 @@ let mkDefnBindings (mWhole, BindingSetPreAttrs (_, isRec, isUse, declsPreAttrs, 
 let idOfPat (parseState: IParseState) m p =
     match p with
     | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop -> mkSynId r "_"
-    | SynPat.Named (SynIdent (id, _), false, _, _) -> id
-    | SynPat.LongIdent (longDotId = SynLongIdent ([ id ], _, _); typarDecls = None; argPats = SynArgPats.Pats []; accessibility = None) ->
-        id
+    | SynPat.Named(SynIdent(id, _), false, _, _) -> id
+    | SynPat.LongIdent(longDotId = SynLongIdent([ id ], _, _); typarDecls = None; argPats = SynArgPats.Pats []; accessibility = None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier ())
 
 let checkForMultipleAugmentations m a1 a2 =
@@ -1085,10 +1085,10 @@ let rangeOfLongIdent (lid: LongIdent) =
 
 let appendValToLeadingKeyword mVal leadingKeyword =
     match leadingKeyword with
-    | SynLeadingKeyword.StaticMember (mStatic, mMember) -> SynLeadingKeyword.StaticMemberVal(mStatic, mMember, mVal)
+    | SynLeadingKeyword.StaticMember(mStatic, mMember) -> SynLeadingKeyword.StaticMemberVal(mStatic, mMember, mVal)
     | SynLeadingKeyword.Member mMember -> SynLeadingKeyword.MemberVal(mMember, mVal)
     | SynLeadingKeyword.Override mOverride -> SynLeadingKeyword.OverrideVal(mOverride, mVal)
-    | SynLeadingKeyword.Default (mDefault) -> SynLeadingKeyword.DefaultVal(mDefault, mVal)
+    | SynLeadingKeyword.Default(mDefault) -> SynLeadingKeyword.DefaultVal(mDefault, mVal)
     | _ -> leadingKeyword
 
 let mkSynUnionCase attributes (access: SynAccess option) id kind mDecl (xmlDoc, mBar) =
@@ -1106,7 +1106,7 @@ let mkAutoPropDefn mVal access ident typ mEquals (expr: SynExpr) accessors xmlDo
     let memberRange =
         match getSetOpt with
         | None -> unionRanges rangeStart expr.Range |> unionRangeWithXmlDoc xmlDoc
-        | Some (getSet: GetSetKeywords) ->
+        | Some(getSet: GetSetKeywords) ->
             unionRanges rangeStart expr.Range
             |> unionRangeWithXmlDoc xmlDoc
             |> unionRanges getSet.Range

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -178,7 +178,14 @@ val mkSynMemberDefnGetSet:
     parseState: IParseState ->
     opt_inline: range option ->
     mWith: range ->
-    classDefnMemberGetSetElements: (range option * SynAttributeList list * (SynPat * range) * (range option * SynReturnInfo) option * range option * SynExpr * range) list ->
+    classDefnMemberGetSetElements:
+        (range option *
+        SynAttributeList list *
+        (SynPat * range) *
+        (range option * SynReturnInfo) option *
+        range option *
+        SynExpr *
+        range) list ->
     mAnd: range option ->
     mWhole: range ->
     propertyNameBindingPat: SynPat ->

--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -288,6 +288,7 @@ let IsIdentifierName (name: string) =
        && IsIdentifierFirstCharacter name[0]
        && let rec loop i =
            (i >= nameLen || (IsIdentifierPartCharacter(name[i]) && loop (i + 1))) in
+
           loop 1
 
 let rec isCoreActivePatternName (name: string) idx seenNonOpChar =
@@ -484,7 +485,7 @@ let decompileCustomOpName =
                     | None ->
                         // Couldn't decompile, so just return the original 'opName'.
                         opName
-                    | Some (opChar, opCharName) ->
+                    | Some(opChar, opCharName) ->
                         // 'opCharName' matched the current position in 'opName'.
                         // Append the corresponding operator character to the StringBuilder
                         // and continue decompiling at the index following this instance of 'opCharName'.
@@ -569,7 +570,8 @@ let ConvertValLogicalNameToDisplayName isBaseVal name =
 let ConvertLogicalNameToDisplayLayout nonOpLayout name =
     if DoesIdentifierNeedBackticks name then
         leftL (TaggedText.tagPunctuation "``")
-        ^^ wordL (TaggedText.tagOperator name) ^^ rightL (TaggedText.tagPunctuation "``")
+        ^^ wordL (TaggedText.tagOperator name)
+        ^^ rightL (TaggedText.tagPunctuation "``")
     else
         nonOpLayout name
 
@@ -583,10 +585,12 @@ let ConvertValLogicalNameToDisplayLayout isBaseVal nonOpLayout name =
             ConvertLogicalNameToDisplayLayout nonOpLayout name
         elif nm.StartsWithOrdinal "*" || nm.EndsWithOrdinal "*" then
             wordL (TaggedText.tagPunctuation "(")
-            ^^ wordL (TaggedText.tagOperator nm) ^^ wordL (TaggedText.tagPunctuation ")")
+            ^^ wordL (TaggedText.tagOperator nm)
+            ^^ wordL (TaggedText.tagPunctuation ")")
         else
             leftL (TaggedText.tagPunctuation "(")
-            ^^ wordL (TaggedText.tagOperator nm) ^^ rightL (TaggedText.tagPunctuation ")")
+            ^^ wordL (TaggedText.tagOperator nm)
+            ^^ rightL (TaggedText.tagPunctuation ")")
     elif name = "get_Zero" then
         ConvertLogicalNameToDisplayLayout nonOpLayout "Zero"
     else
@@ -949,13 +953,13 @@ let IllegalCharactersInTypeAndNamespaceNames =
 type ActivePatternInfo =
     | APInfo of bool * (string * range) list * range
 
-    member x.IsTotal = let (APInfo (p, _, _)) = x in p
+    member x.IsTotal = let (APInfo(p, _, _)) = x in p
 
-    member x.ActiveTags = let (APInfo (_, tags, _)) = x in List.map fst tags
+    member x.ActiveTags = let (APInfo(_, tags, _)) = x in List.map fst tags
 
-    member x.ActiveTagsWithRanges = let (APInfo (_, tags, _)) = x in tags
+    member x.ActiveTagsWithRanges = let (APInfo(_, tags, _)) = x in tags
 
-    member x.Range = let (APInfo (_, _, m)) = x in m
+    member x.Range = let (APInfo(_, _, m)) = x in m
 
 let ActivePatternInfoOfValName nm (m: range) =
     // Note: The approximate range calculations in this code assume the name is of the form "(|A|B|)" not "(|  A   |   B   |)"
@@ -1001,7 +1005,7 @@ let tryDemangleStaticStringArg (mangledText: string) =
     match splitAroundQuotationWithCount mangledText '=' 2 with
     | [| nm; v |] ->
         if v.Length >= 2 then
-            Some(nm, v[ 1 .. v.Length - 2 ].Replace("\\\\", "\\").Replace("\\\"", "\""))
+            Some(nm, v[1 .. v.Length - 2].Replace("\\\\", "\\").Replace("\\\"", "\""))
         else
             Some(nm, v)
     | _ -> None

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -25,26 +25,26 @@ type SynLongIdent =
 
     member this.Range =
         match this with
-        | SynLongIdent ([], _, _) -> failwith "rangeOfLidwd"
-        | SynLongIdent ([ id ], [], _) -> id.idRange
-        | SynLongIdent ([ id ], [ m ], _) -> unionRanges id.idRange m
-        | SynLongIdent (h :: t, [], _) -> unionRanges h.idRange (List.last t).idRange
-        | SynLongIdent (h :: t, dotRanges, _) -> unionRanges h.idRange (List.last t).idRange |> unionRanges (List.last dotRanges)
+        | SynLongIdent([], _, _) -> failwith "rangeOfLidwd"
+        | SynLongIdent([ id ], [], _) -> id.idRange
+        | SynLongIdent([ id ], [ m ], _) -> unionRanges id.idRange m
+        | SynLongIdent(h :: t, [], _) -> unionRanges h.idRange (List.last t).idRange
+        | SynLongIdent(h :: t, dotRanges, _) -> unionRanges h.idRange (List.last t).idRange |> unionRanges (List.last dotRanges)
 
     member this.LongIdent =
         match this with
-        | SynLongIdent (lid, _, _) -> lid
+        | SynLongIdent(lid, _, _) -> lid
 
     member this.Dots =
         match this with
-        | SynLongIdent (dotRanges = dots) -> dots
+        | SynLongIdent(dotRanges = dots) -> dots
 
     member this.Trivia =
         match this with
-        | SynLongIdent (trivia = trivia) -> List.choose id trivia
+        | SynLongIdent(trivia = trivia) -> List.choose id trivia
 
     member this.IdentsWithTrivia =
-        let (SynLongIdent (lid, _, trivia)) = this
+        let (SynLongIdent(lid, _, trivia)) = this
 
         if lid.Length = trivia.Length then
             List.zip lid trivia |> List.map SynIdent
@@ -57,13 +57,13 @@ type SynLongIdent =
 
     member this.ThereIsAnExtraDotAtTheEnd =
         match this with
-        | SynLongIdent (lid, dots, _) -> lid.Length = dots.Length
+        | SynLongIdent(lid, dots, _) -> lid.Length = dots.Length
 
     member this.RangeWithoutAnyExtraDot =
         match this with
-        | SynLongIdent ([], _, _) -> failwith "rangeOfLidwd"
-        | SynLongIdent ([ id ], _, _) -> id.idRange
-        | SynLongIdent (h :: t, dotRanges, _) ->
+        | SynLongIdent([], _, _) -> failwith "rangeOfLidwd"
+        | SynLongIdent([ id ], _, _) -> id.idRange
+        | SynLongIdent(h :: t, dotRanges, _) ->
             let nonExtraDots =
                 if dotRanges.Length = t.Length then
                     dotRanges
@@ -78,7 +78,7 @@ module SynLongIdentHelpers =
     [<Obsolete("Please use SynLongIdent or define a custom active pattern")>]
     let (|LongIdentWithDots|) =
         function
-        | SynLongIdent (lid, dots, _) -> lid, dots
+        | SynLongIdent(lid, dots, _) -> lid, dots
 
     [<Obsolete("Please use SynLongIdent")>]
     let LongIdentWithDots (lid, dots) =
@@ -102,7 +102,7 @@ type SynTypar =
 
     member this.Range =
         match this with
-        | SynTypar (id, _, _) -> id.idRange
+        | SynTypar(id, _, _) -> id.idRange
 
 [<Struct; RequireQualifiedAccess>]
 type SynStringKind =
@@ -164,9 +164,9 @@ type SynConst =
 
     member c.Range dflt =
         match c with
-        | SynConst.String (_, _, m0)
-        | SynConst.Bytes (_, _, m0)
-        | SynConst.SourceIdentifier (_, _, m0) -> m0
+        | SynConst.String(_, _, m0)
+        | SynConst.Bytes(_, _, m0)
+        | SynConst.SourceIdentifier(_, _, m0) -> m0
         | _ -> dflt
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
@@ -342,18 +342,18 @@ type SynTypeConstraint =
 
     member x.Range =
         match x with
-        | WhereTyparIsValueType (range = range)
-        | WhereTyparIsReferenceType (range = range)
-        | WhereTyparIsUnmanaged (range = range)
-        | WhereTyparSupportsNull (range = range)
-        | WhereTyparIsComparable (range = range)
-        | WhereTyparIsEquatable (range = range)
-        | WhereTyparDefaultsToType (range = range)
-        | WhereTyparSubtypeOfType (range = range)
-        | WhereTyparSupportsMember (range = range)
-        | WhereTyparIsEnum (range = range)
-        | WhereTyparIsDelegate (range = range) -> range
-        | WhereSelfConstrained (range = range) -> range
+        | WhereTyparIsValueType(range = range)
+        | WhereTyparIsReferenceType(range = range)
+        | WhereTyparIsUnmanaged(range = range)
+        | WhereTyparSupportsNull(range = range)
+        | WhereTyparIsComparable(range = range)
+        | WhereTyparIsEquatable(range = range)
+        | WhereTyparDefaultsToType(range = range)
+        | WhereTyparSubtypeOfType(range = range)
+        | WhereTyparSupportsMember(range = range)
+        | WhereTyparIsEnum(range = range)
+        | WhereTyparIsDelegate(range = range) -> range
+        | WhereSelfConstrained(range = range) -> range
 
 [<RequireQualifiedAccess>]
 type SynTyparDecls =
@@ -363,23 +363,23 @@ type SynTyparDecls =
 
     member x.TyparDecls =
         match x with
-        | PostfixList (decls = decls)
-        | PrefixList (decls = decls) -> decls
-        | SinglePrefix (decl, _) -> [ decl ]
+        | PostfixList(decls = decls)
+        | PrefixList(decls = decls) -> decls
+        | SinglePrefix(decl, _) -> [ decl ]
 
     member x.Constraints =
         match x with
-        | PostfixList (decls = decls; constraints = constraints) ->
+        | PostfixList(decls = decls; constraints = constraints) ->
             // Synthesize SynTypeConstraints implied with any intersection constraints in SynTyparDecl
             // The parser makes sure we're only dealing with hash constraints here
             let intersectionConstraints =
                 decls
-                |> List.collect (fun (SynTyparDecl (typar = tp; intersectionConstraints = tys)) ->
+                |> List.collect (fun (SynTyparDecl(typar = tp; intersectionConstraints = tys)) ->
                     tys
                     |> List.map (fun ty ->
                         let ty =
                             match ty with
-                            | SynType.HashConstraint (ty, _) -> ty
+                            | SynType.HashConstraint(ty, _) -> ty
                             | _ -> ty
 
                         SynTypeConstraint.WhereTyparSubtypeOfType(tp, ty, ty.Range)))
@@ -389,9 +389,9 @@ type SynTyparDecls =
 
     member x.Range =
         match x with
-        | PostfixList (range = range)
-        | PrefixList (range = range)
-        | SinglePrefix (range = range) -> range
+        | PostfixList(range = range)
+        | PrefixList(range = range)
+        | SinglePrefix(range = range) -> range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynTupleTypeSegment =
@@ -402,8 +402,8 @@ type SynTupleTypeSegment =
     member this.Range =
         match this with
         | SynTupleTypeSegment.Type t -> t.Range
-        | SynTupleTypeSegment.Star (range = range)
-        | SynTupleTypeSegment.Slash (range = range) -> range
+        | SynTupleTypeSegment.Star(range = range)
+        | SynTupleTypeSegment.Slash(range = range) -> range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynType =
@@ -464,25 +464,25 @@ type SynType =
 
     member x.Range =
         match x with
-        | SynType.App (range = m)
-        | SynType.LongIdentApp (range = m)
-        | SynType.Tuple (range = m)
-        | SynType.Array (range = m)
-        | SynType.AnonRecd (range = m)
-        | SynType.Fun (range = m)
-        | SynType.Var (range = m)
-        | SynType.Anon (range = m)
-        | SynType.WithGlobalConstraints (range = m)
-        | SynType.StaticConstant (range = m)
-        | SynType.StaticConstantExpr (range = m)
-        | SynType.StaticConstantNamed (range = m)
-        | SynType.HashConstraint (range = m)
-        | SynType.MeasurePower (range = m)
-        | SynType.Paren (range = m)
-        | SynType.SignatureParameter (range = m)
-        | SynType.Or (range = m)
-        | SynType.Intersection (range = m)
-        | SynType.FromParseError (range = m) -> m
+        | SynType.App(range = m)
+        | SynType.LongIdentApp(range = m)
+        | SynType.Tuple(range = m)
+        | SynType.Array(range = m)
+        | SynType.AnonRecd(range = m)
+        | SynType.Fun(range = m)
+        | SynType.Var(range = m)
+        | SynType.Anon(range = m)
+        | SynType.WithGlobalConstraints(range = m)
+        | SynType.StaticConstant(range = m)
+        | SynType.StaticConstantExpr(range = m)
+        | SynType.StaticConstantNamed(range = m)
+        | SynType.HashConstraint(range = m)
+        | SynType.MeasurePower(range = m)
+        | SynType.Paren(range = m)
+        | SynType.SignatureParameter(range = m)
+        | SynType.Or(range = m)
+        | SynType.Intersection(range = m)
+        | SynType.FromParseError(range = m) -> m
         | SynType.LongIdent lidwd -> lidwd.Range
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
@@ -740,93 +740,93 @@ type SynExpr =
 
     member e.Range =
         match e with
-        | SynExpr.Paren (_, leftParenRange, rightParenRange, r) ->
+        | SynExpr.Paren(_, leftParenRange, rightParenRange, r) ->
             match rightParenRange with
             | Some rightParenRange when leftParenRange.FileIndex <> rightParenRange.FileIndex -> leftParenRange
             | _ -> r
-        | SynExpr.Quote (range = m)
-        | SynExpr.Const (range = m)
-        | SynExpr.Typed (range = m)
-        | SynExpr.Tuple (range = m)
-        | SynExpr.AnonRecd (range = m)
-        | SynExpr.ArrayOrList (range = m)
-        | SynExpr.Record (range = m)
-        | SynExpr.New (range = m)
-        | SynExpr.ObjExpr (range = m)
-        | SynExpr.While (range = m)
-        | SynExpr.For (range = m)
-        | SynExpr.ForEach (range = m)
-        | SynExpr.ComputationExpr (range = m)
-        | SynExpr.ArrayOrListComputed (range = m)
-        | SynExpr.Lambda (range = m)
-        | SynExpr.Match (range = m)
-        | SynExpr.MatchLambda (range = m)
-        | SynExpr.Do (range = m)
-        | SynExpr.Assert (range = m)
-        | SynExpr.App (range = m)
-        | SynExpr.TypeApp (range = m)
-        | SynExpr.LetOrUse (range = m)
-        | SynExpr.TryWith (range = m)
-        | SynExpr.TryFinally (range = m)
-        | SynExpr.Sequential (range = m)
-        | SynExpr.SequentialOrImplicitYield (range = m)
-        | SynExpr.ArbitraryAfterError (range = m)
-        | SynExpr.FromParseError (range = m)
-        | SynExpr.DiscardAfterMissingQualificationAfterDot (range = m)
-        | SynExpr.IfThenElse (range = m)
-        | SynExpr.LongIdent (range = m)
-        | SynExpr.LongIdentSet (range = m)
-        | SynExpr.NamedIndexedPropertySet (range = m)
-        | SynExpr.DotIndexedGet (range = m)
-        | SynExpr.DotIndexedSet (range = m)
-        | SynExpr.DotGet (range = m)
-        | SynExpr.DotLambda (range = m)
-        | SynExpr.DotSet (range = m)
-        | SynExpr.Set (range = m)
-        | SynExpr.DotNamedIndexedPropertySet (range = m)
-        | SynExpr.LibraryOnlyUnionCaseFieldGet (range = m)
-        | SynExpr.LibraryOnlyUnionCaseFieldSet (range = m)
-        | SynExpr.LibraryOnlyILAssembly (range = m)
-        | SynExpr.LibraryOnlyStaticOptimization (range = m)
-        | SynExpr.IndexRange (range = m)
-        | SynExpr.IndexFromEnd (range = m)
-        | SynExpr.TypeTest (range = m)
-        | SynExpr.Upcast (range = m)
-        | SynExpr.AddressOf (range = m)
-        | SynExpr.Downcast (range = m)
-        | SynExpr.JoinIn (range = m)
-        | SynExpr.InferredUpcast (range = m)
-        | SynExpr.InferredDowncast (range = m)
-        | SynExpr.Null (range = m)
-        | SynExpr.Lazy (range = m)
-        | SynExpr.TraitCall (range = m)
-        | SynExpr.ImplicitZero (range = m)
-        | SynExpr.YieldOrReturn (range = m)
-        | SynExpr.YieldOrReturnFrom (range = m)
-        | SynExpr.LetOrUseBang (range = m)
-        | SynExpr.MatchBang (range = m)
-        | SynExpr.DoBang (range = m)
-        | SynExpr.WhileBang (range = m)
-        | SynExpr.Fixed (range = m)
-        | SynExpr.InterpolatedString (range = m)
-        | SynExpr.Dynamic (range = m) -> m
+        | SynExpr.Quote(range = m)
+        | SynExpr.Const(range = m)
+        | SynExpr.Typed(range = m)
+        | SynExpr.Tuple(range = m)
+        | SynExpr.AnonRecd(range = m)
+        | SynExpr.ArrayOrList(range = m)
+        | SynExpr.Record(range = m)
+        | SynExpr.New(range = m)
+        | SynExpr.ObjExpr(range = m)
+        | SynExpr.While(range = m)
+        | SynExpr.For(range = m)
+        | SynExpr.ForEach(range = m)
+        | SynExpr.ComputationExpr(range = m)
+        | SynExpr.ArrayOrListComputed(range = m)
+        | SynExpr.Lambda(range = m)
+        | SynExpr.Match(range = m)
+        | SynExpr.MatchLambda(range = m)
+        | SynExpr.Do(range = m)
+        | SynExpr.Assert(range = m)
+        | SynExpr.App(range = m)
+        | SynExpr.TypeApp(range = m)
+        | SynExpr.LetOrUse(range = m)
+        | SynExpr.TryWith(range = m)
+        | SynExpr.TryFinally(range = m)
+        | SynExpr.Sequential(range = m)
+        | SynExpr.SequentialOrImplicitYield(range = m)
+        | SynExpr.ArbitraryAfterError(range = m)
+        | SynExpr.FromParseError(range = m)
+        | SynExpr.DiscardAfterMissingQualificationAfterDot(range = m)
+        | SynExpr.IfThenElse(range = m)
+        | SynExpr.LongIdent(range = m)
+        | SynExpr.LongIdentSet(range = m)
+        | SynExpr.NamedIndexedPropertySet(range = m)
+        | SynExpr.DotIndexedGet(range = m)
+        | SynExpr.DotIndexedSet(range = m)
+        | SynExpr.DotGet(range = m)
+        | SynExpr.DotLambda(range = m)
+        | SynExpr.DotSet(range = m)
+        | SynExpr.Set(range = m)
+        | SynExpr.DotNamedIndexedPropertySet(range = m)
+        | SynExpr.LibraryOnlyUnionCaseFieldGet(range = m)
+        | SynExpr.LibraryOnlyUnionCaseFieldSet(range = m)
+        | SynExpr.LibraryOnlyILAssembly(range = m)
+        | SynExpr.LibraryOnlyStaticOptimization(range = m)
+        | SynExpr.IndexRange(range = m)
+        | SynExpr.IndexFromEnd(range = m)
+        | SynExpr.TypeTest(range = m)
+        | SynExpr.Upcast(range = m)
+        | SynExpr.AddressOf(range = m)
+        | SynExpr.Downcast(range = m)
+        | SynExpr.JoinIn(range = m)
+        | SynExpr.InferredUpcast(range = m)
+        | SynExpr.InferredDowncast(range = m)
+        | SynExpr.Null(range = m)
+        | SynExpr.Lazy(range = m)
+        | SynExpr.TraitCall(range = m)
+        | SynExpr.ImplicitZero(range = m)
+        | SynExpr.YieldOrReturn(range = m)
+        | SynExpr.YieldOrReturnFrom(range = m)
+        | SynExpr.LetOrUseBang(range = m)
+        | SynExpr.MatchBang(range = m)
+        | SynExpr.DoBang(range = m)
+        | SynExpr.WhileBang(range = m)
+        | SynExpr.Fixed(range = m)
+        | SynExpr.InterpolatedString(range = m)
+        | SynExpr.Dynamic(range = m) -> m
         | SynExpr.Ident id -> id.idRange
-        | SynExpr.Typar (range = m) -> m
-        | SynExpr.DebugPoint (_, _, innerExpr) -> innerExpr.Range
+        | SynExpr.Typar(range = m) -> m
+        | SynExpr.DebugPoint(_, _, innerExpr) -> innerExpr.Range
 
     member e.RangeWithoutAnyExtraDot =
         match e with
-        | SynExpr.DiscardAfterMissingQualificationAfterDot (expr, _, _) -> expr.Range
+        | SynExpr.DiscardAfterMissingQualificationAfterDot(expr, _, _) -> expr.Range
         | _ -> e.Range
 
     member e.RangeOfFirstPortion =
         match e with
         // these are better than just .Range, and also commonly applicable inside queries
-        | SynExpr.Paren (_, m, _, _) -> m
-        | SynExpr.Sequential (_, _, e1, _, _)
-        | SynExpr.SequentialOrImplicitYield (_, e1, _, _, _)
-        | SynExpr.App (_, _, e1, _, _) -> e1.RangeOfFirstPortion
-        | SynExpr.ForEach (pat = pat; range = r) ->
+        | SynExpr.Paren(_, m, _, _) -> m
+        | SynExpr.Sequential(_, _, e1, _, _)
+        | SynExpr.SequentialOrImplicitYield(_, e1, _, _, _)
+        | SynExpr.App(_, _, e1, _, _) -> e1.RangeOfFirstPortion
+        | SynExpr.ForEach(pat = pat; range = r) ->
             let e = (pat.Range: range).Start
             withEnd e r
         | _ -> e.Range
@@ -876,9 +876,9 @@ type SynSimplePat =
 
     member x.Range =
         match x with
-        | SynSimplePat.Id (range = range)
-        | SynSimplePat.Typed (range = range)
-        | SynSimplePat.Attrib (range = range) -> range
+        | SynSimplePat.Id(range = range)
+        | SynSimplePat.Typed(range = range)
+        | SynSimplePat.Attrib(range = range) -> range
 
 [<RequireQualifiedAccess>]
 type SynSimplePatAlternativeIdInfo =
@@ -900,7 +900,7 @@ type SynSimplePats =
 
     member x.Range =
         match x with
-        | SynSimplePats.SimplePats (range = range) -> range
+        | SynSimplePats.SimplePats(range = range) -> range
 
 [<RequireQualifiedAccess>]
 type SynArgPats =
@@ -911,7 +911,7 @@ type SynArgPats =
     member x.Patterns =
         match x with
         | Pats pats -> pats
-        | NamePatPairs (pats = pats) -> pats |> List.map (fun (_, _, pat) -> pat)
+        | NamePatPairs(pats = pats) -> pats |> List.map (fun (_, _, pat) -> pat)
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynPat =
@@ -969,26 +969,26 @@ type SynPat =
 
     member p.Range =
         match p with
-        | SynPat.Const (range = m)
-        | SynPat.Wild (range = m)
-        | SynPat.Named (range = m)
-        | SynPat.Or (range = m)
-        | SynPat.ListCons (range = m)
-        | SynPat.Ands (range = m)
-        | SynPat.As (range = m)
-        | SynPat.LongIdent (range = m)
-        | SynPat.ArrayOrList (range = m)
-        | SynPat.Tuple (range = m)
-        | SynPat.Typed (range = m)
-        | SynPat.Attrib (range = m)
-        | SynPat.Record (range = m)
-        | SynPat.Null (range = m)
-        | SynPat.IsInst (range = m)
-        | SynPat.QuoteExpr (range = m)
-        | SynPat.InstanceMember (range = m)
-        | SynPat.OptionalVal (range = m)
-        | SynPat.Paren (range = m)
-        | SynPat.FromParseError (range = m) -> m
+        | SynPat.Const(range = m)
+        | SynPat.Wild(range = m)
+        | SynPat.Named(range = m)
+        | SynPat.Or(range = m)
+        | SynPat.ListCons(range = m)
+        | SynPat.Ands(range = m)
+        | SynPat.As(range = m)
+        | SynPat.LongIdent(range = m)
+        | SynPat.ArrayOrList(range = m)
+        | SynPat.Tuple(range = m)
+        | SynPat.Typed(range = m)
+        | SynPat.Attrib(range = m)
+        | SynPat.Record(range = m)
+        | SynPat.Null(range = m)
+        | SynPat.IsInst(range = m)
+        | SynPat.QuoteExpr(range = m)
+        | SynPat.InstanceMember(range = m)
+        | SynPat.OptionalVal(range = m)
+        | SynPat.Paren(range = m)
+        | SynPat.FromParseError(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynInterfaceImpl =
@@ -1011,14 +1011,14 @@ type SynMatchClause =
 
     member this.RangeOfGuardAndRhs =
         match this with
-        | SynMatchClause (whenExpr = eo; resultExpr = e) ->
+        | SynMatchClause(whenExpr = eo; resultExpr = e) ->
             match eo with
             | None -> e.Range
             | Some x -> unionRanges e.Range x.Range
 
     member this.Range =
         match this with
-        | SynMatchClause (range = m) -> m
+        | SynMatchClause(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynAttribute =
@@ -1048,7 +1048,7 @@ type SynAttributes = SynAttributeList list
 type SynValData =
     | SynValData of memberFlags: SynMemberFlags option * valInfo: SynValInfo * thisIdOpt: Ident option
 
-    member x.SynValInfo = (let (SynValData (valInfo = synValInfo)) = x in synValInfo)
+    member x.SynValInfo = (let (SynValData(valInfo = synValInfo)) = x in synValInfo)
 
 [<NoEquality; NoComparison>]
 type SynBinding =
@@ -1071,12 +1071,12 @@ type SynBinding =
     //  - for everything else, the 'range' member that appears last/second-to-last is the 'full range' of the whole tree construct
     //  - but for Binding, the 'range' is only the range of the left-hand-side, the right-hand-side range is in the SynExpr
     //  - so we use explicit names to avoid confusion
-    member x.RangeOfBindingWithoutRhs = let (SynBinding (range = m)) = x in m
+    member x.RangeOfBindingWithoutRhs = let (SynBinding(range = m)) = x in m
 
     member x.RangeOfBindingWithRhs =
-        let (SynBinding (expr = e; range = m)) = x in unionRanges e.Range m
+        let (SynBinding(expr = e; range = m)) = x in unionRanges e.Range m
 
-    member x.RangeOfHeadPattern = let (SynBinding (headPat = headPat)) = x in headPat.Range
+    member x.RangeOfHeadPattern = let (SynBinding(headPat = headPat)) = x in headPat.Range
 
 [<NoEquality; NoComparison>]
 type SynBindingReturnInfo =
@@ -1148,11 +1148,11 @@ type SynMemberSig =
 
     member d.Range =
         match d with
-        | SynMemberSig.Member (range = m)
-        | SynMemberSig.Interface (range = m)
-        | SynMemberSig.Inherit (range = m)
-        | SynMemberSig.ValField (range = m)
-        | SynMemberSig.NestedType (range = m) -> m
+        | SynMemberSig.Member(range = m)
+        | SynMemberSig.Interface(range = m)
+        | SynMemberSig.Inherit(range = m)
+        | SynMemberSig.ValField(range = m)
+        | SynMemberSig.NestedType(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynTypeDefnKind =
@@ -1199,13 +1199,13 @@ type SynTypeDefnSimpleRepr =
 
     member this.Range =
         match this with
-        | Union (range = m)
-        | Enum (range = m)
-        | Record (range = m)
-        | General (range = m)
-        | LibraryOnlyILAssembly (range = m)
-        | TypeAbbrev (range = m)
-        | None (range = m) -> m
+        | Union(range = m)
+        | Enum(range = m)
+        | Record(range = m)
+        | General(range = m)
+        | LibraryOnlyILAssembly(range = m)
+        | TypeAbbrev(range = m)
+        | None(range = m) -> m
         | Exception t -> t.Range
 
 [<NoEquality; NoComparison>]
@@ -1221,7 +1221,7 @@ type SynEnumCase =
 
     member this.Range =
         match this with
-        | SynEnumCase (range = m) -> m
+        | SynEnumCase(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynUnionCase =
@@ -1237,7 +1237,7 @@ type SynUnionCase =
 
     member this.Range =
         match this with
-        | SynUnionCase (range = m) -> m
+        | SynUnionCase(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynUnionCaseKind =
@@ -1257,8 +1257,8 @@ type SynTypeDefnSigRepr =
 
     member this.Range =
         match this with
-        | ObjectModel (range = m)
-        | Simple (range = m) -> m
+        | ObjectModel(range = m)
+        | Simple(range = m) -> m
         | Exception e -> e.Range
 
 [<NoEquality; NoComparison>]
@@ -1273,7 +1273,7 @@ type SynTypeDefnSig =
 
     member this.Range =
         match this with
-        | SynTypeDefnSig (range = m) -> m
+        | SynTypeDefnSig(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynField =
@@ -1302,7 +1302,7 @@ type SynComponentInfo =
 
     member this.Range =
         match this with
-        | SynComponentInfo (range = m) -> m
+        | SynComponentInfo(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynValSig =
@@ -1320,18 +1320,18 @@ type SynValSig =
         range: range *
         trivia: SynValSigTrivia
 
-    member x.RangeOfId = let (SynValSig(ident = SynIdent (id, _))) = x in id.idRange
+    member x.RangeOfId = let (SynValSig(ident = SynIdent(id, _))) = x in id.idRange
 
-    member x.SynInfo = let (SynValSig (arity = v)) = x in v
+    member x.SynInfo = let (SynValSig(arity = v)) = x in v
 
-    member x.SynType = let (SynValSig (synType = ty)) = x in ty
+    member x.SynType = let (SynValSig(synType = ty)) = x in ty
 
 [<NoEquality; NoComparison>]
 type SynValInfo =
 
     | SynValInfo of curriedArgInfos: SynArgInfo list list * returnInfo: SynArgInfo
 
-    member x.CurriedArgInfos = (let (SynValInfo (args, _)) = x in args)
+    member x.CurriedArgInfos = (let (SynValInfo(args, _)) = x in args)
 
     member x.ArgNames =
         x.CurriedArgInfos
@@ -1345,9 +1345,9 @@ type SynArgInfo =
 
     | SynArgInfo of attributes: SynAttributes * optional: bool * ident: Ident option
 
-    member x.Ident: Ident option = let (SynArgInfo (_, _, id)) = x in id
+    member x.Ident: Ident option = let (SynArgInfo(_, _, id)) = x in id
 
-    member x.Attributes: SynAttributes = let (SynArgInfo (attrs, _, _)) = x in attrs
+    member x.Attributes: SynAttributes = let (SynArgInfo(attrs, _, _)) = x in attrs
 
 [<NoEquality; NoComparison>]
 type SynValTyparDecls = SynValTyparDecls of typars: SynTyparDecls option * canInfer: bool
@@ -1358,7 +1358,7 @@ type SynReturnInfo =
 
     member this.Range =
         match this with
-        | SynReturnInfo (range = m) -> m
+        | SynReturnInfo(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynExceptionDefnRepr =
@@ -1373,7 +1373,7 @@ type SynExceptionDefnRepr =
 
     member this.Range =
         match this with
-        | SynExceptionDefnRepr (range = m) -> m
+        | SynExceptionDefnRepr(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynExceptionDefn =
@@ -1382,7 +1382,7 @@ type SynExceptionDefn =
 
     member this.Range =
         match this with
-        | SynExceptionDefn (range = m) -> m
+        | SynExceptionDefn(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynTypeDefnRepr =
@@ -1395,8 +1395,8 @@ type SynTypeDefnRepr =
 
     member this.Range =
         match this with
-        | ObjectModel (range = m)
-        | Simple (range = m) -> m
+        | ObjectModel(range = m)
+        | Simple(range = m) -> m
         | Exception t -> t.Range
 
 [<NoEquality; NoComparison>]
@@ -1411,7 +1411,7 @@ type SynTypeDefn =
 
     member this.Range =
         match this with
-        | SynTypeDefn (range = m) -> m
+        | SynTypeDefn(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynMemberDefn =
@@ -1465,18 +1465,18 @@ type SynMemberDefn =
 
     member d.Range =
         match d with
-        | SynMemberDefn.Member (range = m)
-        | SynMemberDefn.GetSetMember (range = m)
-        | SynMemberDefn.Interface (range = m)
-        | SynMemberDefn.Open (range = m)
-        | SynMemberDefn.LetBindings (range = m)
-        | SynMemberDefn.ImplicitCtor (range = m)
-        | SynMemberDefn.ImplicitInherit (range = m)
-        | SynMemberDefn.AbstractSlot (range = m)
-        | SynMemberDefn.Inherit (range = m)
-        | SynMemberDefn.ValField (range = m)
-        | SynMemberDefn.AutoProperty (range = m)
-        | SynMemberDefn.NestedType (range = m) -> m
+        | SynMemberDefn.Member(range = m)
+        | SynMemberDefn.GetSetMember(range = m)
+        | SynMemberDefn.Interface(range = m)
+        | SynMemberDefn.Open(range = m)
+        | SynMemberDefn.LetBindings(range = m)
+        | SynMemberDefn.ImplicitCtor(range = m)
+        | SynMemberDefn.ImplicitInherit(range = m)
+        | SynMemberDefn.AbstractSlot(range = m)
+        | SynMemberDefn.Inherit(range = m)
+        | SynMemberDefn.ValField(range = m)
+        | SynMemberDefn.AutoProperty(range = m)
+        | SynMemberDefn.NestedType(range = m) -> m
 
 type SynMemberDefns = SynMemberDefn list
 
@@ -1511,16 +1511,16 @@ type SynModuleDecl =
 
     member d.Range =
         match d with
-        | SynModuleDecl.ModuleAbbrev (range = m)
-        | SynModuleDecl.NestedModule (range = m)
-        | SynModuleDecl.Let (range = m)
-        | SynModuleDecl.Expr (range = m)
-        | SynModuleDecl.Types (range = m)
-        | SynModuleDecl.Exception (range = m)
-        | SynModuleDecl.Open (range = m)
-        | SynModuleDecl.HashDirective (range = m)
-        | SynModuleDecl.NamespaceFragment (SynModuleOrNamespace (range = m))
-        | SynModuleDecl.Attributes (range = m) -> m
+        | SynModuleDecl.ModuleAbbrev(range = m)
+        | SynModuleDecl.NestedModule(range = m)
+        | SynModuleDecl.Let(range = m)
+        | SynModuleDecl.Expr(range = m)
+        | SynModuleDecl.Types(range = m)
+        | SynModuleDecl.Exception(range = m)
+        | SynModuleDecl.Open(range = m)
+        | SynModuleDecl.HashDirective(range = m)
+        | SynModuleDecl.NamespaceFragment(SynModuleOrNamespace(range = m))
+        | SynModuleDecl.Attributes(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type SynOpenDeclTarget =
@@ -1531,8 +1531,8 @@ type SynOpenDeclTarget =
 
     member this.Range =
         match this with
-        | ModuleOrNamespace (range = m) -> m
-        | Type (range = m) -> m
+        | ModuleOrNamespace(range = m) -> m
+        | Type(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynExceptionSig =
@@ -1564,14 +1564,14 @@ type SynModuleSigDecl =
 
     member d.Range =
         match d with
-        | SynModuleSigDecl.ModuleAbbrev (range = m)
-        | SynModuleSigDecl.NestedModule (range = m)
-        | SynModuleSigDecl.Val (range = m)
-        | SynModuleSigDecl.Types (range = m)
-        | SynModuleSigDecl.Exception (range = m)
-        | SynModuleSigDecl.Open (range = m)
-        | SynModuleSigDecl.NamespaceFragment (SynModuleOrNamespaceSig.SynModuleOrNamespaceSig (range = m))
-        | SynModuleSigDecl.HashDirective (range = m) -> m
+        | SynModuleSigDecl.ModuleAbbrev(range = m)
+        | SynModuleSigDecl.NestedModule(range = m)
+        | SynModuleSigDecl.Val(range = m)
+        | SynModuleSigDecl.Types(range = m)
+        | SynModuleSigDecl.Exception(range = m)
+        | SynModuleSigDecl.Open(range = m)
+        | SynModuleSigDecl.NamespaceFragment(SynModuleOrNamespaceSig.SynModuleOrNamespaceSig(range = m))
+        | SynModuleSigDecl.HashDirective(range = m) -> m
 
 [<Struct; RequireQualifiedAccess>]
 type SynModuleOrNamespaceKind =
@@ -1604,7 +1604,7 @@ type SynModuleOrNamespace =
 
     member this.Range =
         match this with
-        | SynModuleOrNamespace (range = m) -> m
+        | SynModuleOrNamespace(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type SynModuleOrNamespaceSig =
@@ -1621,7 +1621,7 @@ type SynModuleOrNamespaceSig =
 
     member this.Range =
         match this with
-        | SynModuleOrNamespaceSig (range = m) -> m
+        | SynModuleOrNamespaceSig(range = m) -> m
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedHashDirectiveArgument =
@@ -1630,8 +1630,8 @@ type ParsedHashDirectiveArgument =
 
     member this.Range =
         match this with
-        | ParsedHashDirectiveArgument.String (range = m)
-        | ParsedHashDirectiveArgument.SourceIdentifier (range = m) -> m
+        | ParsedHashDirectiveArgument.String(range = m)
+        | ParsedHashDirectiveArgument.SourceIdentifier(range = m) -> m
 
 [<NoEquality; NoComparison>]
 type ParsedHashDirective = ParsedHashDirective of ident: string * args: ParsedHashDirectiveArgument list * range: range
@@ -1706,26 +1706,26 @@ type ParsedImplFileInput =
         identifiers: Set<string>
 
     member x.QualifiedName =
-        (let (ParsedImplFileInput (qualifiedNameOfFile = qualNameOfFile)) = x in qualNameOfFile)
+        (let (ParsedImplFileInput(qualifiedNameOfFile = qualNameOfFile)) = x in qualNameOfFile)
 
     member x.ScopedPragmas =
-        (let (ParsedImplFileInput (scopedPragmas = scopedPragmas)) = x in scopedPragmas)
+        (let (ParsedImplFileInput(scopedPragmas = scopedPragmas)) = x in scopedPragmas)
 
     member x.HashDirectives =
-        (let (ParsedImplFileInput (hashDirectives = hashDirectives)) = x in hashDirectives)
+        (let (ParsedImplFileInput(hashDirectives = hashDirectives)) = x in hashDirectives)
 
-    member x.FileName = (let (ParsedImplFileInput (fileName = fileName)) = x in fileName)
+    member x.FileName = (let (ParsedImplFileInput(fileName = fileName)) = x in fileName)
 
-    member x.Contents = (let (ParsedImplFileInput (contents = contents)) = x in contents)
+    member x.Contents = (let (ParsedImplFileInput(contents = contents)) = x in contents)
 
-    member x.IsScript = (let (ParsedImplFileInput (isScript = isScript)) = x in isScript)
+    member x.IsScript = (let (ParsedImplFileInput(isScript = isScript)) = x in isScript)
 
     member x.IsLastCompiland =
-        (let (ParsedImplFileInput (flags = (isLastCompiland, _))) = x in isLastCompiland)
+        (let (ParsedImplFileInput(flags = (isLastCompiland, _))) = x in isLastCompiland)
 
-    member x.IsExe = (let (ParsedImplFileInput (flags = (_, isExe))) = x in isExe)
+    member x.IsExe = (let (ParsedImplFileInput(flags = (_, isExe))) = x in isExe)
 
-    member x.Trivia = (let (ParsedImplFileInput (trivia = trivia)) = x in trivia)
+    member x.Trivia = (let (ParsedImplFileInput(trivia = trivia)) = x in trivia)
 
 [<NoEquality; NoComparison>]
 type ParsedSigFileInput =
@@ -1739,19 +1739,19 @@ type ParsedSigFileInput =
         identifiers: Set<string>
 
     member x.QualifiedName =
-        (let (ParsedSigFileInput (qualifiedNameOfFile = qualNameOfFile)) = x in qualNameOfFile)
+        (let (ParsedSigFileInput(qualifiedNameOfFile = qualNameOfFile)) = x in qualNameOfFile)
 
     member x.ScopedPragmas =
-        (let (ParsedSigFileInput (scopedPragmas = scopedPragmas)) = x in scopedPragmas)
+        (let (ParsedSigFileInput(scopedPragmas = scopedPragmas)) = x in scopedPragmas)
 
     member x.HashDirectives =
-        (let (ParsedSigFileInput (hashDirectives = hashDirectives)) = x in hashDirectives)
+        (let (ParsedSigFileInput(hashDirectives = hashDirectives)) = x in hashDirectives)
 
-    member x.FileName = (let (ParsedSigFileInput (fileName = fileName)) = x in fileName)
+    member x.FileName = (let (ParsedSigFileInput(fileName = fileName)) = x in fileName)
 
-    member x.Contents = (let (ParsedSigFileInput (contents = contents)) = x in contents)
+    member x.Contents = (let (ParsedSigFileInput(contents = contents)) = x in contents)
 
-    member x.Trivia = (let (ParsedSigFileInput (trivia = trivia)) = x in trivia)
+    member x.Trivia = (let (ParsedSigFileInput(trivia = trivia)) = x in trivia)
 
 [<NoEquality; NoComparison; RequireQualifiedAccess>]
 type ParsedInput =
@@ -1776,12 +1776,12 @@ type ParsedInput =
 
     member inp.Range =
         match inp with
-        | ParsedInput.ImplFile (ParsedImplFileInput(contents = SynModuleOrNamespace (range = m) :: _))
-        | ParsedInput.SigFile (ParsedSigFileInput(contents = SynModuleOrNamespaceSig (range = m) :: _)) -> m
+        | ParsedInput.ImplFile(ParsedImplFileInput(contents = SynModuleOrNamespace(range = m) :: _))
+        | ParsedInput.SigFile(ParsedSigFileInput(contents = SynModuleOrNamespaceSig(range = m) :: _)) -> m
         | _ -> rangeN inp.FileName 0
 
     [<Experimental("This FCS API is experimental and subject to change.")>]
     member inp.Identifiers =
         match inp with
-        | ParsedInput.ImplFile (ParsedImplFileInput (identifiers = identifiers))
-        | ParsedInput.SigFile (ParsedSigFileInput (identifiers = identifiers)) -> identifiers
+        | ParsedInput.ImplFile(ParsedImplFileInput(identifiers = identifiers))
+        | ParsedInput.SigFile(ParsedSigFileInput(identifiers = identifiers)) -> identifiers

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -65,7 +65,7 @@ let mkSynCompGenSimplePatVar id =
 
 let rec pushUnaryArg expr arg =
     match expr with
-    | SynExpr.App (ExprAtomicFlag.Atomic, infix, SynExpr.Ident ident, x1, m1) ->
+    | SynExpr.App(ExprAtomicFlag.Atomic, infix, SynExpr.Ident ident, x1, m1) ->
         SynExpr.App(
             ExprAtomicFlag.Atomic,
             infix,
@@ -73,11 +73,11 @@ let rec pushUnaryArg expr arg =
             x1,
             m1
         )
-    | SynExpr.App (ExprAtomicFlag.Atomic,
-                   infix,
-                   SynExpr.LongIdent (isOptional, SynLongIdent (id, dotRanges, trivia), altNameRefCell, range),
-                   x1,
-                   m1) ->
+    | SynExpr.App(ExprAtomicFlag.Atomic,
+                  infix,
+                  SynExpr.LongIdent(isOptional, SynLongIdent(id, dotRanges, trivia), altNameRefCell, range),
+                  x1,
+                  m1) ->
         SynExpr.App(
             ExprAtomicFlag.Atomic,
             infix,
@@ -85,17 +85,17 @@ let rec pushUnaryArg expr arg =
             x1,
             m1
         )
-    | SynExpr.App (ExprAtomicFlag.Atomic, infix, (SynExpr.App (_) as innerApp), x1, m1) ->
+    | SynExpr.App(ExprAtomicFlag.Atomic, infix, (SynExpr.App(_) as innerApp), x1, m1) ->
         SynExpr.App(ExprAtomicFlag.Atomic, infix, (pushUnaryArg innerApp arg), x1, m1)
-    | SynExpr.App (ExprAtomicFlag.Atomic, infix, SynExpr.DotGet (synExpr, rangeOfDot, synLongIdent, range), x1, m1) ->
+    | SynExpr.App(ExprAtomicFlag.Atomic, infix, SynExpr.DotGet(synExpr, rangeOfDot, synLongIdent, range), x1, m1) ->
         SynExpr.App(ExprAtomicFlag.Atomic, infix, SynExpr.DotGet((pushUnaryArg synExpr arg), rangeOfDot, synLongIdent, range), x1, m1)
-    | SynExpr.App (ExprAtomicFlag.Atomic, infix, innerExpr, x1, m1) ->
+    | SynExpr.App(ExprAtomicFlag.Atomic, infix, innerExpr, x1, m1) ->
         SynExpr.App(ExprAtomicFlag.Atomic, infix, pushUnaryArg innerExpr arg, x1, m1)
     | SynExpr.Ident ident -> SynExpr.LongIdent(false, SynLongIdent(arg :: ident :: [], [ ident.idRange ], [ None ]), None, ident.idRange)
-    | SynExpr.LongIdent (isOptional, SynLongIdent (id, dotRanges, trivia), altNameRefCell, range) ->
+    | SynExpr.LongIdent(isOptional, SynLongIdent(id, dotRanges, trivia), altNameRefCell, range) ->
         SynExpr.LongIdent(isOptional, SynLongIdent(arg :: id, dotRanges, trivia), altNameRefCell, range)
-    | SynExpr.DotGet (synExpr, rangeOfDot, synLongIdent, range) -> SynExpr.DotGet(pushUnaryArg synExpr arg, rangeOfDot, synLongIdent, range)
-    | SynExpr.DotIndexedGet (objectExpr, indexArgs, dotRange, range) ->
+    | SynExpr.DotGet(synExpr, rangeOfDot, synLongIdent, range) -> SynExpr.DotGet(pushUnaryArg synExpr arg, rangeOfDot, synLongIdent, range)
+    | SynExpr.DotIndexedGet(objectExpr, indexArgs, dotRange, range) ->
         SynExpr.DotIndexedGet(pushUnaryArg objectExpr arg, indexArgs, dotRange, range)
     | _ ->
         errorR (Error(FSComp.SR.tcDotLambdaAtNotSupportedExpression (), expr.Range))
@@ -103,19 +103,19 @@ let rec pushUnaryArg expr arg =
 
 let (|SynSingleIdent|_|) x =
     match x with
-    | SynLongIdent ([ id ], _, _) -> Some id
+    | SynLongIdent([ id ], _, _) -> Some id
     | _ -> None
 
 /// Match a long identifier, including the case for single identifiers which gets a more optimized node in the syntax tree.
 let (|LongOrSingleIdent|_|) inp =
     match inp with
-    | SynExpr.LongIdent (isOpt, lidwd, altId, _m) -> Some(isOpt, lidwd, altId, lidwd.RangeWithoutAnyExtraDot)
+    | SynExpr.LongIdent(isOpt, lidwd, altId, _m) -> Some(isOpt, lidwd, altId, lidwd.RangeWithoutAnyExtraDot)
     | SynExpr.Ident id -> Some(false, SynLongIdent([ id ], [], [ None ]), None, id.idRange)
 
-    | SynExpr.DiscardAfterMissingQualificationAfterDot (synExpr, dotRange, _) ->
+    | SynExpr.DiscardAfterMissingQualificationAfterDot(synExpr, dotRange, _) ->
         match synExpr with
         | SynExpr.Ident ident -> Some(false, SynLongIdent([ ident ], [ dotRange ], [ None ]), None, ident.idRange)
-        | SynExpr.LongIdent (false, SynLongIdent (idents, dotRanges, trivia), _, range) ->
+        | SynExpr.LongIdent(false, SynLongIdent(idents, dotRanges, trivia), _, range) ->
             Some(false, SynLongIdent(idents, dotRanges @ [ dotRange ], trivia), None, range)
         | _ -> None
 
@@ -123,44 +123,44 @@ let (|LongOrSingleIdent|_|) inp =
 
 let (|SingleIdent|_|) inp =
     match inp with
-    | SynExpr.LongIdent (false, SynSingleIdent (id), None, _) -> Some id
+    | SynExpr.LongIdent(false, SynSingleIdent(id), None, _) -> Some id
     | SynExpr.Ident id -> Some id
     | _ -> None
 
 let (|SynBinOp|_|) input =
     match input with
-    | SynExpr.App (ExprAtomicFlag.NonAtomic,
-                   false,
-                   SynExpr.App (ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ synId ])), x1, _m1),
-                   x2,
-                   _m2) -> Some(synId, x1, x2)
+    | SynExpr.App(ExprAtomicFlag.NonAtomic,
+                  false,
+                  SynExpr.App(ExprAtomicFlag.NonAtomic, true, SynExpr.LongIdent(longDotId = SynLongIdent(id = [ synId ])), x1, _m1),
+                  x2,
+                  _m2) -> Some(synId, x1, x2)
     | _ -> None
 
 let (|SynPipeRight|_|) input =
     match input with
-    | SynBinOp (synId, x1, x2) when synId.idText = "op_PipeRight" -> Some(x1, x2)
+    | SynBinOp(synId, x1, x2) when synId.idText = "op_PipeRight" -> Some(x1, x2)
     | _ -> None
 
 let (|SynPipeRight2|_|) input =
     match input with
-    | SynBinOp (synId, SynExpr.Paren (SynExpr.Tuple (false, [ x1a; x1b ], _, _), _, _, _), x2) when synId.idText = "op_PipeRight2" ->
+    | SynBinOp(synId, SynExpr.Paren(SynExpr.Tuple(false, [ x1a; x1b ], _, _), _, _, _), x2) when synId.idText = "op_PipeRight2" ->
         Some(x1a, x1b, x2)
     | _ -> None
 
 let (|SynPipeRight3|_|) input =
     match input with
-    | SynBinOp (synId, SynExpr.Paren (SynExpr.Tuple (false, [ x1a; x1b; x1c ], _, _), _, _, _), x2) when synId.idText = "op_PipeRight3" ->
+    | SynBinOp(synId, SynExpr.Paren(SynExpr.Tuple(false, [ x1a; x1b; x1c ], _, _), _, _, _), x2) when synId.idText = "op_PipeRight3" ->
         Some(x1a, x1b, x1c, x2)
     | _ -> None
 
 let (|SynAndAlso|_|) input =
     match input with
-    | SynBinOp (synId, x1, x2) when synId.idText = "op_BooleanAnd" -> Some(x1, x2)
+    | SynBinOp(synId, x1, x2) when synId.idText = "op_BooleanAnd" -> Some(x1, x2)
     | _ -> None
 
 let (|SynOrElse|_|) input =
     match input with
-    | SynBinOp (synId, x1, x2) when synId.idText = "op_BooleanOr" -> Some(x1, x2)
+    | SynBinOp(synId, x1, x2) when synId.idText = "op_BooleanOr" -> Some(x1, x2)
     | _ -> None
 
 /// This affects placement of debug points
@@ -176,7 +176,7 @@ let rec IsControlFlowExpression e =
     | SynExpr.LetOrUse _
     | SynExpr.Sequential _
     // Treat "ident { ... }" as a control flow expression
-    | SynExpr.App (_, _, SynExpr.Ident _, SynExpr.ComputationExpr _, _)
+    | SynExpr.App(_, _, SynExpr.Ident _, SynExpr.ComputationExpr _, _)
     | SynExpr.IfThenElse _
     | SynExpr.LetOrUseBang _
     | SynExpr.Match _
@@ -185,7 +185,7 @@ let rec IsControlFlowExpression e =
     | SynExpr.For _
     | SynExpr.ForEach _
     | SynExpr.While _ -> true
-    | SynExpr.Typed (e, _, _) -> IsControlFlowExpression e
+    | SynExpr.Typed(e, _, _) -> IsControlFlowExpression e
     | _ -> false
 
 // The syntactic criteria for when a debug point for a 'let' is extended to include
@@ -207,8 +207,9 @@ let IsDebugPointBinding synPat synExpr =
     not (IsControlFlowExpression synExpr)
     && let isFunction =
         match synPat with
-        | SynPat.LongIdent (argPats = SynArgPats.Pats args; typarDecls = typarDecls) when not args.IsEmpty || typarDecls.IsSome -> true
+        | SynPat.LongIdent(argPats = SynArgPats.Pats args; typarDecls = typarDecls) when not args.IsEmpty || typarDecls.IsSome -> true
         | _ -> false in
+
        not isFunction
 
 let inline unionRangeWithXmlDoc (xmlDoc: PreXmlDoc) range =
@@ -235,56 +236,56 @@ let mkSynPatMaybeVar lidwd vis m =
 /// Extract the argument for patterns corresponding to the declaration of 'new ... = ...'
 let (|SynPatForConstructorDecl|_|) x =
     match x with
-    | SynPat.LongIdent (longDotId = SynSingleIdent _; argPats = SynArgPats.Pats [ arg ]) -> Some arg
+    | SynPat.LongIdent(longDotId = SynSingleIdent _; argPats = SynArgPats.Pats [ arg ]) -> Some arg
     | _ -> None
 
 /// Recognize the '()' in 'new()'
 let (|SynPatForNullaryArgs|_|) x =
     match x with
-    | SynPat.Paren (SynPat.Const (SynConst.Unit, _), _) -> Some()
+    | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _) -> Some()
     | _ -> None
 
 let (|SynExprErrorSkip|) (p: SynExpr) =
     match p with
-    | SynExpr.FromParseError (p, _) -> p
+    | SynExpr.FromParseError(p, _) -> p
     | _ -> p
 
 let (|SynExprParen|_|) (e: SynExpr) =
     match e with
-    | SynExpr.Paren (SynExprErrorSkip e, a, b, c) -> Some(e, a, b, c)
+    | SynExpr.Paren(SynExprErrorSkip e, a, b, c) -> Some(e, a, b, c)
     | _ -> None
 
 let (|SynPatErrorSkip|) (p: SynPat) =
     match p with
-    | SynPat.FromParseError (p, _) -> p
+    | SynPat.FromParseError(p, _) -> p
     | _ -> p
 
 /// Push non-simple parts of a patten match over onto the r.h.s. of a lambda.
 /// Return a simple pattern and a function to build a match on the r.h.s. if the pattern is complex
 let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
     match p with
-    | SynPat.Typed (p', ty, m) ->
+    | SynPat.Typed(p', ty, m) ->
         let p2, laterF = SimplePatOfPat synArgNameGenerator p'
         SynSimplePat.Typed(p2, ty, m), laterF
 
-    | SynPat.Attrib (p', attribs, m) ->
+    | SynPat.Attrib(p', attribs, m) ->
         let p2, laterF = SimplePatOfPat synArgNameGenerator p'
         SynSimplePat.Attrib(p2, attribs, m), laterF
 
-    | SynPat.Named (SynIdent (v, _), thisV, _, m) -> SynSimplePat.Id(v, None, false, thisV, false, m), None
+    | SynPat.Named(SynIdent(v, _), thisV, _, m) -> SynSimplePat.Id(v, None, false, thisV, false, m), None
 
-    | SynPat.OptionalVal (v, m) -> SynSimplePat.Id(v, None, false, false, true, m), None
+    | SynPat.OptionalVal(v, m) -> SynSimplePat.Id(v, None, false, false, true, m), None
 
-    | SynPat.Paren (p, _) -> SimplePatOfPat synArgNameGenerator p
+    | SynPat.Paren(p, _) -> SimplePatOfPat synArgNameGenerator p
 
-    | SynPat.FromParseError (p, _) -> SimplePatOfPat synArgNameGenerator p
+    | SynPat.FromParseError(p, _) -> SimplePatOfPat synArgNameGenerator p
 
     | _ ->
         let m = p.Range
 
         let isCompGen, altNameRefCell, id, item =
             match p with
-            | SynPat.LongIdent (longDotId = SynSingleIdent (id); typarDecls = None; argPats = SynArgPats.Pats []; accessibility = None) ->
+            | SynPat.LongIdent(longDotId = SynSingleIdent(id); typarDecls = None; argPats = SynArgPats.Pats []; accessibility = None) ->
                 // The pattern is 'V' or some other capitalized identifier.
                 // It may be a real variable, in which case we want to maintain its name.
                 // But it may also be a nullary union case or some other identifier.
@@ -294,8 +295,8 @@ let rec SimplePatOfPat (synArgNameGenerator: SynArgNameGenerator) p =
 
                 let item = mkSynIdGetWithAlt m id altNameRefCell
                 false, altNameRefCell, id, item
-            | SynPat.Named (SynIdent (ident, _), _, _, _)
-            | SynPat.As (_, SynPat.Named (SynIdent (ident, _), _, _, _), _) ->
+            | SynPat.Named(SynIdent(ident, _), _, _, _)
+            | SynPat.As(_, SynPat.Named(SynIdent(ident, _), _, _, _), _) ->
                 // named pats should be referred to as their name in docs, tooltips, etc.
                 let item = mkSynIdGet m ident.idText
                 false, None, ident, item
@@ -337,11 +338,11 @@ let composeFunOpt funOpt1 funOpt2 =
 
 let rec SimplePatsOfPat synArgNameGenerator p =
     match p with
-    | SynPat.FromParseError (p, _) -> SimplePatsOfPat synArgNameGenerator p
+    | SynPat.FromParseError(p, _) -> SimplePatsOfPat synArgNameGenerator p
 
-    | SynPat.Tuple (false, ps, commas, m)
+    | SynPat.Tuple(false, ps, commas, m)
 
-    | SynPat.Paren (SynPat.Tuple (false, ps, commas, _), m) ->
+    | SynPat.Paren(SynPat.Tuple(false, ps, commas, _), m) ->
         let sps = List.map (SimplePatOfPat synArgNameGenerator) ps
 
         let ps2, laterF =
@@ -349,9 +350,9 @@ let rec SimplePatsOfPat synArgNameGenerator p =
 
         SynSimplePats.SimplePats(ps2, commas, m), laterF
 
-    | SynPat.Paren (SynPat.Const (SynConst.Unit, m), _)
+    | SynPat.Paren(SynPat.Const(SynConst.Unit, m), _)
 
-    | SynPat.Const (SynConst.Unit, m) -> SynSimplePats.SimplePats([], [], m), None
+    | SynPat.Const(SynConst.Unit, m) -> SynSimplePats.SimplePats([], [], m), None
 
     | _ ->
         let m = p.Range
@@ -461,11 +462,11 @@ let mkSynQMarkSet m a b c = mkSynTrifix m qmarkSet a b c
 
 let mkSynDotParenGet mLhs mDot a b =
     match b with
-    | SynExpr.Tuple (false, [ _; _ ], _, _) ->
+    | SynExpr.Tuple(false, [ _; _ ], _, _) ->
         errorR (Deprecated(FSComp.SR.astDeprecatedIndexerNotation (), mLhs))
         SynExpr.Const(SynConst.Unit, mLhs)
 
-    | SynExpr.Tuple (false, [ _; _; _ ], _, _) ->
+    | SynExpr.Tuple(false, [ _; _; _ ], _, _) ->
         errorR (Deprecated(FSComp.SR.astDeprecatedIndexerNotation (), mLhs))
         SynExpr.Const(SynConst.Unit, mLhs)
 
@@ -484,23 +485,23 @@ let mkSynAssign (l: SynExpr) (r: SynExpr) =
 
     match l with
     //| SynExpr.Paren (l2, m2)  -> mkSynAssign m l2 r
-    | LongOrSingleIdent (false, v, None, _) -> SynExpr.LongIdentSet(v, r, m)
-    | SynExpr.DotGet (e, _, v, _) -> SynExpr.DotSet(e, v, r, m)
-    | SynExpr.DotIndexedGet (e1, e2, mDot, mLeft) -> SynExpr.DotIndexedSet(e1, e2, r, mLeft, mDot, m)
-    | SynExpr.LibraryOnlyUnionCaseFieldGet (x, y, z, _) -> SynExpr.LibraryOnlyUnionCaseFieldSet(x, y, z, r, m)
-    | SynExpr.App (_, _, SynExpr.App (_, _, SingleIdent nm, a, _), b, _) when nm.idText = opNameQMark -> mkSynQMarkSet m a b r
-    | SynExpr.App (_, _, SynExpr.App (_, _, SingleIdent nm, a, _), b, _) when nm.idText = opNameParenGet -> mkSynDotParenSet m a b r
-    | SynExpr.App (_, _, SynExpr.LongIdent (false, v, None, _), x, _) -> SynExpr.NamedIndexedPropertySet(v, x, r, m)
-    | SynExpr.App (_, _, SynExpr.DotGet (e, _, v, _), x, _) -> SynExpr.DotNamedIndexedPropertySet(e, v, x, r, m)
+    | LongOrSingleIdent(false, v, None, _) -> SynExpr.LongIdentSet(v, r, m)
+    | SynExpr.DotGet(e, _, v, _) -> SynExpr.DotSet(e, v, r, m)
+    | SynExpr.DotIndexedGet(e1, e2, mDot, mLeft) -> SynExpr.DotIndexedSet(e1, e2, r, mLeft, mDot, m)
+    | SynExpr.LibraryOnlyUnionCaseFieldGet(x, y, z, _) -> SynExpr.LibraryOnlyUnionCaseFieldSet(x, y, z, r, m)
+    | SynExpr.App(_, _, SynExpr.App(_, _, SingleIdent nm, a, _), b, _) when nm.idText = opNameQMark -> mkSynQMarkSet m a b r
+    | SynExpr.App(_, _, SynExpr.App(_, _, SingleIdent nm, a, _), b, _) when nm.idText = opNameParenGet -> mkSynDotParenSet m a b r
+    | SynExpr.App(_, _, SynExpr.LongIdent(false, v, None, _), x, _) -> SynExpr.NamedIndexedPropertySet(v, x, r, m)
+    | SynExpr.App(_, _, SynExpr.DotGet(e, _, v, _), x, _) -> SynExpr.DotNamedIndexedPropertySet(e, v, x, r, m)
     | l -> SynExpr.Set(l, r, m)
 
-let mkSynDot mDot m l (SynIdent (r, rTrivia)) =
+let mkSynDot mDot m l (SynIdent(r, rTrivia)) =
     match l with
-    | SynExpr.LongIdent (isOpt, SynLongIdent (lid, dots, trivia), None, _) ->
+    | SynExpr.LongIdent(isOpt, SynLongIdent(lid, dots, trivia), None, _) ->
         // REVIEW: MEMORY PERFORMANCE: This list operation is memory intensive (we create a lot of these list nodes)
         SynExpr.LongIdent(isOpt, SynLongIdent(lid @ [ r ], dots @ [ mDot ], trivia @ [ rTrivia ]), None, m)
     | SynExpr.Ident id -> SynExpr.LongIdent(false, SynLongIdent([ id; r ], [ mDot ], [ None; rTrivia ]), None, m)
-    | SynExpr.DotGet (e, dm, SynLongIdent (lid, dots, trivia), _) ->
+    | SynExpr.DotGet(e, dm, SynLongIdent(lid, dots, trivia), _) ->
         // REVIEW: MEMORY PERFORMANCE: This is memory intensive (we create a lot of these list nodes)
         SynExpr.DotGet(e, dm, SynLongIdent(lid @ [ r ], dots @ [ mDot ], trivia @ [ rTrivia ]), m)
     | expr -> SynExpr.DotGet(expr, mDot, SynLongIdent([ r ], [], [ rTrivia ]), m)
@@ -535,7 +536,7 @@ let (|TyparsAndConstraints|) (typarDecls: SynTyparDecls option) =
     |> Option.map (fun x -> x.TyparDecls, x.Constraints)
     |> Option.defaultValue ([], [])
 
-let (|ValTyparDecls|) (SynValTyparDecls (typarDecls, canInfer)) =
+let (|ValTyparDecls|) (SynValTyparDecls(typarDecls, canInfer)) =
     typarDecls
     |> Option.map (fun x -> x.TyparDecls, x.Constraints, canInfer)
     |> Option.defaultValue ([], [], canInfer)
@@ -545,7 +546,7 @@ let rangeOfNonNilAttrs (attrs: SynAttributes) =
 
 let rec stripParenTypes synType =
     match synType with
-    | SynType.Paren (innerType, _) -> stripParenTypes innerType
+    | SynType.Paren(innerType, _) -> stripParenTypes innerType
     | _ -> synType
 
 let (|StripParenTypes|) synType = stripParenTypes synType
@@ -569,29 +570,29 @@ module SynInfo =
     let selfMetadata = unnamedTopArg
 
     /// Determine if a syntactic information represents a member without arguments (which is implicitly a property getter)
-    let HasNoArgs (SynValInfo (args, _)) = isNil args
+    let HasNoArgs (SynValInfo(args, _)) = isNil args
 
     /// Check if one particular argument is an optional argument. Used when adjusting the
     /// types of optional arguments for function and member signatures.
-    let IsOptionalArg (SynArgInfo (_, isOpt, _)) = isOpt
+    let IsOptionalArg (SynArgInfo(_, isOpt, _)) = isOpt
 
     /// Check if there are any optional arguments in the syntactic argument information. Used when adjusting the
     /// types of optional arguments for function and member signatures.
-    let HasOptionalArgs (SynValInfo (args, _)) =
+    let HasOptionalArgs (SynValInfo(args, _)) =
         List.exists (List.exists IsOptionalArg) args
 
     /// Add a parameter entry to the syntactic value information to represent the '()' argument to a property getter. This is
     /// used for the implicit '()' argument in property getter signature specifications.
-    let IncorporateEmptyTupledArgForPropertyGetter (SynValInfo (args, retInfo)) = SynValInfo([] :: args, retInfo)
+    let IncorporateEmptyTupledArgForPropertyGetter (SynValInfo(args, retInfo)) = SynValInfo([] :: args, retInfo)
 
     /// Add a parameter entry to the syntactic value information to represent the 'this' argument. This is
     /// used for the implicit 'this' argument in member signature specifications.
-    let IncorporateSelfArg (SynValInfo (args, retInfo)) =
+    let IncorporateSelfArg (SynValInfo(args, retInfo)) =
         SynValInfo(selfMetadata :: args, retInfo)
 
     /// Add a parameter entry to the syntactic value information to represent the value argument for a property setter. This is
     /// used for the implicit value argument in property setter signature specifications.
-    let IncorporateSetterArg (SynValInfo (args, retInfo)) =
+    let IncorporateSetterArg (SynValInfo(args, retInfo)) =
         let args =
             match args with
             | [] -> [ unnamedTopArg ]
@@ -601,22 +602,22 @@ module SynInfo =
         SynValInfo(args, retInfo)
 
     /// Get the argument counts for each curried argument group. Used in some adhoc places in tc.fs.
-    let AritiesOfArgs (SynValInfo (args, _)) = List.map List.length args
+    let AritiesOfArgs (SynValInfo(args, _)) = List.map List.length args
 
     /// Get the argument attributes from the syntactic information for an argument.
-    let AttribsOfArgData (SynArgInfo (Attributes attribs, _, _)) = attribs
+    let AttribsOfArgData (SynArgInfo(Attributes attribs, _, _)) = attribs
 
     /// Infer the syntactic argument info for a single argument from a simple pattern.
     let rec InferSynArgInfoFromSimplePat attribs p =
         match p with
-        | SynSimplePat.Id (nm, _, isCompGen, _, isOpt, _) -> SynArgInfo(attribs, isOpt, (if isCompGen then None else Some nm))
-        | SynSimplePat.Typed (a, _, _) -> InferSynArgInfoFromSimplePat attribs a
-        | SynSimplePat.Attrib (a, attribs2, _) -> InferSynArgInfoFromSimplePat (attribs @ attribs2) a
+        | SynSimplePat.Id(nm, _, isCompGen, _, isOpt, _) -> SynArgInfo(attribs, isOpt, (if isCompGen then None else Some nm))
+        | SynSimplePat.Typed(a, _, _) -> InferSynArgInfoFromSimplePat attribs a
+        | SynSimplePat.Attrib(a, attribs2, _) -> InferSynArgInfoFromSimplePat (attribs @ attribs2) a
 
     /// Infer the syntactic argument info for one or more arguments one or more simple patterns.
     let rec InferSynArgInfoFromSimplePats x =
         match x with
-        | SynSimplePats.SimplePats (pats = ps) -> List.map (InferSynArgInfoFromSimplePat []) ps
+        | SynSimplePats.SimplePats(pats = ps) -> List.map (InferSynArgInfoFromSimplePat []) ps
 
     /// Infer the syntactic argument info for one or more arguments a pattern.
     let InferSynArgInfoFromPat p =
@@ -651,7 +652,7 @@ module SynInfo =
         else
             let rec loop e =
                 match e with
-                | SynExpr.Lambda (fromMethod = false; args = spats; body = rest) -> InferSynArgInfoFromSimplePats spats :: loop rest
+                | SynExpr.Lambda(fromMethod = false; args = spats; body = rest) -> InferSynArgInfoFromSimplePats spats :: loop rest
                 | _ -> []
 
             loop origRhsExpr
@@ -659,7 +660,7 @@ module SynInfo =
     let InferSynReturnData (retInfo: SynReturnInfo option) =
         match retInfo with
         | None -> unnamedRetVal
-        | Some (SynReturnInfo ((_, retInfo), _)) -> retInfo
+        | Some(SynReturnInfo((_, retInfo), _)) -> retInfo
 
     let private emptySynValInfo = SynValInfo([], unnamedRetVal)
 
@@ -674,12 +675,12 @@ module SynInfo =
 
         let infosForExplicitArgs =
             match pat with
-            | Some (SynPat.LongIdent(argPats = SynArgPats.Pats curriedArgs)) -> List.map InferSynArgInfoFromPat curriedArgs
+            | Some(SynPat.LongIdent(argPats = SynArgPats.Pats curriedArgs)) -> List.map InferSynArgInfoFromPat curriedArgs
             | _ -> []
 
         let explicitArgsAreSimple =
             match pat with
-            | Some (SynPat.LongIdent(argPats = SynArgPats.Pats curriedArgs)) -> List.forall isSimplePattern curriedArgs
+            | Some(SynPat.LongIdent(argPats = SynArgPats.Pats curriedArgs)) -> List.forall isSimplePattern curriedArgs
             | _ -> true
 
         let retInfo = InferSynReturnData retInfo
@@ -710,7 +711,7 @@ let mkSynBindingRhs staticOptimizations rhsExpr mRhs retInfo =
 
     let rhsExpr, retTyOpt =
         match retInfo with
-        | Some (mColon, SynReturnInfo ((ty, SynArgInfo (rAttribs, _, _)), tym)) ->
+        | Some(mColon, SynReturnInfo((ty, SynArgInfo(rAttribs, _, _)), tym)) ->
             SynExpr.Typed(rhsExpr, ty, rhsExpr.Range), Some(SynBindingReturnInfo(ty, tym, rAttribs, { ColonRange = mColon }))
         | None -> rhsExpr, None
 
@@ -807,13 +808,13 @@ let unionBindingAndMembers (bindings: SynBinding list) (members: SynMemberDefn l
         yield!
             List.choose
                 (function
-                | SynMemberDefn.Member (b, _) -> Some b
+                | SynMemberDefn.Member(b, _) -> Some b
                 | _ -> None)
                 members
     ]
 
 let rec synExprContainsError inpExpr =
-    let rec walkBind (SynBinding (expr = synExpr)) = walkExpr synExpr
+    let rec walkBind (SynBinding(expr = synExpr)) = walkExpr synExpr
 
     and walkExprs es = es |> List.exists walkExpr
 
@@ -821,7 +822,7 @@ let rec synExprContainsError inpExpr =
 
     and walkMatchClauses cl =
         cl
-        |> List.exists (fun (SynMatchClause (whenExpr = whenExpr; resultExpr = e)) -> walkExprOpt whenExpr || walkExpr e)
+        |> List.exists (fun (SynMatchClause(whenExpr = whenExpr; resultExpr = e)) -> walkExprOpt whenExpr || walkExpr e)
 
     and walkExprOpt eOpt = eOpt |> Option.exists walkExpr
 
@@ -843,91 +844,91 @@ let rec synExprContainsError inpExpr =
         | SynExpr.Const _
         | SynExpr.Dynamic _ -> false
 
-        | SynExpr.TypeTest (e, _, _)
-        | SynExpr.Upcast (e, _, _)
-        | SynExpr.AddressOf (_, e, _, _)
-        | SynExpr.ComputationExpr (_, e, _)
-        | SynExpr.ArrayOrListComputed (_, e, _)
-        | SynExpr.Typed (e, _, _)
-        | SynExpr.Do (e, _)
-        | SynExpr.Assert (e, _)
-        | SynExpr.DotGet (e, _, _, _)
-        | SynExpr.LongIdentSet (_, e, _)
-        | SynExpr.New (_, _, e, _)
-        | SynExpr.TypeApp (e, _, _, _, _, _, _)
-        | SynExpr.LibraryOnlyUnionCaseFieldGet (e, _, _, _)
-        | SynExpr.Downcast (e, _, _)
-        | SynExpr.InferredUpcast (e, _)
-        | SynExpr.InferredDowncast (e, _)
-        | SynExpr.Lazy (e, _)
-        | SynExpr.TraitCall (_, _, e, _)
-        | SynExpr.YieldOrReturn (_, e, _)
-        | SynExpr.YieldOrReturnFrom (_, e, _)
-        | SynExpr.DoBang (e, _)
-        | SynExpr.Fixed (e, _)
-        | SynExpr.DebugPoint (_, _, e)
-        | SynExpr.Paren (e, _, _, _) -> walkExpr e
+        | SynExpr.TypeTest(e, _, _)
+        | SynExpr.Upcast(e, _, _)
+        | SynExpr.AddressOf(_, e, _, _)
+        | SynExpr.ComputationExpr(_, e, _)
+        | SynExpr.ArrayOrListComputed(_, e, _)
+        | SynExpr.Typed(e, _, _)
+        | SynExpr.Do(e, _)
+        | SynExpr.Assert(e, _)
+        | SynExpr.DotGet(e, _, _, _)
+        | SynExpr.LongIdentSet(_, e, _)
+        | SynExpr.New(_, _, e, _)
+        | SynExpr.TypeApp(e, _, _, _, _, _, _)
+        | SynExpr.LibraryOnlyUnionCaseFieldGet(e, _, _, _)
+        | SynExpr.Downcast(e, _, _)
+        | SynExpr.InferredUpcast(e, _)
+        | SynExpr.InferredDowncast(e, _)
+        | SynExpr.Lazy(e, _)
+        | SynExpr.TraitCall(_, _, e, _)
+        | SynExpr.YieldOrReturn(_, e, _)
+        | SynExpr.YieldOrReturnFrom(_, e, _)
+        | SynExpr.DoBang(e, _)
+        | SynExpr.Fixed(e, _)
+        | SynExpr.DebugPoint(_, _, e)
+        | SynExpr.Paren(e, _, _, _) -> walkExpr e
 
-        | SynExpr.NamedIndexedPropertySet (_, e1, e2, _)
-        | SynExpr.DotSet (e1, _, e2, _)
-        | SynExpr.Set (e1, e2, _)
-        | SynExpr.LibraryOnlyUnionCaseFieldSet (e1, _, _, e2, _)
-        | SynExpr.JoinIn (e1, _, e2, _)
-        | SynExpr.App (_, _, e1, e2, _) -> walkExpr e1 || walkExpr e2
+        | SynExpr.NamedIndexedPropertySet(_, e1, e2, _)
+        | SynExpr.DotSet(e1, _, e2, _)
+        | SynExpr.Set(e1, e2, _)
+        | SynExpr.LibraryOnlyUnionCaseFieldSet(e1, _, _, e2, _)
+        | SynExpr.JoinIn(e1, _, e2, _)
+        | SynExpr.App(_, _, e1, e2, _) -> walkExpr e1 || walkExpr e2
 
-        | SynExpr.ArrayOrList (_, es, _)
-        | SynExpr.Tuple (_, es, _, _) -> walkExprs es
+        | SynExpr.ArrayOrList(_, es, _)
+        | SynExpr.Tuple(_, es, _, _) -> walkExprs es
 
-        | SynExpr.AnonRecd (copyInfo = origExpr; recordFields = flds) ->
+        | SynExpr.AnonRecd(copyInfo = origExpr; recordFields = flds) ->
             (match origExpr with
-             | Some (e, _) -> walkExpr e
+             | Some(e, _) -> walkExpr e
              | None -> false)
             || walkExprs (List.map (fun (_, _, e) -> e) flds)
 
-        | SynExpr.Record (_, origExpr, fs, _) ->
+        | SynExpr.Record(_, origExpr, fs, _) ->
             (match origExpr with
-             | Some (e, _) -> walkExpr e
+             | Some(e, _) -> walkExpr e
              | None -> false)
-            || (let flds = fs |> List.choose (fun (SynExprRecordField (expr = v)) -> v)
+            || (let flds = fs |> List.choose (fun (SynExprRecordField(expr = v)) -> v)
                 walkExprs flds)
 
-        | SynExpr.ObjExpr (bindings = bs; members = ms; extraImpls = is) ->
+        | SynExpr.ObjExpr(bindings = bs; members = ms; extraImpls = is) ->
             let bs = unionBindingAndMembers bs ms
 
             let binds =
                 [
-                    for SynInterfaceImpl (bindings = bs) in is do
+                    for SynInterfaceImpl(bindings = bs) in is do
                         yield! bs
                 ]
 
             walkBinds bs || walkBinds binds
 
-        | SynExpr.ForEach (_, _, _, _, _, e1, e2, _)
-        | SynExpr.While (_, e1, e2, _)
-        | SynExpr.WhileBang (_, e1, e2, _) -> walkExpr e1 || walkExpr e2
+        | SynExpr.ForEach(_, _, _, _, _, e1, e2, _)
+        | SynExpr.While(_, e1, e2, _)
+        | SynExpr.WhileBang(_, e1, e2, _) -> walkExpr e1 || walkExpr e2
 
-        | SynExpr.For (identBody = e1; toBody = e2; doBody = e3) -> walkExpr e1 || walkExpr e2 || walkExpr e3
+        | SynExpr.For(identBody = e1; toBody = e2; doBody = e3) -> walkExpr e1 || walkExpr e2 || walkExpr e3
 
-        | SynExpr.MatchLambda (_, _, cl, _, _) -> walkMatchClauses cl
+        | SynExpr.MatchLambda(_, _, cl, _, _) -> walkMatchClauses cl
 
-        | SynExpr.Lambda (body = e) -> walkExpr e
+        | SynExpr.Lambda(body = e) -> walkExpr e
 
-        | SynExpr.Match (expr = e; clauses = cl)
-        | SynExpr.MatchBang (expr = e; clauses = cl) -> walkExpr e || walkMatchClauses cl
+        | SynExpr.Match(expr = e; clauses = cl)
+        | SynExpr.MatchBang(expr = e; clauses = cl) -> walkExpr e || walkMatchClauses cl
 
-        | SynExpr.LetOrUse (bindings = bs; body = e) -> walkBinds bs || walkExpr e
+        | SynExpr.LetOrUse(bindings = bs; body = e) -> walkBinds bs || walkExpr e
 
-        | SynExpr.TryWith (tryExpr = e; withCases = cl) -> walkExpr e || walkMatchClauses cl
+        | SynExpr.TryWith(tryExpr = e; withCases = cl) -> walkExpr e || walkMatchClauses cl
 
-        | SynExpr.TryFinally (tryExpr = e1; finallyExpr = e2) -> walkExpr e1 || walkExpr e2
+        | SynExpr.TryFinally(tryExpr = e1; finallyExpr = e2) -> walkExpr e1 || walkExpr e2
 
-        | SynExpr.Sequential (_, _, e1, e2, _) -> walkExpr e1 || walkExpr e2
+        | SynExpr.Sequential(_, _, e1, e2, _) -> walkExpr e1 || walkExpr e2
 
-        | SynExpr.SequentialOrImplicitYield (_, e1, e2, _, _) -> walkExpr e1 || walkExpr e2
+        | SynExpr.SequentialOrImplicitYield(_, e1, e2, _, _) -> walkExpr e1 || walkExpr e2
 
-        | SynExpr.IfThenElse (ifExpr = e1; thenExpr = e2; elseExpr = e3opt) -> walkExpr e1 || walkExpr e2 || walkExprOpt e3opt
+        | SynExpr.IfThenElse(ifExpr = e1; thenExpr = e2; elseExpr = e3opt) -> walkExpr e1 || walkExpr e2 || walkExprOpt e3opt
 
-        | SynExpr.IndexRange (expr1, _, expr2, _, _, _) ->
+        | SynExpr.IndexRange(expr1, _, expr2, _, _, _) ->
             (match expr1 with
              | Some e -> walkExpr e
              | None -> false)
@@ -935,28 +936,28 @@ let rec synExprContainsError inpExpr =
                 | Some e -> walkExpr e
                 | None -> false)
 
-        | SynExpr.IndexFromEnd (e, _) -> walkExpr e
+        | SynExpr.IndexFromEnd(e, _) -> walkExpr e
 
-        | SynExpr.DotIndexedGet (e1, indexArgs, _, _) -> walkExpr e1 || walkExpr indexArgs
+        | SynExpr.DotIndexedGet(e1, indexArgs, _, _) -> walkExpr e1 || walkExpr indexArgs
 
-        | SynExpr.DotIndexedSet (e1, indexArgs, e2, _, _, _) -> walkExpr e1 || walkExpr indexArgs || walkExpr e2
+        | SynExpr.DotIndexedSet(e1, indexArgs, e2, _, _, _) -> walkExpr e1 || walkExpr indexArgs || walkExpr e2
 
-        | SynExpr.DotNamedIndexedPropertySet (e1, _, e2, e3, _) -> walkExpr e1 || walkExpr e2 || walkExpr e3
+        | SynExpr.DotNamedIndexedPropertySet(e1, _, e2, e3, _) -> walkExpr e1 || walkExpr e2 || walkExpr e3
 
-        | SynExpr.LetOrUseBang (rhs = e1; body = e2; andBangs = es) ->
+        | SynExpr.LetOrUseBang(rhs = e1; body = e2; andBangs = es) ->
             walkExpr e1
             || walkExprs
                 [
-                    for SynExprAndBang (body = e) in es do
+                    for SynExprAndBang(body = e) in es do
                         yield e
                 ]
             || walkExpr e2
 
-        | SynExpr.InterpolatedString (parts, _, _m) ->
+        | SynExpr.InterpolatedString(parts, _, _m) ->
             parts
             |> List.choose (function
                 | SynInterpolatedStringPart.String _ -> None
-                | SynInterpolatedStringPart.FillExpr (x, _) -> Some x)
+                | SynInterpolatedStringPart.FillExpr(x, _) -> Some x)
             |> walkExprs
 
     walkExpr inpExpr
@@ -964,25 +965,25 @@ let rec synExprContainsError inpExpr =
 let (|ParsedHashDirectiveArguments|) (input: ParsedHashDirectiveArgument list) =
     List.map
         (function
-        | ParsedHashDirectiveArgument.String (s, _, _) -> s
-        | ParsedHashDirectiveArgument.SourceIdentifier (_, v, _) -> v)
+        | ParsedHashDirectiveArgument.String(s, _, _) -> s
+        | ParsedHashDirectiveArgument.SourceIdentifier(_, v, _) -> v)
         input
 
-let prependIdentInLongIdentWithTrivia (SynIdent (ident, identTrivia)) mDot lid =
+let prependIdentInLongIdentWithTrivia (SynIdent(ident, identTrivia)) mDot lid =
     match lid with
-    | SynLongIdent (lid, dots, trivia) -> SynLongIdent(ident :: lid, mDot :: dots, identTrivia :: trivia)
+    | SynLongIdent(lid, dots, trivia) -> SynLongIdent(ident :: lid, mDot :: dots, identTrivia :: trivia)
 
 let mkDynamicArgExpr expr =
     match expr with
     | SynExpr.Ident ident ->
         let con = SynConst.String(ident.idText, SynStringKind.Regular, ident.idRange)
         SynExpr.Const(con, con.Range ident.idRange)
-    | SynExpr.Paren (expr = e) -> e
+    | SynExpr.Paren(expr = e) -> e
     | e -> e
 
 let rec normalizeTuplePat pats commas : SynPat list * range List =
     match pats with
-    | SynPat.Tuple (false, innerPats, innerCommas, _) :: rest ->
+    | SynPat.Tuple(false, innerPats, innerCommas, _) :: rest ->
         let innerPats, innerCommas =
             normalizeTuplePat (List.rev innerPats) (List.rev innerCommas)
 
@@ -994,20 +995,20 @@ let rec desugarGetSetMembers (memberDefns: SynMemberDefns) =
     memberDefns
     |> List.collect (fun md ->
         match md with
-        | SynMemberDefn.GetSetMember (Some (SynBinding _ as getBinding),
-                                      Some (SynBinding _ as setBinding),
-                                      m,
-                                      {
-                                          GetKeyword = Some mGet
-                                          SetKeyword = Some mSet
-                                      }) ->
+        | SynMemberDefn.GetSetMember(Some(SynBinding _ as getBinding),
+                                     Some(SynBinding _ as setBinding),
+                                     m,
+                                     {
+                                         GetKeyword = Some mGet
+                                         SetKeyword = Some mSet
+                                     }) ->
             if Position.posLt mGet.Start mSet.Start then
                 [ SynMemberDefn.Member(getBinding, m); SynMemberDefn.Member(setBinding, m) ]
             else
                 [ SynMemberDefn.Member(setBinding, m); SynMemberDefn.Member(getBinding, m) ]
-        | SynMemberDefn.GetSetMember (Some binding, None, m, _)
-        | SynMemberDefn.GetSetMember (None, Some binding, m, _) -> [ SynMemberDefn.Member(binding, m) ]
-        | SynMemberDefn.Interface (interfaceType, withKeyword, members, m) ->
+        | SynMemberDefn.GetSetMember(Some binding, None, m, _)
+        | SynMemberDefn.GetSetMember(None, Some binding, m, _) -> [ SynMemberDefn.Member(binding, m) ]
+        | SynMemberDefn.Interface(interfaceType, withKeyword, members, m) ->
             let members = Option.map desugarGetSetMembers members
             [ SynMemberDefn.Interface(interfaceType, withKeyword, members, m) ]
         | md -> [ md ])
@@ -1020,7 +1021,7 @@ let getTypeFromTuplePath (path: SynTupleTypeSegment list) : SynType list =
 
 let (|MultiDimensionArrayType|_|) (t: SynType) =
     match t with
-    | SynType.App (StripParenTypes (SynType.LongIdent (SynLongIdent ([ identifier ], _, _))), _, [ elementType ], _, _, true, m) ->
+    | SynType.App(StripParenTypes(SynType.LongIdent(SynLongIdent([ identifier ], _, _))), _, [ elementType ], _, _, true, m) ->
         if System.Text.RegularExpressions.Regex.IsMatch(identifier.idText, "^array\d\d?d$") then
             let rank =
                 identifier.idText
@@ -1037,8 +1038,8 @@ let (|MultiDimensionArrayType|_|) (t: SynType) =
 let (|TypesForTypar|) (t: SynType) =
     let rec visit continuation t =
         match t with
-        | SynType.Paren (innerT, _) -> visit continuation innerT
-        | SynType.Or (lhsT, rhsT, _, _) -> visit (fun lhsTs -> [ yield! lhsTs; yield rhsT ] |> continuation) lhsT
+        | SynType.Paren(innerT, _) -> visit continuation innerT
+        | SynType.Or(lhsT, rhsT, _, _) -> visit (fun lhsTs -> [ yield! lhsTs; yield rhsT ] |> continuation) lhsT
         | _ -> continuation [ t ]
 
     visit id t

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -151,7 +151,7 @@ type SynTypeDefnLeadingKeyword =
         match this with
         | SynTypeDefnLeadingKeyword.Type range
         | SynTypeDefnLeadingKeyword.And range -> range
-        | SynTypeDefnLeadingKeyword.StaticType (staticRange, typeRange) -> Range.unionRanges staticRange typeRange
+        | SynTypeDefnLeadingKeyword.StaticType(staticRange, typeRange) -> Range.unionRanges staticRange typeRange
         | SynTypeDefnLeadingKeyword.Synthetic -> failwith "Getting range from synthetic keyword"
 
 [<NoEquality; NoComparison>]
@@ -228,20 +228,20 @@ type SynLeadingKeyword =
         | New m
         | Do m
         | Static m -> m
-        | LetRec (m1, m2)
-        | UseRec (m1, m2)
-        | AbstractMember (m1, m2)
-        | StaticMember (m1, m2)
-        | StaticAbstract (m1, m2)
-        | StaticAbstractMember (m1, _, m2)
-        | StaticVal (m1, m2)
-        | StaticLet (m1, m2)
-        | StaticLetRec (m1, _, m2)
-        | StaticDo (m1, m2)
-        | DefaultVal (m1, m2)
-        | MemberVal (m1, m2)
-        | OverrideVal (m1, m2)
-        | StaticMemberVal (m1, _, m2) -> Range.unionRanges m1 m2
+        | LetRec(m1, m2)
+        | UseRec(m1, m2)
+        | AbstractMember(m1, m2)
+        | StaticMember(m1, m2)
+        | StaticAbstract(m1, m2)
+        | StaticAbstractMember(m1, _, m2)
+        | StaticVal(m1, m2)
+        | StaticLet(m1, m2)
+        | StaticLetRec(m1, _, m2)
+        | StaticDo(m1, m2)
+        | DefaultVal(m1, m2)
+        | MemberVal(m1, m2)
+        | OverrideVal(m1, m2)
+        | StaticMemberVal(m1, _, m2) -> Range.unionRanges m1 m2
         | Synthetic -> Range.Zero
 
 [<NoEquality; NoComparison>]
@@ -356,7 +356,7 @@ type GetSetKeywords =
         match x with
         | Get m
         | Set m -> m
-        | GetSet (mG, mS) ->
+        | GetSet(mG, mS) ->
             if Range.rangeBeforePos mG mS.Start then
                 Range.unionRanges mG mS
             else

--- a/src/Compiler/SyntaxTree/UnicodeLexing.fs
+++ b/src/Compiler/SyntaxTree/UnicodeLexing.fs
@@ -9,13 +9,16 @@ open Internal.Utilities.Text.Lexing
 type Lexbuf = LexBuffer<char>
 
 let StringAsLexbuf (reportLibraryOnlyFeatures, langVersion, strictIndentation, s: string) =
-    LexBuffer<char>.FromChars (reportLibraryOnlyFeatures, langVersion, strictIndentation, s.ToCharArray())
+    LexBuffer<char>
+        .FromChars(reportLibraryOnlyFeatures, langVersion, strictIndentation, s.ToCharArray())
 
 let FunctionAsLexbuf (reportLibraryOnlyFeatures, langVersion, strictIndentation, bufferFiller) =
-    LexBuffer<char>.FromFunction (reportLibraryOnlyFeatures, langVersion, strictIndentation, bufferFiller)
+    LexBuffer<char>
+        .FromFunction(reportLibraryOnlyFeatures, langVersion, strictIndentation, bufferFiller)
 
 let SourceTextAsLexbuf (reportLibraryOnlyFeatures, langVersion, strictIndentation, sourceText) =
-    LexBuffer<char>.FromSourceText (reportLibraryOnlyFeatures, langVersion, strictIndentation, sourceText)
+    LexBuffer<char>
+        .FromSourceText(reportLibraryOnlyFeatures, langVersion, strictIndentation, sourceText)
 
 let StreamReaderAsLexbuf (reportLibraryOnlyFeatures, langVersion, strictIndentation, reader: StreamReader) =
     let mutable isFinished = false

--- a/src/Compiler/SyntaxTree/XmlDoc.fs
+++ b/src/Compiler/SyntaxTree/XmlDoc.fs
@@ -29,7 +29,8 @@ type XmlDoc(unprocessedLines: string[], range: range) =
                 lines
             else
                 [ "<summary>" ]
-                @ (lines |> List.map Internal.Utilities.XmlAdapters.escape) @ [ "</summary>" ]
+                @ (lines |> List.map Internal.Utilities.XmlAdapters.escape)
+                @ [ "</summary>" ]
 
     /// Get the lines before insertion of implicit summary tags and encoding
     member _.UnprocessedLines = unprocessedLines
@@ -249,10 +250,10 @@ type PreXmlDoc =
 
     member x.ToXmlDoc(check: bool, paramNamesOpt: string list option) =
         match x with
-        | PreXmlDirect (lines, m) -> XmlDoc(lines, m)
-        | PreXmlMerge (a, b) -> XmlDoc.Merge (a.ToXmlDoc(check, paramNamesOpt)) (b.ToXmlDoc(check, paramNamesOpt))
+        | PreXmlDirect(lines, m) -> XmlDoc(lines, m)
+        | PreXmlMerge(a, b) -> XmlDoc.Merge (a.ToXmlDoc(check, paramNamesOpt)) (b.ToXmlDoc(check, paramNamesOpt))
         | PreXmlDocEmpty -> XmlDoc.Empty
-        | PreXmlDoc (pos, collector) ->
+        | PreXmlDoc(pos, collector) ->
             let preLines = collector.LinesBefore pos
 
             if preLines.Length = 0 then
@@ -269,24 +270,24 @@ type PreXmlDoc =
 
     member x.Range =
         match x with
-        | PreXmlDirect (_, m) -> m
-        | PreXmlMerge (part1, part2) ->
+        | PreXmlDirect(_, m) -> m
+        | PreXmlMerge(part1, part2) ->
             if part1.IsEmpty then part2.Range
             elif part2.IsEmpty then part1.Range
             else unionRanges part1.Range part2.Range
         | PreXmlDocEmpty -> Range.Zero
-        | PreXmlDoc (pos, collector) -> collector.LinesRange pos
+        | PreXmlDoc(pos, collector) -> collector.LinesRange pos
 
     member x.IsEmpty =
         match x with
-        | PreXmlDirect (lines, _) -> lines |> Array.forall String.IsNullOrWhiteSpace
-        | PreXmlMerge (a, b) -> a.IsEmpty && b.IsEmpty
+        | PreXmlDirect(lines, _) -> lines |> Array.forall String.IsNullOrWhiteSpace
+        | PreXmlMerge(a, b) -> a.IsEmpty && b.IsEmpty
         | PreXmlDocEmpty -> true
-        | PreXmlDoc (pos, collector) -> not (collector.HasComments pos)
+        | PreXmlDoc(pos, collector) -> not (collector.HasComments pos)
 
     member x.MarkAsInvalid() =
         match x with
-        | PreXmlDoc (pos, collector) -> collector.SetXmlDocValidity(pos, false)
+        | PreXmlDoc(pos, collector) -> collector.SetXmlDocValidity(pos, false)
         | _ -> ()
 
     static member CreateFromGrabPoint(collector: XmlDocCollector, grabPointPos) =

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -3512,7 +3512,9 @@ type Expr =
     ///
     | Quote of
         quotedExpr: Expr *
-        quotationInfo: ((ILTypeRef list * TTypes * Exprs * QuotationPickler.ExprData) * (ILTypeRef list * TTypes * Exprs * QuotationPickler.ExprData)) option ref *
+        quotationInfo:
+            ((ILTypeRef list * TTypes * Exprs * QuotationPickler.ExprData) *
+            (ILTypeRef list * TTypes * Exprs * QuotationPickler.ExprData)) option ref *
         isFromQueryExpression: bool *
         range: Text.range *
         quotedType: TType

--- a/src/Compiler/Utilities/Activity.fs
+++ b/src/Compiler/Utilities/Activity.fs
@@ -231,13 +231,12 @@ module internal Activity =
             let sw = new StreamWriter(path = pathToFile, append = true)
 
             let msgQueue =
-                MailboxProcessor<string>.Start
-                    (fun inbox ->
-                        async {
-                            while true do
-                                let! msg = inbox.Receive()
-                                do! sw.WriteLineAsync(msg) |> Async.AwaitTask
-                        })
+                MailboxProcessor<string>.Start(fun inbox ->
+                    async {
+                        while true do
+                            let! msg = inbox.Receive()
+                            do! sw.WriteLineAsync(msg) |> Async.AwaitTask
+                    })
 
             let l =
                 new ActivityListener(

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -135,7 +135,7 @@ type CancellableBuilder() =
 #endif
 
             match Cancellable.run ct comp1 with
-            | ValueOrCancelled.Value () -> Cancellable.run ct comp2
+            | ValueOrCancelled.Value() -> Cancellable.run ct comp2
             | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
 
     member inline _.TryWith(comp, [<InlineIfLambda>] handler) =

--- a/src/Compiler/Utilities/FileSystem.fs
+++ b/src/Compiler/Utilities/FileSystem.fs
@@ -968,7 +968,7 @@ type internal ByteBuffer =
         buf.CheckDisposed()
         let newSize = buf.bbCurrent + 1
         buf.Ensure newSize
-        buf.bbArray[ buf.bbCurrent ] <- byte i
+        buf.bbArray[buf.bbCurrent] <- byte i
         buf.bbCurrent <- newSize
 
     member buf.EmitByte(b: byte) =
@@ -990,10 +990,10 @@ type internal ByteBuffer =
 
     member bb.FixupInt32 pos value =
         bb.CheckDisposed()
-        bb.bbArray[ pos ] <- (Bytes.b0 value |> byte)
-        bb.bbArray[ pos + 1 ] <- (Bytes.b1 value |> byte)
-        bb.bbArray[ pos + 2 ] <- (Bytes.b2 value |> byte)
-        bb.bbArray[ pos + 3 ] <- (Bytes.b3 value |> byte)
+        bb.bbArray[pos] <- (Bytes.b0 value |> byte)
+        bb.bbArray[pos + 1] <- (Bytes.b1 value |> byte)
+        bb.bbArray[pos + 2] <- (Bytes.b2 value |> byte)
+        bb.bbArray[pos + 3] <- (Bytes.b3 value |> byte)
 
     member buf.EmitInt32 n =
         buf.CheckDisposed()
@@ -1030,8 +1030,8 @@ type internal ByteBuffer =
         buf.CheckDisposed()
         let newSize = buf.bbCurrent + 2
         buf.Ensure newSize
-        buf.bbArray[ buf.bbCurrent ] <- (Bytes.b0 n |> byte)
-        buf.bbArray[ buf.bbCurrent + 1 ] <- (Bytes.b1 n |> byte)
+        buf.bbArray[buf.bbCurrent] <- (Bytes.b0 n |> byte)
+        buf.bbArray[buf.bbCurrent + 1] <- (Bytes.b1 n |> byte)
         buf.bbCurrent <- newSize
 
     member buf.EmitBoolAsByte(b: bool) =

--- a/src/Compiler/Utilities/FileSystem.fsi
+++ b/src/Compiler/Utilities/FileSystem.fsi
@@ -230,6 +230,7 @@ type DefaultFileSystem =
 
     abstract OpenFileForWriteShim:
         filePath: string * ?fileMode: FileMode * ?fileAccess: FileAccess * ?fileShare: FileShare -> Stream
+
     override OpenFileForWriteShim:
         filePath: string * ?fileMode: FileMode * ?fileAccess: FileAccess * ?fileShare: FileShare -> Stream
 

--- a/src/Compiler/Utilities/ImmutableArray.fs
+++ b/src/Compiler/Utilities/ImmutableArray.fs
@@ -78,7 +78,7 @@ module ImmutableArray =
         match arrs.Length with
         | 0 -> ImmutableArray.Empty
         | 1 -> arrs[0]
-        | 2 -> arrs[ 0 ].AddRange(arrs[1])
+        | 2 -> arrs[0].AddRange(arrs[1])
         | _ ->
             let mutable acc = 0
 
@@ -104,7 +104,7 @@ module ImmutableArray =
         if arr1.Length <> arr2.Length then
             invalidOp "Block lengths do not match."
 
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (predicate)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(predicate)
         let len1 = arr1.Length
 
         let rec loop i =
@@ -180,7 +180,7 @@ module ImmutableArray =
     let isEmpty (arr: ImmutableArray<_>) = arr.IsEmpty
 
     let fold folder state (arr: ImmutableArray<_>) =
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
         let mutable state = state
 
         for i = 0 to arr.Length - 1 do

--- a/src/Compiler/Utilities/InternalCollections.fs
+++ b/src/Compiler/Utilities/InternalCollections.fs
@@ -64,7 +64,7 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStron
 
     let TryGetKeyValueImpl (data, key) =
         match TryPeekKeyValueImpl(data, key) with
-        | Some (similarKey, value) as result ->
+        | Some(similarKey, value) as result ->
             // If the result existed, move it to the end of the list (more likely to keep it)
             result, Promote(data, similarKey, value)
         | None -> None, data
@@ -76,8 +76,8 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStron
         [
             for key, value in refs do
                 match value with
-                | Strong (value) -> yield (key, value)
-                | Weak (weakReference) ->
+                | Strong(value) -> yield (key, value)
+                | Weak(weakReference) ->
 #if FX_NO_GENERIC_WEAKREFERENCE
                     match weakReference.Target with
                     | Null -> ()
@@ -136,7 +136,7 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStron
         AssignWithStrength(tok, newData)
 
         match result with
-        | Some (_, value) -> Some(value)
+        | Some(_, value) -> Some(value)
         | None -> None
 
     member al.Put(tok, key, value) =
@@ -164,14 +164,7 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStron
         AssignWithStrength(tok, keep)
 
 type internal MruCache<'Token, 'Key, 'Value when 'Value: not struct>
-    (
-        keepStrongly,
-        areSame,
-        ?isStillValid: 'Key * 'Value -> bool,
-        ?areSimilar,
-        ?requiredToKeep,
-        ?keepMax
-    ) =
+    (keepStrongly, areSame, ?isStillValid: 'Key * 'Value -> bool, ?areSimilar, ?requiredToKeep, ?keepMax) =
 
     /// Default behavior of <c>areSimilar</c> function is areSame.
     let areSimilar = defaultArg areSimilar areSame
@@ -192,17 +185,17 @@ type internal MruCache<'Token, 'Key, 'Value when 'Value: not struct>
 
     member bc.ContainsSimilarKey(tok, key) =
         match cache.TryPeekKeyValue(tok, key) with
-        | Some (_similarKey, _value) -> true
+        | Some(_similarKey, _value) -> true
         | None -> false
 
     member bc.TryGetAny(tok, key) =
         match cache.TryPeekKeyValue(tok, key) with
-        | Some (similarKey, value) -> if areSame (similarKey, key) then Some(value) else None
+        | Some(similarKey, value) -> if areSame (similarKey, key) then Some(value) else None
         | None -> None
 
     member bc.TryGet(tok, key) =
         match cache.TryGetKeyValue(tok, key) with
-        | Some (similarKey, value) ->
+        | Some(similarKey, value) ->
             if areSame (similarKey, key) && isStillValid (key, value) then
                 Some value
             else
@@ -211,12 +204,12 @@ type internal MruCache<'Token, 'Key, 'Value when 'Value: not struct>
 
     member bc.TryGetSimilarAny(tok, key) =
         match cache.TryGetKeyValue(tok, key) with
-        | Some (_, value) -> Some value
+        | Some(_, value) -> Some value
         | None -> None
 
     member bc.TryGetSimilar(tok, key) =
         match cache.TryGetKeyValue(tok, key) with
-        | Some (_, value) -> if isStillValid (key, value) then Some value else None
+        | Some(_, value) -> if isStillValid (key, value) then Some value else None
         | None -> None
 
     member bc.Set(tok, key: 'Key, value: 'Value) = cache.Put(tok, key, value)

--- a/src/Compiler/Utilities/ResizeArray.fs
+++ b/src/Compiler/Utilities/ResizeArray.fs
@@ -112,7 +112,7 @@ module internal ResizeArray =
         res
 
     let mapi f (arr: ResizeArray<_>) =
-        let f = FSharpFunc<_, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _>.Adapt(f)
         let len = length arr
         let res = ResizeArray<_>(len)
 
@@ -122,7 +122,7 @@ module internal ResizeArray =
         res
 
     let iteri f (arr: ResizeArray<_>) =
-        let f = FSharpFunc<_, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _>.Adapt(f)
 
         for i = 0 to arr.Count - 1 do
             f.Invoke(i, arr[i])
@@ -168,7 +168,7 @@ module internal ResizeArray =
         loop 0
 
     let iter2 f (arr1: ResizeArray<'T>) (arr2: ResizeArray<'b>) =
-        let f = FSharpFunc<_, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _>.Adapt(f)
         let len1 = length arr1
 
         if len1 <> length arr2 then
@@ -178,7 +178,7 @@ module internal ResizeArray =
             f.Invoke(arr1[i], arr2[i])
 
     let map2 f (arr1: ResizeArray<'T>) (arr2: ResizeArray<'b>) =
-        let f = FSharpFunc<_, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _>.Adapt(f)
         let len1 = length arr1
 
         if len1 <> length arr2 then
@@ -320,7 +320,7 @@ module internal ResizeArray =
             foldBackSub f arr 0 (arrn - 2) arr[arrn - 1]
 
     let fold2 f (acc: 'T) (arr1: ResizeArray<'T1>) (arr2: ResizeArray<'T2>) =
-        let f = FSharpFunc<_, _, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _, _>.Adapt(f)
         let mutable res = acc
         let len = length arr1
 
@@ -333,7 +333,7 @@ module internal ResizeArray =
         res
 
     let foldBack2 f (arr1: ResizeArray<'T1>) (arr2: ResizeArray<'T2>) (acc: 'b) =
-        let f = FSharpFunc<_, _, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _, _>.Adapt(f)
         let mutable res = acc
         let len = length arr1
 
@@ -359,7 +359,7 @@ module internal ResizeArray =
     let isEmpty (arr: ResizeArray<_>) = length (arr: ResizeArray<_>) = 0
 
     let iteri2 f (arr1: ResizeArray<'T>) (arr2: ResizeArray<'b>) =
-        let f = FSharpFunc<_, _, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _, _>.Adapt(f)
         let len1 = length arr1
 
         if len1 <> length arr2 then
@@ -369,7 +369,7 @@ module internal ResizeArray =
             f.Invoke(i, arr1[i], arr2[i])
 
     let mapi2 (f: int -> 'T -> 'b -> 'c) (arr1: ResizeArray<'T>) (arr2: ResizeArray<'b>) =
-        let f = FSharpFunc<_, _, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _, _>.Adapt(f)
         let len1 = length arr1
 
         if len1 <> length arr2 then
@@ -378,7 +378,7 @@ module internal ResizeArray =
         init len1 (fun i -> f.Invoke(i, arr1[i], arr2[i]))
 
     let scanBackSub f (arr: ResizeArray<'T>) start fin acc =
-        let f = FSharpFunc<_, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _>.Adapt(f)
         let mutable state = acc
         let res = create (2 + fin - start) acc
 
@@ -389,7 +389,7 @@ module internal ResizeArray =
         res
 
     let scanSub f acc (arr: ResizeArray<'T>) start fin =
-        let f = FSharpFunc<_, _, _>.Adapt (f)
+        let f = FSharpFunc<_, _, _>.Adapt(f)
         let mutable state = acc
         let res = create (fin - start + 2) acc
 

--- a/src/Compiler/Utilities/TaggedCollections.fs
+++ b/src/Compiler/Utilities/TaggedCollections.fs
@@ -382,12 +382,12 @@ module SetTree =
 
     let minimumElement s =
         match minimumElementOpt s with
-        | Some (k) -> k
+        | Some(k) -> k
         | None -> failwith "minimumElement"
 
     let maximumElement s =
         match maximumElementOpt s with
-        | Some (k) -> k
+        | Some(k) -> k
         | None -> failwith "maximumElement"
 
     //--------------------------------------------------------------------------
@@ -615,9 +615,9 @@ type internal Set<'T, 'ComparerTag> when 'ComparerTag :> IComparer<'T>(comparer:
 
     member s.ForAll predicate = SetTree.forall predicate tree
 
-    static member (-)(a: Set<'T, 'ComparerTag>, b: Set<'T, 'ComparerTag>) = Set<_, _>.Difference (a, b)
+    static member (-)(a: Set<'T, 'ComparerTag>, b: Set<'T, 'ComparerTag>) = Set<_, _>.Difference(a, b)
 
-    static member (+)(a: Set<'T, 'ComparerTag>, b: Set<'T, 'ComparerTag>) = Set<_, _>.Union (a, b)
+    static member (+)(a: Set<'T, 'ComparerTag>, b: Set<'T, 'ComparerTag>) = Set<_, _>.Union(a, b)
 
     static member Intersection(a: Set<'T, 'ComparerTag>, b: Set<'T, 'ComparerTag>) : Set<'T, 'ComparerTag> =
         if SetTree.isEmpty b.Tree then
@@ -1256,7 +1256,7 @@ type internal Map<'Key, 'T, 'ComparerTag> when 'ComparerTag :> IComparer<'Key>(c
         let combineHash x y = (x <<< 1) + y + 631
         let mutable res = 0
 
-        for KeyValue (x, y) in this do
+        for KeyValue(x, y) in this do
             res <- combineHash res (Unchecked.hash x)
             res <- combineHash res (Unchecked.hash y)
 

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -1181,8 +1181,8 @@ module NameMap =
             for m in ms do
                 yield! m
         }
-        |> Seq.groupBy (fun (KeyValue (k, _v)) -> k)
-        |> Seq.map (fun (k, es) -> (k, unionf (Seq.map (fun (KeyValue (_k, v)) -> v) es)))
+        |> Seq.groupBy (fun (KeyValue(k, _v)) -> k)
+        |> Seq.map (fun (k, es) -> (k, unionf (Seq.map (fun (KeyValue(_k, v)) -> v) es)))
         |> Map.ofSeq
 
     /// For every entry in m2 find an entry in m1 and fold
@@ -1309,11 +1309,11 @@ module MapAutoOpens =
         static member Empty: Map<'Key, 'Value> = Map.empty
 
 #if FSHARPCORE_USE_PACKAGE
-        member x.Values = [ for KeyValue (_, v) in x -> v ]
+        member x.Values = [ for KeyValue(_, v) in x -> v ]
 #endif
 
         member x.AddMany(kvs: _[]) =
-            (x, kvs) ||> Array.fold (fun x (KeyValue (k, v)) -> x.Add(k, v))
+            (x, kvs) ||> Array.fold (fun x (KeyValue(k, v)) -> x.Add(k, v))
 
         member x.AddOrModify(key, f: 'Value option -> 'Value) = x.Add(key, f (x.TryFind key))
 
@@ -1331,7 +1331,7 @@ type LayeredMultiMap<'Key, 'Value when 'Key: equality and 'Key: comparison>(cont
             | _ -> []
 
     member x.AddMany(kvs: _[]) =
-        (x, kvs) ||> Array.fold (fun x (KeyValue (k, v)) -> x.Add(k, v))
+        (x, kvs) ||> Array.fold (fun x (KeyValue(k, v)) -> x.Add(k, v))
 
     member _.TryFind k = contents.TryFind k
 

--- a/src/Compiler/Utilities/range.fs
+++ b/src/Compiler/Utilities/range.fs
@@ -457,10 +457,9 @@ module Range =
     let unionRanges (m1: range) (m2: range) =
         if m1.FileIndex <> m2.FileIndex then
             m2
-        else
+        else if
 
-        // If all identical then return m1. This preserves NotedSourceConstruct when no merging takes place
-        if
+            // If all identical then return m1. This preserves NotedSourceConstruct when no merging takes place
             m1.Code1 = m2.Code1 && m1.Code2 = m2.Code2
         then
             m1
@@ -557,13 +556,13 @@ module Range =
                     lines |> Seq.tryFind (fun (_, s) -> not (String.IsNullOrWhiteSpace s))
 
                 match nonWhiteLine with
-                | Some (i, s) -> mkRange file (mkPos (i + 1) 0) (mkPos (i + 1) s.Length)
+                | Some(i, s) -> mkRange file (mkPos (i + 1) 0) (mkPos (i + 1) s.Length)
                 | None ->
 
                     let nonEmptyLine = lines |> Seq.tryFind (fun (_, s) -> not (String.IsNullOrEmpty s))
 
                     match nonEmptyLine with
-                    | Some (i, s) -> mkRange file (mkPos (i + 1) 0) (mkPos (i + 1) s.Length)
+                    | Some(i, s) -> mkRange file (mkPos (i + 1) 0) (mkPos (i + 1) s.Length)
                     | None -> mkRange file (mkPos 1 0) (mkPos 1 80)
         with _ ->
             mkRange file (mkPos 1 0) (mkPos 1 80)

--- a/src/Compiler/Utilities/rational.fs
+++ b/src/Compiler/Utilities/rational.fs
@@ -26,7 +26,7 @@ let mkRational p q =
 
     let p, q = if q > BigInteger.Zero then p, q else -p, -q
 
-     in
+    in
 
     { numerator = p; denominator = q }
 

--- a/src/Compiler/Utilities/sformat.fs
+++ b/src/Compiler/Utilities/sformat.fs
@@ -95,20 +95,20 @@ type Layout =
 
     member layout.JuxtapositionLeft =
         match layout with
-        | ObjLeaf (jl, _, _) -> jl
-        | Leaf (jl, _, _) -> jl
-        | Node (left, _, _) -> left.JuxtapositionLeft
-        | Attr (_, _, subLayout) -> subLayout.JuxtapositionLeft
+        | ObjLeaf(jl, _, _) -> jl
+        | Leaf(jl, _, _) -> jl
+        | Node(left, _, _) -> left.JuxtapositionLeft
+        | Attr(_, _, subLayout) -> subLayout.JuxtapositionLeft
 
     static member JuxtapositionMiddle(left: Layout, right: Layout) =
         left.JuxtapositionRight || right.JuxtapositionLeft
 
     member layout.JuxtapositionRight =
         match layout with
-        | ObjLeaf (_, _, jr) -> jr
-        | Leaf (_, _, jr) -> jr
-        | Node (_, right, _) -> right.JuxtapositionRight
-        | Attr (_, _, subLayout) -> subLayout.JuxtapositionRight
+        | ObjLeaf(_, _, jr) -> jr
+        | Leaf(_, _, jr) -> jr
+        | Node(_, right, _) -> right.JuxtapositionRight
+        | Attr(_, _, subLayout) -> subLayout.JuxtapositionRight
 
 [<NoEquality; NoComparison>]
 type IEnvironment =
@@ -279,15 +279,15 @@ module Layout =
 
     let isEmptyL layout =
         match layout with
-        | Leaf (true, s, true) -> s.Text = ""
+        | Leaf(true, s, true) -> s.Text = ""
         | _ -> false
 
 #if COMPILER
     let rec endsWithL (text: string) layout =
         match layout with
-        | Leaf (_, s, _) -> s.Text.EndsWith(text)
-        | Node (_, r, _) -> endsWithL text r
-        | Attr (_, _, l) -> endsWithL text l
+        | Leaf(_, s, _) -> s.Text.EndsWith(text)
+        | Node(_, r, _) -> endsWithL text r
+        | Attr(_, _, l) -> endsWithL text l
         | ObjLeaf _ -> false
 #endif
 
@@ -374,7 +374,8 @@ module Layout =
 
     let listL selector value =
         leftL leftBracket
-        ^^ sepListL (sepL semicolon) (List.map selector value) ^^ rightL rightBracket
+        ^^ sepListL (sepL semicolon) (List.map selector value)
+        ^^ rightL rightBracket
 
     let squareBracketL layout =
         leftL leftBracket ^^ layout ^^ rightL rightBracket
@@ -390,7 +391,7 @@ module Layout =
             else
                 match project z with
                 | None -> [] // exhausted input
-                | Some (x, z) ->
+                | Some(x, z) ->
                     if n <= 0 then
                         [ wordL (tagPunctuation "...") ] // hit print_length limit
                     else
@@ -558,7 +559,7 @@ module ReflectUtils =
         // statically-known type information to aid in the
         // analysis of null values.
 
-        let GetValueInfo bindingFlags (x: 'a, ty: Type) (* x could be null *)  =
+        let GetValueInfo bindingFlags (x: 'a, ty: Type) (* x could be null *) =
             let obj = (box x)
 
             match obj with
@@ -623,7 +624,7 @@ module Display =
     let chunkN = 400
     let breaks0 () = Breaks(0, 0, Array.create chunkN 0)
 
-    let pushBreak saving (Breaks (next, outer, stack)) =
+    let pushBreak saving (Breaks(next, outer, stack)) =
         let stack =
             if next = stack.Length then
                 Array.init (next + chunkN) (fun i -> if i < next then stack[i] else 0) // expand if full
@@ -633,7 +634,7 @@ module Display =
         stack[next] <- saving
         Breaks(next + 1, outer, stack)
 
-    let popBreak (Breaks (next, outer, stack)) =
+    let popBreak (Breaks(next, outer, stack)) =
         if next = 0 then
             raise (Failure "popBreak: underflow")
 
@@ -644,7 +645,7 @@ module Display =
         let next = next - 1
         Breaks(next, outer, stack), topBroke
 
-    let forceBreak (Breaks (next, outer, stack)) =
+    let forceBreak (Breaks(next, outer, stack)) =
         if outer = next then
             // all broken
             None
@@ -675,13 +676,13 @@ module Display =
 
                 let breaks, layout, pos, offset =
                     match layout with
-                    | Attr (tag, attrs, l) ->
+                    | Attr(tag, attrs, l) ->
                         let breaks, layout, pos, offset = fit breaks (pos, l)
                         let layout = Attr(tag, attrs, layout)
                         breaks, layout, pos, offset
 
-                    | Leaf (jl, text, jr)
-                    | ObjLeaf (jl, ObjToTaggedText text, jr) ->
+                    | Leaf(jl, text, jr)
+                    | ObjLeaf(jl, ObjToTaggedText text, jr) ->
                         // save the formatted text from the squash
                         let layout = Leaf(jl, text, jr)
                         let textWidth = length text
@@ -692,13 +693,13 @@ module Display =
                             else
                                 match forceBreak breaks with
                                 | None -> breaks, layout, pos + textWidth, textWidth // tough, no more breaks
-                                | Some (breaks, saving) ->
+                                | Some(breaks, saving) ->
                                     let pos = pos - saving
                                     fitLeaf breaks pos
 
                         fitLeaf breaks pos
 
-                    | Node (l, r, joint) ->
+                    | Node(l, r, joint) ->
                         let jm = Layout.JuxtapositionMiddle(l, r)
                         let mid = if jm then 0 else 1
 
@@ -761,19 +762,19 @@ module Display =
         // addL: pos is tab level
         let rec addL z pos layout =
             match layout with
-            | ObjLeaf (_, obj, _) ->
+            | ObjLeaf(_, obj, _) ->
                 let text = leafFormatter obj
                 addText z text
 
-            | Leaf (_, obj, _) -> addText z obj.Text
+            | Leaf(_, obj, _) -> addText z obj.Text
 
-            | Node (l, r, Broken indent) when not (opts.PrintWidth = 0) ->
+            | Node(l, r, Broken indent) when not (opts.PrintWidth = 0) ->
                 let z = addL z pos l
                 let z = newLine z (pos + indent)
                 let z = addL z (pos + indent) r
                 z
 
-            | Node (l, r, _) ->
+            | Node(l, r, _) ->
                 let jm = Layout.JuxtapositionMiddle(l, r)
                 let z = addL z pos l
                 let z = if jm then z else addText z " "
@@ -781,7 +782,7 @@ module Display =
                 let z = addL z pos r
                 z
 
-            | Attr (_, _, l) -> addL z pos l
+            | Attr(_, _, l) -> addL z pos l
 
         let rstrs, _ = addL z0 0 layout
         extract rstrs
@@ -807,23 +808,23 @@ module Display =
         // addL: pos is tab level
         let rec addL z pos layout =
             match layout with
-            | ObjLeaf (_, obj, _) ->
+            | ObjLeaf(_, obj, _) ->
                 let text = leafFormatter obj
                 addText z text
-            | Leaf (_, obj, _) -> addText z obj
-            | Node (l, r, Broken indent) ->
+            | Leaf(_, obj, _) -> addText z obj
+            | Node(l, r, Broken indent) ->
                 let z = addL z pos l
                 let z = newLine z (pos + indent)
                 let z = addL z (pos + indent) r
                 z
-            | Node (l, r, _) ->
+            | Node(l, r, _) ->
                 let jm = Layout.JuxtapositionMiddle(l, r)
                 let z = addL z pos l
                 let z = if jm then z else addText z space
                 let pos = index z
                 let z = addL z pos r
                 z
-            | Attr (tag, attrs, l) ->
+            | Attr(tag, attrs, l) ->
                 let _ = outAttribute tag attrs true
                 let z = addL z pos l
                 let _ = outAttribute tag attrs false
@@ -843,8 +844,8 @@ module Display =
         | null -> None
         | _ ->
             match Value.GetValueInfo bindingFlags (x, ty) with
-            | UnionCaseValue ("Cons", recd) -> Some(unpackCons recd)
-            | UnionCaseValue ("Empty", [||]) -> None
+            | UnionCaseValue("Cons", recd) -> Some(unpackCons recd)
+            | UnionCaseValue("Empty", [||]) -> None
             | _ -> failwith "List value had unexpected ValueInfo"
 
     let structL = wordL (tagKeyword "struct")
@@ -869,7 +870,7 @@ module Display =
             ^^ (match v with
                 | None -> wordL questionMark
                 | Some xL -> xL)
-               ^^ (rightL semicolon)
+            ^^ (rightL semicolon)
 
         let braceL xs =
             (leftL leftBrace) ^^ xs ^^ (rightL rightBrace)
@@ -878,11 +879,13 @@ module Display =
 
     let makeListL itemLs =
         (leftL leftBracket)
-        ^^ sepListL (rightL semicolon) itemLs ^^ (rightL rightBracket)
+        ^^ sepListL (rightL semicolon) itemLs
+        ^^ (rightL rightBracket)
 
     let makeArrayL xs =
         (leftL (tagPunctuation "[|"))
-        ^^ sepListL (rightL semicolon) xs ^^ (rightL (tagPunctuation "|]"))
+        ^^ sepListL (rightL semicolon) xs
+        ^^ (rightL (tagPunctuation "|]"))
 
     let makeArray2L xs =
         leftL leftBracket ^^ aboveListL xs ^^ rightL rightBracket
@@ -1152,7 +1155,8 @@ module Display =
                                             spaceListL (
                                                 List.rev (
                                                     (sepL (tagText preText)
-                                                     ^^ alternativeObjL ^^ sepL (tagText (replaceEscapedBrackets (remaingPropertyText))))
+                                                     ^^ alternativeObjL
+                                                     ^^ sepL (tagText (replaceEscapedBrackets (remaingPropertyText))))
                                                     :: layouts
                                                 )
                                             )
@@ -1170,7 +1174,7 @@ module Display =
             | txs ->
                 leftL leftParen
                 ^^ commaListL (List.map (snd >> nestedObjL depthLim Precedence.BracketIfTuple) txs)
-                   ^^ rightL rightParen
+                ^^ rightL rightParen
 
         and bracketIfL flag basicL =
             if flag then
@@ -1305,7 +1309,8 @@ module Display =
                         rowsL
                     else
                         wordL (tagText ("bound1=" + string_of_int b1))
-                        :: wordL (tagText ("bound2=" + string_of_int b2)) :: rowsL
+                        :: wordL (tagText ("bound2=" + string_of_int b2))
+                        :: rowsL
                 )
             | n -> makeArrayL [ wordL (tagText ("rank=" + string_of_int n)) ]
 
@@ -1457,20 +1462,20 @@ module Display =
                      |> Array.toList
                      |> makePropertiesL)
 
-        and reprL showMode depthLim prec repr x (* x could be null *)  =
+        and reprL showMode depthLim prec repr x (* x could be null *) =
             match repr with
-            | TupleValue (tupleType, vals) -> tupleValueL depthLim prec vals tupleType
+            | TupleValue(tupleType, vals) -> tupleValueL depthLim prec vals tupleType
 
             | RecordValue items -> recordValueL depthLim (Array.toList items)
 
-            | UnionCaseValue (constr, recd) when // x is List<T>. Note: "null" is never a valid list value.
+            | UnionCaseValue(constr, recd) when // x is List<T>. Note: "null" is never a valid list value.
                 x <> null && isListType (x.GetType())
                 ->
                 listValueL depthLim constr recd
 
-            | UnionCaseValue (unionCaseName, recd) -> unionCaseValueL depthLim prec unionCaseName (Array.toList recd)
+            | UnionCaseValue(unionCaseName, recd) -> unionCaseValueL depthLim prec unionCaseName (Array.toList recd)
 
-            | ExceptionValue (exceptionType, recd) -> fsharpExceptionL depthLim prec exceptionType (Array.toList recd)
+            | ExceptionValue(exceptionType, recd) -> fsharpExceptionL depthLim prec exceptionType (Array.toList recd)
 
             | FunctionClosureValue closureType -> functionClosureL showMode closureType
 

--- a/src/Compiler/Utilities/sr.fs
+++ b/src/Compiler/Utilities/sr.fs
@@ -28,7 +28,7 @@ module internal DiagnosticMessage =
     let mkFunctionValue (tys: System.Type[]) (impl: obj -> obj) =
         FSharpValue.MakeFunction(FSharpType.MakeFunctionType(tys[0], tys[1]), impl)
 
-    let funTyC = typeof<obj -> obj>.GetGenericTypeDefinition ()
+    let funTyC = typeof<obj -> obj>.GetGenericTypeDefinition()
 
     let isNamedType (ty: System.Type) =
         not (ty.IsArray || ty.IsByRef || ty.IsPointer)

--- a/src/Compiler/Utilities/zmap.fs
+++ b/src/Compiler/Utilities/zmap.fs
@@ -10,7 +10,7 @@ type internal Zmap<'Key, 'T> = Internal.Utilities.Collections.Tagged.Map<'Key, '
 
 module internal Zmap =
 
-    let empty (ord: IComparer<'T>) = Map<_, _, _>.Empty (ord)
+    let empty (ord: IComparer<'T>) = Map<_, _, _>.Empty(ord)
 
     let add k v (m: Zmap<_, _>) = m.Add(k, v)
     let find k (m: Zmap<_, _>) = m[k]
@@ -46,7 +46,7 @@ module internal Zmap =
             []
 
     let ofList ord xs =
-        Internal.Utilities.Collections.Tagged.Map<_, _>.FromList (ord, xs)
+        Internal.Utilities.Collections.Tagged.Map<_, _>.FromList(ord, xs)
 
     let keys (m: Zmap<_, _>) = m.Fold (fun k _ s -> k :: s) []
     let values (m: Zmap<_, _>) = m.Fold (fun _ v s -> v :: s) []

--- a/src/Compiler/Utilities/zset.fs
+++ b/src/Compiler/Utilities/zset.fs
@@ -11,7 +11,7 @@ type internal Zset<'T> = Internal.Utilities.Collections.Tagged.Set<'T>
 module internal Zset =
 
     let empty (ord: IComparer<'T>) =
-        Internal.Utilities.Collections.Tagged.Set<_, _>.Empty (ord)
+        Internal.Utilities.Collections.Tagged.Set<_, _>.Empty(ord)
 
     let isEmpty (s: Zset<_>) = s.IsEmpty
 
@@ -38,19 +38,19 @@ module internal Zset =
     let subset (s1: Zset<_>) (s2: Zset<_>) = s1.IsSubsetOf s2
 
     let equal (s1: Zset<_>) (s2: Zset<_>) =
-        Internal.Utilities.Collections.Tagged.Set<_, _>.Equality (s1, s2)
+        Internal.Utilities.Collections.Tagged.Set<_, _>.Equality(s1, s2)
 
     let elements (s: Zset<_>) = s.ToList()
 
     let filter predicate (s: Zset<_>) = s.Filter predicate
 
     let union (s1: Zset<_>) (s2: Zset<_>) =
-        Internal.Utilities.Collections.Tagged.Set<_, _>.Union (s1, s2)
+        Internal.Utilities.Collections.Tagged.Set<_, _>.Union(s1, s2)
 
     let inter (s1: Zset<_>) (s2: Zset<_>) =
-        Internal.Utilities.Collections.Tagged.Set<_, _>.Intersection (s1, s2)
+        Internal.Utilities.Collections.Tagged.Set<_, _>.Intersection(s1, s2)
 
     let diff (s1: Zset<_>) (s2: Zset<_>) =
-        Internal.Utilities.Collections.Tagged.Set<_, _>.Difference (s1, s2)
+        Internal.Utilities.Collections.Tagged.Set<_, _>.Difference(s1, s2)
 
     let memberOf m k = contains k m

--- a/src/FSharp.Build/CreateFSharpManifestResourceName.fs
+++ b/src/FSharp.Build/CreateFSharpManifestResourceName.fs
@@ -16,8 +16,8 @@ type CreateFSharpManifestResourceName public () =
         (
             fileName: string,
             linkFileName: string,
-            rootNamespace: string,  // may be null
-            dependentUponFileName: string,  // may be null
+            rootNamespace: string, // may be null
+            dependentUponFileName: string, // may be null
             binaryStream: Stream // may be null
         ) : string =
 

--- a/src/FSharp.Build/FSharpEmbedResXSource.fs
+++ b/src/FSharp.Build/FSharpEmbedResXSource.fs
@@ -174,7 +174,7 @@ module internal {1} =
                             let generateLiteral = getBooleanMetadata "GenerateLiterals" true item
 
                             match generateSource item.ItemSpec moduleName generateLegacy generateLiteral with
-                            | Some (source) -> yield TaskItem(source) :> ITaskItem
+                            | Some(source) -> yield TaskItem(source) :> ITaskItem
                             | None -> success <- false
                 |]
 

--- a/src/FSharp.Core/QueryExtensions.fs
+++ b/src/FSharp.Core/QueryExtensions.fs
@@ -63,7 +63,7 @@ module internal Adapters =
     let (|LeftSequentialSeries|) e =
         let rec leftSequentialSeries acc e =
             match e with
-            | Patterns.Sequential (e1, e2) -> leftSequentialSeries (e2 :: acc) e1
+            | Patterns.Sequential(e1, e2) -> leftSequentialSeries (e2 :: acc) e1
             | _ -> e :: acc
 
         leftSequentialSeries [] e
@@ -75,10 +75,10 @@ module internal Adapters =
         let rec propSetList acc x =
             match x with
             // detect " v.X <- y"
-            | ((Patterns.PropertySet (Some (Patterns.Var var), _, _, _)) as p) :: xs when var = varArg ->
+            | ((Patterns.PropertySet(Some(Patterns.Var var), _, _, _)) as p) :: xs when var = varArg ->
                 propSetList (p :: acc) xs
             // skip unit values
-            | (Patterns.Value (v, _)) :: xs when v = null -> propSetList acc xs
+            | (Patterns.Value(v, _)) :: xs when v = null -> propSetList acc xs
             // detect "v"
             | [ Patterns.Var var ] when var = varArg -> Some acc
             | _ -> None
@@ -88,7 +88,7 @@ module internal Adapters =
     /// Recognize object construction written using 'new O(Prop1 = <e>, Prop2 = <e>, ...)'
     let (|ObjectConstruction|_|) e =
         match e with
-        | Patterns.Let (var, (Patterns.NewObject (_, []) as init), LeftSequentialSeries propSets) ->
+        | Patterns.Let(var, (Patterns.NewObject(_, []) as init), LeftSequentialSeries propSets) ->
             match propSets with
             | PropSetList var propSets -> Some(var, init, propSets)
             | _ -> None
@@ -128,7 +128,7 @@ module internal Adapters =
     /// Recognize anonymous type construction written using 'new AnonymousObject(<e1>, <e2>, ...)'
     let (|NewAnonymousObject|_|) e =
         match e with
-        | Patterns.NewObject (ctor, args) when
+        | Patterns.NewObject(ctor, args) when
             let dty = ctor.DeclaringType
 
             dty.IsGenericType
@@ -189,7 +189,7 @@ module internal Adapters =
 
     let (|RecordFieldGetSimplification|_|) (expr: Expr) =
         match expr with
-        | Patterns.PropertyGet (Some (Patterns.NewRecord (typ, els)), propInfo, []) ->
+        | Patterns.PropertyGet(Some(Patterns.NewRecord(typ, els)), propInfo, []) ->
             let fields =
                 Microsoft.FSharp.Reflection.FSharpType.GetRecordFields(
                     typ,
@@ -228,11 +228,11 @@ module internal Adapters =
                 let els = [ x1; x2; x3; x4; x5; x6; x7; TupleConv(x8 :: tail) ]
                 RewriteTupleType ty (List.map2 ConvImmutableTypeToMutableType els)
             | _ -> RewriteTupleType ty (List.map2 ConvImmutableTypeToMutableType convs)
-        | RecordConv (_, convs) ->
+        | RecordConv(_, convs) ->
             assert (isPartiallyImmutableRecord ty)
             let types = [| for f in FSharpType.GetRecordFields ty -> f.PropertyType |]
             ConvImmutableTypeToMutableType (TupleConv convs) (FSharpType.MakeTupleType types)
-        | GroupingConv (_keyTy, _elemTy, conv) ->
+        | GroupingConv(_keyTy, _elemTy, conv) ->
             assert ty.IsGenericType
             assert (ty.GetGenericTypeDefinition() = typedefof<IGrouping<_, _>>)
             let keyt1 = ty.GetGenericArguments().[0]
@@ -265,7 +265,7 @@ module internal Adapters =
 
         (fun tm ->
             match tm with
-            | Patterns.Call (_obj, minfo2, _args) ->
+            | Patterns.Call(_obj, minfo2, _args) ->
                 minfo2.IsGenericMethod && (gmd = minfo2.GetGenericMethodDefinition())
             | _ -> false)
 
@@ -278,25 +278,25 @@ module internal Adapters =
             // rewrite bottom-up
             let expr =
                 match expr with
-                | ExprShape.ShapeCombination (comb, args) ->
+                | ExprShape.ShapeCombination(comb, args) ->
                     match args with
                     | [] -> expr
                     | _ -> ExprShape.RebuildShapeCombination(comb, List.map CleanupLeaf args)
-                | ExprShape.ShapeLambda (v, body) -> Expr.Lambda(v, CleanupLeaf body)
+                | ExprShape.ShapeLambda(v, body) -> Expr.Lambda(v, CleanupLeaf body)
                 | ExprShape.ShapeVar _ -> expr
 
             match expr with
 
             // Detect all object construction expressions - wrap them in 'MemberInitializationHelper'
             // so that it can be translated to Expression.MemberInit
-            | ObjectConstruction (var, init, propSets) ->
+            | ObjectConstruction(var, init, propSets) ->
                 // Wrap object initialization into a value (
                 let methInfo = MemberInitializationHelperMeth.MakeGenericMethod [| var.Type |]
                 Expr.Call(methInfo, [ List.reduceBack (fun a b -> Expr.Sequential(a, b)) (propSets @ [ init ]) ])
 
             // Detect all anonymous type constructions - wrap them in 'NewAnonymousObjectHelper'
             // so that it can be translated to Expression.New with member arguments.
-            | NewAnonymousObject (ctor, args) ->
+            | NewAnonymousObject(ctor, args) ->
                 let methInfo =
                     NewAnonymousObjectHelperMeth.MakeGenericMethod [| ctor.DeclaringType |]
 
@@ -308,13 +308,13 @@ module internal Adapters =
         // rewrite bottom-up
         let e =
             match e with
-            | ExprShape.ShapeCombination (comb, args) ->
+            | ExprShape.ShapeCombination(comb, args) ->
                 ExprShape.RebuildShapeCombination(comb, List.map SimplifyConsumingExpr args)
-            | ExprShape.ShapeLambda (v, body) -> Expr.Lambda(v, SimplifyConsumingExpr body)
+            | ExprShape.ShapeLambda(v, body) -> Expr.Lambda(v, SimplifyConsumingExpr body)
             | ExprShape.ShapeVar _ -> e
 
         match e with
-        | Patterns.TupleGet (Patterns.NewTuple els, i) -> els.[i]
+        | Patterns.TupleGet(Patterns.NewTuple els, i) -> els.[i]
         | RecordFieldGetSimplification newExpr -> newExpr
         | _ -> e
 
@@ -332,7 +332,7 @@ module internal Adapters =
             NewAnonymousObject argExprsNow, TupleConv argScripts
 
         // Replace immutable records by anonymous objects
-        | Patterns.NewRecord (typ, args) when isPartiallyImmutableRecord typ ->
+        | Patterns.NewRecord(typ, args) when isPartiallyImmutableRecord typ ->
             let argExprsNow, argScripts =
                 args |> List.map (ProduceMoreMutables tipf) |> List.unzip
 

--- a/src/FSharp.Core/array.fs
+++ b/src/FSharp.Core/array.fs
@@ -350,7 +350,7 @@ module Array =
     let iter2 action (array1: 'T[]) (array2: 'U[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (action)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(action)
 
         if array1.Length <> array2.Length then
             invalidArgDifferentArrayLength "array1" array1.Length "array2" array2.Length
@@ -382,7 +382,7 @@ module Array =
     let map2 mapping (array1: 'T[]) (array2: 'U[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (mapping)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(mapping)
 
         if array1.Length <> array2.Length then
             invalidArgDifferentArrayLength "array1" array1.Length "array2" array2.Length
@@ -399,7 +399,7 @@ module Array =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
         checkNonNull "array3" array3
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (mapping)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(mapping)
         let len1 = array1.Length
 
         if len1 <> array2.Length || len1 <> array3.Length then
@@ -416,7 +416,7 @@ module Array =
     let mapi2 mapping (array1: 'T[]) (array2: 'U[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (mapping)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(mapping)
 
         if array1.Length <> array2.Length then
             invalidArgDifferentArrayLength "array1" array1.Length "array2" array2.Length
@@ -431,7 +431,7 @@ module Array =
     [<CompiledName("IterateIndexed")>]
     let iteri action (array: 'T[]) =
         checkNonNull "array" array
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (action)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(action)
 
         for i = 0 to array.Length - 1 do
             f.Invoke(i, array.[i])
@@ -440,7 +440,7 @@ module Array =
     let iteri2 action (array1: 'T[]) (array2: 'U[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (action)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(action)
 
         if array1.Length <> array2.Length then
             invalidArgDifferentArrayLength "array1" array1.Length "array2" array2.Length
@@ -451,7 +451,7 @@ module Array =
     [<CompiledName("MapIndexed")>]
     let mapi (mapping: int -> 'T -> 'U) (array: 'T[]) =
         checkNonNull "array" array
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (mapping)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(mapping)
         let res = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked array.Length
 
         for i = 0 to array.Length - 1 do
@@ -497,7 +497,7 @@ module Array =
     let exists2 predicate (array1: _[]) (array2: _[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (predicate)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(predicate)
         let len1 = array1.Length
 
         if len1 <> array2.Length then
@@ -522,7 +522,7 @@ module Array =
     let forall2 predicate (array1: _[]) (array2: _[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (predicate)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(predicate)
         let len1 = array1.Length
 
         if len1 <> array2.Length then
@@ -1292,7 +1292,7 @@ module Array =
         let rec loop state =
             match generator state with
             | None -> ()
-            | Some (x, s') ->
+            | Some(x, s') ->
                 res.Add(x)
                 loop s'
 
@@ -1344,7 +1344,7 @@ module Array =
     [<CompiledName("Fold")>]
     let fold<'T, 'State> (folder: 'State -> 'T -> 'State) (state: 'State) (array: 'T[]) =
         checkNonNull "array" array
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
         let mutable state = state
 
         for i = 0 to array.Length - 1 do
@@ -1355,7 +1355,7 @@ module Array =
     [<CompiledName("FoldBack")>]
     let foldBack<'T, 'State> (folder: 'T -> 'State -> 'State) (array: 'T[]) (state: 'State) =
         checkNonNull "array" array
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
         let mutable res = state
 
         for i = array.Length - 1 downto 0 do
@@ -1367,7 +1367,7 @@ module Array =
     let foldBack2<'T1, 'T2, 'State> folder (array1: 'T1[]) (array2: 'T2[]) (state: 'State) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(folder)
         let mutable res = state
         let len = array1.Length
 
@@ -1383,7 +1383,7 @@ module Array =
     let fold2<'T1, 'T2, 'State> folder (state: 'State) (array1: 'T1[]) (array2: 'T2[]) =
         checkNonNull "array1" array1
         checkNonNull "array2" array2
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(folder)
         let mutable state = state
 
         if array1.Length <> array2.Length then
@@ -1396,7 +1396,7 @@ module Array =
 
     let foldSubRight f (array: _[]) start fin acc =
         checkNonNull "array" array
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (f)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(f)
         let mutable res = acc
 
         for i = fin downto start do
@@ -1406,7 +1406,7 @@ module Array =
 
     let scanSubLeft f initState (array: _[]) start fin =
         checkNonNull "array" array
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (f)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(f)
         let mutable state = initState
         let res = create (2 + fin - start) initState
 
@@ -1448,7 +1448,7 @@ module Array =
         if len = 0 then
             invalidArg "array" LanguagePrimitives.ErrorStrings.InputArrayEmptyString
         else
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (reduction)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(reduction)
             let mutable res = array.[0]
 
             for i = 1 to array.Length - 1 do
@@ -2065,7 +2065,7 @@ module Array =
         [<CompiledName("MapIndexed")>]
         let mapi mapping (array: 'T[]) =
             checkNonNull "array" array
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (mapping)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(mapping)
             let inputLength = array.Length
 
             let result =
@@ -2321,7 +2321,7 @@ module Array =
         [<CompiledName("IterateIndexed")>]
         let iteri action (array: 'T[]) =
             checkNonNull "array" array
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (action)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(action)
             Parallel.For(0, array.Length, (fun i -> f.Invoke(i, array.[i]))) |> ignore
 
         [<CompiledName("Initialize")>]

--- a/src/FSharp.Core/async.fs
+++ b/src/FSharp.Core/async.fs
@@ -992,10 +992,9 @@ module AsyncPrimitives =
                     // Ignore multiple sets of the result. This can happen, e.g. for a race between a cancellation and a success
                     if x.ResultAvailable then
                         [] // invalidOp "multiple results registered for asynchronous operation"
-                    else
-                    // In this case the ResultCell has already been disposed, e.g. due to a timeout.
-                    // The result is dropped on the floor.
-                    if
+                    else if
+                        // In this case the ResultCell has already been disposed, e.g. due to a timeout.
+                        // The result is dropped on the floor.
                         disposed
                     then
                         []
@@ -1182,7 +1181,12 @@ module AsyncPrimitives =
 
         trampolineHolder.ExecuteWithTrampoline(fun () ->
             let ctxt =
-                AsyncActivation.Create cancellationToken trampolineHolder (cont >> fake) (econt >> fake) (ccont >> fake)
+                AsyncActivation.Create
+                    cancellationToken
+                    trampolineHolder
+                    (cont >> fake)
+                    (econt >> fake)
+                    (ccont >> fake)
 
             computation.Invoke ctxt)
         |> unfake
@@ -1323,9 +1327,9 @@ module AsyncPrimitives =
 
         member s.GetResult() =
             match result.TryWaitForResultSynchronously(-1) with
-            | Some (AsyncResult.Ok v) -> v
-            | Some (AsyncResult.Error edi) -> edi.ThrowAny()
-            | Some (AsyncResult.Canceled err) -> raise err
+            | Some(AsyncResult.Ok v) -> v
+            | Some(AsyncResult.Error edi) -> edi.ThrowAny()
+            | Some(AsyncResult.Canceled err) -> raise err
             | None -> failwith "unreachable"
 
         member x.IsClosed = disposed
@@ -1568,9 +1572,9 @@ type Async =
 
                             match firstExn with
                             | None -> ctxt.trampolineHolder.ExecuteWithTrampoline(fun () -> ctxt.cont results)
-                            | Some (Choice1Of2 exn) ->
+                            | Some(Choice1Of2 exn) ->
                                 ctxt.trampolineHolder.ExecuteWithTrampoline(fun () -> ctxt.econt exn)
-                            | Some (Choice2Of2 cexn) ->
+                            | Some(Choice2Of2 cexn) ->
                                 ctxt.trampolineHolder.ExecuteWithTrampoline(fun () -> ctxt.ccont cexn)
                         else
                             fake ()
@@ -2059,7 +2063,10 @@ type Async =
     static member AsBeginEnd<'Arg, 'T>
         (computation: ('Arg -> Async<'T>))
         // The 'Begin' member
-        : ('Arg * System.AsyncCallback * obj -> System.IAsyncResult) * (System.IAsyncResult -> 'T) * (System.IAsyncResult -> unit) =
+        : ('Arg * System.AsyncCallback * obj -> System.IAsyncResult) *
+          (System.IAsyncResult -> 'T) *
+          (System.IAsyncResult -> unit)
+        =
         let beginAction =
             fun (a1, callback, state) -> AsBeginEndHelpers.beginAction ((computation a1), callback, state)
 

--- a/src/FSharp.Core/collections.fs
+++ b/src/FSharp.Core/collections.fs
@@ -35,7 +35,7 @@ module HashIdentity =
         }
 
     let inline FromFunctions hasher equality : IEqualityComparer<'T> =
-        let eq = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (equality)
+        let eq = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(equality)
 
         { new IEqualityComparer<'T> with
             member _.GetHashCode(x) =
@@ -58,7 +58,7 @@ module ComparisonIdentity =
         }
 
     let FromFunction comparer =
-        let comparer = OptimizedClosures.FSharpFunc<'T, 'T, int>.Adapt (comparer)
+        let comparer = OptimizedClosures.FSharpFunc<'T, 'T, int>.Adapt(comparer)
 
         { new IComparer<'T> with
             member _.Compare(x, y) =

--- a/src/FSharp.Core/event.fs
+++ b/src/FSharp.Core/event.fs
@@ -92,7 +92,7 @@ type Event<'Delegate, 'Args
             ||| BindingFlags.NonPublic
             ||| BindingFlags.DeclaredOnly
 
-        let mi = typeof<'Delegate>.GetMethod ("Invoke", instanceBindingFlags)
+        let mi = typeof<'Delegate>.GetMethod("Invoke", instanceBindingFlags)
         let actualTypes = mi.GetParameters() |> Array.map (fun p -> p.ParameterType)
         mi, actualTypes.[1..]
 
@@ -113,7 +113,7 @@ type Event<'Delegate, 'Args
             ||| BindingFlags.DeclaredOnly
 
         let mi =
-            typeof<EventDelegee<'Args>>.GetMethods (instanceBindingFlags)
+            typeof<EventDelegee<'Args>>.GetMethods(instanceBindingFlags)
             |> Seq.filter (fun mi -> mi.Name = "Invoke" && mi.GetParameters().Length = argTypes.Length + 1)
             |> Seq.exactlyOne
 

--- a/src/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/FSharp.Core/fslib-extra-pervasives.fs
@@ -46,11 +46,7 @@ module ExtraTopLevelOperators =
     [<DebuggerDisplay("Count = {Count}")>]
     [<DebuggerTypeProxy(typedefof<DictDebugView<_, _, _>>)>]
     type DictImpl<'SafeKey, 'Key, 'T>
-        (
-            t: Dictionary<'SafeKey, 'T>,
-            makeSafeKey: 'Key -> 'SafeKey,
-            getKey: 'SafeKey -> 'Key
-        ) =
+        (t: Dictionary<'SafeKey, 'T>, makeSafeKey: 'Key -> 'SafeKey, getKey: 'SafeKey -> 'Key) =
 
         member _.Count = t.Count
 
@@ -144,13 +140,13 @@ module ExtraTopLevelOperators =
             member _.Remove(_) =
                 raise (NotSupportedException(SR.GetString(SR.thisValueCannotBeMutated)))
 
-            member _.Contains(KeyValue (k, v)) =
+            member _.Contains(KeyValue(k, v)) =
                 ICollection_Contains t (KeyValuePair<_, _>(makeSafeKey k, v))
 
             member _.CopyTo(arr, i) =
                 let mutable n = 0
 
-                for (KeyValue (k, v)) in t do
+                for (KeyValue(k, v)) in t do
                     arr.[i + n] <- KeyValuePair<_, _>(getKey k, v)
                     n <- n + 1
 
@@ -166,7 +162,7 @@ module ExtraTopLevelOperators =
             member _.GetEnumerator() =
                 // We use an array comprehension here instead of seq {} as otherwise we get incorrect
                 // IEnumerator.Reset() and IEnumerator.Current semantics.
-                let kvps = [| for (KeyValue (k, v)) in t -> KeyValuePair(getKey k, v) |] :> seq<_>
+                let kvps = [| for (KeyValue(k, v)) in t -> KeyValuePair(getKey k, v) |] :> seq<_>
                 kvps.GetEnumerator()
 
         interface System.Collections.IEnumerable with
@@ -174,7 +170,7 @@ module ExtraTopLevelOperators =
                 // We use an array comprehension here instead of seq {} as otherwise we get incorrect
                 // IEnumerator.Reset() and IEnumerator.Current semantics.
                 let kvps =
-                    [| for (KeyValue (k, v)) in t -> KeyValuePair(getKey k, v) |] :> System.Collections.IEnumerable
+                    [| for (KeyValue(k, v)) in t -> KeyValuePair(getKey k, v) |] :> System.Collections.IEnumerable
 
                 kvps.GetEnumerator()
 
@@ -416,10 +412,7 @@ type TypeProviderTypeAttributes =
     | IsErased = 0x40000000
 
 type TypeProviderConfig
-    (
-        systemRuntimeContainsType: string -> bool,
-        getReferencedAssembliesOption: (unit -> string array) option
-    ) =
+    (systemRuntimeContainsType: string -> bool, getReferencedAssembliesOption: (unit -> string array) option) =
     let mutable resolutionFolder: string = null
     let mutable runtimeAssembly: string = null
     let mutable referencedAssemblies: string[] = null

--- a/src/FSharp.Core/list.fs
+++ b/src/FSharp.Core/list.fs
@@ -114,7 +114,7 @@ module List =
         | [] -> [], state
         | [ h ] -> let h', s' = mapping h state in [ h' ], s'
         | _ ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (mapping)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(mapping)
 
             let rec loop res list =
                 match list, res with
@@ -243,7 +243,7 @@ module List =
 
     [<CompiledName("Iterate2")>]
     let iter2 action list1 list2 =
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (action)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(action)
 
         let rec loop list1 list2 =
             match list1, list2 with
@@ -258,7 +258,7 @@ module List =
 
     [<CompiledName("IterateIndexed2")>]
     let iteri2 action list1 list2 =
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (action)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(action)
 
         let rec loop n list1 list2 =
             match list1, list2 with
@@ -288,7 +288,7 @@ module List =
         match list with
         | [] -> state
         | _ ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (folder)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
             let mutable acc = state
 
             for x in list do
@@ -316,7 +316,7 @@ module List =
 
     [<CompiledName("Fold2")>]
     let fold2<'T1, 'T2, 'State> folder (state: 'State) (list1: 'T1 list) (list2: 'T2 list) =
-        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(folder)
 
         let rec loop acc list1 list2 =
             match list1, list2 with
@@ -338,7 +338,7 @@ module List =
     // this version doesn't causes stack overflow - it uses a private stack
     [<CompiledName("FoldBack")>]
     let foldBack<'T, 'State> folder (list: 'T list) (state: 'State) =
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (folder)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
 
         match list with
         | [] -> state
@@ -358,7 +358,7 @@ module List =
         match list with
         | [] -> invalidArg "list" (SR.GetString(SR.inputListWasEmpty))
         | _ ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (reduction)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(reduction)
             let arr = toArray list
             let arrn = arr.Length
             foldArraySubRight f arr 0 (arrn - 2) arr.[arrn - 1]
@@ -385,7 +385,7 @@ module List =
         | [] -> [ state ]
         | [ h ] -> [ folder h state; state ]
         | _ ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (folder)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(folder)
             // It is faster to allocate and iterate an array than to create all those
             // highly nested stacks.  It also means we won't get stack overflows here.
             let arr = toArray list
@@ -416,7 +416,7 @@ module List =
         match list1, list2 with
         | [], [] -> state
         | h1 :: rest1, k1 :: rest2 ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (folder)
+            let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(folder)
 
             match rest1, rest2 with
             | [], [] -> f.Invoke(h1, k1, state)
@@ -440,7 +440,7 @@ module List =
         match list1, list2 with
         | [], [] -> true
         | _ ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (predicate)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(predicate)
             forall2aux f list1 list2
 
     [<CompiledName("ForAll")>]
@@ -474,7 +474,7 @@ module List =
         match list1, list2 with
         | [], [] -> false
         | _ ->
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (predicate)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(predicate)
             exists2aux f list1 list2
 
     [<CompiledName("Find")>]

--- a/src/FSharp.Core/mailbox.fs
+++ b/src/FSharp.Core/mailbox.fs
@@ -204,7 +204,7 @@ type Mailbox<'Msg>(cancellationSupported: bool) =
                     | Choice1Of2 true -> return! scan timeoutAsync timeoutCts
                     | Choice1Of2 false ->
                         return failwith "should not happen - waitOneNoTimeoutOrCancellation always returns true"
-                    | Choice2Of2 () ->
+                    | Choice2Of2() ->
                         lock syncRoot (fun () ->
                             // Cancel the outstanding wait for messages installed by waitOneWithCancellation
                             //

--- a/src/FSharp.Core/map.fs
+++ b/src/FSharp.Core/map.fs
@@ -23,13 +23,7 @@ type internal MapTree<'Key, 'Value>(k: 'Key, v: 'Value, h: int) =
 [<Sealed>]
 [<AllowNullLiteral>]
 type internal MapTreeNode<'Key, 'Value>
-    (
-        k: 'Key,
-        v: 'Value,
-        left: MapTree<'Key, 'Value>,
-        right: MapTree<'Key, 'Value>,
-        h: int
-    ) =
+    (k: 'Key, v: 'Value, left: MapTree<'Key, 'Value>, right: MapTree<'Key, 'Value>, h: int) =
     inherit MapTree<'Key, 'Value>(k, v, h)
     member _.Left = left
     member _.Right = right
@@ -685,10 +679,7 @@ module MapTree =
 [<Sealed>]
 [<CompiledName("FSharpMap`2")>]
 type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonConditionalOn>] 'Value when 'Key: comparison>
-    (
-        comparer: IComparer<'Key>,
-        tree: MapTree<'Key, 'Value>
-    ) =
+    (comparer: IComparer<'Key>, tree: MapTree<'Key, 'Value>) =
 
     [<System.NonSerialized>]
     // This type is logically immutable. This field is only mutated during deserialization.
@@ -854,7 +845,7 @@ type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonCond
 
         let mutable res = 0
 
-        for (KeyValue (x, y)) in this do
+        for (KeyValue(x, y)) in this do
             res <- combineHash res (hash x)
             res <- combineHash res (Unchecked.hash y)
 
@@ -911,7 +902,7 @@ type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonCond
 
             let mutable res = 0
 
-            for (KeyValue (x, y)) in this do
+            for (KeyValue(x, y)) in this do
                 res <- combineHash res (comparer.GetHashCode x)
                 res <- combineHash res (comparer.GetHashCode y)
 
@@ -1053,9 +1044,7 @@ and [<Sealed>] MapDebugView<'Key, 'Value when 'Key: comparison>(v: Map<'Key, 'Va
         v |> Seq.truncate 10000 |> Seq.map KeyValuePairDebugFriendly |> Seq.toArray
 
 and [<DebuggerDisplay("{keyValue.Value}", Name = "[{keyValue.Key}]", Type = "")>] KeyValuePairDebugFriendly<'Key, 'Value>
-    (
-        keyValue: KeyValuePair<'Key, 'Value>
-    ) =
+    (keyValue: KeyValuePair<'Key, 'Value>) =
 
     [<DebuggerBrowsable(DebuggerBrowsableState.RootHidden)>]
     member x.KeyValue = keyValue

--- a/src/FSharp.Core/map.fsi
+++ b/src/FSharp.Core/map.fsi
@@ -15,7 +15,8 @@ open Microsoft.FSharp.Collections
 /// All members of this class are thread-safe and may be used concurrently from multiple threads.</remarks>
 [<CompiledName("FSharpMap`2")>]
 [<Sealed>]
-type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonConditionalOn>] 'Value when 'Key: comparison> =
+type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonConditionalOn>] 'Value when 'Key: comparison>
+    =
     /// <summary>Returns a new map with the binding added to the given map.
     /// If a binding with the given key already exists in the input map, the existing binding is replaced by the new binding in the result map.</summary>
     /// <param name="key">The key to add.</param>

--- a/src/FSharp.Core/quotations.fs
+++ b/src/FSharp.Core/quotations.fs
@@ -27,7 +27,7 @@ module Helpers =
     let qOneOrMoreRLinear q inp =
         let rec queryAcc rvs e =
             match q e with
-            | Some (v, body) -> queryAcc (v :: rvs) body
+            | Some(v, body) -> queryAcc (v :: rvs) body
             | None ->
                 match rvs with
                 | [] -> None
@@ -38,7 +38,7 @@ module Helpers =
     let qOneOrMoreLLinear q inp =
         let rec queryAcc e rvs =
             match q e with
-            | Some (body, v) -> queryAcc body (v :: rvs)
+            | Some(body, v) -> queryAcc body (v :: rvs)
             | None ->
                 match rvs with
                 | [] -> None
@@ -237,10 +237,10 @@ and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(
             let rec eq t1 t2 =
                 match t1, t2 with
                 // We special-case ValueOp to ensure that ValueWithName = Value
-                | CombTerm (ValueOp (v1, ty1, _), []), CombTerm (ValueOp (v2, ty2, _), []) -> (v1 = v2) && (ty1 = ty2)
+                | CombTerm(ValueOp(v1, ty1, _), []), CombTerm(ValueOp(v2, ty2, _), []) -> (v1 = v2) && (ty1 = ty2)
 
                 // We strip off InstanceMethodCallWOp to ensure that CallWithWitness = Call
-                | CombTerm (InstanceMethodCallWOp (minfo1, _minfoW1, nWitnesses1), obj1 :: args1WithoutObj), _ ->
+                | CombTerm(InstanceMethodCallWOp(minfo1, _minfoW1, nWitnesses1), obj1 :: args1WithoutObj), _ ->
                     if nWitnesses1 <= args1WithoutObj.Length then
                         let args1WithoutWitnesses = List.skip nWitnesses1 args1WithoutObj
                         eq (CombTerm(InstanceMethodCallOp(minfo1), obj1 :: args1WithoutWitnesses)) t2
@@ -248,30 +248,30 @@ and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(
                         false
 
                 // We strip off InstanceMethodCallWOp to ensure that CallWithWitness = Call
-                | _, CombTerm (InstanceMethodCallWOp (minfo2, _minfoW2, nWitnesses2), obj2 :: args2WithoutObj) when
+                | _, CombTerm(InstanceMethodCallWOp(minfo2, _minfoW2, nWitnesses2), obj2 :: args2WithoutObj) when
                     nWitnesses2 <= args2WithoutObj.Length
                     ->
                     let args2WithoutWitnesses = List.skip nWitnesses2 args2WithoutObj
                     eq t1 (CombTerm(InstanceMethodCallOp(minfo2), obj2 :: args2WithoutWitnesses))
 
                 // We strip off StaticMethodCallWOp to ensure that CallWithWitness = Call
-                | CombTerm (StaticMethodCallWOp (minfo1, _minfoW1, nWitnesses1), args1), _ when
+                | CombTerm(StaticMethodCallWOp(minfo1, _minfoW1, nWitnesses1), args1), _ when
                     nWitnesses1 <= args1.Length
                     ->
                     let argsWithoutWitnesses1 = List.skip nWitnesses1 args1
                     eq (CombTerm(StaticMethodCallOp(minfo1), argsWithoutWitnesses1)) t2
 
                 // We strip off StaticMethodCallWOp to ensure that CallWithWitness = Call
-                | _, CombTerm (StaticMethodCallWOp (minfo2, _minfoW2, nWitnesses2), args2) when
+                | _, CombTerm(StaticMethodCallWOp(minfo2, _minfoW2, nWitnesses2), args2) when
                     nWitnesses2 <= args2.Length
                     ->
                     let argsWithoutWitnesses2 = List.skip nWitnesses2 args2
                     eq t1 (CombTerm(StaticMethodCallOp(minfo2), argsWithoutWitnesses2))
 
-                | CombTerm (c1, es1), CombTerm (c2, es2) -> c1 = c2 && es1.Length = es2.Length && (es1 = es2)
+                | CombTerm(c1, es1), CombTerm(c2, es2) -> c1 = c2 && es1.Length = es2.Length && (es1 = es2)
                 | VarTerm v1, VarTerm v2 -> (v1 = v2)
-                | LambdaTerm (v1, e1), LambdaTerm (v2, e2) -> (v1 = v2) && (e1 = e2)
-                | HoleTerm (ty1, n1), HoleTerm (ty2, n2) -> (ty1 = ty2) && (n1 = n2)
+                | LambdaTerm(v1, e1), LambdaTerm(v2, e2) -> (v1 = v2) && (e1 = e2)
+                | HoleTerm(ty1, n1), HoleTerm(ty2, n2) -> (ty1 = ty2) && (n1 = n2)
                 | _ -> false
 
             eq x.Tree y.Tree
@@ -329,7 +329,7 @@ and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(
 
         let (|Lambda|_|) (E x) =
             match x with
-            | LambdaTerm (a, b) -> Some(a, b)
+            | LambdaTerm(a, b) -> Some(a, b)
             | _ -> None
 
         let (|IteratedLambda|_|) (e: Expr) =
@@ -368,66 +368,66 @@ and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(
         let rec (|NLambdas|_|) n (e: Expr) =
             match e with
             | _ when n <= 0 -> Some([], e)
-            | Lambda (v, NLambdas ((-) n 1) (vs, b)) -> Some(v :: vs, b)
+            | Lambda(v, NLambdas ((-) n 1) (vs, b)) -> Some(v :: vs, b)
             | _ -> None
 
         match x.Tree with
-        | CombTerm (AppOp, args) -> combL "Application" (exprs args)
-        | CombTerm (IfThenElseOp, args) -> combL "IfThenElse" (exprs args)
-        | CombTerm (LetRecOp, [ IteratedLambda (vs, E (CombTerm (LetRecCombOp, b2 :: bs))) ]) ->
+        | CombTerm(AppOp, args) -> combL "Application" (exprs args)
+        | CombTerm(IfThenElseOp, args) -> combL "IfThenElse" (exprs args)
+        | CombTerm(LetRecOp, [ IteratedLambda(vs, E(CombTerm(LetRecCombOp, b2 :: bs))) ]) ->
             combL "LetRecursive" [ listL (List.map2 pairL (List.map varL vs) (exprs bs)); b2.GetLayout long ]
-        | CombTerm (LetOp, [ e; E (LambdaTerm (v, b)) ]) -> combL "Let" [ varL v; e.GetLayout long; b.GetLayout long ]
-        | CombTerm (NewRecordOp ty, args) -> combL "NewRecord" (typeL ty :: exprs args)
-        | CombTerm (NewUnionCaseOp unionCase, args) -> combL "NewUnionCase" (ucaseL unionCase :: exprs args)
-        | CombTerm (UnionCaseTestOp unionCase, args) -> combL "UnionCaseTest" (exprs args @ [ ucaseL unionCase ])
-        | CombTerm (NewTupleOp _, args) -> combL "NewTuple" (exprs args)
-        | CombTerm (TupleGetOp (_, i), [ arg ]) -> combL "TupleGet" ([ expr arg ] @ [ objL i ])
-        | CombTerm (ValueOp (v, _, Some nm), []) -> combL "ValueWithName" [ objL v; wordL (tagLocal nm) ]
-        | CombTerm (ValueOp (v, _, None), []) -> combL "Value" [ objL v ]
-        | CombTerm (WithValueOp (v, _), [ defn ]) -> combL "WithValue" [ objL v; expr defn ]
+        | CombTerm(LetOp, [ e; E(LambdaTerm(v, b)) ]) -> combL "Let" [ varL v; e.GetLayout long; b.GetLayout long ]
+        | CombTerm(NewRecordOp ty, args) -> combL "NewRecord" (typeL ty :: exprs args)
+        | CombTerm(NewUnionCaseOp unionCase, args) -> combL "NewUnionCase" (ucaseL unionCase :: exprs args)
+        | CombTerm(UnionCaseTestOp unionCase, args) -> combL "UnionCaseTest" (exprs args @ [ ucaseL unionCase ])
+        | CombTerm(NewTupleOp _, args) -> combL "NewTuple" (exprs args)
+        | CombTerm(TupleGetOp(_, i), [ arg ]) -> combL "TupleGet" ([ expr arg ] @ [ objL i ])
+        | CombTerm(ValueOp(v, _, Some nm), []) -> combL "ValueWithName" [ objL v; wordL (tagLocal nm) ]
+        | CombTerm(ValueOp(v, _, None), []) -> combL "Value" [ objL v ]
+        | CombTerm(WithValueOp(v, _), [ defn ]) -> combL "WithValue" [ objL v; expr defn ]
 
-        | CombTerm (InstanceMethodCallOp (minfo), obj :: args) ->
+        | CombTerm(InstanceMethodCallOp(minfo), obj :: args) ->
             combL "Call" [ someL obj; minfoL minfo; listL (exprs args) ]
 
-        | CombTerm (StaticMethodCallOp (minfo), args) -> combL "Call" [ noneL; minfoL minfo; listL (exprs args) ]
+        | CombTerm(StaticMethodCallOp(minfo), args) -> combL "Call" [ noneL; minfoL minfo; listL (exprs args) ]
 
-        | CombTerm (InstanceMethodCallWOp (minfo, _minfoW, nWitnesses), obj :: argsWithoutObj) when
+        | CombTerm(InstanceMethodCallWOp(minfo, _minfoW, nWitnesses), obj :: argsWithoutObj) when
             nWitnesses <= argsWithoutObj.Length
             ->
             let argsWithoutWitnesses = List.skip nWitnesses argsWithoutObj
             combL "Call" [ someL obj; minfoL minfo; listL (exprs argsWithoutWitnesses) ]
 
-        | CombTerm (StaticMethodCallWOp (minfo, _minfoW, nWitnesses), args) when nWitnesses <= args.Length ->
+        | CombTerm(StaticMethodCallWOp(minfo, _minfoW, nWitnesses), args) when nWitnesses <= args.Length ->
             let argsWithoutWitnesses = List.skip nWitnesses args
             combL "Call" [ noneL; minfoL minfo; listL (exprs argsWithoutWitnesses) ]
 
-        | CombTerm (InstancePropGetOp (pinfo), (obj :: args)) ->
+        | CombTerm(InstancePropGetOp(pinfo), (obj :: args)) ->
             combL "PropertyGet" [ someL obj; pinfoL pinfo; listL (exprs args) ]
-        | CombTerm (StaticPropGetOp (pinfo), args) -> combL "PropertyGet" [ noneL; pinfoL pinfo; listL (exprs args) ]
-        | CombTerm (InstancePropSetOp (pinfo), (obj :: args)) ->
+        | CombTerm(StaticPropGetOp(pinfo), args) -> combL "PropertyGet" [ noneL; pinfoL pinfo; listL (exprs args) ]
+        | CombTerm(InstancePropSetOp(pinfo), (obj :: args)) ->
             combL "PropertySet" [ someL obj; pinfoL pinfo; listL (exprs args) ]
-        | CombTerm (StaticPropSetOp (pinfo), args) -> combL "PropertySet" [ noneL; pinfoL pinfo; listL (exprs args) ]
-        | CombTerm (InstanceFieldGetOp (finfo), [ obj ]) -> combL "FieldGet" [ someL obj; finfoL finfo ]
-        | CombTerm (StaticFieldGetOp (finfo), []) -> combL "FieldGet" [ noneL; finfoL finfo ]
-        | CombTerm (InstanceFieldSetOp (finfo), [ obj; v ]) -> combL "FieldSet" [ someL obj; finfoL finfo; expr v ]
-        | CombTerm (StaticFieldSetOp (finfo), [ v ]) -> combL "FieldSet" [ noneL; finfoL finfo; expr v ]
-        | CombTerm (CoerceOp (ty), [ arg ]) -> combL "Coerce" [ expr arg; typeL ty ]
-        | CombTerm (NewObjectOp cinfo, args) -> combL "NewObject" ([ cinfoL cinfo ] @ exprs args)
-        | CombTerm (DefaultValueOp ty, args) -> combL "DefaultValue" ([ typeL ty ] @ exprs args)
-        | CombTerm (NewArrayOp ty, args) -> combL "NewArray" ([ typeL ty ] @ exprs args)
-        | CombTerm (TypeTestOp ty, args) -> combL "TypeTest" ([ typeL ty ] @ exprs args)
-        | CombTerm (AddressOfOp, args) -> combL "AddressOf" (exprs args)
-        | CombTerm (VarSetOp, [ E (VarTerm v); e ]) -> combL "VarSet" [ varL v; expr e ]
-        | CombTerm (AddressSetOp, args) -> combL "AddressSet" (exprs args)
-        | CombTerm (ForIntegerRangeLoopOp, [ e1; e2; E (LambdaTerm (v, e3)) ]) ->
+        | CombTerm(StaticPropSetOp(pinfo), args) -> combL "PropertySet" [ noneL; pinfoL pinfo; listL (exprs args) ]
+        | CombTerm(InstanceFieldGetOp(finfo), [ obj ]) -> combL "FieldGet" [ someL obj; finfoL finfo ]
+        | CombTerm(StaticFieldGetOp(finfo), []) -> combL "FieldGet" [ noneL; finfoL finfo ]
+        | CombTerm(InstanceFieldSetOp(finfo), [ obj; v ]) -> combL "FieldSet" [ someL obj; finfoL finfo; expr v ]
+        | CombTerm(StaticFieldSetOp(finfo), [ v ]) -> combL "FieldSet" [ noneL; finfoL finfo; expr v ]
+        | CombTerm(CoerceOp(ty), [ arg ]) -> combL "Coerce" [ expr arg; typeL ty ]
+        | CombTerm(NewObjectOp cinfo, args) -> combL "NewObject" ([ cinfoL cinfo ] @ exprs args)
+        | CombTerm(DefaultValueOp ty, args) -> combL "DefaultValue" ([ typeL ty ] @ exprs args)
+        | CombTerm(NewArrayOp ty, args) -> combL "NewArray" ([ typeL ty ] @ exprs args)
+        | CombTerm(TypeTestOp ty, args) -> combL "TypeTest" ([ typeL ty ] @ exprs args)
+        | CombTerm(AddressOfOp, args) -> combL "AddressOf" (exprs args)
+        | CombTerm(VarSetOp, [ E(VarTerm v); e ]) -> combL "VarSet" [ varL v; expr e ]
+        | CombTerm(AddressSetOp, args) -> combL "AddressSet" (exprs args)
+        | CombTerm(ForIntegerRangeLoopOp, [ e1; e2; E(LambdaTerm(v, e3)) ]) ->
             combL "ForIntegerRangeLoop" [ varL v; expr e1; expr e2; expr e3 ]
-        | CombTerm (WhileLoopOp, args) -> combL "WhileLoop" (exprs args)
-        | CombTerm (TryFinallyOp, args) -> combL "TryFinally" (exprs args)
-        | CombTerm (TryWithOp, [ e1; Lambda (v1, e2); Lambda (v2, e3) ]) ->
+        | CombTerm(WhileLoopOp, args) -> combL "WhileLoop" (exprs args)
+        | CombTerm(TryFinallyOp, args) -> combL "TryFinally" (exprs args)
+        | CombTerm(TryWithOp, [ e1; Lambda(v1, e2); Lambda(v2, e3) ]) ->
             combL "TryWith" [ expr e1; varL v1; expr e2; varL v2; expr e3 ]
-        | CombTerm (SequentialOp, args) -> combL "Sequential" (exprs args)
+        | CombTerm(SequentialOp, args) -> combL "Sequential" (exprs args)
 
-        | CombTerm (NewDelegateOp ty, [ e ]) ->
+        | CombTerm(NewDelegateOp ty, [ e ]) ->
             let nargs = (getDelegateInvoke ty).GetParameters().Length
 
             if nargs = 0 then
@@ -440,9 +440,9 @@ and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(
                 | NLambdas nargs (vs, e) -> combL "NewDelegate" ([ typeL ty ] @ (vs |> List.map varL) @ [ expr e ])
                 | _ -> combL "NewDelegate" [ typeL ty; expr e ]
         | VarTerm v -> wordL (tagLocal v.Name)
-        | LambdaTerm (v, b) -> combL "Lambda" [ varL v; expr b ]
+        | LambdaTerm(v, b) -> combL "Lambda" [ varL v; expr b ]
         | HoleTerm _ -> wordL (tagLocal "_")
-        | CombTerm (QuoteOp _, args) -> combL "Quote" (exprs args)
+        | CombTerm(QuoteOp _, args) -> combL "Quote" (exprs args)
         | _ -> failwithf "Unexpected term"
 
 and [<CompiledName("FSharpExpr`1")>] Expr<'T>(term: Tree, attribs) =
@@ -500,7 +500,7 @@ module Patterns =
 
         loop [] es
 
-    let funTyC = typeof<(obj -> obj)>.GetGenericTypeDefinition ()
+    let funTyC = typeof<(obj -> obj)>.GetGenericTypeDefinition()
     let exprTyC = typedefof<Expr<int>>
     let voidTy = typeof<System.Void>
     let unitTy = typeof<unit>
@@ -526,22 +526,22 @@ module Patterns =
 
     let (|Comb0|_|) (E x) =
         match x with
-        | CombTerm (k, []) -> Some k
+        | CombTerm(k, []) -> Some k
         | _ -> None
 
     let (|Comb1|_|) (E x) =
         match x with
-        | CombTerm (k, [ x ]) -> Some(k, x)
+        | CombTerm(k, [ x ]) -> Some(k, x)
         | _ -> None
 
     let (|Comb2|_|) (E x) =
         match x with
-        | CombTerm (k, [ x1; x2 ]) -> Some(k, x1, x2)
+        | CombTerm(k, [ x1; x2 ]) -> Some(k, x1, x2)
         | _ -> None
 
     let (|Comb3|_|) (E x) =
         match x with
-        | CombTerm (k, [ x1; x2; x3 ]) -> Some(k, x1, x2, x3)
+        | CombTerm(k, [ x1; x2; x3 ]) -> Some(k, x1, x2, x3)
         | _ -> None
 
     [<CompiledName("VarPattern")>]
@@ -553,218 +553,218 @@ module Patterns =
     [<CompiledName("ApplicationPattern")>]
     let (|Application|_|) input =
         match input with
-        | Comb2 (AppOp, a, b) -> Some(a, b)
+        | Comb2(AppOp, a, b) -> Some(a, b)
         | _ -> None
 
     [<CompiledName("LambdaPattern")>]
     let (|Lambda|_|) (E x) =
         match x with
-        | LambdaTerm (a, b) -> Some(a, b)
+        | LambdaTerm(a, b) -> Some(a, b)
         | _ -> None
 
     [<CompiledName("QuotePattern")>]
     let (|Quote|_|) (E x) =
         match x with
-        | CombTerm (QuoteOp _, [ a ]) -> Some(a)
+        | CombTerm(QuoteOp _, [ a ]) -> Some(a)
         | _ -> None
 
     [<CompiledName("QuoteRawPattern")>]
     let (|QuoteRaw|_|) (E x) =
         match x with
-        | CombTerm (QuoteOp false, [ a ]) -> Some(a)
+        | CombTerm(QuoteOp false, [ a ]) -> Some(a)
         | _ -> None
 
     [<CompiledName("QuoteTypedPattern")>]
     let (|QuoteTyped|_|) (E x) =
         match x with
-        | CombTerm (QuoteOp true, [ a ]) -> Some(a)
+        | CombTerm(QuoteOp true, [ a ]) -> Some(a)
         | _ -> None
 
     [<CompiledName("IfThenElsePattern")>]
     let (|IfThenElse|_|) input =
         match input with
-        | Comb3 (IfThenElseOp, e1, e2, e3) -> Some(e1, e2, e3)
+        | Comb3(IfThenElseOp, e1, e2, e3) -> Some(e1, e2, e3)
         | _ -> None
 
     [<CompiledName("NewTuplePattern")>]
     let (|NewTuple|_|) input =
         match input with
-        | E (CombTerm (NewTupleOp (_), es)) -> Some es
+        | E(CombTerm(NewTupleOp(_), es)) -> Some es
         | _ -> None
 
     [<CompiledName("NewStructTuplePattern")>]
     let (|NewStructTuple|_|) input =
         match input with
-        | E (CombTerm (NewTupleOp (ty), es)) when ty.IsValueType -> Some es
+        | E(CombTerm(NewTupleOp(ty), es)) when ty.IsValueType -> Some es
         | _ -> None
 
     [<CompiledName("DefaultValuePattern")>]
     let (|DefaultValue|_|) input =
         match input with
-        | E (CombTerm (DefaultValueOp ty, [])) -> Some ty
+        | E(CombTerm(DefaultValueOp ty, [])) -> Some ty
         | _ -> None
 
     [<CompiledName("NewRecordPattern")>]
     let (|NewRecord|_|) input =
         match input with
-        | E (CombTerm (NewRecordOp x, es)) -> Some(x, es)
+        | E(CombTerm(NewRecordOp x, es)) -> Some(x, es)
         | _ -> None
 
     [<CompiledName("NewUnionCasePattern")>]
     let (|NewUnionCase|_|) input =
         match input with
-        | E (CombTerm (NewUnionCaseOp unionCase, es)) -> Some(unionCase, es)
+        | E(CombTerm(NewUnionCaseOp unionCase, es)) -> Some(unionCase, es)
         | _ -> None
 
     [<CompiledName("UnionCaseTestPattern")>]
     let (|UnionCaseTest|_|) input =
         match input with
-        | Comb1 (UnionCaseTestOp unionCase, e) -> Some(e, unionCase)
+        | Comb1(UnionCaseTestOp unionCase, e) -> Some(e, unionCase)
         | _ -> None
 
     [<CompiledName("TupleGetPattern")>]
     let (|TupleGet|_|) input =
         match input with
-        | Comb1 (TupleGetOp (_, n), e) -> Some(e, n)
+        | Comb1(TupleGetOp(_, n), e) -> Some(e, n)
         | _ -> None
 
     [<CompiledName("CoercePattern")>]
     let (|Coerce|_|) input =
         match input with
-        | Comb1 (CoerceOp ty, e1) -> Some(e1, ty)
+        | Comb1(CoerceOp ty, e1) -> Some(e1, ty)
         | _ -> None
 
     [<CompiledName("TypeTestPattern")>]
     let (|TypeTest|_|) input =
         match input with
-        | Comb1 (TypeTestOp ty, e1) -> Some(e1, ty)
+        | Comb1(TypeTestOp ty, e1) -> Some(e1, ty)
         | _ -> None
 
     [<CompiledName("NewArrayPattern")>]
     let (|NewArray|_|) input =
         match input with
-        | E (CombTerm (NewArrayOp ty, es)) -> Some(ty, es)
+        | E(CombTerm(NewArrayOp ty, es)) -> Some(ty, es)
         | _ -> None
 
     [<CompiledName("AddressSetPattern")>]
     let (|AddressSet|_|) input =
         match input with
-        | E (CombTerm (AddressSetOp, [ e; v ])) -> Some(e, v)
+        | E(CombTerm(AddressSetOp, [ e; v ])) -> Some(e, v)
         | _ -> None
 
     [<CompiledName("TryFinallyPattern")>]
     let (|TryFinally|_|) input =
         match input with
-        | E (CombTerm (TryFinallyOp, [ e1; e2 ])) -> Some(e1, e2)
+        | E(CombTerm(TryFinallyOp, [ e1; e2 ])) -> Some(e1, e2)
         | _ -> None
 
     [<CompiledName("TryWithPattern")>]
     let (|TryWith|_|) input =
         match input with
-        | E (CombTerm (TryWithOp, [ e1; Lambda (v1, e2); Lambda (v2, e3) ])) -> Some(e1, v1, e2, v2, e3)
+        | E(CombTerm(TryWithOp, [ e1; Lambda(v1, e2); Lambda(v2, e3) ])) -> Some(e1, v1, e2, v2, e3)
         | _ -> None
 
     [<CompiledName("VarSetPattern")>]
     let (|VarSet|_|) input =
         match input with
-        | E (CombTerm (VarSetOp, [ E (VarTerm v); e ])) -> Some(v, e)
+        | E(CombTerm(VarSetOp, [ E(VarTerm v); e ])) -> Some(v, e)
         | _ -> None
 
     [<CompiledName("ValuePattern")>]
     let (|Value|_|) input =
         match input with
-        | E (CombTerm (ValueOp (v, ty, _), _)) -> Some(v, ty)
+        | E(CombTerm(ValueOp(v, ty, _), _)) -> Some(v, ty)
         | _ -> None
 
     [<CompiledName("ValueObjPattern")>]
     let (|ValueObj|_|) input =
         match input with
-        | E (CombTerm (ValueOp (v, _, _), _)) -> Some v
+        | E(CombTerm(ValueOp(v, _, _), _)) -> Some v
         | _ -> None
 
     [<CompiledName("ValueWithNamePattern")>]
     let (|ValueWithName|_|) input =
         match input with
-        | E (CombTerm (ValueOp (v, ty, Some nm), _)) -> Some(v, ty, nm)
+        | E(CombTerm(ValueOp(v, ty, Some nm), _)) -> Some(v, ty, nm)
         | _ -> None
 
     [<CompiledName("WithValuePattern")>]
     let (|WithValue|_|) input =
         match input with
-        | E (CombTerm (WithValueOp (v, ty), [ e ])) -> Some(v, ty, e)
+        | E(CombTerm(WithValueOp(v, ty), [ e ])) -> Some(v, ty, e)
         | _ -> None
 
     [<CompiledName("AddressOfPattern")>]
     let (|AddressOf|_|) input =
         match input with
-        | Comb1 (AddressOfOp, e) -> Some e
+        | Comb1(AddressOfOp, e) -> Some e
         | _ -> None
 
     [<CompiledName("SequentialPattern")>]
     let (|Sequential|_|) input =
         match input with
-        | Comb2 (SequentialOp, e1, e2) -> Some(e1, e2)
+        | Comb2(SequentialOp, e1, e2) -> Some(e1, e2)
         | _ -> None
 
     [<CompiledName("ForIntegerRangeLoopPattern")>]
     let (|ForIntegerRangeLoop|_|) input =
         match input with
-        | Comb3 (ForIntegerRangeLoopOp, e1, e2, Lambda (v, e3)) -> Some(v, e1, e2, e3)
+        | Comb3(ForIntegerRangeLoopOp, e1, e2, Lambda(v, e3)) -> Some(v, e1, e2, e3)
         | _ -> None
 
     [<CompiledName("WhileLoopPattern")>]
     let (|WhileLoop|_|) input =
         match input with
-        | Comb2 (WhileLoopOp, e1, e2) -> Some(e1, e2)
+        | Comb2(WhileLoopOp, e1, e2) -> Some(e1, e2)
         | _ -> None
 
     [<CompiledName("PropertyGetPattern")>]
     let (|PropertyGet|_|) input =
         match input with
-        | E (CombTerm (StaticPropGetOp pinfo, args)) -> Some(None, pinfo, args)
-        | E (CombTerm (InstancePropGetOp pinfo, obj :: args)) -> Some(Some obj, pinfo, args)
+        | E(CombTerm(StaticPropGetOp pinfo, args)) -> Some(None, pinfo, args)
+        | E(CombTerm(InstancePropGetOp pinfo, obj :: args)) -> Some(Some obj, pinfo, args)
         | _ -> None
 
     [<CompiledName("PropertySetPattern")>]
     let (|PropertySet|_|) input =
         match input with
-        | E (CombTerm (StaticPropSetOp pinfo, FrontAndBack (args, v))) -> Some(None, pinfo, args, v)
-        | E (CombTerm (InstancePropSetOp pinfo, obj :: FrontAndBack (args, v))) -> Some(Some obj, pinfo, args, v)
+        | E(CombTerm(StaticPropSetOp pinfo, FrontAndBack(args, v))) -> Some(None, pinfo, args, v)
+        | E(CombTerm(InstancePropSetOp pinfo, obj :: FrontAndBack(args, v))) -> Some(Some obj, pinfo, args, v)
         | _ -> None
 
     [<CompiledName("FieldGetPattern")>]
     let (|FieldGet|_|) input =
         match input with
-        | E (CombTerm (StaticFieldGetOp finfo, [])) -> Some(None, finfo)
-        | E (CombTerm (InstanceFieldGetOp finfo, [ obj ])) -> Some(Some obj, finfo)
+        | E(CombTerm(StaticFieldGetOp finfo, [])) -> Some(None, finfo)
+        | E(CombTerm(InstanceFieldGetOp finfo, [ obj ])) -> Some(Some obj, finfo)
         | _ -> None
 
     [<CompiledName("FieldSetPattern")>]
     let (|FieldSet|_|) input =
         match input with
-        | E (CombTerm (StaticFieldSetOp finfo, [ v ])) -> Some(None, finfo, v)
-        | E (CombTerm (InstanceFieldSetOp finfo, [ obj; v ])) -> Some(Some obj, finfo, v)
+        | E(CombTerm(StaticFieldSetOp finfo, [ v ])) -> Some(None, finfo, v)
+        | E(CombTerm(InstanceFieldSetOp finfo, [ obj; v ])) -> Some(Some obj, finfo, v)
         | _ -> None
 
     [<CompiledName("NewObjectPattern")>]
     let (|NewObject|_|) input =
         match input with
-        | E (CombTerm (NewObjectOp ty, e)) -> Some(ty, e)
+        | E(CombTerm(NewObjectOp ty, e)) -> Some(ty, e)
         | _ -> None
 
     [<CompiledName("CallPattern")>]
     let (|Call|_|) input =
         match input with
-        | E (CombTerm (StaticMethodCallOp minfo, args)) -> Some(None, minfo, args)
+        | E(CombTerm(StaticMethodCallOp minfo, args)) -> Some(None, minfo, args)
 
-        | E (CombTerm (InstanceMethodCallOp minfo, (obj :: args))) -> Some(Some(obj), minfo, args)
+        | E(CombTerm(InstanceMethodCallOp minfo, (obj :: args))) -> Some(Some(obj), minfo, args)
 
         // A StaticMethodCallWOp matches as if it were a StaticMethodCallOp
-        | E (CombTerm (StaticMethodCallWOp (minfo, _minfoW, nWitnesses), args)) when nWitnesses <= args.Length ->
+        | E(CombTerm(StaticMethodCallWOp(minfo, _minfoW, nWitnesses), args)) when nWitnesses <= args.Length ->
             Some(None, minfo, List.skip nWitnesses args)
 
         // A InstanceMethodCallWOp matches as if it were a InstanceMethodCallOp
-        | E (CombTerm (InstanceMethodCallWOp (minfo, _minfoW, nWitnesses), obj :: argsWithoutObj)) when
+        | E(CombTerm(InstanceMethodCallWOp(minfo, _minfoW, nWitnesses), obj :: argsWithoutObj)) when
             nWitnesses <= argsWithoutObj.Length
             ->
             let argsWithoutWitnesses = List.skip nWitnesses argsWithoutObj
@@ -775,14 +775,14 @@ module Patterns =
     [<CompiledName("CallWithWitnessesPattern")>]
     let (|CallWithWitnesses|_|) input =
         match input with
-        | E (CombTerm (StaticMethodCallWOp (minfo, minfoW, nWitnesses), args)) ->
+        | E(CombTerm(StaticMethodCallWOp(minfo, minfoW, nWitnesses), args)) ->
             if args.Length >= nWitnesses then
                 let witnessArgs, argsWithoutWitnesses = List.splitAt nWitnesses args
                 Some(None, minfo, minfoW, witnessArgs, argsWithoutWitnesses)
             else
                 None
 
-        | E (CombTerm (InstanceMethodCallWOp (minfo, minfoW, nWitnesses), obj :: argsWithoutObj)) ->
+        | E(CombTerm(InstanceMethodCallWOp(minfo, minfoW, nWitnesses), obj :: argsWithoutObj)) ->
             if argsWithoutObj.Length >= nWitnesses then
                 let witnessArgs, argsWithoutWitnesses = List.splitAt nWitnesses argsWithoutObj
                 Some(Some obj, minfo, minfoW, witnessArgs, argsWithoutWitnesses)
@@ -793,18 +793,18 @@ module Patterns =
 
     let (|LetRaw|_|) input =
         match input with
-        | Comb2 (LetOp, e1, e2) -> Some(e1, e2)
+        | Comb2(LetOp, e1, e2) -> Some(e1, e2)
         | _ -> None
 
     let (|LetRecRaw|_|) input =
         match input with
-        | Comb1 (LetRecOp, e1) -> Some e1
+        | Comb1(LetRecOp, e1) -> Some e1
         | _ -> None
 
     [<CompiledName("LetPattern")>]
     let (|Let|_|) input =
         match input with
-        | LetRaw (e, Lambda (v, body)) -> Some(v, e, body)
+        | LetRaw(e, Lambda(v, body)) -> Some(v, e, body)
         | _ -> None
 
     let (|IteratedLambda|_|) (e: Expr) =
@@ -813,13 +813,13 @@ module Patterns =
     let rec (|NLambdas|_|) n (e: Expr) =
         match e with
         | _ when n <= 0 -> Some([], e)
-        | Lambda (v, NLambdas ((-) n 1) (vs, b)) -> Some(v :: vs, b)
+        | Lambda(v, NLambdas ((-) n 1) (vs, b)) -> Some(v :: vs, b)
         | _ -> None
 
     [<CompiledName("NewDelegatePattern")>]
     let (|NewDelegate|_|) input =
         match input with
-        | Comb1 (NewDelegateOp ty, e) ->
+        | Comb1(NewDelegateOp ty, e) ->
             let nargs = (getDelegateInvoke ty).GetParameters().Length
 
             if nargs = 0 then
@@ -836,7 +836,7 @@ module Patterns =
     [<CompiledName("LetRecursivePattern")>]
     let (|LetRecursive|_|) input =
         match input with
-        | LetRecRaw (IteratedLambda (vs1, E (CombTerm (LetRecCombOp, body :: es)))) -> Some(List.zip vs1 es, body)
+        | LetRecRaw(IteratedLambda(vs1, E(CombTerm(LetRecCombOp, body :: es)))) -> Some(List.zip vs1 es, body)
         | _ -> None
 
     //--------------------------------------------------------------------------
@@ -848,7 +848,7 @@ module Patterns =
         let mems = FSharpType.GetRecordFields(ty, publicOrPrivateBindingFlags)
 
         match mems |> Array.tryFind (fun minfo -> minfo.Name = fieldName) with
-        | Some (m) -> m
+        | Some(m) -> m
         | _ -> invalidArg "fieldName" (String.Format(SR.GetString(SR.QmissingRecordField), ty.FullName, fieldName))
 
     let getUnionCaseInfo (ty, unionCaseName) =
@@ -882,27 +882,27 @@ module Patterns =
 
         match t with
         | VarTerm v -> v.Type
-        | LambdaTerm (v, b) -> mkFunTy v.Type (typeOf b)
-        | HoleTerm (ty, _) -> ty
-        | CombTerm (c, args) ->
+        | LambdaTerm(v, b) -> mkFunTy v.Type (typeOf b)
+        | HoleTerm(ty, _) -> ty
+        | CombTerm(c, args) ->
             match c, args with
             | AppOp, [ f; _ ] -> typeOfAppliedLambda f
             | LetOp, _ ->
                 match e with
-                | Let (_, _, b) -> typeOf b
+                | Let(_, _, b) -> typeOf b
                 | _ -> failwith "unreachable"
             | IfThenElseOp, [ _; t; _ ] -> typeOf t
             | LetRecOp, _ ->
                 match e with
-                | LetRecursive (_, b) -> typeOf b
+                | LetRecursive(_, b) -> typeOf b
                 | _ -> failwith "unreachable"
             | LetRecCombOp, _ -> failwith "typeOfConst: LetRecCombOp"
             | NewRecordOp ty, _ -> ty
             | NewUnionCaseOp unionCase, _ -> unionCase.DeclaringType
             | UnionCaseTestOp _, _ -> typeof<Boolean>
-            | ValueOp (_, ty, _), _ -> ty
-            | WithValueOp (_, ty), _ -> ty
-            | TupleGetOp (ty, i), _ -> FSharpType.GetTupleElements(ty).[i]
+            | ValueOp(_, ty, _), _ -> ty
+            | WithValueOp(_, ty), _ -> ty
+            | TupleGetOp(ty, i), _ -> FSharpType.GetTupleElements(ty).[i]
             | NewTupleOp ty, _ -> ty
             | StaticPropGetOp prop, _ -> prop.PropertyType
             | InstancePropGetOp prop, _ -> prop.PropertyType
@@ -915,8 +915,8 @@ module Patterns =
             | NewObjectOp ctor, _ -> ctor.DeclaringType
             | InstanceMethodCallOp minfo, _ -> minfo.ReturnType |> removeVoid
             | StaticMethodCallOp minfo, _ -> minfo.ReturnType |> removeVoid
-            | InstanceMethodCallWOp (_, minfoW, _), _ -> minfoW.ReturnType |> removeVoid
-            | StaticMethodCallWOp (_, minfoW, _), _ -> minfoW.ReturnType |> removeVoid
+            | InstanceMethodCallWOp(_, minfoW, _), _ -> minfoW.ReturnType |> removeVoid
+            | StaticMethodCallWOp(_, minfoW, _), _ -> minfoW.ReturnType |> removeVoid
             | CoerceOp ty, _ -> ty
             | SequentialOp, [ _; b ] -> typeOf b
             | ForIntegerRangeLoopOp, _ -> typeof<Unit>
@@ -1433,10 +1433,9 @@ module Patterns =
                     // check for match
                     if nargTs <> haveArgTs.Length then
                         false (* method argument length mismatch *)
-                    else
+                    else if
 
-                    // If a known-number-of-arguments-including-object-argument has been given then check that
-                    if
+                        // If a known-number-of-arguments-including-object-argument has been given then check that
                         (match knownArgCount with
                          | ValueNone -> false
                          | ValueSome n -> n <> (if methInfo.IsStatic then 0 else 1) + nargTs)
@@ -1510,6 +1509,7 @@ module Patterns =
                             mi.GetGenericArguments().Length
                         else
                             0 in
+
                        methodTyArgCount = tyArgs.Length)
 
             let fail () =
@@ -2034,7 +2034,7 @@ module Patterns =
             | [| minfo |] ->
                 match witnessInfo with
                 | None -> Unique(StaticMethodCallOp(minfo))
-                | Some (nmW, nWitnesses) ->
+                | Some(nmW, nWitnesses) ->
                     let methsW =
                         ty.GetMethods(staticBindingFlags) |> Array.filter (fun mi -> mi.Name = nmW)
 
@@ -2051,7 +2051,7 @@ module Patterns =
                     | None ->
                         let minfo = bindModuleFunctionWithCallSiteArgs (ty, nm, argTypes, tyargs)
                         StaticMethodCallOp minfo
-                    | Some (nmW, nWitnesses) ->
+                    | Some(nmW, nWitnesses) ->
                         let minfo =
                             bindModuleFunctionWithCallSiteArgs (ty, nm, List.skip nWitnesses argTypes, tyargs)
 
@@ -2073,9 +2073,9 @@ module Patterns =
         match tag with
         | 0 ->
             match u_ModuleDefn None st with
-            | Unique (StaticMethodCallOp minfo) -> (minfo :> MethodBase)
-            | Unique (StaticPropGetOp pinfo) -> (pinfo.GetGetMethod true :> MethodBase)
-            | Ambiguous (_) -> raise (System.Reflection.AmbiguousMatchException())
+            | Unique(StaticMethodCallOp minfo) -> (minfo :> MethodBase)
+            | Unique(StaticPropGetOp pinfo) -> (pinfo.GetGetMethod true :> MethodBase)
+            | Ambiguous(_) -> raise (System.Reflection.AmbiguousMatchException())
             | _ -> failwith "unreachable"
         | 1 ->
             let ((genericType, _, _, methName, _) as data) = u_MethodInfoData st
@@ -2095,17 +2095,17 @@ module Patterns =
             let nWitnesses = u_int st
 
             match u_ModuleDefn (Some(methNameW, nWitnesses)) st with
-            | Unique (StaticMethodCallOp (minfo)) -> (minfo :> MethodBase)
-            | Unique (StaticMethodCallWOp (_minfo, minfoW, _)) -> (minfoW :> MethodBase)
-            | Unique (StaticPropGetOp (pinfo)) -> (pinfo.GetGetMethod(true) :> MethodBase)
-            | Ambiguous (_) -> raise (System.Reflection.AmbiguousMatchException())
+            | Unique(StaticMethodCallOp(minfo)) -> (minfo :> MethodBase)
+            | Unique(StaticMethodCallWOp(_minfo, minfoW, _)) -> (minfoW :> MethodBase)
+            | Unique(StaticPropGetOp(pinfo)) -> (pinfo.GetGetMethod(true) :> MethodBase)
+            | Ambiguous(_) -> raise (System.Reflection.AmbiguousMatchException())
             | _ -> failwith "unreachable"
         | _ -> failwith "u_MethodBase"
 
     and instModuleDefnOp r tyargs _ =
         match r with
-        | StaticMethodCallOp (minfo) -> StaticMethodCallOp(instMeth (minfo, tyargs))
-        | StaticMethodCallWOp (minfo, minfoW, n) ->
+        | StaticMethodCallOp(minfo) -> StaticMethodCallOp(instMeth (minfo, tyargs))
+        | StaticMethodCallWOp(minfo, minfoW, n) ->
             StaticMethodCallWOp(instMeth (minfo, tyargs), instMeth (minfoW, tyargs), n)
         // OK to throw away the tyargs here since this only non-generic values in modules get represented by static properties
         | x -> x
@@ -2259,9 +2259,9 @@ module Patterns =
     let rec fillHolesInRawExpr (l: Expr[]) (E t as e) =
         match t with
         | VarTerm _ -> e
-        | LambdaTerm (v, b) -> EA(LambdaTerm(v, fillHolesInRawExpr l b), e.CustomAttributes)
-        | CombTerm (op, args) -> EA(CombTerm(op, args |> List.map (fillHolesInRawExpr l)), e.CustomAttributes)
-        | HoleTerm (ty, idx) ->
+        | LambdaTerm(v, b) -> EA(LambdaTerm(v, fillHolesInRawExpr l b), e.CustomAttributes)
+        | CombTerm(op, args) -> EA(CombTerm(op, args |> List.map (fillHolesInRawExpr l)), e.CustomAttributes)
+        | HoleTerm(ty, idx) ->
             if idx < 0 || idx >= l.Length then
                 failwith "hole index out of range"
 
@@ -2275,13 +2275,13 @@ module Patterns =
     let rec freeInExprAcc bvs acc (E t) =
         match t with
         | HoleTerm _ -> acc
-        | CombTerm (_, ag) -> ag |> List.fold (freeInExprAcc bvs) acc
+        | CombTerm(_, ag) -> ag |> List.fold (freeInExprAcc bvs) acc
         | VarTerm v ->
             if Set.contains v bvs || Set.contains v acc then
                 acc
             else
                 Set.add v acc
-        | LambdaTerm (v, b) -> freeInExprAcc (Set.add v bvs) acc b
+        | LambdaTerm(v, b) -> freeInExprAcc (Set.add v bvs) acc b
 
     and freeInExpr e =
         freeInExprAcc Set.empty Set.empty e
@@ -2293,7 +2293,7 @@ module Patterns =
     /// given substitution functions/maps.
     let rec substituteInExpr bvs tmsubst (E t as e) =
         match t with
-        | CombTerm (c, args) ->
+        | CombTerm(c, args) ->
             let substargs = args |> List.map (fun arg -> substituteInExpr bvs tmsubst arg)
             EA(CombTerm(c, substargs), e.CustomAttributes)
         | VarTerm v ->
@@ -2307,7 +2307,7 @@ module Patterns =
                     e2
                 else
                     raise (Clash(clashes.MinimumElement))
-        | LambdaTerm (v, b) ->
+        | LambdaTerm(v, b) ->
             try
                 EA(LambdaTerm(v, substituteInExpr (Set.add v bvs) tmsubst b), e.CustomAttributes)
             with Clash bv ->
@@ -2404,7 +2404,9 @@ module Patterns =
                                         | x -> x)
                                         |> Array.tryPick (fun ca ->
                                             match ca with
-                                            | :? CompilationMappingAttribute as cma when cma.ResourceName = resourceName ->
+                                            | :? CompilationMappingAttribute as cma when
+                                                cma.ResourceName = resourceName
+                                                ->
                                                 Some cma
                                             | _ -> None)
 
@@ -2437,7 +2439,7 @@ module Patterns =
                 if ok then Some res else None
 
         match data with
-        | Some (Entry exprBuilder) ->
+        | Some(Entry exprBuilder) ->
             let expectedNumTypars =
                 getNumGenericArguments (methodBase.DeclaringType)
                 + (match methodBase with
@@ -2721,85 +2723,85 @@ module DerivedPatterns =
     [<CompiledName("BoolPattern")>]
     let (|Bool|_|) input =
         match input with
-        | ValueObj (:? bool as v) -> Some v
+        | ValueObj(:? bool as v) -> Some v
         | _ -> None
 
     [<CompiledName("StringPattern")>]
     let (|String|_|) input =
         match input with
-        | ValueObj (:? string as v) -> Some v
+        | ValueObj(:? string as v) -> Some v
         | _ -> None
 
     [<CompiledName("SinglePattern")>]
     let (|Single|_|) input =
         match input with
-        | ValueObj (:? single as v) -> Some v
+        | ValueObj(:? single as v) -> Some v
         | _ -> None
 
     [<CompiledName("DoublePattern")>]
     let (|Double|_|) input =
         match input with
-        | ValueObj (:? double as v) -> Some v
+        | ValueObj(:? double as v) -> Some v
         | _ -> None
 
     [<CompiledName("CharPattern")>]
     let (|Char|_|) input =
         match input with
-        | ValueObj (:? char as v) -> Some v
+        | ValueObj(:? char as v) -> Some v
         | _ -> None
 
     [<CompiledName("SBytePattern")>]
     let (|SByte|_|) input =
         match input with
-        | ValueObj (:? sbyte as v) -> Some v
+        | ValueObj(:? sbyte as v) -> Some v
         | _ -> None
 
     [<CompiledName("BytePattern")>]
     let (|Byte|_|) input =
         match input with
-        | ValueObj (:? byte as v) -> Some v
+        | ValueObj(:? byte as v) -> Some v
         | _ -> None
 
     [<CompiledName("Int16Pattern")>]
     let (|Int16|_|) input =
         match input with
-        | ValueObj (:? int16 as v) -> Some v
+        | ValueObj(:? int16 as v) -> Some v
         | _ -> None
 
     [<CompiledName("UInt16Pattern")>]
     let (|UInt16|_|) input =
         match input with
-        | ValueObj (:? uint16 as v) -> Some v
+        | ValueObj(:? uint16 as v) -> Some v
         | _ -> None
 
     [<CompiledName("Int32Pattern")>]
     let (|Int32|_|) input =
         match input with
-        | ValueObj (:? int32 as v) -> Some v
+        | ValueObj(:? int32 as v) -> Some v
         | _ -> None
 
     [<CompiledName("UInt32Pattern")>]
     let (|UInt32|_|) input =
         match input with
-        | ValueObj (:? uint32 as v) -> Some v
+        | ValueObj(:? uint32 as v) -> Some v
         | _ -> None
 
     [<CompiledName("Int64Pattern")>]
     let (|Int64|_|) input =
         match input with
-        | ValueObj (:? int64 as v) -> Some v
+        | ValueObj(:? int64 as v) -> Some v
         | _ -> None
 
     [<CompiledName("UInt64Pattern")>]
     let (|UInt64|_|) input =
         match input with
-        | ValueObj (:? uint64 as v) -> Some v
+        | ValueObj(:? uint64 as v) -> Some v
         | _ -> None
 
     [<CompiledName("UnitPattern")>]
     let (|Unit|_|) input =
         match input with
-        | Comb0 (ValueOp (_, ty, None)) when ty = typeof<unit> -> Some()
+        | Comb0(ValueOp(_, ty, None)) when ty = typeof<unit> -> Some()
         | _ -> None
 
     /// (fun (x, y) -> z) is represented as 'fun p -> let x = p#0 let y = p#1' etc.
@@ -2808,13 +2810,13 @@ module DerivedPatterns =
         /// Strip off the 'let' bindings for an TupledLambda
         let rec stripSuccessiveProjLets (p: Var) n expr =
             match expr with
-            | Let (v1, TupleGet (Var pA, m), rest) when p = pA && m = n ->
+            | Let(v1, TupleGet(Var pA, m), rest) when p = pA && m = n ->
                 let restvs, b = stripSuccessiveProjLets p (n + 1) rest
                 v1 :: restvs, b
             | _ -> ([], expr)
 
         match lam.Tree with
-        | LambdaTerm (v, body) ->
+        | LambdaTerm(v, body) ->
             match stripSuccessiveProjLets v 0 body with
             | [], b -> Some([ v ], b)
             | letvs, b -> Some(letvs, b)
@@ -2822,7 +2824,7 @@ module DerivedPatterns =
 
     let (|TupledApplication|_|) e =
         match e with
-        | Application (f, x) ->
+        | Application(f, x) ->
             match x with
             | Unit -> Some(f, [])
             | NewTuple x -> Some(f, x)
@@ -2841,20 +2843,20 @@ module DerivedPatterns =
     [<CompiledName("AndAlsoPattern")>]
     let (|AndAlso|_|) input =
         match input with
-        | IfThenElse (x, y, Bool false) -> Some(x, y)
+        | IfThenElse(x, y, Bool false) -> Some(x, y)
         | _ -> None
 
     [<CompiledName("OrElsePattern")>]
     let (|OrElse|_|) input =
         match input with
-        | IfThenElse (x, Bool true, y) -> Some(x, y)
+        | IfThenElse(x, Bool true, y) -> Some(x, y)
         | _ -> None
 
     [<CompiledName("SpecificCallPattern")>]
     let (|SpecificCall|_|) templateParameter =
         // Note: precomputation
         match templateParameter with
-        | (Lambdas (_, Call (_, minfo1, _)) | Call (_, minfo1, _)) ->
+        | (Lambdas(_, Call(_, minfo1, _)) | Call(_, minfo1, _)) ->
             let isg1 = minfo1.IsGenericMethod
 
             let gmd =
@@ -2867,7 +2869,7 @@ module DerivedPatterns =
 
             (fun tm ->
                 match tm with
-                | Call (obj, minfo2, args) when
+                | Call(obj, minfo2, args) when
 #if FX_NO_REFLECTION_METADATA_TOKENS
                     ( // if metadata tokens are not available we'll rely only on equality of method references
 #else
@@ -2892,7 +2894,7 @@ module DerivedPatterns =
     [<CompiledName("DecimalPattern")>]
     let (|Decimal|_|) input =
         match input with
-        | Call (None, mi, [ Int32 low; Int32 medium; Int32 high; Bool isNegative; Byte scale ]) when
+        | Call(None, mi, [ Int32 low; Int32 medium; Int32 high; Bool isNegative; Byte scale ]) when
             mi.Name = new_decimal_info.Name
             && mi.DeclaringType.FullName = new_decimal_info.DeclaringType.FullName
             ->
@@ -2930,11 +2932,11 @@ module ExprShape =
             | NewUnionCaseOp unionCase, _ -> mkNewUnionCase (unionCase, arguments)
             | UnionCaseTestOp unionCase, [ arg ] -> mkUnionCaseTest (unionCase, arg)
             | NewTupleOp ty, _ -> mkNewTupleWithType (ty, arguments)
-            | TupleGetOp (ty, i), [ arg ] -> mkTupleGet (ty, i, arg)
+            | TupleGetOp(ty, i), [ arg ] -> mkTupleGet (ty, i, arg)
             | InstancePropGetOp pinfo, (obj :: args) -> mkInstancePropGet (obj, pinfo, args)
             | StaticPropGetOp pinfo, _ -> mkStaticPropGet (pinfo, arguments)
-            | InstancePropSetOp pinfo, obj :: (FrontAndBack (args, v)) -> mkInstancePropSet (obj, pinfo, args, v)
-            | StaticPropSetOp pinfo, (FrontAndBack (args, v)) -> mkStaticPropSet (pinfo, args, v)
+            | InstancePropSetOp pinfo, obj :: (FrontAndBack(args, v)) -> mkInstancePropSet (obj, pinfo, args, v)
+            | StaticPropSetOp pinfo, (FrontAndBack(args, v)) -> mkStaticPropSet (pinfo, args, v)
             | InstanceFieldGetOp finfo, [ obj ] -> mkInstanceFieldGet (obj, finfo)
             | StaticFieldGetOp finfo, [] -> mkStaticFieldGet (finfo)
             | InstanceFieldSetOp finfo, [ obj; v ] -> mkInstanceFieldSet (obj, finfo, v)
@@ -2943,8 +2945,8 @@ module ExprShape =
             | DefaultValueOp ty, _ -> mkDefaultValue ty
             | StaticMethodCallOp minfo, _ -> mkStaticMethodCall (minfo, arguments)
             | InstanceMethodCallOp minfo, obj :: args -> mkInstanceMethodCall (obj, minfo, args)
-            | StaticMethodCallWOp (minfo, minfoW, n), _ -> mkStaticMethodCallW (minfo, minfoW, n, arguments)
-            | InstanceMethodCallWOp (minfo, minfoW, n), obj :: args ->
+            | StaticMethodCallWOp(minfo, minfoW, n), _ -> mkStaticMethodCallW (minfo, minfoW, n, arguments)
+            | InstanceMethodCallWOp(minfo, minfoW, n), obj :: args ->
                 mkInstanceMethodCallW (obj, minfo, minfoW, n, args)
             | CoerceOp ty, [ arg ] -> mkCoerce (ty, arg)
             | NewArrayOp ty, _ -> mkNewArray (ty, arguments)
@@ -2952,16 +2954,16 @@ module ExprShape =
             | SequentialOp, [ e1; e2 ] -> mkSequential (e1, e2)
             | TypeTestOp ty, [ e1 ] -> mkTypeTest (e1, ty)
             | AddressOfOp, [ e1 ] -> mkAddressOf e1
-            | VarSetOp, [ E (VarTerm v); e ] -> mkVarSet (v, e)
+            | VarSetOp, [ E(VarTerm v); e ] -> mkVarSet (v, e)
             | AddressSetOp, [ e1; e2 ] -> mkAddressSet (e1, e2)
-            | ForIntegerRangeLoopOp, [ e1; e2; E (LambdaTerm (v, e3)) ] -> mkForLoop (v, e1, e2, e3)
+            | ForIntegerRangeLoopOp, [ e1; e2; E(LambdaTerm(v, e3)) ] -> mkForLoop (v, e1, e2, e3)
             | WhileLoopOp, [ e1; e2 ] -> mkWhileLoop (e1, e2)
             | TryFinallyOp, [ e1; e2 ] -> mkTryFinally (e1, e2)
-            | TryWithOp, [ e1; Lambda (v1, e2); Lambda (v2, e3) ] -> mkTryWith (e1, v1, e2, v2, e3)
+            | TryWithOp, [ e1; Lambda(v1, e2); Lambda(v2, e3) ] -> mkTryWith (e1, v1, e2, v2, e3)
             | QuoteOp flg, [ e1 ] -> mkQuote (e1, flg)
-            | ValueOp (v, ty, None), [] -> mkValue (v, ty)
-            | ValueOp (v, ty, Some nm), [] -> mkValueWithName (v, ty, nm)
-            | WithValueOp (v, ty), [ e ] -> mkValueWithDefn (v, ty, e)
+            | ValueOp(v, ty, None), [] -> mkValue (v, ty)
+            | ValueOp(v, ty, Some nm), [] -> mkValueWithName (v, ty, nm)
+            | WithValueOp(v, ty), [ e ] -> mkValueWithDefn (v, ty, e)
             | _ -> invalidOp (SR.GetString(SR.QillFormedAppOrLet))
 
         EA(e.Tree, attrs)
@@ -2973,8 +2975,8 @@ module ExprShape =
 
             match t with
             | VarTerm v -> ShapeVar v
-            | LambdaTerm (v, b) -> ShapeLambda(v, b)
-            | CombTerm (op, args) -> ShapeCombination(box<ExprConstInfo * Expr list> (op, expr.CustomAttributes), args)
+            | LambdaTerm(v, b) -> ShapeLambda(v, b)
+            | CombTerm(op, args) -> ShapeCombination(box<ExprConstInfo * Expr list> (op, expr.CustomAttributes), args)
             | HoleTerm _ -> invalidArg "expr" (SR.GetString(SR.QunexpectedHole))
 
         loop (input :> Expr)

--- a/src/FSharp.Core/reflect.fs
+++ b/src/FSharp.Core/reflect.fs
@@ -208,10 +208,10 @@ module internal Impl =
                 let elements =
                     match getTupleElementAccessors typ with
                     // typ is a struct tuple and its elements are accessed via fields
-                    | Choice1Of2 (fi: FieldInfo[]) ->
+                    | Choice1Of2(fi: FieldInfo[]) ->
                         fi |> Array.map (fun fi -> Expression.Field(tuple, fi), fi.FieldType)
                     // typ is a class tuple and its elements are accessed via properties
-                    | Choice2Of2 (pi: PropertyInfo[]) ->
+                    | Choice2Of2(pi: PropertyInfo[]) ->
                         pi |> Array.map (fun pi -> Expression.Property(tuple, pi), pi.PropertyType)
 
                 for index, (element, elementType) in elements |> Array.indexed do
@@ -362,12 +362,12 @@ module internal Impl =
     let isFieldProperty (prop: PropertyInfo) =
         match tryFindCompilationMappingAttributeFromMemberInfo prop with
         | None -> false
-        | Some (flags, _n, _vn) -> (flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.Field
+        | Some(flags, _n, _vn) -> (flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.Field
 
     let tryFindSourceConstructFlagsOfType (typ: Type) =
         match tryFindCompilationMappingAttributeFromType typ with
         | None -> None
-        | Some (flags, _n, _vn) -> Some flags
+        | Some(flags, _n, _vn) -> Some flags
 
     //-----------------------------------------------------------------
     // UNION DECOMPILATION
@@ -394,7 +394,7 @@ module internal Impl =
             |> Array.choose (fun minfo ->
                 match tryFindCompilationMappingAttributeFromMemberInfo minfo with
                 | None -> None
-                | Some (flags, n, _vn) ->
+                | Some(flags, n, _vn) ->
                     if (flags &&& SourceConstructFlags.KindMask) = SourceConstructFlags.UnionCase then
                         let nm = minfo.Name
                         // chop "get_" or  "New" off the front
@@ -505,13 +505,13 @@ module internal Impl =
     let fieldsPropsOfUnionCase (typ, tag, bindingFlags) =
         if isOptionType typ then
             match tag with
-            | 0 (* None *)  -> getInstancePropertyInfos (typ, [||], bindingFlags)
-            | 1 (* Some *)  -> getInstancePropertyInfos (typ, [| "Value" |], bindingFlags)
+            | 0 (* None *) -> getInstancePropertyInfos (typ, [||], bindingFlags)
+            | 1 (* Some *) -> getInstancePropertyInfos (typ, [| "Value" |], bindingFlags)
             | _ -> failwith "fieldsPropsOfUnionCase"
         elif isListType typ then
             match tag with
-            | 0 (* Nil *)  -> getInstancePropertyInfos (typ, [||], bindingFlags)
-            | 1 (* Cons *)  -> getInstancePropertyInfos (typ, [| "Head"; "Tail" |], bindingFlags)
+            | 0 (* Nil *) -> getInstancePropertyInfos (typ, [||], bindingFlags)
+            | 1 (* Cons *) -> getInstancePropertyInfos (typ, [| "Head"; "Tail" |], bindingFlags)
             | _ -> failwith "fieldsPropsOfUnionCase"
         else
             // Lookup the type holding the fields for the union case
@@ -783,7 +783,7 @@ module internal Impl =
         assert (nestedTupIndex = tupTyTbl.Length - 1)
 
         match tblIdx with
-        | idx when idx < nestedTupIndex -> tupTyTbl[ idx ].MakeGenericType tys
+        | idx when idx < nestedTupIndex -> tupTyTbl[idx].MakeGenericType tys
         | _ ->
             let tysA = tys.[0..lastRegularTupIndex]
             let tysB = tys.[nestedTupIndex..]

--- a/src/FSharp.Core/seq.fs
+++ b/src/FSharp.Core/seq.fs
@@ -33,7 +33,7 @@ module Internal =
     let inline addToBuilder (item: 'T) (builder: byref<ArrayBuilder<'T>>) =
         match builder.currentCount = builder.currentArray.Length with
         | false ->
-            builder.currentArray[ builder.currentCount ] <- item
+            builder.currentArray[builder.currentCount] <- item
             builder.currentCount <- builder.currentCount + 1
         | true ->
             let newArr = Array.zeroCreateUnchecked (builder.currentArray.Length * 2)
@@ -138,7 +138,7 @@ module Internal =
                 }
 
         let mapi f (e: IEnumerator<_>) : IEnumerator<_> =
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (f)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(f)
             let mutable i = -1
 
             upcast
@@ -157,7 +157,7 @@ module Internal =
                 }
 
         let map2 f (e1: IEnumerator<_>) (e2: IEnumerator<_>) : IEnumerator<_> =
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (f)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(f)
 
             upcast
                 { new MapEnumerator<_>() with
@@ -179,7 +179,7 @@ module Internal =
                 }
 
         let mapi2 f (e1: IEnumerator<_>) (e2: IEnumerator<_>) : IEnumerator<_> =
-            let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (f)
+            let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(f)
             let mutable i = -1
 
             upcast
@@ -201,7 +201,7 @@ module Internal =
                 }
 
         let map3 f (e1: IEnumerator<_>) (e2: IEnumerator<_>) (e3: IEnumerator<_>) : IEnumerator<_> =
-            let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt (f)
+            let f = OptimizedClosures.FSharpFunc<_, _, _, _>.Adapt(f)
 
             upcast
                 { new MapEnumerator<_>() with
@@ -299,7 +299,7 @@ module Internal =
                     member _.DoMoveNext curr =
                         match f state with
                         | None -> false
-                        | Some (r, s) ->
+                        | Some(r, s) ->
                             curr <- r
                             state <- s
                             true
@@ -344,7 +344,7 @@ module Internal =
                         alreadyFinished ()
 
                     match box current with
-                    | null -> current <- Lazy<_>.Create (fun () -> f index)
+                    | null -> current <- Lazy<_>.Create(fun () -> f index)
                     | _ -> ()
                     // forced or re-forced immediately.
                     current.Force()
@@ -471,18 +471,19 @@ module Internal =
 
                         | Yield _ as res -> res
 
-                        | Goto next -> Goto(GenerateThen<_>.Bind (next, cont)))
+                        | Goto next -> Goto(GenerateThen<_>.Bind(next, cont)))
 
                 member _.Disposer = g.Disposer
 
             static member Bind(g: Generator<'T>, cont) =
                 match g with
                 | :? GenerateThen<'T> as g ->
-                    GenerateThen<_>.Bind (g.Generator, (fun () -> GenerateThen<_>.Bind (g.Cont(), cont)))
+                    GenerateThen<_>
+                        .Bind(g.Generator, (fun () -> GenerateThen<_>.Bind(g.Cont(), cont)))
                 | g -> (new GenerateThen<'T>(g, cont) :> Generator<'T>)
 
         let bindG g cont =
-            GenerateThen<_>.Bind (g, cont)
+            GenerateThen<_>.Bind(g, cont)
 
         // Internal type. Drive an underlying generator. Crucially when the generator returns
         // a new generator we simply update our current generator and continue. Thus the enumerator
@@ -659,7 +660,7 @@ module Seq =
     let iteri action (source: seq<'T>) =
         checkNonNull "source" source
         use e = source.GetEnumerator()
-        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (action)
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(action)
         let mutable i = 0
 
         while e.MoveNext() do
@@ -1274,7 +1275,7 @@ module Seq =
                 prefix.Clear()
 
                 match enumeratorR with
-                | Some (Some e) -> IEnumerator.dispose e
+                | Some(Some e) -> IEnumerator.dispose e
                 | _ -> ()
 
                 enumeratorR <- None)
@@ -1339,10 +1340,8 @@ module Seq =
     // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
     let groupByRefType (keyf: 'T -> 'Key) (seq: seq<'T>) =
         seq
-        |> groupByImpl
-            RuntimeHelpers.StructBox<'Key>.Comparer
-            (fun t -> RuntimeHelpers.StructBox(keyf t))
-            (fun sb -> sb.Value)
+        |> groupByImpl RuntimeHelpers.StructBox<'Key>.Comparer (fun t -> RuntimeHelpers.StructBox(keyf t)) (fun sb ->
+            sb.Value)
 
     [<CompiledName("GroupBy")>]
     let groupBy (projection: 'T -> 'Key) (source: seq<'T>) =
@@ -1455,10 +1454,8 @@ module Seq =
     // Wrap a StructBox around all keys in case the key type is itself a type using null as a representation
     let countByRefType (keyf: 'T -> 'Key) (seq: seq<'T>) =
         seq
-        |> countByImpl
-            RuntimeHelpers.StructBox<'Key>.Comparer
-            (fun t -> RuntimeHelpers.StructBox(keyf t))
-            (fun sb -> sb.Value)
+        |> countByImpl RuntimeHelpers.StructBox<'Key>.Comparer (fun t -> RuntimeHelpers.StructBox(keyf t)) (fun sb ->
+            sb.Value)
 
     [<CompiledName("CountBy")>]
     let countBy (projection: 'T -> 'Key) (source: seq<'T>) =

--- a/src/FSharp.Core/seqcore.fsi
+++ b/src/FSharp.Core/seqcore.fsi
@@ -188,10 +188,13 @@ type ListCollector<'T> =
 type ArrayCollector<'T> =
     [<DefaultValue(false)>]
     val mutable internal ResizeArray: ResizeArray<'T>
+
     [<DefaultValue(false)>]
     val mutable internal First: 'T
+
     [<DefaultValue(false)>]
     val mutable internal Second: 'T
+
     [<DefaultValue(false)>]
     val mutable internal Count: int
 

--- a/src/FSharp.Core/set.fs
+++ b/src/FSharp.Core/set.fs
@@ -1062,7 +1062,7 @@ module Set =
 
     [<CompiledName("Intersect")>]
     let intersect (set1: Set<'T>) (set2: Set<'T>) =
-        Set<'T>.Intersection (set1, set2)
+        Set<'T>.Intersection(set1, set2)
 
     [<CompiledName("IntersectMany")>]
     let intersectMany sets =

--- a/src/FSharp.Core/string.fs
+++ b/src/FSharp.Core/string.fs
@@ -49,7 +49,7 @@ module String =
     [<CompiledName("IterateIndexed")>]
     let iteri action (str: string) =
         if not (String.IsNullOrEmpty str) then
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (action)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(action)
 
             for i = 0 to str.Length - 1 do
                 f.Invoke(i, str.[i])
@@ -76,7 +76,7 @@ module String =
             String.Empty
         else
             let result = str.ToCharArray()
-            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt (mapping)
+            let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt(mapping)
 
             let mutable i = 0
 

--- a/src/FSharp.Core/tasks.fs
+++ b/src/FSharp.Core/tasks.fs
@@ -197,7 +197,7 @@ type TaskBuilder() =
             }
 
         sm.ResumptionDynamicInfo <- resumptionInfo
-        sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create ()
+        sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create()
         sm.Data.MethodBuilder.Start(&sm)
         sm.Data.MethodBuilder.Task
 
@@ -224,7 +224,7 @@ type TaskBuilder() =
                 ))
                 (SetStateMachineMethodImpl<_>(fun sm state -> sm.Data.MethodBuilder.SetStateMachine(state)))
                 (AfterCode<_, _>(fun sm ->
-                    sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create ()
+                    sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create()
                     sm.Data.MethodBuilder.Start(&sm)
                     sm.Data.MethodBuilder.Task))
         else
@@ -270,7 +270,7 @@ type BackgroundTaskBuilder() =
                         isNull SynchronizationContext.Current
                         && obj.ReferenceEquals(TaskScheduler.Current, TaskScheduler.Default)
                     then
-                        sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create ()
+                        sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create()
                         sm.Data.MethodBuilder.Start(&sm)
                         sm.Data.MethodBuilder.Task
                     else
@@ -278,7 +278,7 @@ type BackgroundTaskBuilder() =
 
                         Task.Run<'T>(fun () ->
                             let mutable sm = sm // host local mutable copy of contents of state machine on this thread pool thread
-                            sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create ()
+                            sm.Data.MethodBuilder <- AsyncTaskMethodBuilder<'T>.Create()
                             sm.Data.MethodBuilder.Start(&sm)
                             sm.Data.MethodBuilder.Task)))
         else

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -197,7 +197,7 @@ module internal Utilities =
             psi.EnvironmentVariables.Remove("MSBuildSDKsPath") // Host can sometimes add this, and it can break things
 
             for varname, value in environment do
-                psi.EnvironmentVariables[ varname ] <- value
+                psi.EnvironmentVariables[varname] <- value
 
             psi.UseShellExecute <- false
 
@@ -224,7 +224,7 @@ module internal Utilities =
     let buildProject projectPath binLogPath timeout =
         let binLoggingArguments =
             match binLogPath with
-            | Some (path) ->
+            | Some(path) ->
                 let path =
                     match path with
                     | Some path -> path // specific file
@@ -235,7 +235,7 @@ module internal Utilities =
 
         let timeout =
             match timeout with
-            | Some (timeout) -> timeout
+            | Some(timeout) -> timeout
             | None -> -1
 
         let arguments prefix =

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.fs
@@ -251,14 +251,7 @@ module FSharpDependencyManager =
 
 /// The results of ResolveDependencies
 type ResolveDependenciesResult
-    (
-        success: bool,
-        stdOut: string array,
-        stdError: string array,
-        resolutions: string seq,
-        sourceFiles: string seq,
-        roots: string seq
-    ) =
+    (success: bool, stdOut: string array, stdError: string array, resolutions: string seq, sourceFiles: string seq, roots: string seq) =
 
     /// Succeded?
     member _.Success = success

--- a/src/fsi/console.fs
+++ b/src/fsi/console.fs
@@ -266,7 +266,7 @@ type internal ReadLineConsole() =
                 i
             else
                 match input.Chars(i - 1) with
-                | c when Char.IsLetterOrDigit(c) (* or Char.IsWhiteSpace(c) *)  -> look parenCount (i - 1)
+                | c when Char.IsLetterOrDigit(c) (* or Char.IsWhiteSpace(c) *) -> look parenCount (i - 1)
                 | '.'
                 | '_' -> look parenCount (i - 1)
                 | '}'

--- a/vsintegration/src/FSharp.Editor/AutomaticCompletion/BraceCompletionSessionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/AutomaticCompletion/BraceCompletionSessionProvider.fs
@@ -137,7 +137,7 @@ type BraceCompletionSession
 
                         match nextSnapshot with
                         | ValueNone -> ()
-                        | ValueSome (nextSnapshot) ->
+                        | ValueSome(nextSnapshot) ->
 
                             let beforePoint = beforeTrackingPoint.GetPoint(textView.TextSnapshot)
 
@@ -564,11 +564,9 @@ type EditorBraceCompletionSessionFactory() =
 [<BracePair(VerticalBar.OpenCharacter, VerticalBar.CloseCharacter)>]
 [<BracePair(AngleBrackets.OpenCharacter, AngleBrackets.CloseCharacter)>]
 [<BracePair(Asterisk.OpenCharacter, Asterisk.CloseCharacter)>]
-type BraceCompletionSessionProvider [<ImportingConstructor>]
-    (
-        undoManager: ITextBufferUndoManagerProvider,
-        editorOperationsFactoryService: IEditorOperationsFactoryService
-    ) =
+type BraceCompletionSessionProvider
+    [<ImportingConstructor>]
+    (undoManager: ITextBufferUndoManagerProvider, editorOperationsFactoryService: IEditorOperationsFactoryService) =
 
     interface IBraceCompletionSessionProvider with
 

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -83,7 +83,8 @@ module internal ClassificationDefinitions =
 
     [<Export>]
     [<Export(typeof<ISetThemeColors>)>]
-    type internal ThemeColors [<ImportingConstructor>]
+    type internal ThemeColors
+        [<ImportingConstructor>]
         (
             classificationformatMapService: IClassificationFormatMapService,
             classificationTypeRegistry: IClassificationTypeRegistryService,

--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddOpenCodeFixProvider.fs
@@ -45,7 +45,7 @@ type internal AddOpenCodeFixProvider [<ImportingConstructor>] (assemblyContentPr
         let startLineNumber, openDeclaration =
             match ctx.ScopeKind with
             | ScopeKind.TopModule ->
-                match sourceText.Lines[ insertionLineNumber ].ToString().Trim() with
+                match sourceText.Lines[insertionLineNumber].ToString().Trim() with
 
                 // explicit top level module
                 | line when line.StartsWith "module" && not (line.EndsWith "=") -> insertionLineNumber + 2, $"{margin}open {ns}{br}{br}"
@@ -67,7 +67,7 @@ type internal AddOpenCodeFixProvider [<ImportingConstructor>] (assemblyContentPr
                     | Some number ->
                         // add back the skipped lines
                         let moduleDeclLineNumber = insertionLineNumber + number
-                        let moduleDeclLineText = sourceText.Lines[ moduleDeclLineNumber ].ToString().Trim()
+                        let moduleDeclLineText = sourceText.Lines[moduleDeclLineNumber].ToString().Trim()
 
                         if moduleDeclLineText.EndsWith "=" then
                             insertionLineNumber, $"{margin}open {ns}{br}{br}"
@@ -203,7 +203,9 @@ type internal AddOpenCodeFixProvider [<ImportingConstructor>] (assemblyContentPr
                                                 s.AutoOpenParent,
                                                 s.Namespace,
                                                 s.CleanedIdents
-                                                |> Array.replace (s.CleanedIdents.Length - 1) (lastIdent.Substring(0, lastIdent.Length - 9))
+                                                |> Array.replace
+                                                    (s.CleanedIdents.Length - 1)
+                                                    (lastIdent.Substring(0, lastIdent.Length - 9))
                                 |])
 
                         ParsedInput.GetLongIdentAt parseResults.ParseTree unresolvedIdentRange.End

--- a/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
@@ -38,7 +38,8 @@ module internal UnusedCodeFixHelper =
 
                 return
                     lexerSymbol
-                    |> Option.bind (fun symbol -> checkResults.GetSymbolUseAtLocation(m.StartLine, m.EndColumn, lineText, symbol.FullIsland))
+                    |> Option.bind (fun symbol ->
+                        checkResults.GetSymbolUseAtLocation(m.StartLine, m.EndColumn, lineText, symbol.FullIsland))
                     |> ValueOption.ofOption
                     |> ValueOption.bind (fun symbolUse ->
                         match symbolUse.Symbol with

--- a/vsintegration/src/FSharp.Editor/CodeFixes/ImplementInterface.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/ImplementInterface.fs
@@ -69,13 +69,13 @@ type internal ImplementInterfaceCodeFixProvider [<ImportingConstructor>] () =
     let inferStartColumn indentSize state (sourceText: SourceText) =
         match InterfaceStubGenerator.GetMemberNameAndRanges state.InterfaceData with
         | (_, range) :: _ ->
-            let lineStr = sourceText.Lines[ range.StartLine - 1 ].ToString()
+            let lineStr = sourceText.Lines[range.StartLine - 1].ToString()
             getLineIdent lineStr
         | [] ->
             match state.InterfaceData with
             | InterfaceData.Interface _ as iface ->
                 // 'interface ISomething with' is often in a new line, we use the indentation of that line
-                let lineStr = sourceText.Lines[ iface.Range.StartLine - 1 ].ToString()
+                let lineStr = sourceText.Lines[iface.Range.StartLine - 1].ToString()
                 getLineIdent lineStr + indentSize
             | InterfaceData.ObjExpr _ as iface ->
                 state.Tokens
@@ -146,7 +146,7 @@ type internal ImplementInterfaceCodeFixProvider [<ImportingConstructor>] () =
             if hasTypeCheckError && List.length membersAndRanges <> Seq.length interfaceMembers then
 
                 let getMemberByLocation (name, range: range) =
-                    let lineStr = sourceText.Lines[ range.EndLine - 1 ].ToString()
+                    let lineStr = sourceText.Lines[range.EndLine - 1].ToString()
                     results.GetSymbolUseAtLocation(range.EndLine, range.EndColumn, lineStr, [ name ])
 
                 cancellableTask {

--- a/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnnecessaryParentheses.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnnecessaryParentheses.fs
@@ -55,7 +55,7 @@ module private Patterns =
             else
                 let rec loop offsides lineNo startCol =
                     if lineNo <= endLine then
-                        let line = sourceText.Lines[ lineNo ].ToString()
+                        let line = sourceText.Lines[lineNo].ToString()
 
                         match offsides with
                         | ValueNone ->
@@ -88,7 +88,7 @@ module private Patterns =
 
             let rec loop lineNo =
                 if lineNo <= endLine then
-                    let line = sourceText.Lines[ lineNo ].ToString().AsSpan()
+                    let line = sourceText.Lines[lineNo].ToString().AsSpan()
                     let i = line.IndexOfAnyExcept("*/%-+:^@><=!|0$.?) ".AsSpan())
                     i > offsides || loop (lineNo + 1)
                 else
@@ -194,7 +194,7 @@ type internal FSharpRemoveUnnecessaryParenthesesCodeFixProvider [<ImportingConst
                         | ShouldPutSpaceAfter, _ -> txt[1 .. txt.Length - 2] + " "
                         | NewOffsidesOnFirstLine,
                           ContainsSensitiveIndentation context.Span & (HasPrecedingConstructOnSameLine context.Span | FollowingLineMovesOffsidesRightward context.Span) ->
-                            txt[ 1 .. txt.Length - 2 ].Replace("\n ", "\n")
+                            txt[1 .. txt.Length - 2].Replace("\n ", "\n")
                         | NewOffsidesOnFirstLine, ContainsSensitiveIndentation context.Span -> " " + txt[1 .. txt.Length - 2]
                         | _ -> txt[1 .. txt.Length - 2]
 

--- a/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnusedBinding.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnusedBinding.fs
@@ -43,7 +43,7 @@ type internal RemoveUnusedBindingCodeFixProvider [<ImportingConstructor>] () =
                         |> fun r -> parseResults.TryRangeOfBindingWithHeadPatternWithPos(r.Start)
 
                     match bindingRangeOpt with
-                    | Some (Expression range) ->
+                    | Some(Expression range) ->
                         let span = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
 
                         let keywordEndColumn =
@@ -60,7 +60,7 @@ type internal RemoveUnusedBindingCodeFixProvider [<ImportingConstructor>] () =
 
                         ValueSome(TextChange(fullSpan, ""))
 
-                    | Some (SelfId range) ->
+                    | Some(SelfId range) ->
                         let span = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
 
                         let rec findAs index (str: SourceText) =

--- a/vsintegration/src/FSharp.Editor/Commands/FsiCommandService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/FsiCommandService.fs
@@ -93,11 +93,9 @@ type internal FsiCommandFilter(serviceProvider: System.IServiceProvider) =
 [<Export(typeof<IWpfTextViewCreationListener>)>]
 [<ContentType(FSharpConstants.FSharpContentTypeName)>]
 [<TextViewRole(PredefinedTextViewRoles.PrimaryDocument)>]
-type internal FsiCommandFilterProvider [<ImportingConstructor>]
-    (
-        [<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider,
-        editorFactory: IVsEditorAdaptersFactoryService
-    ) =
+type internal FsiCommandFilterProvider
+    [<ImportingConstructor>]
+    ([<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider, editorFactory: IVsEditorAdaptersFactoryService) =
     interface IWpfTextViewCreationListener with
         member _.TextViewCreated(textView) =
             match editorFactory.GetViewAdapter(textView) with

--- a/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/HelpContextService.fs
@@ -88,7 +88,7 @@ type internal FSharpHelpContextService [<ImportingConstructor>] () =
                         let island = QuickParse.GetCompleteIdentifierIsland false lineText col
 
                         match island with
-                        | Some (s, colAtEndOfNames, _) when check.HasFullTypeCheckInfo ->
+                        | Some(s, colAtEndOfNames, _) when check.HasFullTypeCheckInfo ->
                             let qualId = PrettyNaming.GetLongNameFromString s
 
                             let f1Keyword =

--- a/vsintegration/src/FSharp.Editor/Commands/XmlDocCommandService.fs
+++ b/vsintegration/src/FSharp.Editor/Commands/XmlDocCommandService.fs
@@ -82,11 +82,11 @@ type internal XmlDocCommandFilter(wpfTextView: IWpfTextView, filePath: string, w
                                 let xmlDocablesBelowThisLine =
                                     // +1 because looking below current line for e.g. a 'member' or 'let'
                                     xmlDocables
-                                    |> List.filter (fun (XmlDocable (line, _indent, _paramNames)) -> line = curEditorLineNum + 1)
+                                    |> List.filter (fun (XmlDocable(line, _indent, _paramNames)) -> line = curEditorLineNum + 1)
 
                                 match xmlDocablesBelowThisLine with
                                 | [] -> ()
-                                | XmlDocable (_line, indent, paramNames) :: _xs ->
+                                | XmlDocable(_line, indent, paramNames) :: _xs ->
                                     // delete the slashes the user typed (they may be indented wrong)
                                     let editorLineToDelete =
                                         wpfTextView.TextBuffer.CurrentSnapshot.GetLineFromLineNumber(
@@ -156,7 +156,8 @@ type internal XmlDocCommandFilter(wpfTextView: IWpfTextView, filePath: string, w
 [<Export(typeof<IWpfTextViewCreationListener>)>]
 [<ContentType(FSharpConstants.FSharpContentTypeName)>]
 [<TextViewRole(PredefinedTextViewRoles.PrimaryDocument)>]
-type internal XmlDocCommandFilterProvider [<ImportingConstructor>]
+type internal XmlDocCommandFilterProvider
+    [<ImportingConstructor>]
     (
         workspace: VisualStudioWorkspace,
         textDocumentFactoryService: ITextDocumentFactoryService,

--- a/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CodeAnalysisExtensions.fs
@@ -9,17 +9,17 @@ type Project with
 
     /// Returns the projectIds of all projects within the same solution that directly reference this project
     member this.GetDependentProjectIds() =
-        this
-            .Solution
+        this.Solution
             .GetProjectDependencyGraph()
-            .GetProjectsThatDirectlyDependOnThisProject this.Id
+            .GetProjectsThatDirectlyDependOnThisProject
+            this.Id
 
     /// Returns all projects within the same solution that directly reference this project.
     member this.GetDependentProjects() =
-        this
-            .Solution
+        this.Solution
             .GetProjectDependencyGraph()
-            .GetProjectsThatDirectlyDependOnThisProject this.Id
+            .GetProjectsThatDirectlyDependOnThisProject
+            this.Id
         |> Seq.map this.Solution.GetProject
 
     /// Returns the ProjectIds of all of the projects that this project directly or transitively depneds on
@@ -65,16 +65,12 @@ type Solution with
 
     /// Returns the projectIds of all projects within this solution that directly reference the provided project
     member self.GetDependentProjects(projectId: ProjectId) =
-        self
-            .GetProjectDependencyGraph()
-            .GetProjectsThatDirectlyDependOnThisProject projectId
+        self.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject projectId
         |> Seq.map self.GetProject
 
     /// Returns the projectIds of all projects within this solution that directly reference the provided project
     member self.GetDependentProjectIds(projectId: ProjectId) =
-        self
-            .GetProjectDependencyGraph()
-            .GetProjectsThatDirectlyDependOnThisProject projectId
+        self.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject projectId
 
     /// Returns the ProjectIds of all of the projects that directly or transitively depends on
     member self.GetProjectIdsOfAllProjectReferences(projectId: ProjectId) =

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -204,7 +204,11 @@ module private SourceText =
 type SourceText with
 
     member this.ToFSharpSourceText() =
-        SourceText.weakTable.GetValue(this, Runtime.CompilerServices.ConditionalWeakTable<_, _>.CreateValueCallback (SourceText.create))
+        SourceText.weakTable.GetValue(
+            this,
+            Runtime.CompilerServices.ConditionalWeakTable<_, _>
+                .CreateValueCallback(SourceText.create)
+        )
 
 type NavigationItem with
 
@@ -215,68 +219,68 @@ type NavigationItem with
         | FSharpGlyph.Type
         | FSharpGlyph.Exception ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ClassPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ClassInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.ClassPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.ClassInternal
             | _ -> FSharpRoslynGlyph.ClassPublic
         | FSharpGlyph.Constant ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ConstantPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ConstantInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.ConstantPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.ConstantInternal
             | _ -> FSharpRoslynGlyph.ConstantPublic
         | FSharpGlyph.Delegate ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.DelegatePrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.DelegateInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.DelegatePrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.DelegateInternal
             | _ -> FSharpRoslynGlyph.DelegatePublic
         | FSharpGlyph.Union
         | FSharpGlyph.Enum ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.EnumPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.EnumInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.EnumPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.EnumInternal
             | _ -> FSharpRoslynGlyph.EnumPublic
         | FSharpGlyph.EnumMember
         | FSharpGlyph.Variable
         | FSharpGlyph.Field ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.FieldPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.FieldInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.FieldPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.FieldInternal
             | _ -> FSharpRoslynGlyph.FieldPublic
         | FSharpGlyph.Event ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.EventPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.EventInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.EventPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.EventInternal
             | _ -> FSharpRoslynGlyph.EventPublic
         | FSharpGlyph.Interface ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.InterfacePrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.InterfaceInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.InterfacePrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.InterfaceInternal
             | _ -> FSharpRoslynGlyph.InterfacePublic
         | FSharpGlyph.Method
         | FSharpGlyph.OverridenMethod ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.MethodPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.MethodInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.MethodPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.MethodInternal
             | _ -> FSharpRoslynGlyph.MethodPublic
         | FSharpGlyph.Module ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ModulePrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ModuleInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.ModulePrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.ModuleInternal
             | _ -> FSharpRoslynGlyph.ModulePublic
         | FSharpGlyph.NameSpace -> FSharpRoslynGlyph.Namespace
         | FSharpGlyph.Property ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.PropertyPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.PropertyInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.PropertyPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.PropertyInternal
             | _ -> FSharpRoslynGlyph.PropertyPublic
         | FSharpGlyph.Struct ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.StructurePrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.StructureInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.StructurePrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.StructureInternal
             | _ -> FSharpRoslynGlyph.StructurePublic
         | FSharpGlyph.ExtensionMethod ->
             match x.Access with
-            | Some (SynAccess.Private _) -> FSharpRoslynGlyph.ExtensionMethodPrivate
-            | Some (SynAccess.Internal _) -> FSharpRoslynGlyph.ExtensionMethodInternal
+            | Some(SynAccess.Private _) -> FSharpRoslynGlyph.ExtensionMethodPrivate
+            | Some(SynAccess.Internal _) -> FSharpRoslynGlyph.ExtensionMethodInternal
             | _ -> FSharpRoslynGlyph.ExtensionMethodPublic
         | FSharpGlyph.Error -> FSharpRoslynGlyph.Error
         | FSharpGlyph.TypeParameter -> FSharpRoslynGlyph.TypeParameter

--- a/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/FSharpCodeAnalysisExtensions.fs
@@ -23,13 +23,13 @@ type FSharpParseFileResults with
 
                 override _.VisitBinding(_path, defaultTraverse, binding) =
                     match binding with
-                    | SynBinding (kind = SynBindingKind.Normal; headPat = pat) as binding ->
+                    | SynBinding(kind = SynBindingKind.Normal; headPat = pat) as binding ->
                         if Position.posEq binding.RangeOfHeadPattern.Start pos then
                             Some(Expression binding.RangeOfBindingWithRhs)
                         else
                             // Check if it's an operator
                             match pat with
-                            | SynPat.LongIdent(longDotId = LongIdentWithDots ([ id ], _)) when id.idText.StartsWith("op_") ->
+                            | SynPat.LongIdent(longDotId = LongIdentWithDots([ id ], _)) when id.idText.StartsWith("op_") ->
                                 if Position.posEq id.idRange.Start pos then
                                     Some(Expression binding.RangeOfBindingWithRhs)
                                 else
@@ -42,19 +42,19 @@ type FSharpParseFileResults with
                     path
                     |> List.collect (fun node ->
                         match node with
-                        | SyntaxNode.SynModule (SynModuleDecl.Types (types, _)) -> types
+                        | SyntaxNode.SynModule(SynModuleDecl.Types(types, _)) -> types
                         | _ -> [])
                     |> Seq.choose (fun node ->
                         match node with
-                        | SynTypeDefn(implicitConstructor = Some (SynMemberDefn.ImplicitCtor(selfIdentifier = Some ident))) when
+                        | SynTypeDefn(implicitConstructor = Some(SynMemberDefn.ImplicitCtor(selfIdentifier = Some ident))) when
                             ident.idRange.Start = pos
                             ->
                             Some(SelfId ident.idRange)
-                        | SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel (members = defs)) ->
+                        | SynTypeDefn(typeRepr = SynTypeDefnRepr.ObjectModel(members = defs)) ->
                             defs
                             |> List.choose (fun node ->
                                 match node with
-                                | SynMemberDefn.Member (SynBinding(headPat = SynPat.LongIdent (longDotId = id)), _) when
+                                | SynMemberDefn.Member(SynBinding(headPat = SynPat.LongIdent(longDotId = id)), _) when
                                     id.Range.Start = pos
                                     ->
                                     Some Member
@@ -72,9 +72,9 @@ type FSharpParseFileResults with
             { new SyntaxVisitorBase<_>() with
                 member _.VisitExpr(_path, _, defaultTraverse, expr) =
                     match expr with
-                    | SynExpr.DotGet (expr, _, _, range) ->
+                    | SynExpr.DotGet(expr, _, _, range) ->
                         match expr with
-                        | SynExpr.TypeApp (SynExpr.Ident ident, _, typeArgs, _, _, _, _) ->
+                        | SynExpr.TypeApp(SynExpr.Ident ident, _, typeArgs, _, _, _, _) ->
                             let onlyOneTypeArg =
                                 match typeArgs with
                                 | [] -> false

--- a/vsintegration/src/FSharp.Editor/Common/Logging.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Logging.fs
@@ -44,7 +44,7 @@ type Logger [<ImportingConstructor>] ([<Import(typeof<SVsServiceProvider>)>] ser
 
     let getPane () =
         match outputWindow |> Option.map (fun x -> x.GetPane(ref fsharpOutputGuid)) with
-        | Some (0, pane) ->
+        | Some(0, pane) ->
             pane.Activate() |> ignore
             Some pane
         | _ -> None

--- a/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Pervasive.fs
@@ -51,7 +51,7 @@ type MaybeBuilder() =
     member inline _.Combine(r1, r2: 'T option) : 'T option =
         match r1 with
         | None -> None
-        | Some () -> r2
+        | Some() -> r2
 
     // M<'T> * ('T -> M<'U>) -> M<'U>
     [<DebuggerStepThrough>]
@@ -116,7 +116,7 @@ type AsyncMaybeBuilder() =
 
             match r1' with
             | None -> return None
-            | Some () -> return! r2
+            | Some() -> return! r2
         }
 
     [<DebuggerStepThrough>]

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionProvider.fs
@@ -26,11 +26,7 @@ open CancellableTasks
 module Logger = Microsoft.VisualStudio.FSharp.Editor.Logger
 
 type internal FSharpCompletionProvider
-    (
-        workspace: Workspace,
-        serviceProvider: SVsServiceProvider,
-        assemblyContentProvider: AssemblyContentProvider
-    ) =
+    (workspace: Workspace, serviceProvider: SVsServiceProvider, assemblyContentProvider: AssemblyContentProvider) =
 
     inherit FSharpCompletionProviderBase()
 
@@ -121,9 +117,8 @@ type internal FSharpCompletionProvider
                 Char.IsLetterOrDigit(sourceText.[triggerPosition]) || triggerChar = '.'
             elif not (trigger = CompletionTriggerKind.Insertion) then
                 false
-            else
-            // Do not trigger completion if it's not single dot, i.e. range expression
-            if
+            else if
+                // Do not trigger completion if it's not single dot, i.e. range expression
                 not intelliSenseOptions.ShowAfterCharIsTyped
                 && triggerPosition > 0
                 && sourceText.[triggerPosition - 1] = '.'

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionService.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionService.fs
@@ -14,17 +14,11 @@ open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
 open Microsoft.VisualStudio.Shell
 
 type internal FSharpCompletionService
-    (
-        workspace: Workspace,
-        serviceProvider: SVsServiceProvider,
-        assemblyContentProvider: AssemblyContentProvider,
-        settings: EditorOptions
-    ) =
+    (workspace: Workspace, serviceProvider: SVsServiceProvider, assemblyContentProvider: AssemblyContentProvider, settings: EditorOptions) =
     inherit FSharpCompletionServiceWithProviders(workspace)
 
     let projectInfoManager =
-        workspace
-            .Services
+        workspace.Services
             .GetRequiredService<IFSharpWorkspaceService>()
             .FSharpProjectOptionsManager
 
@@ -44,8 +38,7 @@ type internal FSharpCompletionService
             | NewlineOnCompleteWord -> EnterKeyRule.AfterFullyTypedWord
             | AlwaysNewline -> EnterKeyRule.Always
 
-        CompletionRules
-            .Default
+        CompletionRules.Default
             .WithDismissIfEmpty(true)
             .WithDismissIfLastCharacterDeleted(true)
             .WithDefaultEnterKeyRule(enterKeyRule)
@@ -71,12 +64,9 @@ type internal FSharpCompletionService
 
 [<Shared>]
 [<ExportLanguageServiceFactory(typeof<CompletionService>, FSharpConstants.FSharpLanguageName)>]
-type internal FSharpCompletionServiceFactory [<ImportingConstructor>]
-    (
-        serviceProvider: SVsServiceProvider,
-        assemblyContentProvider: AssemblyContentProvider,
-        settings: EditorOptions
-    ) =
+type internal FSharpCompletionServiceFactory
+    [<ImportingConstructor>]
+    (serviceProvider: SVsServiceProvider, assemblyContentProvider: AssemblyContentProvider, settings: EditorOptions) =
     interface ILanguageServiceFactory with
         member _.CreateLanguageService(hostLanguageServices: HostLanguageServices) : ILanguageService =
             upcast

--- a/vsintegration/src/FSharp.Editor/Completion/CompletionUtils.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/CompletionUtils.fs
@@ -131,6 +131,7 @@ module internal CompletionUtils =
                     | ClassificationTypeNames.NumericLiteral -> false
                     | _ -> true) // anything else is a valid classification type
             ) in
+
         result
 
     let inline getKindPriority kind =

--- a/vsintegration/src/FSharp.Editor/Completion/HashDirectiveCompletionProvider.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/HashDirectiveCompletionProvider.fs
@@ -29,11 +29,7 @@ type internal HashCompletion =
         }
 
 type internal HashDirectiveCompletionProvider
-    (
-        workspace: Workspace,
-        projectInfoManager: FSharpProjectOptionsManager,
-        completions: HashCompletion list
-    ) =
+    (workspace: Workspace, projectInfoManager: FSharpProjectOptionsManager, completions: HashCompletion list) =
 
     inherit FSharpCommonCompletionProviderBase()
 

--- a/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
+++ b/vsintegration/src/FSharp.Editor/Completion/SignatureHelp.fs
@@ -161,7 +161,7 @@ type internal FSharpSignatureHelpProvider [<ImportingConstructor>] (serviceProvi
             // should not result in a prompt, whereas this one will:
             //    Console.WriteLine( [(1,2)],
             match triggerIsTypedChar with
-            | Some ('<' | '(' | ',') when not (tupleEnds |> Array.exists (fun lp -> lp.Character = caretLineColumn)) -> return! None // comma or paren at wrong location = remove help display
+            | Some('<' | '(' | ',') when not (tupleEnds |> Array.exists (fun lp -> lp.Character = caretLineColumn)) -> return! None // comma or paren at wrong location = remove help display
             | _ ->
 
                 // Compute the argument index by working out where the caret is between the various commas.
@@ -363,7 +363,7 @@ type internal FSharpSignatureHelpProvider [<ImportingConstructor>] (serviceProvi
                     let numArgsAlreadyAppliedViaPipeline =
                         match possiblePipelineIdent with
                         | None -> 0
-                        | Some (_, numArgsApplied) -> numArgsApplied
+                        | Some(_, numArgsApplied) -> numArgsApplied
 
                     let definedArgs = mfv.CurriedParameterGroups |> Array.ofSeq
 

--- a/vsintegration/src/FSharp.Editor/Debugging/LanguageDebugInfoService.fs
+++ b/vsintegration/src/FSharp.Editor/Debugging/LanguageDebugInfoService.fs
@@ -37,7 +37,7 @@ type internal FSharpLanguageDebugInfoService [<ImportingConstructor>] () =
 
                 match QuickParse.GetCompleteIdentifierIsland false (textLine.ToString()) textLineColumn with
                 | None -> None
-                | Some (island, islandEnd, _) ->
+                | Some(island, islandEnd, _) ->
                     let islandDocumentStart = textLine.Start + islandEnd - island.Length
                     Some(TextSpan.FromBounds(islandDocumentStart, islandDocumentStart + island.Length))
 

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnnecessaryParenthesesDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnnecessaryParenthesesDiagnosticAnalyzer.fs
@@ -68,7 +68,7 @@ type internal UnnecessaryParenthesesDiagnosticAnalyzer [<ImportingConstructor>] 
                         let! sourceText = document.GetTextAsync cancellationToken
 
                         let getLineString line =
-                            sourceText.Lines[ Line.toZ line ].ToString()
+                            sourceText.Lines[Line.toZ line].ToString()
 
                         let! unnecessaryParentheses = UnnecessaryParentheses.getUnnecessaryParentheses getLineString parseResults.ParseTree
 

--- a/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/UnusedOpensDiagnosticAnalyzer.fs
@@ -30,7 +30,7 @@ type internal UnusedOpensDiagnosticAnalyzer [<ImportingConstructor>] () =
                 let! _, checkResults = document.GetFSharpParseAndCheckResultsAsync(nameof UnusedOpensDiagnosticAnalyzer)
 
                 let! unusedOpens =
-                    UnusedOpens.getUnusedOpens (checkResults, (fun lineNumber -> sourceText.Lines[ Line.toZ lineNumber ].ToString()))
+                    UnusedOpens.getUnusedOpens (checkResults, (fun lineNumber -> sourceText.Lines[Line.toZ lineNumber].ToString()))
 
                 return (ValueSome unusedOpens)
         }

--- a/vsintegration/src/FSharp.Editor/DocComments/XMLDocumentation.fs
+++ b/vsintegration/src/FSharp.Editor/DocComments/XMLDocumentation.fs
@@ -337,7 +337,7 @@ module internal XmlDocumentation =
                 ) =
                 try
                     match GetMemberIndexOfAssembly(fileName) with
-                    | Some (index) ->
+                    | Some(index) ->
                         let _, idx = index.ParseMemberSignature(signature)
 
                         if idx <> 0u then
@@ -371,7 +371,7 @@ module internal XmlDocumentation =
         ) =
         match xml with
         | FSharpXmlDoc.None -> ()
-        | FSharpXmlDoc.FromXmlFile (fileName, signature) ->
+        | FSharpXmlDoc.FromXmlFile(fileName, signature) ->
             documentationProvider.AppendDocumentation(
                 xmlCollector,
                 exnCollector,
@@ -381,7 +381,7 @@ module internal XmlDocumentation =
                 showParameters,
                 paramName
             )
-        | FSharpXmlDoc.FromXmlText (xmlDoc) ->
+        | FSharpXmlDoc.FromXmlText(xmlDoc) ->
             let elaboratedXml = xmlDoc.GetElaboratedXmlLines()
             let processedXml = ProcessXml("\n\n" + String.concat "\n" elaboratedXml)
 
@@ -487,7 +487,7 @@ module internal XmlDocumentation =
 
             item0.Symbol, mainDescription |> List.ofSeq, collectDocumentation ()
 
-        | ToolTipElement.CompositionError (errText) ->
+        | ToolTipElement.CompositionError(errText) ->
             textCollector.Add(tagText errText)
             None, mainDescription |> List.ofSeq, collectDocumentation ()
 
@@ -542,7 +542,7 @@ module internal XmlDocumentation =
             match dataTipElement with
             | ToolTipElement.None -> false
 
-            | ToolTipElement.Group (overloads) ->
+            | ToolTipElement.Group(overloads) ->
                 let overloads = Array.ofList overloads
                 let len = overloads.Length
 
@@ -600,7 +600,7 @@ module internal XmlDocumentation =
                 else
                     false
 
-            | ToolTipElement.CompositionError (errText) ->
+            | ToolTipElement.CompositionError(errText) ->
                 textCollector.Add(tagText errText)
                 true
 
@@ -614,7 +614,7 @@ module internal XmlDocumentation =
             typeParameterMapCollector,
             usageCollector,
             exnCollector,
-            ToolTipText (dataTipText)
+            ToolTipText(dataTipText)
         ) =
         BuildTipText(
             documentationProvider,
@@ -629,7 +629,7 @@ module internal XmlDocumentation =
             false
         )
 
-    let BuildMethodOverloadTipText (documentationProvider, textCollector, xmlCollector, ToolTipText (dataTipText), showParams) =
+    let BuildMethodOverloadTipText (documentationProvider, textCollector, xmlCollector, ToolTipText(dataTipText), showParams) =
         BuildTipText(
             documentationProvider,
             dataTipText,

--- a/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
+++ b/vsintegration/src/FSharp.Editor/Formatting/IndentationService.fs
@@ -145,4 +145,4 @@ type internal FSharpIndentationService [<ImportingConstructor>] () =
 
             match indent with
             | None -> Nullable()
-            | Some (indentation) -> Nullable<FSharpIndentationResult>(FSharpIndentationResult(text.Lines.[lineNumber].Start, indentation))
+            | Some(indentation) -> Nullable<FSharpIndentationResult>(FSharpIndentationResult(text.Lines.[lineNumber].Start, indentation))

--- a/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
+++ b/vsintegration/src/FSharp.Editor/InlineRename/InlineRenameService.fs
@@ -29,12 +29,7 @@ type internal InlineRenameReplacementInfo(newSolution: Solution, replacementText
     override _.GetReplacements _ = Seq.empty
 
 type internal InlineRenameLocationSet
-    (
-        locations: FSharpInlineRenameLocation[],
-        originalSolution: Solution,
-        symbolKind: LexerSymbolKind,
-        symbol: FSharpSymbol
-    ) =
+    (locations: FSharpInlineRenameLocation[], originalSolution: Solution, symbolKind: LexerSymbolKind, symbol: FSharpSymbol) =
 
     inherit FSharpInlineRenameLocationSet()
 
@@ -156,7 +151,7 @@ type internal InlineRenameInfo
 
             let! results =
                 seq {
-                    for (KeyValue (documentId, symbolUses)) in symbolUsesByDocumentId do
+                    for (KeyValue(documentId, symbolUses)) in symbolUsesByDocumentId do
 
                         cancellableTask {
                             let! cancellationToken = CancellableTask.getCancellationToken ()

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -286,7 +286,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         if referencedProject.Language = FSharpConstants.FSharpLanguageName then
                             match! tryComputeOptions referencedProject with
                             | ValueNone -> canBail <- true
-                            | ValueSome (_, projectOptions) ->
+                            | ValueSome(_, projectOptions) ->
                                 referencedProjects.Add(
                                     FSharpReferencedProject.FSharpReference(referencedProject.OutputFilePath, projectOptions)
                                 )
@@ -387,7 +387,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
         async {
             while true do
                 match! agent.Receive() with
-                | FSharpProjectOptionsMessage.TryGetOptionsByDocument (document, reply, ct, userOpName) ->
+                | FSharpProjectOptionsMessage.TryGetOptionsByDocument(document, reply, ct, userOpName) ->
                     if ct.IsCancellationRequested then
                         reply.Reply ValueNone
                     else
@@ -423,7 +423,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         with _ ->
                             reply.Reply ValueNone
 
-                | FSharpProjectOptionsMessage.TryGetOptionsByProject (project, reply, ct) ->
+                | FSharpProjectOptionsMessage.TryGetOptionsByProject(project, reply, ct) ->
                     if ct.IsCancellationRequested then
                         reply.Reply ValueNone
                     else
@@ -450,7 +450,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         with _ ->
                             reply.Reply ValueNone
 
-                | FSharpProjectOptionsMessage.ClearOptions (projectId) ->
+                | FSharpProjectOptionsMessage.ClearOptions(projectId) ->
                     match cache.TryRemove(projectId) with
                     | true, (_, _, projectOptions) ->
                         lastSuccessfulCompilations.TryRemove(projectId) |> ignore
@@ -458,7 +458,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                     | _ -> ()
 
                     legacyProjectSites.TryRemove(projectId) |> ignore
-                | FSharpProjectOptionsMessage.ClearSingleFileOptionsCache (documentId) ->
+                | FSharpProjectOptionsMessage.ClearSingleFileOptionsCache(documentId) ->
                     match singleFileCache.TryRemove(documentId) with
                     | true, (_, _, _, projectOptions) ->
                         lastSuccessfulCompilations.TryRemove(documentId.ProjectId) |> ignore
@@ -544,7 +544,7 @@ type internal FSharpProjectOptionsManager(checker: FSharpChecker, workspace: Wor
     member _.GetCompilationDefinesAndLangVersionForEditingDocument(document: Document) =
         let parsingOptions =
             match reactor.TryGetCachedOptionsByProjectId(document.Project.Id) with
-            | Some (_, parsingOptions, _) -> parsingOptions
+            | Some(_, parsingOptions, _) -> parsingOptions
             | _ ->
                 { FSharpParsingOptions.Default with
                     ApplyLineDirectives = false
@@ -568,7 +568,7 @@ type internal FSharpProjectOptionsManager(checker: FSharpChecker, workspace: Wor
     /// Quicker it doesn't need to recompute the exact project options for a script.
     member this.TryGetQuickParsingOptionsForEditingDocumentOrProject(documentId: DocumentId, path: string) =
         match reactor.TryGetCachedOptionsByProjectId(documentId.ProjectId) with
-        | Some (_, parsingOptions, _) -> parsingOptions
+        | Some(_, parsingOptions, _) -> parsingOptions
         | _ ->
             { FSharpParsingOptions.Default with
                 IsInteractive = CompilerEnvironment.IsScriptFile path

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -265,9 +265,7 @@ type internal FSharpSettingsFactory [<Composition.ImportingConstructor>] (settin
 [<Guid(FSharpConstants.packageGuidString)>]
 [<ProvideOptionPage(typeof<FSharp.Interactive.FsiPropertyPage>, "F# Tools", "F# Interactive", 6000s, 6001s, true)>] // true = supports automation
 
-
 [<ProvideKeyBindingTable("{dee22b65-9761-4a26-8fb2-759b971d6dfc}", 6001s)>] // <-- resource ID for localised name
-
 
 [<ProvideToolWindow(typeof<FSharp.Interactive.FsiToolWindow>,
                     Orientation = ToolWindowOrientation.Bottom,
@@ -277,8 +275,8 @@ type internal FSharpSettingsFactory [<Composition.ImportingConstructor>] (settin
                     Width = 360,
                     Height = 120,
                     Window = "34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3")
-  // The following should place the ToolWindow with the OutputWindow by default.
-  >]
+// The following should place the ToolWindow with the OutputWindow by default.
+>]
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.IntelliSenseOptionPage>, "F#", null, "IntelliSense", "6008", "IntelliSensePageKeywords")>]
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.QuickInfoOptionPage>, "F#", null, "QuickInfo", "6009", "QuickInfoPageKeywords")>]
 [<ProvideLanguageEditorOptionPage(typeof<OptionsUI.CodeFixesOptionPage>, "F#", null, "Code Fixes", "6010", "CodeFixesPageKeywords")>]
@@ -370,15 +368,12 @@ type internal FSharpPackage() as this =
                 this.ComponentModel.DefaultExportProvider.GetExport<HackCpsCommandLineChanges>()
 
             let optionsManager =
-                workspace
-                    .Services
+                workspace.Services
                     .GetService<IFSharpWorkspaceService>()
                     .FSharpProjectOptionsManager
 
             let metadataAsSource =
-                this
-                    .ComponentModel
-                    .DefaultExportProvider
+                this.ComponentModel.DefaultExportProvider
                     .GetExport<FSharpMetadataAsSourceService>()
                     .Value
 
@@ -440,11 +435,9 @@ type internal FSharpLanguageService(package: FSharpPackage) =
         let workspace = package.ComponentModel.GetService<VisualStudioWorkspace>()
 
         let solutionAnalysis =
-            workspace
-                .Services
+            workspace.Services
                 .GetService<EditorOptions>()
-                .Advanced
-                .SolutionBackgroundAnalysis
+                .Advanced.SolutionBackgroundAnalysis
 
         globalOptions.SetBackgroundAnalysisScope(openFilesOnly = not solutionAnalysis)
 
@@ -478,10 +471,9 @@ type internal FSharpLanguageService(package: FSharpPackage) =
 
 [<Composition.Shared>]
 [<ComponentModel.Composition.Export(typeof<HackCpsCommandLineChanges>)>]
-type internal HackCpsCommandLineChanges [<ComponentModel.Composition.ImportingConstructor>]
-    (
-        [<ComponentModel.Composition.Import(typeof<VisualStudioWorkspace>)>] workspace: VisualStudioWorkspace
-    ) =
+type internal HackCpsCommandLineChanges
+    [<ComponentModel.Composition.ImportingConstructor>]
+    ([<ComponentModel.Composition.Import(typeof<VisualStudioWorkspace>)>] workspace: VisualStudioWorkspace) =
 
     static let projectDisplayNameOf projectFileName =
         if String.IsNullOrWhiteSpace projectFileName then

--- a/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
@@ -21,11 +21,8 @@ open Microsoft.VisualStudio.Shell.Interop
 
 [<Sealed>]
 type internal LegacyProjectWorkspaceMap
-    (
-        solution: IVsSolution,
-        projectInfoManager: FSharpProjectOptionsManager,
-        projectContextFactory: FSharpWorkspaceProjectContextFactory
-    ) as this =
+    (solution: IVsSolution, projectInfoManager: FSharpProjectOptionsManager, projectContextFactory: FSharpWorkspaceProjectContextFactory) as this
+    =
 
     let invalidPathChars = set (Path.GetInvalidPathChars())
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SingleFileWorkspaceMap.fs
@@ -12,18 +12,13 @@ open Microsoft.VisualStudio.Shell.Interop
 open FSharp.Compiler.CodeAnalysis
 
 type internal FSharpMiscellaneousFileService
-    (
-        workspace: Workspace,
-        miscFilesWorkspace: Workspace,
-        projectContextFactory: IFSharpWorkspaceProjectContextFactory
-    ) =
+    (workspace: Workspace, miscFilesWorkspace: Workspace, projectContextFactory: IFSharpWorkspaceProjectContextFactory) =
 
     let files =
         ConcurrentDictionary<string, Lazy<IFSharpWorkspaceProjectContext>>(StringComparer.OrdinalIgnoreCase)
 
     let optionsManager =
-        workspace
-            .Services
+        workspace.Services
             .GetRequiredService<IFSharpWorkspaceService>()
             .FSharpProjectOptionsManager
 
@@ -177,7 +172,7 @@ type internal FSharpMiscellaneousFileService
 
                 match documentOpt with
                 | ValueNone -> ()
-                | ValueSome (document) ->
+                | ValueSome(document) ->
                     optionsManager.ClearSingleFileOptionsCache(document.Id)
                     projectContext.Value.Dispose()
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/SymbolHelpers.fs
@@ -128,14 +128,14 @@ module internal SymbolHelpers =
             | scope ->
                 let projectsToCheck =
                     match scope with
-                    | Some (SymbolScope.Projects (scopeProjects, false)) ->
+                    | Some(SymbolScope.Projects(scopeProjects, false)) ->
                         [
                             for scopeProject in scopeProjects do
                                 yield scopeProject
                                 yield! scopeProject.GetDependentProjects()
                         ]
                         |> List.distinct
-                    | Some (SymbolScope.Projects (scopeProjects, true)) -> scopeProjects
+                    | Some(SymbolScope.Projects(scopeProjects, true)) -> scopeProjects
                     // The symbol is declared in .NET framework, an external assembly or in a C# project within the solution.
                     // In order to find all its usages we have to check all F# projects.
                     | _ -> Seq.toList currentDocument.Project.Solution.Projects

--- a/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Tokenizer.fs
@@ -782,7 +782,7 @@ module internal Tokenizer =
             ||> Array.foldi (fun (acc, lastToken: DraftTokenInfo voption) index token ->
                 match lastToken with
                 | ValueSome t when token.LeftColumn <= t.RightColumn -> acc, lastToken
-                | ValueSome ({ Kind = LexerSymbolKind.ActivePattern } as lastToken) when
+                | ValueSome({ Kind = LexerSymbolKind.ActivePattern } as lastToken) when
                     wholeActivePatterns
                     && (token.Tag = FSharpTokenTag.BAR
                         || token.Tag = FSharpTokenTag.IDENT
@@ -825,7 +825,7 @@ module internal Tokenizer =
                                     LeftColumn = token.LeftColumn - 1
                                     MatchedLength = 1
                                 }
-                            | ValueSome ({ Kind = LexerSymbolKind.ActivePattern } as ap) when
+                            | ValueSome({ Kind = LexerSymbolKind.ActivePattern } as ap) when
                                 wholeActivePatterns && token.Tag = FSharpTokenTag.RPAREN
                                 ->
                                 {

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -57,7 +57,7 @@ module private CheckerExtensions =
                         return
                             match checkFileAnswer with
                             | FSharpCheckFileAnswer.Aborted -> None
-                            | FSharpCheckFileAnswer.Succeeded (checkFileResults) -> Some(parseResults, checkFileResults)
+                            | FSharpCheckFileAnswer.Succeeded(checkFileResults) -> Some(parseResults, checkFileResults)
                     }
 
                 let tryGetFreshResultsWithTimeout () =
@@ -88,7 +88,7 @@ module private CheckerExtensions =
                         | None ->
                             cancellableTask {
                                 match checker.TryGetRecentCheckResultsForFile(filePath, options, userOpName = userOpName) with
-                                | Some (parseResults, checkFileResults, _) -> return Some(parseResults, checkFileResults)
+                                | Some(parseResults, checkFileResults, _) -> return Some(parseResults, checkFileResults)
                                 | None -> return! parseAndCheckFile
                             }
 
@@ -146,12 +146,11 @@ type Document with
 
                     match! projectOptionsManager.TryGetOptionsForDocumentOrProject(this, ct, userOpName) with
                     | ValueNone -> return raise (OperationCanceledException("FSharp project options not found."))
-                    | ValueSome (parsingOptions, projectOptions) ->
+                    | ValueSome(parsingOptions, projectOptions) ->
                         let result =
                             (service.Checker, projectOptionsManager, parsingOptions, projectOptions)
 
-                        return
-                            ProjectCache.Projects.GetValue(this.Project, ConditionalWeakTable<_, _>.CreateValueCallback (fun _ -> result))
+                        return ProjectCache.Projects.GetValue(this.Project, ConditionalWeakTable<_, _>.CreateValueCallback(fun _ -> result))
                 }
 
     /// Get the compilation defines and language version from F# project that is associated with the given F# document.
@@ -331,9 +330,9 @@ type Project with
 
                     match! projectOptionsManager.TryGetOptionsByProject(this, ct) with
                     | ValueNone -> return raise (OperationCanceledException("FSharp project options not found."))
-                    | ValueSome (parsingOptions, projectOptions) ->
+                    | ValueSome(parsingOptions, projectOptions) ->
                         let result =
                             (service.Checker, projectOptionsManager, parsingOptions, projectOptions)
 
-                        return ProjectCache.Projects.GetValue(this, ConditionalWeakTable<_, _>.CreateValueCallback (fun _ -> result))
+                        return ProjectCache.Projects.GetValue(this, ConditionalWeakTable<_, _>.CreateValueCallback(fun _ -> result))
                 }

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -343,7 +343,7 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                 | Some targetSymbolUse ->
 
                     match declarations with
-                    | FindDeclResult.ExternalDecl (assembly, targetExternalSym) ->
+                    | FindDeclResult.ExternalDecl(assembly, targetExternalSym) ->
                         let projectOpt =
                             originDocument.Project.Solution.Projects
                             |> Seq.tryFindV (fun p -> p.AssemblyName.Equals(assembly, StringComparison.OrdinalIgnoreCase))
@@ -388,10 +388,9 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
                         if not (originDocument.Project.Solution.ContainsDocumentWithFilePath(targetRange.FileName)) then
                             let metadataReferences = originDocument.Project.MetadataReferences
                             return ValueSome(FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), idRange)
-                        else
-                        // if goto definition is called at we are alread at the declaration location of a symbol in
-                        // either a signature or an implementation file then we jump to it's respective postion in thethe
-                        if
+                        else if
+                            // if goto definition is called at we are alread at the declaration location of a symbol in
+                            // either a signature or an implementation file then we jump to it's respective postion in thethe
                             lexerSymbol.Range = targetRange
                         then
                             // jump from signature to the corresponding implementation
@@ -594,7 +593,7 @@ type internal GoToDefinition(metadataAsSource: FSharpMetadataAsSourceService) =
             | _ -> None
 
         match textOpt with
-        | Some (text, fileName) ->
+        | Some(text, fileName) ->
             let tmpProjInfo, tmpDocInfo =
                 MetadataAsSource.generateTemporaryDocument (
                     AssemblyIdentity(targetSymbolUse.Symbol.Assembly.QualifiedName),
@@ -709,7 +708,7 @@ type internal FSharpNavigation(metadataAsSource: FSharpMetadataAsSourceService, 
 
             return
                 match result with
-                | ValueSome (FSharpGoToDefinitionResult.NavigableItem (navItem), _) -> ImmutableArray.create navItem
+                | ValueSome(FSharpGoToDefinitionResult.NavigableItem(navItem), _) -> ImmutableArray.create navItem
                 | _ -> ImmutableArray.empty
         }
 
@@ -728,10 +727,10 @@ type internal FSharpNavigation(metadataAsSource: FSharpMetadataAsSourceService, 
 
             if gtdTask.Status = TaskStatus.RanToCompletion && gtdTask.Result.IsSome then
                 match gtdTask.Result with
-                | ValueSome (FSharpGoToDefinitionResult.NavigableItem (navItem), _) ->
+                | ValueSome(FSharpGoToDefinitionResult.NavigableItem(navItem), _) ->
                     gtd.NavigateToItem(navItem, cancellationToken) |> ignore
                     true
-                | ValueSome (FSharpGoToDefinitionResult.ExternalAssembly (targetSymbolUse, metadataReferences), _) ->
+                | ValueSome(FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), _) ->
                     gtd.NavigateToExternalDeclaration(targetSymbolUse, metadataReferences, cancellationToken)
                     |> ignore
 
@@ -811,8 +810,7 @@ type FSharpCrossLanguageSymbolNavigationService() =
     let workspace = componentModel.GetService<VisualStudioWorkspace>()
 
     let metadataAsSource =
-        componentModel
-            .DefaultExportProvider
+        componentModel.DefaultExportProvider
             .GetExport<FSharpMetadataAsSourceService>()
             .Value
 
@@ -930,7 +928,7 @@ type FSharpCrossLanguageSymbolNavigationService() =
         match m.Success, t with
         | true, ("M" | "P" | "E") ->
             // TODO: Probably, there's less janky way of dealing with those.
-            let parts = m.Groups[ "entity" ].Value.Split('.')
+            let parts = m.Groups["entity"].Value.Split('.')
             let entityPath = parts[.. (parts.Length - 2)] |> List.ofArray
             let memberOrVal = parts[parts.Length - 1]
 
@@ -963,10 +961,10 @@ type FSharpCrossLanguageSymbolNavigationService() =
                     (SymbolMemberType.FromString t)
                 )
         | true, "T" ->
-            let entityPath = m.Groups[ "entity" ].Value.Split('.') |> List.ofArray
+            let entityPath = m.Groups["entity"].Value.Split('.') |> List.ofArray
             DocCommentId.Type entityPath
         | true, "F" ->
-            let parts = m.Groups[ "entity" ].Value.Split('.')
+            let parts = m.Groups["entity"].Value.Split('.')
             let entityPath = parts[.. (parts.Length - 2)] |> List.ofArray
             let memberOrVal = parts[parts.Length - 1]
 
@@ -1000,12 +998,12 @@ type FSharpCrossLanguageSymbolNavigationService() =
                     let! result = checker.ParseAndCheckProject(options)
 
                     match path with
-                    | DocCommentId.Member ({
-                                               EntityPath = entityPath
-                                               MemberOrValName = memberOrVal
-                                               GenericParameters = genericParametersCount
-                                           },
-                                           memberType) ->
+                    | DocCommentId.Member({
+                                              EntityPath = entityPath
+                                              MemberOrValName = memberOrVal
+                                              GenericParameters = genericParametersCount
+                                          },
+                                          memberType) ->
                         let entity = result.AssemblySignature.FindEntityByPath(entityPath)
 
                         entity

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigableSymbolsService.fs
@@ -55,17 +55,17 @@ type internal FSharpNavigableSymbolSource(metadataAsSource) =
 
                         match definition with
                         | ValueNone -> return null
-                        | ValueSome (result, range) ->
+                        | ValueSome(result, range) ->
 
                             let declarationTextSpan = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
                             let declarationSpan = Span(declarationTextSpan.Start, declarationTextSpan.Length)
                             let symbolSpan = SnapshotSpan(snapshot, declarationSpan)
 
                             match result with
-                            | FSharpGoToDefinitionResult.NavigableItem (navItem) ->
+                            | FSharpGoToDefinitionResult.NavigableItem(navItem) ->
                                 return FSharpNavigableSymbol(navItem, symbolSpan, gtd) :> INavigableSymbol
 
-                            | FSharpGoToDefinitionResult.ExternalAssembly (targetSymbolUse, metadataReferences) ->
+                            | FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences) ->
                                 let nav =
                                     { new INavigableSymbol with
                                         member _.Navigate(_: INavigableRelationship) =

--- a/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/NavigateToSearchService.fs
@@ -20,11 +20,9 @@ open FSharp.Compiler.EditorServices
 open CancellableTasks
 
 [<Export(typeof<IFSharpNavigateToSearchService>); Shared>]
-type internal FSharpNavigateToSearchService [<ImportingConstructor>]
-    (
-        patternMatcherFactory: IPatternMatcherFactory,
-        [<Import(AllowDefault = true)>] workspace: VisualStudioWorkspace
-    ) =
+type internal FSharpNavigateToSearchService
+    [<ImportingConstructor>]
+    (patternMatcherFactory: IPatternMatcherFactory, [<Import(AllowDefault = true)>] workspace: VisualStudioWorkspace) =
 
     let cache = ConcurrentDictionary<DocumentId, VersionStamp * NavigableItem array>()
 

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -21,12 +21,7 @@ open FSharp.Compiler.EditorServices
 open CancellableTasks
 
 type internal FSharpAsyncQuickInfoSource
-    (
-        xmlMemberIndexService,
-        metadataAsSource: FSharpMetadataAsSourceService,
-        textBuffer: ITextBuffer,
-        editorOptions: EditorOptions
-    ) =
+    (xmlMemberIndexService, metadataAsSource: FSharpMetadataAsSourceService, textBuffer: ITextBuffer, editorOptions: EditorOptions) =
 
     let getQuickInfoItem (sourceText, (document: Document), (lexerSymbol: LexerSymbol), (ToolTipText elements)) =
         cancellableTask {
@@ -144,7 +139,8 @@ type internal FSharpAsyncQuickInfoSource
 [<Name("F# Quick Info Provider")>]
 [<ContentType(FSharpConstants.FSharpLanguageName)>]
 [<Order>]
-type internal FSharpAsyncQuickInfoSourceProvider [<ImportingConstructor>]
+type internal FSharpAsyncQuickInfoSourceProvider
+    [<ImportingConstructor>]
     (
         [<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider,
         metadataAsSource: FSharpMetadataAsSourceService,

--- a/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/Views.fs
@@ -52,7 +52,7 @@ module internal QuickInfoViewProvider =
 
     let (|LineBreak|_|) =
         function
-        | TaggedText (TextTag.LineBreak, _) -> Some()
+        | TaggedText(TextTag.LineBreak, _) -> Some()
         | _ -> None
 
     let wrapContent (elements: obj seq) =

--- a/vsintegration/tests/FSharp.Editor.Tests/BraceMatchingServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/BraceMatchingServiceTests.fs
@@ -62,7 +62,7 @@ type BraceMatchingServiceTests() =
             |> Async.RunImmediateExceptOnUI
         with
         | None -> failwith $"Didn't find a match for start brace at position '{startMarkerPosition}"
-        | Some (left, right) ->
+        | Some(left, right) ->
             let endPositionInRange (range) =
                 let span = RoslynHelpers.FSharpRangeToTextSpan(sourceText, range)
                 span.Start <= endMarkerPosition && endMarkerPosition <= span.End

--- a/vsintegration/tests/FSharp.Editor.Tests/BreakpointResolutionServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/BreakpointResolutionServiceTests.fs
@@ -67,7 +67,7 @@ let main argv =
 
         match actualResolutionOption with
         | ValueNone -> Assert.True(expectedResolution.IsNone, "BreakpointResolutionService failed to resolve breakpoint position")
-        | ValueSome (actualResolutionRange) ->
+        | ValueSome(actualResolutionRange) ->
             let actualResolution =
                 sourceText
                     .GetSubText(RoslynHelpers.FSharpRangeToTextSpan(sourceText, actualResolutionRange))

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
@@ -67,7 +67,7 @@ module FSharpDiagnostics =
     /// Generates F# diagnostics using the given document according to the given mode.
     let generate mode (document: Document) =
         match mode with
-        | Manual (squiggly, diagnostic) ->
+        | Manual(squiggly, diagnostic) ->
             cancellableTask {
                 let! sourceText = document.GetTextAsync()
                 let spanStart = sourceText.ToString().IndexOf squiggly

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -1311,8 +1311,8 @@ let _ = (2 + 2) { return 5 }
 
                 override this.ToString() =
                     match this with
-                    | OuterLeft (l, r) -> $"x {l} (y {r} z)"
-                    | OuterRight (l, r) -> $"(x {l} y) {r} z"
+                    | OuterLeft(l, r) -> $"x {l} (y {r} z)"
+                    | OuterRight(l, r) -> $"(x {l} y) {r} z"
 
             module ParenthesizedInfixOperatorAppPair =
                 /// Reduces the operator strings to simpler, more easily identifiable forms.
@@ -1330,8 +1330,8 @@ let _ = (2 + 2) { return 5 }
                         | c, _ -> $"{c}op"
 
                     function
-                    | OuterLeft (l, r) -> OuterLeft(simplify l, simplify r)
-                    | OuterRight (l, r) -> OuterRight(simplify l, simplify r)
+                    | OuterLeft(l, r) -> OuterLeft(simplify l, simplify r)
+                    | OuterRight(l, r) -> OuterRight(simplify l, simplify r)
 
                 /// Indicates that the pairing is syntactically invalid
                 /// (for unoverloadable operators like :?, :>, :?>)
@@ -1347,63 +1347,63 @@ let _ = (2 + 2) { return 5 }
 
                     let fix =
                         match pair with
-                        | OuterLeft (l, r)
-                        | OuterRight (l, r) -> $"x {l} y {r} z"
+                        | OuterLeft(l, r)
+                        | OuterRight(l, r) -> $"x {l} y {r} z"
 
                     Some(expr, fix)
 
                 let expectation pair =
                     match simplify pair with
-                    | OuterLeft ((":?" | ":>" | ":?>"), _) -> invalidPairing
-                    | OuterLeft (_, "**op") -> fixable pair
-                    | OuterLeft ("**op", _) -> unfixable pair
-                    | OuterLeft ("*op", "*op") -> fixable pair
-                    | OuterLeft (("%op" | "/op" | "*op"), ("%op" | "/op" | "*op")) -> unfixable pair
-                    | OuterLeft (_, ("%op" | "/op" | "*op")) -> fixable pair
-                    | OuterLeft (("%op" | "/op" | "*op"), _) -> unfixable pair
-                    | OuterLeft ("+op", "+op") -> fixable pair
-                    | OuterLeft (("-op" | "+op"), ("-op" | "+op")) -> unfixable pair
-                    | OuterLeft (_, ("-op" | "+op")) -> fixable pair
-                    | OuterLeft (("-op" | "+op"), _) -> unfixable pair
-                    | OuterLeft (_, ":?") -> fixable pair
-                    | OuterLeft (_, "::") -> fixable pair
-                    | OuterLeft ("::", _) -> unfixable pair
-                    | OuterLeft (_, ("^op" | "@op")) -> fixable pair
-                    | OuterLeft (("^op" | "@op"), _) -> unfixable pair
-                    | OuterLeft (l & ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op"),
-                                 r & ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op")) ->
+                    | OuterLeft((":?" | ":>" | ":?>"), _) -> invalidPairing
+                    | OuterLeft(_, "**op") -> fixable pair
+                    | OuterLeft("**op", _) -> unfixable pair
+                    | OuterLeft("*op", "*op") -> fixable pair
+                    | OuterLeft(("%op" | "/op" | "*op"), ("%op" | "/op" | "*op")) -> unfixable pair
+                    | OuterLeft(_, ("%op" | "/op" | "*op")) -> fixable pair
+                    | OuterLeft(("%op" | "/op" | "*op"), _) -> unfixable pair
+                    | OuterLeft("+op", "+op") -> fixable pair
+                    | OuterLeft(("-op" | "+op"), ("-op" | "+op")) -> unfixable pair
+                    | OuterLeft(_, ("-op" | "+op")) -> fixable pair
+                    | OuterLeft(("-op" | "+op"), _) -> unfixable pair
+                    | OuterLeft(_, ":?") -> fixable pair
+                    | OuterLeft(_, "::") -> fixable pair
+                    | OuterLeft("::", _) -> unfixable pair
+                    | OuterLeft(_, ("^op" | "@op")) -> fixable pair
+                    | OuterLeft(("^op" | "@op"), _) -> unfixable pair
+                    | OuterLeft(l & ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op"),
+                                r & ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op")) ->
                         if l = r then fixable pair else unfixable pair
-                    | OuterLeft (_, ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op")) -> fixable pair
-                    | OuterLeft (("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op"), _) -> unfixable pair
-                    | OuterLeft (_, (":>" | ":?>")) -> fixable pair
-                    | OuterLeft (_, ("&" | "&&")) -> fixable pair
-                    | OuterLeft (("&" | "&&"), _) -> unfixable pair
-                    | OuterLeft (_, ("||" | "or")) -> fixable pair
-                    | OuterLeft (("||" | "or"), _) -> unfixable pair
-                    | OuterLeft (":=", ":=") -> fixable pair
+                    | OuterLeft(_, ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op")) -> fixable pair
+                    | OuterLeft(("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op"), _) -> unfixable pair
+                    | OuterLeft(_, (":>" | ":?>")) -> fixable pair
+                    | OuterLeft(_, ("&" | "&&")) -> fixable pair
+                    | OuterLeft(("&" | "&&"), _) -> unfixable pair
+                    | OuterLeft(_, ("||" | "or")) -> fixable pair
+                    | OuterLeft(("||" | "or"), _) -> unfixable pair
+                    | OuterLeft(":=", ":=") -> fixable pair
 
-                    | OuterRight ((":?" | ":>" | ":?>"), _) -> invalidPairing
-                    | OuterRight (_, "**op") -> unfixable pair
-                    | OuterRight ("**op", _) -> fixable pair
-                    | OuterRight (("%op" | "/op" | "*op"), _) -> fixable pair
-                    | OuterRight (_, ("%op" | "/op" | "*op")) -> unfixable pair
-                    | OuterRight (("-op" | "+op"), _) -> fixable pair
-                    | OuterRight (_, ("-op" | "+op")) -> unfixable pair
-                    | OuterRight (_, ":?") -> unfixable pair
-                    | OuterRight ("::", "::") -> unfixable pair
-                    | OuterRight ("::", _) -> fixable pair
-                    | OuterRight (_, "::") -> unfixable pair
-                    | OuterRight (("^op" | "@op"), ("^op" | "@op")) -> unfixable pair
-                    | OuterRight (("^op" | "@op"), _) -> fixable pair
-                    | OuterRight (_, ("^op" | "@op")) -> unfixable pair
-                    | OuterRight (("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op"), _) -> fixable pair
-                    | OuterRight (_, ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op")) -> unfixable pair
-                    | OuterRight (_, (":>" | ":?>")) -> unfixable pair
-                    | OuterRight (("&" | "&&"), _) -> fixable pair
-                    | OuterRight (_, ("&" | "&&")) -> unfixable pair
-                    | OuterRight (("||" | "or"), _) -> fixable pair
-                    | OuterRight (_, ("||" | "or")) -> unfixable pair
-                    | OuterRight (":=", ":=") -> unfixable pair
+                    | OuterRight((":?" | ":>" | ":?>"), _) -> invalidPairing
+                    | OuterRight(_, "**op") -> unfixable pair
+                    | OuterRight("**op", _) -> fixable pair
+                    | OuterRight(("%op" | "/op" | "*op"), _) -> fixable pair
+                    | OuterRight(_, ("%op" | "/op" | "*op")) -> unfixable pair
+                    | OuterRight(("-op" | "+op"), _) -> fixable pair
+                    | OuterRight(_, ("-op" | "+op")) -> unfixable pair
+                    | OuterRight(_, ":?") -> unfixable pair
+                    | OuterRight("::", "::") -> unfixable pair
+                    | OuterRight("::", _) -> fixable pair
+                    | OuterRight(_, "::") -> unfixable pair
+                    | OuterRight(("^op" | "@op"), ("^op" | "@op")) -> unfixable pair
+                    | OuterRight(("^op" | "@op"), _) -> fixable pair
+                    | OuterRight(_, ("^op" | "@op")) -> unfixable pair
+                    | OuterRight(("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op"), _) -> fixable pair
+                    | OuterRight(_, ("=op" | "|op" | "&op" | "$" | ">op" | "<op" | "!=op")) -> unfixable pair
+                    | OuterRight(_, (":>" | ":?>")) -> unfixable pair
+                    | OuterRight(("&" | "&&"), _) -> fixable pair
+                    | OuterRight(_, ("&" | "&&")) -> unfixable pair
+                    | OuterRight(("||" | "or"), _) -> fixable pair
+                    | OuterRight(_, ("||" | "or")) -> unfixable pair
+                    | OuterRight(":=", ":=") -> unfixable pair
 
                     | _ -> unfixable pair
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
@@ -261,12 +261,9 @@ type RoslynTestHelpers private () =
         )
 
     static member SetProjectOptions projId (solution: Solution) (options: FSharpProjectOptions) =
-        solution
-            .Workspace
-            .Services
+        solution.Workspace.Services
             .GetService<IFSharpWorkspaceService>()
-            .FSharpProjectOptionsManager
-            .SetCommandLineOptions(
+            .FSharpProjectOptionsManager.SetCommandLineOptions(
                 projId,
                 options.SourceFiles,
                 options.OtherOptions |> ImmutableArray.CreateRange

--- a/vsintegration/tests/FSharp.Editor.Tests/LanguageDebugInfoServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/LanguageDebugInfoServiceTests.fs
@@ -71,7 +71,7 @@ let main argv =
 
         match actualDataTipSpanOption with
         | None -> Assert.True(expectedDataTip.IsNone, "LanguageDebugInfoService failed to produce a data tip")
-        | Some (actualDataTipSpan) ->
+        | Some(actualDataTipSpan) ->
             let actualDataTipText = sourceText.GetSubText(actualDataTipSpan).ToString()
 
             Assert.True(expectedDataTip.IsSome, $"LanguageDebugInfoService produced a data tip while it shouldn't at: {actualDataTipText}")

--- a/vsintegration/tests/FSharp.Editor.Tests/NavigateToSearchServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/NavigateToSearchServiceTests.fs
@@ -42,13 +42,7 @@ module HeyHo =
         let service: IFSharpNavigateToSearchService = provider.GetExportedValue()
 
         service
-            .SearchProjectAsync(
-                project,
-                [] |> Seq.toImmutableArray,
-                pattern,
-                service.KindsProvided,
-                CancellationToken.None
-            )
+            .SearchProjectAsync(project, [] |> Seq.toImmutableArray, pattern, service.KindsProvided, CancellationToken.None)
             .Result
 
     let assertResultsContain pattern expected =

--- a/vsintegration/tests/FSharp.Editor.Tests/QuickInfoProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/QuickInfoProviderTests.fs
@@ -42,7 +42,7 @@ module QuickInfoProviderTests =
     let private tooltipElementToExpected expected =
         function
         | ToolTipElement.None -> Empty
-        | ToolTipElement.Group (xs) ->
+        | ToolTipElement.Group(xs) ->
             let descriptions = xs |> List.map (fun item -> item.MainDescription)
 
             let descriptionTexts =
@@ -92,7 +92,7 @@ module QuickInfoProviderTests =
             RoslynTestHelpers.CreateSolution(programText)
             |> RoslynTestHelpers.GetSingleDocument
 
-        for TestCase (symbol, expected) in testCases do
+        for TestCase(symbol, expected) in testCases do
             let caretPosition = programText.IndexOf(symbol) + symbol.Length - 1
 
             let quickInfo =

--- a/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
@@ -47,7 +47,7 @@ module QuickInfo =
         let sigHelp = GetQuickInfo code caretPosition
 
         match sigHelp with
-        | Some (ToolTipText elements) when not elements.IsEmpty ->
+        | Some(ToolTipText elements) when not elements.IsEmpty ->
             let documentationBuilder =
                 { new IDocumentationBuilder with
                     override _.AppendDocumentationFromProcessedXML(_, _, _, _, _, _) = ()

--- a/vsintegration/tests/FSharp.Editor.Tests/SignatureHelpProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/SignatureHelpProviderTests.fs
@@ -44,9 +44,7 @@ module SignatureHelpProvider =
 
             let paramInfoLocations =
                 parseResults
-                    .FindParameterLocations(
-                        Position.fromZ caretLinePos.Line caretLineColumn
-                    )
+                    .FindParameterLocations(Position.fromZ caretLinePos.Line caretLineColumn)
                     .Value
 
             let triggered =


### PR DESCRIPTION
This updates the Fantomas tool from 5.0.3 to 6.1.2
As a result, the codebase is much more in line with the community [style guide](https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting).

Yes, there will be some pain but it's one of these _the-longer-we-wait-the-worse-it-gets_ things.
One could argue, we already waited too long.
Most of the changes are about single space changes, so I'd say it's not all _that_ bad.

A lot of bugs were fixed since 5.0.3, so we could remove some files from `.fantomasignore`.
But to keep this PR as small as possible, this is not yet done.

A big win will be the parallel processing we have since 6.0, thanks to @TheAngryByrd
Locally I'm seeing a speedup > 2x: `dotnet fantomas . --check` going down from ~15s to ~7s.

Best of all, we now have this enjoyable colourful output 😉 
![image](https://github.com/dotnet/fsharp/assets/3221269/428c5c04-2b60-47af-b4eb-a14db80096b0)

If you're interested in all the changes:
Here's our [upgrage guide](https://fsprojects.github.io/fantomas/docs/end-users/UpgradeGuide.html)
Here are our [releases](https://github.com/fsprojects/fantomas/releases)