### PR TITLE
Fix finding internal symbols in internals-visible-to projects

### DIFF
--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -408,7 +408,7 @@ type BoundModel private (
 
     member this.TryPeekTcInfo() = this.TcInfo.TryPeekValue() |> ValueOption.toOption
     
-    member this.TryPeekTcInfoWithExtras() = 
+    member this.TryPeekTcInfoWithExtras() =
         (this.TcInfo.TryPeekValue(), this.TcInfoExtras.TryPeekValue())
         ||> ValueOption.map2 (fun a b -> a, b)
         |> ValueOption.toOption

--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -408,7 +408,7 @@ type BoundModel private (
 
     member this.TryPeekTcInfo() = this.TcInfo.TryPeekValue() |> ValueOption.toOption
     
-    member this.TryPeekTcInfoWithExtras() =
+    member this.TryPeekTcInfoWithExtras() = 
         (this.TcInfo.TryPeekValue(), this.TcInfoExtras.TryPeekValue())
         ||> ValueOption.map2 (fun a b -> a, b)
         |> ValueOption.toOption

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/FindReferences.fs
@@ -129,11 +129,13 @@ let ``Find references to internal symbols in other projects`` () =
     let library = {
         SyntheticProject.Create("Library",
             { sourceFile "Library" [] with Source = """
-module internal Lib.Library
-let foo x = x + 5
+namespace Lib
 
-[<assembly: System.Runtime.CompilerServices.InternalsVisibleTo("App")>]
-do ()""" })
+module internal Library =
+    let foo x = x + 5
+
+[<assembly: System.Runtime.CompilerServices.InternalsVisibleTo("FileFirst")>]
+do ()    """ })
             with AutoAddModules = false }
 
     let project =
@@ -147,7 +149,7 @@ let bar x = Library.foo x""" })
         placeCursor "Library" "foo"
         findAllReferences (expectToFind [
             "FileFirst.fs", 4, 12, 23
-            "FileLibrary.fs", 3, 4, 7
+            "FileLibrary.fs", 5, 8, 11
         ])
     }
 

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -441,6 +441,9 @@ let private renderFsProj (p: SyntheticProject) =
             let version = reference.Version |> Option.map (fun v -> $" Version=\"{v}\"") |> Option.defaultValue ""
             $"<PackageReference Include=\"{reference.Name}\"{version}/>"
 
+        for project in p.DependsOn do
+            $"<ProjectReference Include=\"{project.ProjectFileName}\" />"
+
         for f in p.SourceFiles do
             if f.HasSignatureFile then
                 $"<Compile Include=\"{f.SignatureFileName}\" />"
@@ -1019,10 +1022,10 @@ type ProjectWorkflowBuilder
 
     member this.FindSymbolUse(ctx: WorkflowContext, fileId, symbolName: string) =
         async {
-            let file = ctx.Project.Find fileId
-            let fileName = ctx.Project.ProjectDir ++ file.FileName
-            let source = renderSourceFile ctx.Project file
-            let options= ctx.Project.GetProjectOptions checker
+            let project, file = ctx.Project.FindInAllProjects fileId
+            let fileName = project.ProjectDir ++ file.FileName
+            let source = renderSourceFile project file
+            let options= project.GetProjectOptions checker
             return! getSymbolUse fileName source symbolName options checker
         }
 
@@ -1072,7 +1075,6 @@ type ProjectWorkflowBuilder
     member this.FindAllReferences(workflow: Async<WorkflowContext>, processResults) =
         async {
             let! ctx = workflow
-            let options = ctx.Project.GetProjectOptions checker
 
             let symbolUse =
                 ctx.Cursor
@@ -1080,8 +1082,10 @@ type ProjectWorkflowBuilder
                     failwith $"Please place cursor at a valid location via placeCursor first")
 
             let! results =
-                [ for f in options.SourceFiles do
-                      checker.FindBackgroundReferencesInFile(f, options, symbolUse.Symbol, fastCheck = true) ]
+                [ for p, f in ctx.Project.GetAllFiles() do
+                    let options = p.GetProjectOptions checker
+                    let fileName = getFilePath p f
+                    checker.FindBackgroundReferencesInFile(fileName, options, symbolUse.Symbol, fastCheck = true) ]
                 |> Async.Parallel
 
             results |> Seq.collect id |> Seq.toList |> processResults

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -1084,8 +1084,8 @@ type ProjectWorkflowBuilder
             let! results =
                 [ for p, f in ctx.Project.GetAllFiles() do
                     let options = p.GetProjectOptions checker
-                    let fileName = getFilePath p f
-                    checker.FindBackgroundReferencesInFile(fileName, options, symbolUse.Symbol, fastCheck = true) ]
+                    for fileName in [getFilePath p f; if f.SignatureFile <> No then getSignatureFilePath p f] do
+                        checker.FindBackgroundReferencesInFile(fileName, options, symbolUse.Symbol, fastCheck = true) ]
                 |> Async.Parallel
 
             results |> Seq.collect id |> Seq.toList |> processResults

--- a/vsintegration/src/FSharp.Editor/LanguageService/Symbols.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Symbols.fs
@@ -25,6 +25,7 @@ type FSharpSymbol with
 
     member this.IsInternalToProject =
         let publicOrInternal = this.Accessibility.IsPublic || this.Accessibility.IsInternal
+
         match this with
         | :? FSharpParameter -> true
         | :? FSharpMemberOrFunctionOrValue as m -> not m.IsModuleValueOrMember || not publicOrInternal

--- a/vsintegration/src/FSharp.Editor/LanguageService/Symbols.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/Symbols.fs
@@ -24,13 +24,14 @@ type SymbolUse =
 type FSharpSymbol with
 
     member this.IsInternalToProject =
+        let publicOrInternal = this.Accessibility.IsPublic || this.Accessibility.IsInternal
         match this with
         | :? FSharpParameter -> true
-        | :? FSharpMemberOrFunctionOrValue as m -> not m.IsModuleValueOrMember || not m.Accessibility.IsPublic
-        | :? FSharpEntity as m -> not m.Accessibility.IsPublic
+        | :? FSharpMemberOrFunctionOrValue as m -> not m.IsModuleValueOrMember || not publicOrInternal
+        | :? FSharpEntity -> not publicOrInternal
         | :? FSharpGenericParameter -> true
-        | :? FSharpUnionCase as m -> not m.Accessibility.IsPublic
-        | :? FSharpField as m -> not m.Accessibility.IsPublic
+        | :? FSharpUnionCase -> not publicOrInternal
+        | :? FSharpField -> not publicOrInternal
         | _ -> false
 
 type FSharpSymbolUse with


### PR DESCRIPTION
Fixes #15365

~But so far I didn't figure out how to make a test for it, i.e. how to make `SyntheticProject` work with `InternalsVisibleTo`.~
Now with a working test.