### PR TITLE
Update scripts in documentation.

### DIFF
--- a/docs/fcs/editor.fsx
+++ b/docs/fcs/editor.fsx
@@ -184,7 +184,7 @@ let decls =
 
 // Print the names of available items
 for item in decls.Items do
-    printfn " - %s" item.Name
+    printfn " - %s" item.NameInList
 
 (**
 

--- a/docs/fcs/filesystem.fsx
+++ b/docs/fcs/filesystem.fsx
@@ -130,6 +130,9 @@ let B = File1.A + File1.A"""
         member _.IsStableFileHeuristic(path) =
             defaultFileSystem.IsStableFileHeuristic(path)
 
+        member this.ChangeExtensionShim(path, extension) =
+            defaultFileSystem.ChangeExtensionShim(path, extension)
+
 let myFileSystem = MyFileSystem()
 FileSystem <- MyFileSystem()
 

--- a/docs/fcs/tokenizer.fsx
+++ b/docs/fcs/tokenizer.fsx
@@ -36,7 +36,7 @@ file name of the source code. The defined symbols are required because the
 tokenizer handles `#if` directives. The file name is required only to specify
 locations of the source code (and it does not have to exist):
 *)
-let sourceTok = FSharpSourceTokenizer([], Some "C:\\test.fsx")
+let sourceTok = FSharpSourceTokenizer([], Some "C:\\test.fsx", Some "PREVIEW", None)
 (**
 Using the `sourceTok` object, we can now (repeatedly) tokenize lines of 
 F# source code.

--- a/docs/fcs/untypedtree.fsx
+++ b/docs/fcs/untypedtree.fsx
@@ -111,11 +111,11 @@ used more often):
 /// Walk over a pattern - this is for example used in 
 /// let <pat> = <expr> or in the 'match' expression
 let rec visitPattern = function
-  | SynPat.Wild(_) -> 
+  | SynPat.Wild _ -> 
       printfn "  .. underscore pattern"
-  | SynPat.Named(name, _, _, _) ->
+  | SynPat.Named(ident = SynIdent(ident = name)) ->
       printfn "  .. named as '%s'" name.idText
-  | SynPat.LongIdent(LongIdentWithDots(ident, _), _, _, _, _, _, _) ->
+  | SynPat.LongIdent(longDotId = SynLongIdent(id = ident)) ->
       let names = String.concat "." [ for i in ident -> i.idText ]
       printfn "  .. identifier: %s" names
   | pat -> printfn "  .. other pattern: %A" pat
@@ -145,9 +145,7 @@ let rec visitExpression e =
       // for 'let .. = .. and .. = .. in ...'
       printfn "LetOrUse with the following bindings:"
       for binding in bindings do
-        let (SynBinding(
-          access, kind, isInline, isMutable, attrs, xmlDoc, data,
-          headPat, retInfo, init, equalsRange, debugPoint, trivia)) = binding
+        let (SynBinding(headPat = headPat; expr = init)) = binding
         visitPattern headPat
         visitExpression init
       // Visit the body expression
@@ -177,9 +175,7 @@ let visitDeclarations decls =
         // Let binding as a declaration is similar to let binding
         // as an expression (in visitExpression), but has no body
         for binding in bindings do
-          let (SynBinding(
-            access, kind, isInline, isMutable, attrs, xmlDoc, 
-            valData, pat, retInfo, body, equalsRange, debugPoint, trivia)) = binding
+          let (SynBinding(headPat = pat; expr = body)) = binding
           visitPattern pat 
           visitExpression body         
     | _ -> printfn " - not supported declaration: %A" declaration
@@ -194,7 +190,7 @@ with multiple `namespace Foo` declarations:
 /// does not explicitly define it..
 let visitModulesAndNamespaces modulesOrNss =
   for moduleOrNs in modulesOrNss do
-    let (SynModuleOrNamespace(lid, isRec, isMod, decls, xml, attrs, accessibility, range)) = moduleOrNs
+    let (SynModuleOrNamespace(longId = lid; decls = decls)) = moduleOrNs
     printfn "Namespace or module: %A" lid
     visitDeclarations decls
 (**
@@ -238,7 +234,7 @@ in the previous step:
 match tree with
 | ParsedInput.ImplFile(implFile) ->
     // Extract declarations and walk over them
-    let (ParsedImplFileInput(fn, script, name, _, _, modules, _, _)) = implFile
+    let (ParsedImplFileInput(contents = modules)) = implFile
     visitModulesAndNamespaces modules
 | _ -> failwith "F# Interface file (*.fsi) not supported."
 (**


### PR DESCRIPTION
I'm trying to update https://fsharp.github.io/fsharp-compiler-docs/ to the latest and I noticed some scripts aren't working anymore.

<strike>(The broken website is unrelated to any changes here, I'm looking into that over at https://github.com/fsharp/fsharp-compiler-docs)</strike>