### PR TITLE
Prevent crashing with integeroverflow on optData hashing

### DIFF
--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -908,7 +908,8 @@ let main3
                     use s = ilResource.GetBytes().AsStream()
                     let sha256 = System.Security.Cryptography.SHA256.Create()
                     sha256.ComputeHash s)
-                |> List.sumBy hash
+                |> List.sumBy (hash >> int64)
+                |> hash
 
             try
                 Fsharp.Compiler.SignatureHash.calculateSignatureHashOfFiles typedImplFiles tcGlobals observer


### PR DESCRIPTION
Fixing my own mistake from the past.

When working on nullness PR, there is a situation where a 2nd optimization data resource can exist if compiling with `optimize:+` (cc @vzarytovskii )
Depending on the contents, adding a hash of the two optimization resources can overflow an int32. Via a regular plus addition, it would just overflow and it would be ok for a hash result - so far so good.

However, the `List.sumBy` function is doing a `Checked` addition and therefore throw at runtime with an integeroverflow. I/We should be definitely more careful about the usage of `.sum / .sumBy` in the compiler codebase.

This was really strange to investigate, as only some projects have been failing - depending on the numeric value of their optimization data hashes.