### PR TITLE
Diagnostics logger: remove exception rethrow during recovery

### DIFF
--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -131,6 +131,7 @@ type Exception with
         | DiagnosticEnabledWithLanguageFeature (_, _, m, _)
         | SyntaxError (_, m)
         | InternalError (_, m)
+        | InternalException (_, _, m)
         | InterfaceNotRevealed (_, _, m)
         | WrappedError (_, m)
         | PatternMatchCompilation.MatchIncomplete (_, _, m)
@@ -1673,6 +1674,7 @@ type Exception with
             OutputNameSuggestions os suggestNames suggestionF idText
 
         | InternalError (s, _)
+        | InternalException(_, s, _)
         | InvalidArgument s
         | Failure s as exn ->
             ignore exn // use the argument, even in non DEBUG

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -1674,7 +1674,7 @@ type Exception with
             OutputNameSuggestions os suggestNames suggestionF idText
 
         | InternalError (s, _)
-        | InternalException(_, s, _)
+        | InternalException (_, s, _)
         | InvalidArgument s
         | Failure s as exn ->
             ignore exn // use the argument, even in non DEBUG

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -174,7 +174,8 @@ let rec AttachRange m (exn: exn) =
         | :? TargetInvocationException -> AttachRange m exn.InnerException
         | UnresolvedReferenceNoRange a -> UnresolvedReferenceError(a, m)
         | UnresolvedPathReferenceNoRange (a, p) -> UnresolvedPathReference(a, p, m)
-        | _ -> InternalException(exn, exn.Message, m)
+        | :? SystemException -> InternalException(exn, exn.Message, m)
+        | _ -> exn
 
 type Exiter =
     abstract Exit: int -> 'T

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -174,6 +174,7 @@ let rec AttachRange m (exn: exn) =
         | :? TargetInvocationException -> AttachRange m exn.InnerException
         | UnresolvedReferenceNoRange a -> UnresolvedReferenceError(a, m)
         | UnresolvedPathReferenceNoRange (a, p) -> UnresolvedPathReference(a, p, m)
+        | :? NotSupportedException -> exn 
         | :? SystemException -> InternalException(exn, exn.Message, m)
         | _ -> exn
 

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -411,20 +411,6 @@ module DiagnosticsLoggerExtensions =
             Debug.Assert(false, "Could not preserve stack trace for watson exception.")
             ()
 
-    /// Reraise an exception if it is one we want to report to Watson.
-    let ReraiseIfWatsonable (exn: exn) =
-        match exn with
-        // These few SystemExceptions which we don't report to Watson are because we handle these in some way in Build.fs
-        | :? TargetInvocationException -> ()
-        | :? NotSupportedException -> ()
-        | :? System.IO.IOException -> () // This covers FileNotFoundException and DirectoryNotFoundException
-        | :? UnauthorizedAccessException -> ()
-        | Failure _ // This gives reports for compiler INTERNAL ERRORs
-        | :? SystemException ->
-            PreserveStackTrace exn
-            raise exn
-        | _ -> ()
-
     type DiagnosticsLogger with
 
         member x.EmitDiagnostic(exn, severity) =
@@ -473,7 +459,6 @@ module DiagnosticsLoggerExtensions =
             | _ ->
                 try
                     x.ErrorR(AttachRange m exn) // may raise exceptions, e.g. an fsi error sink raises StopProcessing.
-                    ReraiseIfWatsonable exn
                 with
                 | ReportedError _
                 | WrappedError (ReportedError _, _) -> ()

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -88,12 +88,12 @@ exception InternalError of message: string * range: range with
 exception InternalException of exn: Exception * msg: string * range: range with
     override this.Message =
         match this :> exn with
-        | InternalException(_, msg, _) -> msg
+        | InternalException (_, msg, _) -> msg
         | _ -> "impossible"
 
     override this.ToString() =
         match this :> exn with
-        | InternalException(exn, _, _) -> exn.ToString()
+        | InternalException (exn, _, _) -> exn.ToString()
         | _ -> "impossible"
 
 exception UserCompilerMessage of message: string * number: int * range: range

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -174,7 +174,7 @@ let rec AttachRange m (exn: exn) =
         | :? TargetInvocationException -> AttachRange m exn.InnerException
         | UnresolvedReferenceNoRange a -> UnresolvedReferenceError(a, m)
         | UnresolvedPathReferenceNoRange (a, p) -> UnresolvedPathReference(a, p, m)
-        | :? NotSupportedException -> exn 
+        | :? NotSupportedException -> exn
         | :? SystemException -> InternalException(exn, exn.Message, m)
         | _ -> exn
 

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -242,9 +242,6 @@ module DiagnosticsLoggerExtensions =
     /// Instruct the exception not to reset itself when thrown again.
     val PreserveStackTrace: exn: 'T -> unit
 
-    /// Reraise an exception if it is one we want to report to Watson.
-    val ReraiseIfWatsonable: exn: exn -> unit
-
     type DiagnosticsLogger with
 
         /// Report a diagnostic as an error and recover

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -56,6 +56,8 @@ val Error: (int * string) * range -> exn
 
 exception InternalError of message: string * range: range
 
+exception InternalException of exn: Exception * msg: string * range: range
+
 exception UserCompilerMessage of message: string * number: int * range: range
 
 exception LibraryUseOnly of range: range


### PR DESCRIPTION
Partially fixes https://github.com/dotnet/fsharp/issues/15905. Removes rethrowing exceptions in `DiagnosticsLoggerExtensions.ErrorRecovery`, which was making the error recovery non-existent for many exceptions other than `InternalError`. System exceptions like `ArgumentException` or `NullReferenceException` were never recovered because of this call, breaking analysis for the whole file in many cases.

With this change the analysis recovery properly continues but the internal error isn't reported anymore, I'm still looking into it.