### PR TITLE
Parser: fix tree for missing item in top tuple type

### DIFF
--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -663,6 +663,8 @@ module SynInfo =
 
     let emptySynValData = SynValData(None, emptySynValInfo, None, None)
 
+    let emptySynArgInfo = SynArgInfo([], false, None)
+
     /// Infer the syntactic information for a 'let' or 'member' definition, based on the argument pattern,
     /// any declared return information (e.g. .NET attributes on the return element), and the r.h.s. expression
     /// in the case of 'let' definitions.

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
@@ -257,6 +257,8 @@ module SynInfo =
 
     val emptySynValData: SynValData
 
+    val emptySynArgInfo: SynArgInfo
+
     /// Infer the syntactic information for a 'let' or 'member' definition, based on the argument pattern,
     /// any declared return information (e.g. .NET attributes on the return element), and the r.h.s. expression
     /// in the case of 'let' definitions.

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5690,7 +5690,7 @@ topTupleType:
        let mStar = rhs parseState 2
        let ty2 = SynType.FromParseError(mStar.EndRange)
        let path = [SynTupleTypeSegment.Type ty1; SynTupleTypeSegment.Star mStar; SynTupleTypeSegment.Type ty2]
-       mkSynTypeTuple path, [argInfo] }
+       mkSynTypeTuple path, [argInfo; SynInfo.emptySynArgInfo] }
 
   | STAR topTupleTypeElements
       { let mStar = rhs parseState 1
@@ -5713,7 +5713,7 @@ topTupleTypeElements:
       { let ty1, argInfo = $1
         let mStar = rhs parseState 2
         let ty2 = SynType.FromParseError(mStar.EndRange)
-        [(SynTupleTypeSegment.Type ty1, Some argInfo); (SynTupleTypeSegment.Star mStar, None); (SynTupleTypeSegment.Type ty2, None)] }
+        [SynTupleTypeSegment.Type ty1, Some argInfo; SynTupleTypeSegment.Star mStar, None; SynTupleTypeSegment.Type ty2, Some SynInfo.emptySynArgInfo] }
 
   | STAR topTupleTypeElements
       { let mStar = rhs parseState 1

--- a/tests/service/data/SyntaxTree/ModuleMember/Val 01.fsi
+++ b/tests/service/data/SyntaxTree/ModuleMember/Val 01.fsi
@@ -1,0 +1,3 @@
+module Module
+
+val f: int * -> unit

--- a/tests/service/data/SyntaxTree/ModuleMember/Val 01.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleMember/Val 01.fsi.bsl
@@ -1,0 +1,30 @@
+SigFile
+  (ParsedSigFileInput
+     ("/root/ModuleMember/Val 01.fsi", QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespaceSig
+         ([Module], false, NamedModule,
+          [Val
+             (SynValSig
+                ([], SynIdent (f, None), SynValTyparDecls (None, true),
+                 Fun
+                   (Tuple
+                      (false,
+                       [Type (LongIdent (SynLongIdent ([int], [], [None])));
+                        Star (3,11--3,12); Type (FromParseError (3,12--3,12))],
+                       (3,7--3,12)),
+                    LongIdent (SynLongIdent ([unit], [], [None])), (3,7--3,20),
+                    { ArrowRange = (3,13--3,15) }),
+                 SynValInfo
+                   ([[SynArgInfo ([], false, None); SynArgInfo ([], false, None)]],
+                    SynArgInfo ([], false, None)), false, false,
+                 PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector), None,
+                 None, (3,0--3,20), { LeadingKeyword = Val (3,0--3,3)
+                                      InlineKeyword = None
+                                      WithKeyword = None
+                                      EqualsRange = None }), (3,0--3,20))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,20), { LeadingKeyword = Module (1,0--1,6) })],
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,13)-(3,15) parse error Unexpected symbol '->' in value signature


### PR DESCRIPTION
Partially fixes https://github.com/dotnet/fsharp/issues/15905. Fixes incorrect tree shape produced by recovery rules that caused an exception in type checking:
```
--- EXCEPTION #1/5 [ArgumentException]
Message = "
  The lists had different lengths.
  list2 is 1 element shorter than list1
"
ExceptionPath = Root.InnerException.InnerException.InnerException.InnerException
ClassName = System.ArgumentException
RemoteStackTraceString = "
  at Microsoft.FSharp.Core.DetailedExceptions.invalidArgDifferentListLength[?](String arg1, String arg2, Int32 diff) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 26
     at Microsoft.FSharp.Primitives.Basics.List.zipToFreshConsTail[a,b](FSharpList`1 cons, FSharpList`1 xs1, FSharpList`1 xs2) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 914
     at Microsoft.FSharp.Primitives.Basics.List.zip[T1,T2](FSharpList`1 xs1, FSharpList`1 xs2) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 926
     at Microsoft.FSharp.Primitives.Basics.List.map2[T1,T2,TResult](FSharpFunc`2 mapping, FSharpList`1 xs1, FSharpList`1 xs2) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 288
     at FSharp.Compiler.TypedTreeOps.GetTopTauTypeInFSharpForm(TcGlobals g, FSharpList`1 curriedArgInfos, TType tau, Range m) in C:\Developer\fsharp-rebase\src\Compiler\TypedTree\TypedTreeOps.fs:line 1710
     at FSharp.Compiler.TypedTreeOps.GetValReprTypeInFSharpForm(TcGlobals g, ValReprInfo valReprInfo, TType ty, Range m) in C:\Developer\fsharp-rebase\src\Compiler\TypedTree\TypedTreeOps.fs:line 1730
     at FSharp.Compiler.TypedTreeOps.GetValReprTypeInCompiledForm(TcGlobals g, ValReprInfo valReprInfo, Int32 numEnclosingTypars, TType ty, Range m) in C:\Developer\fsharp-rebase\src\Compiler\TypedTree\TypedTreeOps.fs:line 2628
     at FSharp.Compiler.CheckExpressions.PublishArguments(TcFileState cenv, TcEnv env, Val vspec, SynValSig synValSig, Int32 numEnclosingTypars) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckExpressions.fs:line 12113
     at FSharp.Compiler.CheckExpressions.TcAndPublishValSpec@12136.Invoke(UnscopedTyparEnv tpenv, ValSpecResult valSpecResult) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckExpressions.fs:line 12188
     at Microsoft.FSharp.Primitives.Basics.List.mapFold[TState,T,TResult](FSharpFunc`2 f, TState acc, FSharpList`1 xs) in D:\a\_work\1\s\src\FSharp.Core\local.fs:line 393
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4516-1.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckDeclarations.fs:line 4540
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4516-15.Invoke(CancellationToken ct)
     at FSharp.Compiler.DiagnosticsLogger.DiagnosticsLoggerExtensions.ReraiseIfWatsonable(Exception exn) in C:\Developer\fsharp-rebase\src\Compiler\Facilities\DiagnosticsLogger.fs:line 425
     at FSharp.Compiler.DiagnosticsLogger.DiagnosticsLoggerExtensions.DiagnosticsLogger.ErrorRecovery(DiagnosticsLogger x, Exception exn, Range m) in C:\Developer\fsharp-rebase\src\Compiler\Facilities\DiagnosticsLogger.fs:line 476
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4516-15.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckDeclarations.fs:line 4664
     at Internal.Utilities.Library.Cancellable.fold@876.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Utilities\illib.fs:line 884
     at FSharp.Compiler.CheckDeclarations.TcModuleOrNamespaceSignatureElementsNonMutRec@4751-1.Invoke(CancellationToken ct)
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4570-6.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckDeclarations.fs:line 4576
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4516-15.Invoke(CancellationToken ct)
     at FSharp.Compiler.DiagnosticsLogger.DiagnosticsLoggerExtensions.ReraiseIfWatsonable(Exception exn) in C:\Developer\fsharp-rebase\src\Compiler\Facilities\DiagnosticsLogger.fs:line 425
     at FSharp.Compiler.DiagnosticsLogger.DiagnosticsLoggerExtensions.DiagnosticsLogger.ErrorRecovery(DiagnosticsLogger x, Exception exn, Range m) in C:\Developer\fsharp-rebase\src\Compiler\Facilities\DiagnosticsLogger.fs:line 476
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4516-15.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckDeclarations.fs:line 4664
     at Internal.Utilities.Library.Cancellable.fold@876.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Utilities\illib.fs:line 884
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4640-14.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Checking\CheckDeclarations.fs:line 4659
     at FSharp.Compiler.CheckDeclarations.TcSignatureElementNonMutRec@4516-15.Invoke(CancellationToken ct)
     at FSharp.Compiler.ParseAndCheckInputs.CheckOneInput@1259-2.Invoke(CancellationToken ct) in C:\Developer\fsharp-rebase\src\Compiler\Driver\ParseAndCheckInputs.fs:line 1329
     at FSharp.Compiler.ParseAndCheckInputs.CheckOneInput@1258-17.Invoke(CancellationToken ct)
"
```