### PR TITLE
Add VisitValSig to SyntaxVisitorBase.

### DIFF
--- a/src/Compiler/Service/ServiceParseTreeWalk.fsi
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fsi
@@ -17,6 +17,9 @@ type SyntaxNode =
     | SynMemberDefn of SynMemberDefn
     | SynMatchClause of SynMatchClause
     | SynBinding of SynBinding
+    | SynModuleOrNamespaceSig of SynModuleOrNamespaceSig
+    | SynModuleSigDecl of SynModuleSigDecl
+    | SynValSig of SynValSig
 
 type SyntaxVisitorPath = SyntaxNode list
 
@@ -150,6 +153,24 @@ type SyntaxVisitorBase<'T> =
 
     abstract VisitAttributeApplication: path: SyntaxVisitorPath * attributes: SynAttributeList -> 'T option
     default VisitAttributeApplication: path: SyntaxVisitorPath * attributes: SynAttributeList -> 'T option
+
+    abstract VisitModuleOrNamespaceSig:
+        path: SyntaxVisitorPath * synModuleOrNamespaceSig: SynModuleOrNamespaceSig -> 'T option
+    default VisitModuleOrNamespaceSig:
+        path: SyntaxVisitorPath * synModuleOrNamespaceSig: SynModuleOrNamespaceSig -> 'T option
+
+    abstract VisitModuleSigDecl:
+        path: SyntaxVisitorPath * defaultTraverse: (SynModuleSigDecl -> 'T option) * synModuleSigDecl: SynModuleSigDecl ->
+            'T option
+    default VisitModuleSigDecl:
+        path: SyntaxVisitorPath * defaultTraverse: (SynModuleSigDecl -> 'T option) * synModuleSigDecl: SynModuleSigDecl ->
+            'T option
+
+    abstract VisitValSig:
+        path: SyntaxVisitorPath * defaultTraverse: (SynValSig -> 'T option) * valSig: SynValSig -> 'T option
+
+    default VisitValSig:
+        path: SyntaxVisitorPath * defaultTraverse: (SynValSig -> 'T option) * valSig: SynValSig -> 'T option
 
 module public SyntaxTraversal =
 

--- a/src/Compiler/Service/ServiceParseTreeWalk.fsi
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fsi
@@ -20,6 +20,8 @@ type SyntaxNode =
     | SynModuleOrNamespaceSig of SynModuleOrNamespaceSig
     | SynModuleSigDecl of SynModuleSigDecl
     | SynValSig of SynValSig
+    | SynTypeDefnSig of SynTypeDefnSig
+    | SynMemberSig of SynMemberSig
 
 type SyntaxVisitorPath = SyntaxNode list
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -9242,57 +9242,78 @@ FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDec
 FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDecl get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace Item
 FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl Item
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynPat: FSharp.Compiler.Syntax.SynPat Item
 FSharp.Compiler.Syntax.SyntaxNode+SynPat: FSharp.Compiler.Syntax.SynPat get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType Item
 FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn Item
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynBinding
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynExpr
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMemberDefn
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModule
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespace
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespaceSig
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynPat
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynType
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynBinding
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynExpr
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMemberDefn
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModule
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespace
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespaceSig
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynPat
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynType
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynBinding()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynExpr()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMatchClause()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMemberDefn()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModule()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespace()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespaceSig()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleSigDecl()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynPat()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynType()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynTypeDefn()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynValSig()
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynBinding(FSharp.Compiler.Syntax.SynBinding)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynExpr(FSharp.Compiler.Syntax.SynExpr)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMatchClause(FSharp.Compiler.Syntax.SynMatchClause)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMemberDefn(FSharp.Compiler.Syntax.SynMemberDefn)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModule(FSharp.Compiler.Syntax.SynModuleDecl)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespace(FSharp.Compiler.Syntax.SynModuleOrNamespace)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespaceSig(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleSigDecl(FSharp.Compiler.Syntax.SynModuleSigDecl)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynPat(FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynType(FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynTypeDefn(FSharp.Compiler.Syntax.SynTypeDefn)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynValSig(FSharp.Compiler.Syntax.SynValSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynBinding
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynExpr
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModule
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynPat
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynType
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+Tags
 FSharp.Compiler.Syntax.SyntaxNode: Int32 Tag
 FSharp.Compiler.Syntax.SyntaxNode: Int32 get_Tag()
@@ -9311,6 +9332,8 @@ FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOptio
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitMatchClause(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMatchClause,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynMatchClause)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleDecl(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynModuleDecl,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynModuleDecl)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynModuleOrNamespace)
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleOrNamespaceSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleSigDecl(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynModuleSigDecl,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynModuleSigDecl)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitPat(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynPat,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordDefn(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynLongIdent])
@@ -9318,6 +9341,7 @@ FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOptio
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitType(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynType,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitTypeAbbrev(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitUnionDefn(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynUnionCase], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynValSig,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynValSig)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Void .ctor()
 FSharp.Compiler.Syntax.TyparStaticReq+Tags: Int32 HeadType
 FSharp.Compiler.Syntax.TyparStaticReq+Tags: Int32 None

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -9238,6 +9238,8 @@ FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause: FSharp.Compiler.Syntax.SynMatc
 FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause: FSharp.Compiler.Syntax.SynMatchClause get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn Item
 FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynMemberSig: FSharp.Compiler.Syntax.SynMemberSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynMemberSig: FSharp.Compiler.Syntax.SynMemberSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDecl Item
 FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDecl get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace Item
@@ -9252,12 +9254,15 @@ FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType Item
 FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn Item
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig Item
 FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynBinding
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynExpr
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMemberDefn
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMemberSig
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModule
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespace
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespaceSig
@@ -9265,11 +9270,13 @@ FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynPat
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynType
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynTypeDefnSig
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynBinding
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynExpr
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMemberDefn
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMemberSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModule
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespace
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespaceSig
@@ -9277,11 +9284,13 @@ FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynPat
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynType
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynTypeDefnSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynBinding()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynExpr()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMatchClause()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMemberDefn()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMemberSig()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModule()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespace()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespaceSig()
@@ -9289,11 +9298,13 @@ FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleSigDecl()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynPat()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynType()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynTypeDefn()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynTypeDefnSig()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynValSig()
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynBinding(FSharp.Compiler.Syntax.SynBinding)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynExpr(FSharp.Compiler.Syntax.SynExpr)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMatchClause(FSharp.Compiler.Syntax.SynMatchClause)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMemberDefn(FSharp.Compiler.Syntax.SynMemberDefn)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMemberSig(FSharp.Compiler.Syntax.SynMemberSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModule(FSharp.Compiler.Syntax.SynModuleDecl)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespace(FSharp.Compiler.Syntax.SynModuleOrNamespace)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespaceSig(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
@@ -9301,11 +9312,13 @@ FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModul
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynPat(FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynType(FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynTypeDefn(FSharp.Compiler.Syntax.SynTypeDefn)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynTypeDefnSig(FSharp.Compiler.Syntax.SynTypeDefnSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynValSig(FSharp.Compiler.Syntax.SynValSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynBinding
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynExpr
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMemberSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModule
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig
@@ -9313,6 +9326,7 @@ FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleSi
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynPat
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynType
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefnSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+Tags
 FSharp.Compiler.Syntax.SyntaxNode: Int32 Tag

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -9242,57 +9242,78 @@ FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDec
 FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDecl get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace Item
 FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig: FSharp.Compiler.Syntax.SynModuleOrNamespaceSig get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl Item
+FSharp.Compiler.Syntax.SyntaxNode+SynModuleSigDecl: FSharp.Compiler.Syntax.SynModuleSigDecl get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynPat: FSharp.Compiler.Syntax.SynPat Item
 FSharp.Compiler.Syntax.SyntaxNode+SynPat: FSharp.Compiler.Syntax.SynPat get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType Item
 FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn Item
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynBinding
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynExpr
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMemberDefn
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModule
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespace
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespaceSig
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynPat
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynType
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynBinding
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynExpr
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMemberDefn
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModule
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespace
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespaceSig
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynPat
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynType
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynBinding()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynExpr()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMatchClause()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMemberDefn()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModule()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespace()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespaceSig()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleSigDecl()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynPat()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynType()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynTypeDefn()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynValSig()
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynBinding(FSharp.Compiler.Syntax.SynBinding)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynExpr(FSharp.Compiler.Syntax.SynExpr)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMatchClause(FSharp.Compiler.Syntax.SynMatchClause)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMemberDefn(FSharp.Compiler.Syntax.SynMemberDefn)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModule(FSharp.Compiler.Syntax.SynModuleDecl)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespace(FSharp.Compiler.Syntax.SynModuleOrNamespace)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespaceSig(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleSigDecl(FSharp.Compiler.Syntax.SynModuleSigDecl)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynPat(FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynType(FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynTypeDefn(FSharp.Compiler.Syntax.SynTypeDefn)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynValSig(FSharp.Compiler.Syntax.SynValSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynBinding
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynExpr
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModule
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynPat
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynType
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+Tags
 FSharp.Compiler.Syntax.SyntaxNode: Int32 Tag
 FSharp.Compiler.Syntax.SyntaxNode: Int32 get_Tag()
@@ -9311,6 +9332,8 @@ FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOptio
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitMatchClause(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynMatchClause,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynMatchClause)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleDecl(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynModuleDecl,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynModuleDecl)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleOrNamespace(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynModuleOrNamespace)
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleOrNamespaceSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitModuleSigDecl(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynModuleSigDecl,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynModuleSigDecl)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitPat(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynPat,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordDefn(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynField], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitRecordField(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynLongIdent])
@@ -9318,6 +9341,7 @@ FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOptio
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitType(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynType,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitTypeAbbrev(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitUnionDefn(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynUnionCase], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Microsoft.FSharp.Core.FSharpOption`1[T] VisitValSig(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], Microsoft.FSharp.Core.FSharpFunc`2[FSharp.Compiler.Syntax.SynValSig,Microsoft.FSharp.Core.FSharpOption`1[T]], FSharp.Compiler.Syntax.SynValSig)
 FSharp.Compiler.Syntax.SyntaxVisitorBase`1[T]: Void .ctor()
 FSharp.Compiler.Syntax.TyparStaticReq+Tags: Int32 HeadType
 FSharp.Compiler.Syntax.TyparStaticReq+Tags: Int32 None

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -9238,6 +9238,8 @@ FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause: FSharp.Compiler.Syntax.SynMatc
 FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause: FSharp.Compiler.Syntax.SynMatchClause get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn Item
 FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynMemberSig: FSharp.Compiler.Syntax.SynMemberSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynMemberSig: FSharp.Compiler.Syntax.SynMemberSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDecl Item
 FSharp.Compiler.Syntax.SyntaxNode+SynModule: FSharp.Compiler.Syntax.SynModuleDecl get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace: FSharp.Compiler.Syntax.SynModuleOrNamespace Item
@@ -9252,12 +9254,15 @@ FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType Item
 FSharp.Compiler.Syntax.SyntaxNode+SynType: FSharp.Compiler.Syntax.SynType get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn Item
 FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn: FSharp.Compiler.Syntax.SynTypeDefn get_Item()
+FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSig Item
+FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefnSig: FSharp.Compiler.Syntax.SynTypeDefnSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig Item
 FSharp.Compiler.Syntax.SyntaxNode+SynValSig: FSharp.Compiler.Syntax.SynValSig get_Item()
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynBinding
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynExpr
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMemberDefn
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynMemberSig
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModule
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespace
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleOrNamespaceSig
@@ -9265,11 +9270,13 @@ FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynPat
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynType
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynTypeDefnSig
 FSharp.Compiler.Syntax.SyntaxNode+Tags: Int32 SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynBinding
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynExpr
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMemberDefn
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynMemberSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModule
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespace
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleOrNamespaceSig
@@ -9277,11 +9284,13 @@ FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynModuleSigDecl
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynPat
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynType
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynTypeDefnSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean IsSynValSig
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynBinding()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynExpr()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMatchClause()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMemberDefn()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynMemberSig()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModule()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespace()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleOrNamespaceSig()
@@ -9289,11 +9298,13 @@ FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynModuleSigDecl()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynPat()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynType()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynTypeDefn()
+FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynTypeDefnSig()
 FSharp.Compiler.Syntax.SyntaxNode: Boolean get_IsSynValSig()
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynBinding(FSharp.Compiler.Syntax.SynBinding)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynExpr(FSharp.Compiler.Syntax.SynExpr)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMatchClause(FSharp.Compiler.Syntax.SynMatchClause)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMemberDefn(FSharp.Compiler.Syntax.SynMemberDefn)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynMemberSig(FSharp.Compiler.Syntax.SynMemberSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModule(FSharp.Compiler.Syntax.SynModuleDecl)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespace(FSharp.Compiler.Syntax.SynModuleOrNamespace)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModuleOrNamespaceSig(FSharp.Compiler.Syntax.SynModuleOrNamespaceSig)
@@ -9301,11 +9312,13 @@ FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynModul
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynPat(FSharp.Compiler.Syntax.SynPat)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynType(FSharp.Compiler.Syntax.SynType)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynTypeDefn(FSharp.Compiler.Syntax.SynTypeDefn)
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynTypeDefnSig(FSharp.Compiler.Syntax.SynTypeDefnSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode NewSynValSig(FSharp.Compiler.Syntax.SynValSig)
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynBinding
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynExpr
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMatchClause
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMemberDefn
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynMemberSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModule
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespace
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleOrNamespaceSig
@@ -9313,6 +9326,7 @@ FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynModuleSi
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynPat
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynType
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefn
+FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynTypeDefnSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+SynValSig
 FSharp.Compiler.Syntax.SyntaxNode: FSharp.Compiler.Syntax.SyntaxNode+Tags
 FSharp.Compiler.Syntax.SyntaxNode: Int32 Tag

--- a/tests/FSharp.Compiler.UnitTests/TreeVisitorTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/TreeVisitorTests.fs
@@ -75,3 +75,23 @@ let ``Visit recursive let binding`` () =
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
     | Some [ SynBinding(valData = SynValData(valInfo = SynValInfo(curriedArgInfos = [ [ SynArgInfo(ident = Some id) ] ]))) ] when id.idText = "n" -> ()
     | _ -> failwith "Did not visit recursive let binding"
+
+[<Fact>]
+let ``Visit ValSig`` () =
+    let visitor =
+        { new SyntaxVisitorBase<_>() with
+            member x.VisitValSig(path, defaultTraverse, SynValSig(ident = SynIdent(ident = valIdent))) =
+                Some valIdent.idText
+        }
+
+    let source = """
+module X
+
+val y: int -> int
+"""
+
+    let parseTree = parseSourceCode("C:\\test.fsi", source)
+
+    match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
+    | Some "y" -> ()
+    | _ -> failwith "Did not visit SynValSig"

--- a/tests/FSharp.Compiler.UnitTests/TreeVisitorTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/TreeVisitorTests.fs
@@ -116,3 +116,54 @@ module Y =
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
     | Some "z" -> ()
     | _ -> failwith "Did not visit SynValSig"
+
+[<Fact>]
+let ``Visit Record in SynTypeDefnSig`` () =
+    let visitor =
+        { new SyntaxVisitorBase<_>() with
+            member x.VisitRecordDefn(path, fields, range) =
+                fields
+                |> List.choose (fun (SynField(idOpt = idOpt)) -> idOpt |> Option.map (fun ident -> ident.idText))
+                |> String.concat ","
+                |> Some
+        }
+
+    let source = """
+module X
+
+type Y =
+    {
+        A: int
+        B: char
+        C: string
+    }
+"""
+
+    let parseTree = parseSourceCode("C:\\test.fsi", source)
+
+    match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
+    | Some "A,B,C" -> ()
+    | _ -> failwith "Did not visit SynTypeDefnSimpleRepr.Record in SynTypeDefnSig"
+
+[<Fact>]
+let ``Visit SynValSig in SynMemberSig`` () =
+    let visitor =
+        { new SyntaxVisitorBase<_>() with
+            member x.VisitValSig(path, defaultTraverse, SynValSig(ident = SynIdent(ident = valIdent))) =
+                Some valIdent.idText
+        }
+
+    let source = """
+module Lib
+
+type Meh =
+    new: unit -> Meh
+    member Foo: y: int -> int
+"""
+
+    let parseTree = parseSourceCode("C:\\test.fsi", source)
+    let pos = mkPos 6 4
+
+    match SyntaxTraversal.Traverse(pos, parseTree, visitor) with
+    | Some "Foo" -> ()
+    | _ -> failwith "Did not visit SynValSig in SynMemberSig.Member"

--- a/tests/FSharp.Compiler.UnitTests/TreeVisitorTests.fs
+++ b/tests/FSharp.Compiler.UnitTests/TreeVisitorTests.fs
@@ -95,3 +95,24 @@ val y: int -> int
     match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
     | Some "y" -> ()
     | _ -> failwith "Did not visit SynValSig"
+
+[<Fact>]
+let ``Visit nested ValSig`` () =
+    let visitor =
+        { new SyntaxVisitorBase<_>() with
+            member x.VisitValSig(path, defaultTraverse, SynValSig(ident = SynIdent(ident = valIdent))) =
+                Some valIdent.idText
+        }
+
+    let source = """
+module X
+
+module Y =
+    val z: int -> int
+"""
+
+    let parseTree = parseSourceCode("C:\\test.fsi", source)
+
+    match SyntaxTraversal.Traverse(pos0, parseTree, visitor) with
+    | Some "z" -> ()
+    | _ -> failwith "Did not visit SynValSig"


### PR DESCRIPTION
I want to expand the `SyntaxVisitorBase` to be able to traverse signature files as well.
I'm no expert in this, nor do I claim to grasp all the details here.
I looked at how `SynBinding` works and tried to mimic it for `SynValSig`.

 