### PR TITLE
Experiment: Find a better error range for NoOverloadsFound

### DIFF
--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -3114,34 +3114,13 @@ and ResolveOverloading
                             | ErrorResult(_warnings, exn) ->
                                 Some {methodSlot = calledMeth; infoReader = infoReader; error = exn })
 
-                // WIP Trying to find a better error range for CE NoOverloadsFound
                 let m =
                     callerArgs.Unnamed
                     |> List.concat
-                    |> List.map(
-                        fun x ->
-                            match x.Expr with
-                            | Expr.Const(_value, m, _constType) -> m
-                            | Expr.Val(_valRef, _flags, m) -> m
-                            | Expr.Sequential(_expr1, _expr2, _kind, m) -> m
-                            | Expr.Lambda(_unique, _ctorThisValOpt, _baseValOpt, _valParams, _bodyExpr, m, _overallType) -> m
-                            | Expr.TyLambda(_unique, _typeParams, _bodyExpr, m, _overallType) -> m
-                            | Expr.App(_funcExpr, _formalType, _typeArgs, _args, m) -> m
-                            | Expr.LetRec(_bindings, _bodyExpr, m, _frees) -> m
-                            | Expr.Let(_binding, _bodyExpr, m, _frees) -> m
-                            | Expr.Obj(_unique, _objTy, _baseVal, _ctorCall, _overrides, _interfaceImpls, m) -> m
-                            | Expr.Match(_debugPoint, _inputm, _decision, _targets, _fullm, _exprType) -> m
-                            | Expr.StaticOptimization(_conditions, _expr, _alternativeExpr, m) -> m
-                            | Expr.Op(_op, _typeArgs, _args, m) -> m
-                            | Expr.Quote(_quotedExpr, _quotationInfo, _isFromQueryExpression, m, _quotedType) -> m
-                            | Expr.WitnessArg(_traitInfo, m) -> m
-                            | Expr.TyChoose(_typeParams, _bodyExpr, m) -> m
-                            | Expr.Link _exprRef -> m
-                            | Expr.DebugPoint(_debugPointAtLeafExpr, _expr) -> m)
+                    |> List.map(fun x -> x.Range)
                     |> List.tryHead
                     |> Option.defaultValue m
-                    
-                    
+        
                 let err = FailOverloading csenv calledMethGroup reqdRetTyOpt isOpConversion callerArgs (NoOverloadsFound (methodName, errors, cx)) m
 
                 None, ErrorD err, NoTrace

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -3114,6 +3114,34 @@ and ResolveOverloading
                             | ErrorResult(_warnings, exn) ->
                                 Some {methodSlot = calledMeth; infoReader = infoReader; error = exn })
 
+                // WIP Trying to find a better error range for CE NoOverloadsFound
+                let m =
+                    callerArgs.Unnamed
+                    |> List.concat
+                    |> List.map(
+                        fun x ->
+                            match x.Expr with
+                            | Expr.Const(_value, m, _constType) -> m
+                            | Expr.Val(_valRef, _flags, m) -> m
+                            | Expr.Sequential(_expr1, _expr2, _kind, m) -> m
+                            | Expr.Lambda(_unique, _ctorThisValOpt, _baseValOpt, _valParams, _bodyExpr, m, _overallType) -> m
+                            | Expr.TyLambda(_unique, _typeParams, _bodyExpr, m, _overallType) -> m
+                            | Expr.App(_funcExpr, _formalType, _typeArgs, _args, m) -> m
+                            | Expr.LetRec(_bindings, _bodyExpr, m, _frees) -> m
+                            | Expr.Let(_binding, _bodyExpr, m, _frees) -> m
+                            | Expr.Obj(_unique, _objTy, _baseVal, _ctorCall, _overrides, _interfaceImpls, m) -> m
+                            | Expr.Match(_debugPoint, _inputm, _decision, _targets, _fullm, _exprType) -> m
+                            | Expr.StaticOptimization(_conditions, _expr, _alternativeExpr, m) -> m
+                            | Expr.Op(_op, _typeArgs, _args, m) -> m
+                            | Expr.Quote(_quotedExpr, _quotationInfo, _isFromQueryExpression, m, _quotedType) -> m
+                            | Expr.WitnessArg(_traitInfo, m) -> m
+                            | Expr.TyChoose(_typeParams, _bodyExpr, m) -> m
+                            | Expr.Link _exprRef -> m
+                            | Expr.DebugPoint(_debugPointAtLeafExpr, _expr) -> m)
+                    |> List.tryHead
+                    |> Option.defaultValue m
+                    
+                    
                 let err = FailOverloading csenv calledMethGroup reqdRetTyOpt isOpConversion callerArgs (NoOverloadsFound (methodName, errors, cx)) m
 
                 None, ErrorD err, NoTrace

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -136,3 +136,65 @@ let _pythags = seqbuilder {{
         |> FSharp     
         |> typecheck
         |> shouldSucceed
+        
+    [<Fact>]
+    let ``Better CE error range 1`` () =
+        Fsx """
+let test = task {
+    let! x = 1
+    return x
+}
+        """
+        |> compile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 41, Line 3, Col 14, Line 3, Col 15, "No overloads match for method 'Bind'.
+
+Known types of arguments: int * ('a -> TaskCode<'a,'a>)
+
+Available overloads:
+ - member TaskBuilderBase.Bind: computation: Async<'TResult1> * continuation: ('TResult1 -> TaskCode<'TOverall,'TResult2>) -> TaskCode<'TOverall,'TResult2> // Argument 'computation' doesn't match
+ - member TaskBuilderBase.Bind: task: System.Threading.Tasks.Task<'TResult1> * continuation: ('TResult1 -> TaskCode<'TOverall,'TResult2>) -> TaskCode<'TOverall,'TResult2> // Argument 'task' doesn't match
+ - member TaskBuilderBase.Bind: task: ^TaskLike * continuation: ('TResult1 -> TaskCode<'TOverall,'TResult2>) -> TaskCode<'TOverall,'TResult2> when ^TaskLike: (member GetAwaiter: unit -> ^Awaiter) and ^Awaiter :> System.Runtime.CompilerServices.ICriticalNotifyCompletion and ^Awaiter: (member get_IsCompleted: unit -> bool) and ^Awaiter: (member GetResult: unit -> 'TResult1) // Argument 'task' doesn't match")
+        ]
+        
+    [<Fact>]
+    let ``Better CE error range 2`` () =
+        Fsx """
+let test = task {
+    let! x = (1, 2)
+    return x
+}
+        """
+        |> compile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 41, Line 3, Col 15, Line 3, Col 19, "No overloads match for method 'Bind'.
+
+Known types of arguments: (int * int) * ('a -> TaskCode<'a,'a>)
+
+Available overloads:
+ - member TaskBuilderBase.Bind: computation: Async<'TResult1> * continuation: ('TResult1 -> TaskCode<'TOverall,'TResult2>) -> TaskCode<'TOverall,'TResult2> // Argument 'computation' doesn't match
+ - member TaskBuilderBase.Bind: task: System.Threading.Tasks.Task<'TResult1> * continuation: ('TResult1 -> TaskCode<'TOverall,'TResult2>) -> TaskCode<'TOverall,'TResult2> // Argument 'task' doesn't match
+ - member TaskBuilderBase.Bind: task: ^TaskLike * continuation: ('TResult1 -> TaskCode<'TOverall,'TResult2>) -> TaskCode<'TOverall,'TResult2> when ^TaskLike: (member GetAwaiter: unit -> ^Awaiter) and ^Awaiter :> System.Runtime.CompilerServices.ICriticalNotifyCompletion and ^Awaiter: (member get_IsCompleted: unit -> bool) and ^Awaiter: (member GetResult: unit -> 'TResult1) // Argument 'task' doesn't match")
+        ]
+        
+    [<Fact>]
+    let ``Better CE error range 3`` () =
+        Fsx """
+let test = task {
+    return! 1
+}
+        """
+        |> compile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 41, Line 3, Col 13, Line 3, Col 14, "No overloads match for method 'ReturnFrom'.
+
+Known type of argument: int
+
+Available overloads:
+ - member TaskBuilderBase.ReturnFrom: computation: Async<'T> -> TaskCode<'T,'T> // Argument 'computation' doesn't match
+ - member TaskBuilderBase.ReturnFrom: task: System.Threading.Tasks.Task<'T> -> TaskCode<'T,'T> // Argument 'task' doesn't match
+ - member TaskBuilderBase.ReturnFrom: task: ^TaskLike -> TaskCode<'T,'T> when ^TaskLike: (member GetAwaiter: unit -> ^Awaiter) and ^Awaiter :> System.Runtime.CompilerServices.ICriticalNotifyCompletion and ^Awaiter: (member get_IsCompleted: unit -> bool) and ^Awaiter: (member GetResult: unit -> 'T) // Argument 'task' doesn't match")
+        ]

--- a/tests/fsharp/core/auto-widen/5.0/test.bsl
+++ b/tests/fsharp/core/auto-widen/5.0/test.bsl
@@ -149,7 +149,7 @@ test.fsx(69,26,69,29): typecheck error FS0001: This expression was expected to h
 but here has type
     'int'    
 
-test.fsx(93,13,93,20): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(93,18,93,19): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: int
 
@@ -170,7 +170,7 @@ test.fsx(116,20,116,21): typecheck error FS0001: This expression was expected to
 but here has type
     'int'    
 
-test.fsx(121,14,121,21): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(121,19,121,20): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: int
 
@@ -188,7 +188,7 @@ test.fsx(122,22,122,23): typecheck error FS0001: This expression was expected to
 but here has type
     'int'    
 
-test.fsx(127,14,127,21): typecheck error FS0041: No overloads match for method 'M1'.
+test.fsx(127,19,127,20): typecheck error FS0041: No overloads match for method 'M1'.
 
 Known type of argument: int
 


### PR DESCRIPTION
As part of this PR, I want to get a more accurate range for `NoOverloadsFound.`

Let's see what the CI says :) 

Considering make it consistent how this same scenario is reported in C# 

<img width="414" alt="Screenshot 2023-08-26 095235" src="https://github.com/dotnet/fsharp/assets/31915729/24fbf218-0140-41e7-a3b0-9378ed788f42">

Currently, for F# 5, we show the complete range

<img width="445" alt="Screenshot 2023-08-26 095659" src="https://github.com/dotnet/fsharp/assets/31915729/b108bfaa-301d-4409-a658-6b069fbb9ad9">


