### PR TITLE
Incremental build: catch exception during file checking

### DIFF
--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -391,7 +391,7 @@ type BoundModel private (
                 GraphNode.FromResult tcInfo, tcInfoExtras
             | _ ->
                 // start computing extras, so that typeCheckNode can be GC'd quickly 
-                startComputingFullTypeCheck |> Async.AwaitNodeCode |> Async.Ignore |> Async.Start
+                startComputingFullTypeCheck |> Async.AwaitNodeCode |> Async.Catch |> Async.Ignore |> Async.Start
                 getTcInfo typeCheckNode, tcInfoExtras
 
     member val Diagnostics = diagnostics


### PR DESCRIPTION
Partially fixes https://github.com/dotnet/fsharp/issues/15905. Prevents the crash of the host process. Catches exception happening during a file analysis, preventing the host process crash. With this fix analysis of subsequent files don't work, but this prevents the crash and allows to fix the source code when it's the reason of the initial exception.