### PR TITLE
Reword policheck issue

### DIFF
--- a/docs/debug-emit.md
+++ b/docs/debug-emit.md
@@ -87,7 +87,7 @@ The intended debug points for constructs are determined by syntax as follows.  P
 
 * The bodies of functions, methods, lambdas and initialization code for top-level-bindings are all processed as control flow
 
-* Each CAPITAL-EXPR below is processed as control-flow (the bodies of loops, conditionals etc.)
+* Each Upper-Cased EXPR below is processed as control-flow (the bodies of loops, conditionals etc.)
 
 * Leaf expressions are the other composite expressions like applications that are not covered by the other constructs.
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1118,7 +1118,7 @@ Contains commits from 32b124966 to d7018737c from dotnet/fsharp. Notable changes
 * lowered allocations for several internal compiler structures
 * better error messages for anonymous record mismatches
 * FSharpChecker learned how to keep background symbol uses
-* Project cracker/project cracker tool were removed
+* The tool for parsing projects was removed
 * Better support for consuming C# in-ref parameters
 * new services around simplifying names and finding unused declarations
 * package management in scripts (in preview)

--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -187,7 +187,7 @@ module internal Parse =
             if p = None then None, fmtPos else p, pos'
         | _ -> None, fmtPos
 
-    // Explicitly typed holes in interpolated strings "....%d{x}..." get additional '%P()' as a hole place marker
+    // Explicitly typed expression gaps in interpolated strings "....%d{x}..." get additional '%P()' as an expression gap place marker
     let skipPossibleInterpolationHole isInterpolated isFormattableString (fmt: string) i =
         let len = fmt.Length
         if isInterpolated then

--- a/src/FSharp.Core/printf.fsi
+++ b/src/FSharp.Core/printf.fsi
@@ -28,7 +28,7 @@ type PrintfFormat<'Printer, 'State, 'Residue, 'Result> =
     /// <summary>Construct a format string </summary>
     /// <param name="value">The input string.</param>
     /// <param name="captures">The captured expressions in an interpolated string.</param>
-    /// <param name="captureTys">The types of expressions for %A holes in interpolated string.</param>
+    /// <param name="captureTys">The types of expressions for %A expression gaps in interpolated string.</param>
     /// <returns>The PrintfFormat containing the formatted result.</returns>
     new: value: string * captures: obj[] * captureTys: Type[] -> PrintfFormat<'Printer, 'State, 'Residue, 'Result>
 
@@ -65,7 +65,7 @@ type PrintfFormat<'Printer, 'State, 'Residue, 'Result, 'Tuple> =
     ///
     /// <param name="value">The input string.</param>
     /// <param name="captures">The captured expressions in an interpolated string.</param>
-    /// <param name="captureTys">The types of expressions for %A holes in interpolated string.</param>
+    /// <param name="captureTys">The types of expressions for %A expression gaps in interpolated string.</param>
     ///
     /// <returns>The created format string.</returns>
     new:


### PR DESCRIPTION
Policheck an automated tool that verifies text in shipped files against flagged the term: %A holes in the file FSharp.Core.xml as a profanity - this probably needs no further explanation.

I replaced the term with "%A expression gaps".

Thanks
