### PR TITLE
use new range helper functions in src/Compiler

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -8152,7 +8152,7 @@ and TcNameOfExpr (cenv: cenv) env tpenv (synArg: SynExpr) =
 
 and TcNameOfExprResult (cenv: cenv) (lastIdent: Ident) m =
     let g = cenv.g
-    let constRange = mkRange m.FileName m.Start (mkPos m.StartLine (m.StartColumn + lastIdent.idText.Length + 2)) // `2` are for quotes
+    let constRange = withEnd (mkPos m.StartLine (m.StartColumn + lastIdent.idText.Length + 2)) m // `2` are for quotes
     Expr.Const(Const.String(lastIdent.idText), constRange, g.string_ty)
 
 //-------------------------------------------------------------------------

--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
@@ -79,14 +79,14 @@ let TransformAstForNestedUpdates (cenv: TcFileState) (env: TcEnv) overallTy (lid
                 | [ _ ] -> [ origSepRng ]
                 | _ :: t ->
                     origSepRng
-                    :: List.map (fun (s: Ident, e: Ident) -> mkRange s.idRange.FileName s.idRange.End e.idRange.Start) t
+                    :: List.map (fun (s: Ident, e: Ident) -> withStartEnd s.idRange.End e.idRange.Start s.idRange) t
 
             let lid = buildLid [] id lidwd |> List.rev
 
             (lid, List.pairwise lid |> calcLidSeparatorRanges origSepRng)
 
         let totalRange (origId: Ident) (id: Ident) =
-            mkRange origId.idRange.FileName origId.idRange.End id.idRange.Start
+            withStartEnd origId.idRange.End id.idRange.Start origId.idRange
 
         let rangeOfBlockSeperator (id: Ident) =
             let idEnd = id.idRange.End
@@ -95,7 +95,7 @@ let TransformAstForNestedUpdates (cenv: TcFileState) (env: TcEnv) overallTy (lid
             let blockSeperatorStartPos = mkPos idEnd.Line blockSeperatorStartCol
             let blockSeporatorEndPos = mkPos idEnd.Line blockSeperatorEndCol
 
-            mkRange id.idRange.FileName blockSeperatorStartPos blockSeporatorEndPos
+            withStartEnd blockSeperatorStartPos blockSeporatorEndPos id.idRange
 
         match withExpr with
         | SynExpr.Ident origId, (sepRange, _) ->

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -2001,7 +2001,7 @@ let FormatDiagnosticLocation (tcConfig: TcConfig) m : FormattedDiagnosticLocatio
             // We're adjusting the columns here to be 1-based - both for parity with C# and for MSBuild, which assumes 1-based columns for error output
             | DiagnosticStyle.Default ->
                 let file = file.Replace('/', Path.DirectorySeparatorChar)
-                let m = mkRange m.FileName (mkPos m.StartLine (m.StartColumn + 1)) m.End
+                let m = withStart (mkPos m.StartLine (m.StartColumn + 1)) m
                 (sprintf "%s(%d,%d): " file m.StartLine m.StartColumn), m, file
 
             // We may also want to change Test to be 1-based
@@ -2009,7 +2009,7 @@ let FormatDiagnosticLocation (tcConfig: TcConfig) m : FormattedDiagnosticLocatio
                 let file = file.Replace("/", "\\")
 
                 let m =
-                    mkRange m.FileName (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn + 1))
+                    withStartEnd (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn + 1)) m
 
                 sprintf "%s(%d,%d-%d,%d): " file m.StartLine m.StartColumn m.EndLine m.EndColumn, m, file
 
@@ -2017,7 +2017,7 @@ let FormatDiagnosticLocation (tcConfig: TcConfig) m : FormattedDiagnosticLocatio
                 let file = file.Replace('/', Path.DirectorySeparatorChar)
 
                 let m =
-                    mkRange m.FileName (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn + 1))
+                    withStartEnd (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn + 1)) m
 
                 sprintf "%s:%d:%d: " file m.StartLine m.StartColumn, m, file
 
@@ -2033,7 +2033,7 @@ let FormatDiagnosticLocation (tcConfig: TcConfig) m : FormattedDiagnosticLocatio
                     let file = file.Replace("/", "\\")
 
                     let m =
-                        mkRange m.FileName (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn + 1))
+                        withStartEnd (mkPos m.StartLine (m.StartColumn + 1)) (mkPos m.EndLine (m.EndColumn + 1)) m
 
                     sprintf "%s(%d,%d,%d,%d): " file m.StartLine m.StartColumn m.EndLine m.EndColumn, m, file
                 else

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -373,7 +373,7 @@ module SimplifyNames =
                         r.EndColumn - name.Length - (getPlidLength necessaryPlid)
 
                     let unnecessaryRange =
-                        mkRange r.FileName (Position.mkPos r.StartLine plidStartCol) (Position.mkPos r.EndLine necessaryPlidStartCol)
+                        withStartEnd (Position.mkPos r.StartLine plidStartCol) (Position.mkPos r.EndLine necessaryPlidStartCol) r
 
                     let relativeName = (String.concat "." plid) + "." + name
 

--- a/src/Compiler/Service/ServiceParamInfoLocations.fs
+++ b/src/Compiler/Service/ServiceParamInfoLocations.fs
@@ -220,7 +220,7 @@ module internal ParameterLocationsImpl =
                        _pf,
                        wholem) ->
             let lidm = lidwd.Range
-            let betweenTheBrackets = mkRange wholem.FileName mLess.Start wholem.End
+            let betweenTheBrackets = withStart mLess.Start wholem
 
             if
                 SyntaxTraversal.rangeContainsPosEdgesExclusive betweenTheBrackets pos
@@ -290,7 +290,7 @@ module internal ParameterLocationsImpl =
                         match fResult with
                         | Some _ -> fResult
                         | _ ->
-                            let typeArgsm = mkRange mLess.FileName mLess.Start wholem.End
+                            let typeArgsm = withEnd wholem.End mLess
 
                             if SyntaxTraversal.rangeContainsPosEdgesExclusive typeArgsm pos then
                                 // We found it, dig out ident
@@ -344,7 +344,7 @@ module internal ParameterLocationsImpl =
                         match traverseSynExpr synExpr with
                         | Some _ as r -> r
                         | None ->
-                            let typeArgsm = mkRange mLess.FileName mLess.Start wholem.End
+                            let typeArgsm = withEnd wholem.End mLess
 
                             if
                                 SyntaxTraversal.rangeContainsPosEdgesExclusive typeArgsm pos

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -516,7 +516,7 @@ module ParsedInput =
                             |> pick expr
 
                         | SynExpr.DotGet (exprLeft, mDot, lidwd, _m) ->
-                            let afterDotBeforeLid = mkRange mDot.FileName mDot.End lidwd.Range.Start
+                            let afterDotBeforeLid = withStartEnd mDot.End lidwd.Range.Start mDot
 
                             [
                                 dive exprLeft exprLeft.Range traverseSynExpr

--- a/src/Compiler/Service/ServiceStructure.fs
+++ b/src/Compiler/Service/ServiceStructure.fs
@@ -572,7 +572,7 @@ module Structure =
                 | SynValData(memberFlags = Some {
                                                     MemberKind = SynMemberKind.PropertyGet | SynMemberKind.PropertySet
                                                 }) ->
-                    let range = mkRange d.Range.FileName (mkPos d.Range.StartLine objectModelRange.StartColumn) d.Range.End
+                    let range = withStart (mkPos d.Range.StartLine objectModelRange.StartColumn) d.Range
 
                     let collapse =
                         match synPat with

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -920,7 +920,7 @@ let mkSynExprDecl (e: SynExpr) = SynModuleDecl.Expr(e, e.Range)
 let addAttribs attrs p = SynPat.Attrib(p, attrs, p.Range)
 
 let unionRangeWithPos (r: range) p =
-    let r2 = mkRange r.FileName p p
+    let r2 = withStartEnd p p r
     unionRanges r r2
 
 /// Report a good error at the end of file, e.g. for non-terminated strings

--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -965,16 +965,13 @@ let ActivePatternInfoOfValName nm (m: range) =
         let n = nm.IndexOf '|'
 
         if n > 0 then
-            let m1 =
-                Range.mkRange mp.FileName mp.Start (Position.mkPos mp.StartLine (mp.StartColumn + n))
+            let m1 = Range.withEnd (Position.mkPos mp.StartLine (mp.StartColumn + n)) mp
 
-            let m2 =
-                Range.mkRange mp.FileName (Position.mkPos mp.StartLine (mp.StartColumn + n + 1)) mp.End
+            let m2 = Range.withStart (Position.mkPos mp.StartLine (mp.StartColumn + n + 1)) mp
 
             (nm[0 .. n - 1], m1) :: loop nm[n + 1 ..] m2
         else
-            let m1 =
-                Range.mkRange mp.FileName mp.Start (Position.mkPos mp.StartLine (mp.StartColumn + nm.Length))
+            let m1 = Range.withEnd (Position.mkPos mp.StartLine (mp.StartColumn + nm.Length)) mp
 
             [ (nm, m1) ]
 
@@ -983,7 +980,7 @@ let ActivePatternInfoOfValName nm (m: range) =
     if IsActivePatternName nm then
         // Skip the '|' at each end when recovering ranges
         let m0 =
-            Range.mkRange m.FileName (Position.mkPos m.StartLine (m.StartColumn + 1)) (Position.mkPos m.EndLine (m.EndColumn - 1))
+            Range.withStartEnd (Position.mkPos m.StartLine (m.StartColumn + 1)) (Position.mkPos m.EndLine (m.EndColumn - 1)) m
 
         let names = loop nm[1 .. nm.Length - 2] m0
         let resH, resT = List.frontAndBack names

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -825,9 +825,8 @@ type SynExpr =
         | SynExpr.SequentialOrImplicitYield (_, e1, _, _, _)
         | SynExpr.App (_, _, e1, _, _) -> e1.RangeOfFirstPortion
         | SynExpr.ForEach (pat = pat; range = r) ->
-            let start = r.Start
             let e = (pat.Range: range).Start
-            mkRange r.FileName start e
+            withEnd e r
         | _ -> e.Range
 
     member this.IsArbExprAndThusAlreadyReportedError =


### PR DESCRIPTION
This replaces `mkRange` for the new range helper functions with the benefit of not going through `FileToIndex`