### PR TITLE
Fix regression for FS0725

### DIFF
--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -603,7 +603,7 @@ and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (m
         | SynArgPats.Pats args ->
             if warnOnUnionWithNoData then
                 match args with
-                | [ SynPat.Wild m ] | [ SynPat.Named(range = m) ] when argNames.IsEmpty  ->
+                | [ SynPat.Wild _ ] | [ SynPat.Named _ ] when argNames.IsEmpty  ->
                     // Here we only care about the cases where the user has written:
                     // | Case _ -> ...
                     // | Case name -> ...

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -595,18 +595,25 @@ and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (m
 
     let mkf, argTys, argNames = ApplyUnionCaseOrExn m cenv env ty item
     let numArgTys = argTys.Length
+    let warnOnUnionWithNoData =
+        g.langVersion.SupportsFeature(LanguageFeature.MatchNotAllowedForUnionCaseWithNoData)
 
     let args, extraPatternsFromNames =
         match args with
         | SynArgPats.Pats args ->
-            if g.langVersion.SupportsFeature(LanguageFeature.MatchNotAllowedForUnionCaseWithNoData) then
+            if warnOnUnionWithNoData then
                 match args with
-                | [ SynPat.Wild _ ] | [ SynPat.Named _ ] when argNames.IsEmpty  ->
+                | [ SynPat.Wild m ] | [ SynPat.Named(range = m) ] when argNames.IsEmpty  ->
+                    // Here we only care about the cases where the user has written:
+                    // | Case _ -> ...
+                    // | Case name -> ...
+                    // let myDiscardedArgFunc(Case _) = ..."""
+                    // let myDiscardedArgFunc(Case name) = ..."""
+                    // This needs to be a waring because it was a valid pattern in version 7.0 and earlier and we don't want to break existing code.
+                    // The rest of the cases will still be reported as FS0725
                     warning(Error(FSComp.SR.matchNotAllowedForUnionCaseWithNoData(), m))
-                    args, []
-                | _ -> args, []
-            else
-                args, []
+                | _ -> ()
+            args, []
         | SynArgPats.NamePatPairs (pairs, m, _) ->
             // rewrite patterns from the form (name-N = pat-N; ...) to (..._, pat-N, _...)
             // so type T = Case of name: int * value: int
@@ -664,12 +671,11 @@ and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (m
         | [SynPatErrorSkip(SynPat.Wild _ as e) | SynPatErrorSkip(SynPat.Paren(SynPatErrorSkip(SynPat.Wild _ as e), _))] -> List.replicate numArgTys e, []
 
         | args when numArgTys = 0 ->
-            if g.langVersion.SupportsFeature(LanguageFeature.MatchNotAllowedForUnionCaseWithNoData) then
-                [], args
-            else
+            match args with
+            | [ SynPat.Named _ ] when warnOnUnionWithNoData -> [], args
+            | _ -> 
                 errorR (Error (FSComp.SR.tcUnionCaseDoesNotTakeArguments (), m))
                 [], args
-
         | arg :: rest when numArgTys = 1 ->
             if numArgTys = 1 && not (List.isEmpty rest) then
                 errorR (Error (FSComp.SR.tcUnionCaseRequiresOneArgument (), m))

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -603,12 +603,10 @@ and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (m
         | SynArgPats.Pats args ->
             if warnOnUnionWithNoData then
                 match args with
-                | [ SynPat.Wild _ ] | [ SynPat.Named _ ] when argNames.IsEmpty  ->
-                    // Here we only care about the cases where the user has written:
+                | [ SynPat.Wild _ ] when argNames.IsEmpty  ->
+                    // Here we only care about the cases where the user has written the wildcard pattern explicitly
                     // | Case _ -> ...
-                    // | Case name -> ...
                     // let myDiscardedArgFunc(Case _) = ..."""
-                    // let myDiscardedArgFunc(Case name) = ..."""
                     // This needs to be a waring because it was a valid pattern in version 7.0 and earlier and we don't want to break existing code.
                     // The rest of the cases will still be reported as FS0725
                     warning(Error(FSComp.SR.matchNotAllowedForUnionCaseWithNoData(), m))
@@ -671,11 +669,8 @@ and TcPatLongIdentUnionCaseOrExnCase warnOnUpper cenv env ad vFlags patEnv ty (m
         | [SynPatErrorSkip(SynPat.Wild _ as e) | SynPatErrorSkip(SynPat.Paren(SynPatErrorSkip(SynPat.Wild _ as e), _))] -> List.replicate numArgTys e, []
 
         | args when numArgTys = 0 ->
-            match args with
-            | [ SynPat.Named _ ] when warnOnUnionWithNoData -> [], args
-            | _ -> 
-                errorR (Error (FSComp.SR.tcUnionCaseDoesNotTakeArguments (), m))
-                [], args
+            errorR (Error (FSComp.SR.tcUnionCaseDoesNotTakeArguments (), m))
+            [], args
         | arg :: rest when numArgTys = 1 ->
             if numArgTys = 1 && not (List.isEmpty rest) then
                 errorR (Error (FSComp.SR.tcUnionCaseRequiresOneArgument (), m))

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/E_UnionCaseTakesNoArguments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/E_UnionCaseTakesNoArguments.fs
@@ -1,0 +1,59 @@
+type A = { X: int }
+
+type B = | B of int
+
+type C = | C
+
+match None with
+| None 1 -> ()
+
+match None with
+| None (1, 2) -> ()
+
+match None with
+| None [] -> ()
+
+match None with
+| None [||] -> ()
+
+match None with
+| None { X = 1 } -> ()
+
+match None with
+| None (B 1) -> ()
+
+match None with
+| None (x, y) -> ()
+
+match None with
+| None false -> ()
+
+match None with
+| None _ -> () // Wildcard pattern raises a warning in F# 8.0
+
+match None with
+| None x -> ()
+
+match None with
+| None (x, y) -> ()
+| Some _ -> ()
+
+match None with
+| None x y -> ()
+| Some _ -> ()
+
+let c = C
+
+match c with
+| C _ _ -> ()
+
+match c with
+| C __ -> ()
+
+let myDiscardedArgFunc(C _) = () // Wildcard pattern raises a warning in F# 8.0
+
+let myDiscardedArgFunc2(C c) = ()
+
+let myDiscardedArgFunc3(C __) = 5+5
+
+let myDiscardedArgFunc(None x y) = None

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnionCasePatternMatchingErrors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnionCasePatternMatchingErrors.fs
@@ -85,7 +85,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 9, Col 9, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 9, Col 7, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
  
 [<Fact>]
 let ``Union Pattern discard allowed for union case that takes no data with Lang version 7`` () =
@@ -131,7 +131,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 9, Col 9, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 9, Col 7, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
     
 [<Fact>]
 let ``Pattern discard not allowed for union case that takes no data with Lang preview`` () =
@@ -152,7 +152,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 12, Col 9, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 12, Col 7, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
 
 [<Fact>]
 let ``Pattern function discard not allowed for union case that takes no data with Lang preview`` () =
@@ -173,7 +173,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 12, Col 9, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 12, Col 7, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
     
 [<Fact>]
 let ``Pattern discard allowed for union case that takes no data with Lang version 7`` () =
@@ -214,7 +214,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 12, Col 9, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 12, Col 7, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
 
 [<Fact>]
 let ``Multiple pattern discards not allowed for union case that takes no data with Lang preview`` () =
@@ -240,8 +240,8 @@ let myVal =
     |> typecheck
     |> shouldFail
     |> withDiagnostics [
-        (Warning 3548, Line 16, Col 9, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 17, Col 22, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 16, Col 7, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 17, Col 20, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
     ]
     
 [<Fact>]
@@ -268,8 +268,8 @@ let myVal =
     |> typecheck
     |> shouldFail
     |> withDiagnostics [
-        (Warning 3548, Line 16, Col 9, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 17, Col 22, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 16, Col 7, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 17, Col 20, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
     ]
     
 [<Fact>]
@@ -284,6 +284,30 @@ let myDiscardedArgFunc(A _) = 5+5"""
     |> shouldSucceed
     
 [<Fact>]
+let ``Pattern discard 2 allowed for single-case unions when using them as a deconstruct syntax in functions  with Lang 7`` () =
+     FSharp """
+module Tests
+type MyWrapper = A
+
+let myDiscardedArgFunc(A __) = 5+5"""
+    |> withLangVersion70
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 5, Col 24, Line 5, Col 28, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern discard 2 allowed for single-case unions when using them as a deconstruct syntax in functions  with Lang preview`` () =
+     FSharp """
+module Tests
+type MyWrapper = A
+
+let myDiscardedArgFunc(A __) = 5+5"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Warning 3548, Line 5, Col 24, Line 5, Col 28, "Pattern discard is not allowed for union case that takes no data.")
+   
+[<Fact>]
 let ``Pattern discard not allowed for single-case unions when using them as a deconstruct syntax in functions  with Lang preview`` () =
      FSharp """
 module Tests
@@ -293,7 +317,7 @@ let myDiscardedArgFunc(A _) = 5+5"""
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 5, Col 26, Line 5, Col 27, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 5, Col 24, Line 5, Col 27, "Pattern discard is not allowed for union case that takes no data.")
 
 [<Fact>]
 let ``Pattern named not allowed for single-case unions when using them as a deconstruct syntax in functions  with Lang 7`` () =
@@ -317,7 +341,7 @@ let myFunc(A a) = 5+5"""
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 5, Col 14, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 5, Col 12, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
     
 [<Fact>]
 let ``Pattern named not allowed for unions cases with no data and using them as a deconstruct syntax in functions Lang 7`` () =
@@ -366,9 +390,35 @@ let myDiscardedArgFunc(A _) = 5+5"""
     |> typecheck
     |> shouldFail
     |> withDiagnostics [
-        (Warning 3548, Line 5, Col 14, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 6, Col 26, Line 6, Col 27, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 5, Col 12, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 6, Col 24, Line 6, Col 27, "Pattern discard is not allowed for union case that takes no data.")
     ]
+    
+[<Fact>]
+let ``Pattern discard not allowed union case does not take discarded 2 arguments with Lang 7`` () =
+     FSharp """
+module Tests
+    type A = | A
+    let a = A
+    match a with
+    | A __ -> ()"""
+    |> withLangVersion70
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 6, Col 7, Line 6, Col 11, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern discard not allowed union case does not take discarded 2 arguments with Lang preview`` () =
+     FSharp """
+module Tests
+    type A = | A
+    let a = A
+    match a with
+    | A __ -> ()"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Warning 3548, Line 6, Col 7, Line 6, Col 11, "Pattern discard is not allowed for union case that takes no data.")
     
 [<Fact>]
 let ``Pattern discard not allowed union case does not take discarded arguments with Lang 7`` () =
@@ -558,8 +608,8 @@ module Tests
         (Error 725, Line 21, Col 7, Line 21, Col 17, "This union case does not take arguments")
         (Error 725, Line 24, Col 7, Line 24, Col 18, "This union case does not take arguments")
         (Error 725, Line 27, Col 7, Line 27, Col 17, "This union case does not take arguments")
-        (Warning 3548, Line 30, Col 12, Line 30, Col 13, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 34, Col 30, Line 34, Col 31, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 36, Col 31, Line 36, Col 32, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 39, Col 12, Line 39, Col 13, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 30, Col 7, Line 30, Col 13, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 34, Col 28, Line 34, Col 31, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 36, Col 29, Line 36, Col 32, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 39, Col 7, Line 39, Col 13, "Pattern discard is not allowed for union case that takes no data.")
     ]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnionCasePatternMatchingErrors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnionCasePatternMatchingErrors.fs
@@ -482,6 +482,9 @@ module Tests
     let myDiscardedArgFunc(C _) = ()
     
     let myDiscardedArgFunc2(C c) = ()
+    
+    match None with
+    | None x -> ()
     """
     |> withLangVersion70
     |> withOptions ["--nowarn:25"]
@@ -497,6 +500,7 @@ module Tests
         (Error 725, Line 24, Col 7, Line 24, Col 18, "This union case does not take arguments")
         (Error 725, Line 27, Col 7, Line 27, Col 17, "This union case does not take arguments")
         (Error 725, Line 36, Col 29, Line 36, Col 32, "This union case does not take arguments")
+        (Error 725, Line 39, Col 7, Line 39, Col 13, "This union case does not take arguments")
     ]
     
 [<Fact>]
@@ -537,6 +541,9 @@ module Tests
     let myDiscardedArgFunc(C _) = ()
     
     let myDiscardedArgFunc2(C c) = ()
+
+    match None with
+    | None x -> ()
     """
     |> withLangVersionPreview
     |> withOptions ["--nowarn:25"]
@@ -554,4 +561,5 @@ module Tests
         (Warning 3548, Line 30, Col 12, Line 30, Col 13, "Pattern discard is not allowed for union case that takes no data.")
         (Warning 3548, Line 34, Col 30, Line 34, Col 31, "Pattern discard is not allowed for union case that takes no data.")
         (Warning 3548, Line 36, Col 31, Line 36, Col 32, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 39, Col 12, Line 39, Col 13, "Pattern discard is not allowed for union case that takes no data.")
     ]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnionCasePatternMatchingErrors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UnionCasePatternMatchingErrors.fs
@@ -85,9 +85,8 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 9, Col 7, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
-    
-      
+    |> withSingleDiagnostic (Warning 3548, Line 9, Col 9, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+ 
 [<Fact>]
 let ``Union Pattern discard allowed for union case that takes no data with Lang version 7`` () =
      FSharp """
@@ -132,7 +131,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 9, Col 7, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 9, Col 9, Line 9, Col 10, "Pattern discard is not allowed for union case that takes no data.")
     
 [<Fact>]
 let ``Pattern discard not allowed for union case that takes no data with Lang preview`` () =
@@ -153,7 +152,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 12, Col 7, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 12, Col 9, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
 
 [<Fact>]
 let ``Pattern function discard not allowed for union case that takes no data with Lang preview`` () =
@@ -174,7 +173,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 12, Col 7, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 12, Col 9, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
     
 [<Fact>]
 let ``Pattern discard allowed for union case that takes no data with Lang version 7`` () =
@@ -215,7 +214,7 @@ let myVal =
     |> withLangVersionPreview
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3548, Line 12, Col 7, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+    |> withSingleDiagnostic (Warning 3548, Line 12, Col 9, Line 12, Col 10, "Pattern discard is not allowed for union case that takes no data.")
 
 [<Fact>]
 let ``Multiple pattern discards not allowed for union case that takes no data with Lang preview`` () =
@@ -241,8 +240,8 @@ let myVal =
     |> typecheck
     |> shouldFail
     |> withDiagnostics [
-        (Warning 3548, Line 16, Col 7, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 17, Col 20, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 16, Col 9, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 17, Col 22, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
     ]
     
 [<Fact>]
@@ -269,8 +268,8 @@ let myVal =
     |> typecheck
     |> shouldFail
     |> withDiagnostics [
-        (Warning 3548, Line 16, Col 7, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 17, Col 20, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 16, Col 9, Line 16, Col 10, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 17, Col 22, Line 17, Col 23, "Pattern discard is not allowed for union case that takes no data.")
     ]
     
 [<Fact>]
@@ -283,6 +282,18 @@ let myDiscardedArgFunc(A _) = 5+5"""
     |> withLangVersion70
     |> typecheck
     |> shouldSucceed
+    
+[<Fact>]
+let ``Pattern discard not allowed for single-case unions when using them as a deconstruct syntax in functions  with Lang preview`` () =
+     FSharp """
+module Tests
+type MyWrapper = A
+
+let myDiscardedArgFunc(A _) = 5+5"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Warning 3548, Line 5, Col 26, Line 5, Col 27, "Pattern discard is not allowed for union case that takes no data.")
 
 [<Fact>]
 let ``Pattern named not allowed for single-case unions when using them as a deconstruct syntax in functions  with Lang 7`` () =
@@ -294,9 +305,54 @@ let myFunc(A a) = 5+5"""
     |> withLangVersion70
     |> typecheck
     |> shouldFail
-    |> withDiagnostics [
-        (Error 725, Line 5, Col 12, Line 5, Col 15, "This union case does not take arguments")
-    ]
+    |> withSingleDiagnostic (Error 725, Line 5, Col 12, Line 5, Col 15, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern named not allowed for single-case unions when using them as a deconstruct syntax in functions with Lang preview`` () =
+     FSharp """
+module Tests
+type MyWrapper = A
+
+let myFunc(A a) = 5+5"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Warning 3548, Line 5, Col 14, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
+    
+[<Fact>]
+let ``Pattern named not allowed for unions cases with no data and using them as a deconstruct syntax in functions Lang 7`` () =
+     FSharp """
+module Tests
+    let myDiscardedArgFunc(None x y) = None"""
+    |> withLangVersion70
+    |> withOptions ["--nowarn:25"]
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 3, Col 28, Line 3, Col 36, "This union case does not take arguments")
+
+[<Fact>]
+let ``Pattern named not allowed for unions cases with no data and using them as a deconstruct syntax in functions Lang preview`` () =
+     FSharp """
+module Tests
+    let myDiscardedArgFunc(None x y) = None"""
+    |> withLangVersionPreview
+    |> withOptions ["--nowarn:25"]
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 3, Col 28, Line 3, Col 36, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern discard or named are not allowed for single-case union case that takes no data with Lang 7`` () =
+     FSharp """
+module Tests
+type MyWrapper = A
+
+let myFunc(A a) = 5+5
+let myDiscardedArgFunc(A _) = 5+5"""
+    |> withLangVersion70
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 5, Col 12, Line 5, Col 15, "This union case does not take arguments")
 
 [<Fact>]
 let ``Pattern discard or named are not allowed for single-case union case that takes no data with Lang preview`` () =
@@ -310,6 +366,192 @@ let myDiscardedArgFunc(A _) = 5+5"""
     |> typecheck
     |> shouldFail
     |> withDiagnostics [
-        (Warning 3548, Line 5, Col 12, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
-        (Warning 3548, Line 6, Col 24, Line 6, Col 27, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 5, Col 14, Line 5, Col 15, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 6, Col 26, Line 6, Col 27, "Pattern discard is not allowed for union case that takes no data.")
+    ]
+    
+[<Fact>]
+let ``Pattern discard not allowed union case does not take discarded arguments with Lang 7`` () =
+     FSharp """
+module Tests
+    type A = | A
+    let a = A
+    match a with
+    | A _ _ -> ()"""
+    |> withLangVersion70
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 6, Col 7, Line 6, Col 12, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern discard not allowed union case does not take discarded arguments with Lang preview`` () =
+     FSharp """
+module Tests
+    type A = | A
+    let a = A
+    match a with
+    | A _ _ -> ()"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 6, Col 7, Line 6, Col 12, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern named not allowed union case does not take arguments with Lang 7`` () =
+     FSharp """
+module Tests
+    match None with
+    | None x y -> ()
+    | Some _ -> ()"""
+    |> withLangVersion70
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 4, Col 7, Line 4, Col 15, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern named not allowed union case does not take arguments with Lang preview`` () =
+     FSharp """
+module Tests
+    match None with
+    | None x y -> ()
+    | Some _ -> ()"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 4, Col 7, Line 4, Col 15, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern named not allowed union case does not take arguments wrapped with parens with Lang preview`` () =
+     FSharp """
+module Tests
+    match None with
+    | None (x, y) -> ()
+    | Some _ -> ()"""
+    |> withLangVersionPreview
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 4, Col 7, Line 4, Col 18, "This union case does not take arguments")
+    
+[<Fact>]
+let ``Pattern named not allowed union case does not take arguments wrapped with parens with Lang 7`` () =
+     FSharp """
+module Tests
+    match None with
+    | None (x, y) -> ()
+    | Some _ -> ()"""
+    |> withLangVersion70
+    |> typecheck
+    |> shouldFail
+    |> withSingleDiagnostic (Error 725, Line 4, Col 7, Line 4, Col 18, "This union case does not take arguments")
+
+[<Fact>]
+let ``Pattern named not allowed union case does not take any arguments with Lang 7`` () =
+     FSharp """
+module Tests
+    type A = { X: int }
+    type B = B of int
+    match None with
+    | None 1 -> ()
+    
+    match None with
+    | None (1, 2) -> ()
+    
+    match None with
+    | None [] -> ()
+    
+    match None with
+    | None [||] -> ()
+    
+    match None with
+    | None { X = 1 } -> ()
+    
+    match None with
+    | None (B 1) -> ()
+    
+    match None with
+    | None (x, y) -> ()
+    
+    match None with
+    | None false -> ()
+    
+    match None with
+    | None _ -> ()
+    
+    type C = | C
+    
+    let myDiscardedArgFunc(C _) = ()
+    
+    let myDiscardedArgFunc2(C c) = ()
+    """
+    |> withLangVersion70
+    |> withOptions ["--nowarn:25"]
+    |> typecheck
+    |> shouldFail
+    |> withDiagnostics [
+        (Error 725, Line 6, Col 7, Line 6, Col 13, "This union case does not take arguments")
+        (Error 725, Line 9, Col 7, Line 9, Col 18, "This union case does not take arguments")
+        (Error 725, Line 12, Col 7, Line 12, Col 14, "This union case does not take arguments")
+        (Error 725, Line 15, Col 7, Line 15, Col 16, "This union case does not take arguments")
+        (Error 725, Line 18, Col 7, Line 18, Col 21, "This union case does not take arguments")
+        (Error 725, Line 21, Col 7, Line 21, Col 17, "This union case does not take arguments")
+        (Error 725, Line 24, Col 7, Line 24, Col 18, "This union case does not take arguments")
+        (Error 725, Line 27, Col 7, Line 27, Col 17, "This union case does not take arguments")
+        (Error 725, Line 36, Col 29, Line 36, Col 32, "This union case does not take arguments")
+    ]
+    
+[<Fact>]
+let ``Pattern named not allowed union case does not take any arguments with Lang preview`` () =
+     FSharp """
+module Tests
+    type A = { X: int }
+    type B = | B of int
+    match None with
+    | None 1 -> ()
+    
+    match None with
+    | None (1, 2) -> ()
+    
+    match None with
+    | None [] -> ()
+    
+    match None with
+    | None [||] -> ()
+    
+    match None with
+    | None { X = 1 } -> ()
+    
+    match None with
+    | None (B 1) -> ()
+    
+    match None with
+    | None (x, y) -> ()
+    
+    match None with
+    | None false -> ()
+    
+    match None with
+    | None _ -> ()
+    
+    type C = | C
+    
+    let myDiscardedArgFunc(C _) = ()
+    
+    let myDiscardedArgFunc2(C c) = ()
+    """
+    |> withLangVersionPreview
+    |> withOptions ["--nowarn:25"]
+    |> typecheck
+    |> shouldFail
+    |> withDiagnostics [
+        (Error 725, Line 6, Col 7, Line 6, Col 13, "This union case does not take arguments")
+        (Error 725, Line 9, Col 7, Line 9, Col 18, "This union case does not take arguments")
+        (Error 725, Line 12, Col 7, Line 12, Col 14, "This union case does not take arguments")
+        (Error 725, Line 15, Col 7, Line 15, Col 16, "This union case does not take arguments")
+        (Error 725, Line 18, Col 7, Line 18, Col 21, "This union case does not take arguments")
+        (Error 725, Line 21, Col 7, Line 21, Col 17, "This union case does not take arguments")
+        (Error 725, Line 24, Col 7, Line 24, Col 18, "This union case does not take arguments")
+        (Error 725, Line 27, Col 7, Line 27, Col 17, "This union case does not take arguments")
+        (Warning 3548, Line 30, Col 12, Line 30, Col 13, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 34, Col 30, Line 34, Col 31, "Pattern discard is not allowed for union case that takes no data.")
+        (Warning 3548, Line 36, Col 31, Line 36, Col 32, "Pattern discard is not allowed for union case that takes no data.")
     ]


### PR DESCRIPTION
As discovered by [failing test]( https://github.com/fsharp/FsAutoComplete/pull/1153#issuecomment-1693079092 )  on `FsAutoComplete` in F# 8 we no longer show `FS0725` in cases where it is supposed to.


```fsharp

module Tests
    type A = { X: int }
    type B = B of int
    match None with
    | None 1 -> ()  // FS0725
    
    match None with
    | None (1, 2) -> () // FS0725
    
    match None with
    | None [] -> () // FS0725
    
    match None with
    | None [||] -> () // FS0725
    
    match None with
    | None { X = 1 } -> () // FS0725
    
    match None with
    | None (B 1) -> ()   // FS0725
    
    match None with
    | None (x, y) -> ()  // FS0725
    
    match None with
    | None false -> ()  // FS0725

    match None with
    | None x -> ()  //FS0725
    
    match None with
    | None _ -> ()  // F#7 this compiles. In F#8 this shows FS3548
    
    type C = | C
    
    let myDiscardedArgFunc(C _) = ()  // F#7 this compiles. In F#8 this shows FS3548
    
    let myDiscardedArgFunc2(C c) = ()  // FS0725

```

PR that introduced the regression https://github.com/dotnet/fsharp/pull/14055
