### PR TITLE
Fix finding references to CtorGroup

### DIFF
--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -271,7 +271,12 @@ type Item =
         | Item.Property(name = nm) -> nm |> ConvertValLogicalNameToDisplayNameCore
         | Item.MethodGroup(_, FSMeth(_, _, v, _) :: _, _) -> v.DisplayNameCore
         | Item.MethodGroup(nm, _, _) -> nm |> ConvertValLogicalNameToDisplayNameCore
-        | Item.CtorGroup(nm, _) -> nm |> DemangleGenericTypeName 
+        | Item.CtorGroup(nm, ILMeth(_, ilMethInfo, _) :: _) ->
+            match ilMethInfo.ApparentEnclosingType |> tryNiceEntityRefOfTy with
+            | ValueSome tcref -> tcref.DisplayNameCore
+            | _ -> nm
+            |> DemangleGenericTypeName
+        | Item.CtorGroup(nm, _) -> nm |> DemangleGenericTypeName
         | Item.FakeInterfaceCtor ty
         | Item.DelegateCtor ty ->
             match ty with 

--- a/src/Compiler/Service/ItemKey.fs
+++ b/src/Compiler/Service/ItemKey.fs
@@ -415,11 +415,12 @@ and [<Sealed>] ItemKeyStoreBuilder() =
             match info with
             | FSMeth (_, ty, vref, _) when vref.IsConstructor -> writeType true ty
             | FSMeth (_, _, vref, _) -> writeValue vref
-            | ILMeth (_, info, _) ->
-                info.ILMethodRef.ArgTypes |> List.iter writeILType
-                writeILType info.ILMethodRef.ReturnType
-                writeString info.ILName
-                writeType false info.ApparentEnclosingType
+            | ILMeth (_, ilMethInfo, _) when info.IsConstructor -> writeType true ilMethInfo.ApparentEnclosingType
+            | ILMeth (_, ilMethInfo, _) ->
+                ilMethInfo.ILMethodRef.ArgTypes |> List.iter writeILType
+                writeILType ilMethInfo.ILMethodRef.ReturnType
+                writeString ilMethInfo.ILName
+                writeType false ilMethInfo.ApparentEnclosingType
             | _ ->
                 writeString ItemKeyTags.itemValueMember
                 writeEntityRef info.DeclaringTyconRef

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
@@ -152,6 +152,28 @@ let foo x = x ++ 4""" })
             ])
         }
 
+[<Theory>]
+[<InlineData("First")>]
+[<InlineData("Second")>]
+let ``We find disposable constructors`` searchIn =
+    let source1 = "type MyReader = System.IO.StreamReader"
+    let source2 = """open ModuleFirst
+let reader = MyReader "test.txt"
+"""
+    { SyntheticProject.Create(
+        { sourceFile "First" [] with Source = source1 },
+        { sourceFile "Second" [] with Source = source2 })
+        with SkipInitialCheck = true }
+
+        .Workflow {
+            placeCursor searchIn "MyReader"
+            findAllReferences (expectToFind [
+                "FileFirst.fs", 2, 5, 13
+                "FileSecond.fs", 3, 13, 21
+            ])
+        }
+
+
 module Parameters =
 
     [<Fact>]

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -3070,7 +3070,7 @@ let ``Test Project21 all symbols`` () =
             ("unit", "unit", "file1", ((12, 43), (12, 47)), ["type"], ["abbrev"]);
             ("val raise", "raise", "file1", ((13, 18), (13, 23)), [], ["val"]);
             ("System", "System", "file1", ((13, 25), (13, 31)), [], ["namespace"]);
-            ("member .ctor", "``.ctor``", "file1", ((13, 25), (13, 55)), [], ["member"]);
+            ("member .ctor", "NotImplementedException", "file1", ((13, 25), (13, 55)), [], ["member"]);
             ("Impl", "Impl", "file1", ((2, 7), (2, 11)), ["defn"], ["module"])|]
 
 //-----------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #15721

There are two issues
1. writing to `itemKeyStore` where without the `new` it's an `ILMeth` instead of `FSMeth` for some reason and that's written differently. 
2. with "fast find references" because `DisplayNameCore` for it is `".ctor"` instead of the type name.

I tried to fix those, let's see if something else depended on the original behavior...

I couldn't reproduce the "You cannot rename this element" dialogue or the first rename failure after adding `new`. 