### PR TITLE
Process longId for SynTypeDefnKind.Augmentation.

### DIFF
--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -103,7 +103,7 @@ let visitSynUnionCase (SynUnionCase (attributes = attributes; caseType = caseTyp
 let visitSynEnumCase (SynEnumCase (attributes = attributes)) = visitSynAttributes attributes
 
 let visitSynTypeDefn
-    (SynTypeDefn (typeInfo = SynComponentInfo (attributes = attributes; typeParams = typeParams; constraints = constraints)
+    (SynTypeDefn (typeInfo = SynComponentInfo (attributes = attributes; longId = longId; typeParams = typeParams; constraints = constraints)
                   typeRepr = typeRepr
                   members = members))
     : FileContentEntry list =
@@ -130,6 +130,9 @@ let visitSynTypeDefn
             match kind with
             | SynTypeDefnKind.Delegate (signature, _) ->
                 yield! visitSynType signature
+                yield! List.collect visitSynMemberDefn members
+            | SynTypeDefnKind.Augmentation _ ->
+                yield! visitLongIdent longId
                 yield! List.collect visitSynMemberDefn members
             | _ -> yield! List.collect visitSynMemberDefn members
         | SynTypeDefnRepr.Exception _ ->

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -143,7 +143,10 @@ let visitSynTypeDefn
     ]
 
 let visitSynTypeDefnSig
-    (SynTypeDefnSig (typeInfo = SynComponentInfo (attributes = attributes; typeParams = typeParams; constraints = constraints)
+    (SynTypeDefnSig (typeInfo = SynComponentInfo (attributes = attributes
+                                                  longId = longId
+                                                  typeParams = typeParams
+                                                  constraints = constraints)
                      typeRepr = typeRepr
                      members = members))
     =
@@ -162,7 +165,10 @@ let visitSynTypeDefnSig
             | SynTypeDefnSimpleRepr.General _
             | SynTypeDefnSimpleRepr.LibraryOnlyILAssembly _ -> ()
             | SynTypeDefnSimpleRepr.TypeAbbrev (rhsType = rhsType) -> yield! visitSynType rhsType
-            | SynTypeDefnSimpleRepr.None _
+            // This is a type augmentation in a signature file
+            | SynTypeDefnSimpleRepr.None _ ->
+                yield! visitLongIdent longId
+                yield! List.collect visitSynMemberSig members
             // This is only used in the typed tree
             // The parser doesn't construct this
             | SynTypeDefnSimpleRepr.Exception _ -> ()

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -612,4 +612,30 @@ open Foo.Bar.Y // Y.fs
 """
                     (set [| 1 |])
             ]
+        scenario
+            "Identifier in type augmentation can link files"
+            [
+                sourceFile
+                    "PoolingValueTasks.fs"
+                    """
+namespace IcedTasks
+
+module PoolingValueTasks =
+    type PoolingValueTaskBuilderBase() =
+        class
+        end
+"""
+                    Set.empty
+                sourceFile
+                    "ColdTask.fs"
+                    """
+namespace IcedTasks
+
+module ColdTasks =
+    module AsyncExtensions =
+        type PoolingValueTasks.PoolingValueTaskBuilderBase with
+            member this.Source (a:int) = a
+"""
+                    (set [| 0 |])
+            ]
     ]

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -638,4 +638,54 @@ module ColdTasks =
 """
                     (set [| 0 |])
             ]
+        scenario
+            "Identifier in type augmentation in signature file can link files"
+            [
+                sourceFile
+                    "PoolingValueTasks.fsi"
+                    """
+namespace IcedTasks
+
+module PoolingValueTasks =
+    type PoolingValueTaskBuilderBase =
+        class
+            new: unit -> PoolingValueTaskBuilderBase
+        end
+"""
+                    Set.empty
+                sourceFile
+                    "PoolingValueTasks.fs"
+                    """
+namespace IcedTasks
+
+module PoolingValueTasks =
+    type PoolingValueTaskBuilderBase() =
+        class
+        end
+"""
+                    (set [| 0 |])
+                sourceFile
+                    "ColdTask.fsi"
+                    """
+namespace IcedTasks
+
+module ColdTasks =
+    module AsyncExtensions =
+        type PoolingValueTasks.PoolingValueTaskBuilderBase with
+
+            member Source: a: int -> int
+"""
+                    (set [| 0 |])
+                sourceFile
+                    "ColdTask.fs"
+                    """
+namespace IcedTasks
+
+module ColdTasks =
+    module AsyncExtensions =
+        type PoolingValueTasks.PoolingValueTaskBuilderBase with
+            member this.Source (a:int) = a
+"""
+                    (set [| 0; 2 |])
+            ]
     ]


### PR DESCRIPTION
> In the code's embrace, types intertwine,
Augmenting forms, a dance so fine.
Processing identifiers, a coder's art,
New dimensions unfold, a work of heart.

A problem with `--test:GraphBasedChecking` was found by @TheAngryByrd in https://github.com/TheAngryByrd/IcedTasks/tree/graph-based-playground-1

A link between files was not detected for type extensions. Thus this leads to a consistent compiler error.

The fix of this PR was in the untyped AST processing we do to detect links between the identifiers found in a file and the project Trie. This wasn't overly complicated to fix and I'd like to write down what my methodology was.

First up, I cloned the branch and scrapped the compiler arguments for the project that was failing.
I used [telplin](https://github.com/nojaf/telplin) for this, but I could have used the [scrape.fsx](https://github.com/dotnet/fsharp/blob/main/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/scrape.fsx) file. In both cases, a build of the project happens and the `binlog` is processed to extract the compiler arguments of `CoreCompile`. (Yes, a design-time build would be the more clever thing to do, but let's not get carried away).

Having the compiler arguments or response file (`*.rsp`) can be used to debug the actual project in 
https://github.com/dotnet/fsharp/blob/97a5b6584b54707e3e8541fe758e1aa22132a8fe/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/CompilationFromCmdlineArgsTests.fs#L55-L58
Running that sufficed, as it was clear that the problem still existed on the main branch.

The compiler error was pretty clear that a type was not known during the checking of a type extension.
So, I extracted a sample from the real project into a scenario:

```fsharp
scenario
            "Identifier in type augmentation can link files"
            [
                sourceFile
                    "PoolingValueTasks.fs"
                    """
namespace IcedTasks
module PoolingValueTasks =
    type PoolingValueTaskBuilderBase() =
        class
        end
"""
                    Set.empty
                sourceFile
                    "ColdTask.fs"
                    """
namespace IcedTasks
module ColdTasks =
    module AsyncExtensions =
        type PoolingValueTasks.PoolingValueTaskBuilderBase with
            member this.Source (a:int) = a
"""
                    (set [| 0 |])
            ]
```

Mimicking the problem, this was a lot easier to debug of course to see what was happening in `FileContentMapping.fs`.

Both `tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/DependencyResolutionTests.fs` and `/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/CompilationTests.fs` were failing for the newly added scenario.

It soon became obvious that `PoolingValueTasks.PoolingValueTaskBuilderBase` should be processed as well because the combined link `IceTasks.PoolingValueTasks.PoolingValueTaskBuilderBase` does link a module in the Trie and thus introduces the link between the files.

Afterwards, I added another test for signature files. There the AST is surprisingly different for type extensions compared to implementation files. I'm not sure if that is by design or a bit of a gap.

Anyway, this is ready for review.