### PR TITLE
Parser: recover on unfinished accessors clause

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -1058,6 +1058,19 @@ classMemberSpfnGetSetElements:
       else
           SynMemberKind.PropertyGetSet, Some(GetSetKeywords.GetSet(id2.idRange, id.idRange)) }
 
+  | nameop COMMA recover
+    { (let (SynIdent(id:Ident, _)) = $1
+       if id.idText = "get" then
+           SynMemberKind.PropertyGet, Some(GetSetKeywords.Get id.idRange)
+       else if id.idText = "set" then
+           SynMemberKind.PropertySet, Some(GetSetKeywords.Set id.idRange)
+       else
+           raiseParseErrorAt (rhs parseState 1) (FSComp.SR.parsGetOrSetRequired())) }
+
+  | OBLOCKBEGIN oblockend ODECLEND
+    { reportParseErrorAt (rhs parseState 1) (FSComp.SR.parsIdentifierExpected())
+      SynMemberKind.Member, None }
+
 memberSpecFlags:
   | memberFlags { $1 }
   | abstractMemberFlags { $1 }

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 01.fs
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    abstract P: int

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 01.fs.bsl
@@ -1,0 +1,41 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Abstract - Property 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (4,4--4,19),
+                            { LeadingKeyword = Abstract (4,4--4,12)
+                              InlineKeyword = None
+                              WithKeyword = None
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGet }, (4,4--4,19),
+                         { GetSetKeywords = None })], (4,4--4,19)), [], None,
+                  (3,5--4,19), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,19))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,19), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 02.fs
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    abstract P: int with get, set

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 02.fs.bsl
@@ -1,0 +1,43 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Abstract - Property 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (4,4--4,33),
+                            { LeadingKeyword = Abstract (4,4--4,12)
+                              InlineKeyword = None
+                              WithKeyword = Some (4,20--4,24)
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGetSet }, (4,4--4,33),
+                         { GetSetKeywords =
+                            Some (GetSet ((4,25--4,28), (4,30--4,33))) })],
+                     (4,4--4,33)), [], None, (3,5--4,33),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,33))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,33), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 03.fs
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    abstract P: int with get,
+
+()

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 03.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Abstract - Property 03.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (4,4--4,28),
+                            { LeadingKeyword = Abstract (4,4--4,12)
+                              InlineKeyword = None
+                              WithKeyword = Some (4,20--4,24)
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGet }, (4,4--4,28),
+                         { GetSetKeywords = Some (Get (4,25--4,28)) })],
+                     (4,4--4,28)), [], None, (3,5--4,28),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,28));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in member definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 04.fs
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    abstract P: int with
+
+()

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 04.fs.bsl
@@ -1,0 +1,45 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Abstract - Property 04.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (4,4--4,19),
+                            { LeadingKeyword = Abstract (4,4--4,12)
+                              InlineKeyword = None
+                              WithKeyword = Some (4,20--4,24)
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGet }, (4,4--4,19),
+                         { GetSetKeywords = None })], (4,4--4,19)), [], None,
+                  (3,5--4,19), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,19));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(4,20)-(4,24) parse error Identifier expected

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 05.fs
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 05.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    abstract P1: int with
+    abstract P2: int
+
+()

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 05.fs.bsl
@@ -1,0 +1,65 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Abstract - Property 05.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P1, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (4,4--4,20),
+                            { LeadingKeyword = Abstract (4,4--4,12)
+                              InlineKeyword = None
+                              WithKeyword = Some (4,21--4,25)
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGet }, (4,4--4,20),
+                         { GetSetKeywords = None });
+                      AbstractSlot
+                        (SynValSig
+                           ([], SynIdent (P2, None),
+                            SynValTyparDecls (None, true),
+                            LongIdent (SynLongIdent ([int], [], [None])),
+                            SynValInfo ([], SynArgInfo ([], false, None)), false,
+                            false,
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, None, (5,4--5,20),
+                            { LeadingKeyword = Abstract (5,4--5,12)
+                              InlineKeyword = None
+                              WithKeyword = None
+                              EqualsRange = None }),
+                         { IsInstance = true
+                           IsDispatchSlot = true
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertyGet }, (5,4--5,20),
+                         { GetSetKeywords = None })], (4,4--5,20)), [], None,
+                  (3,5--5,20), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--5,20));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,12) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(4,21)-(4,25) parse error Identifier expected

--- a/tests/service/data/SyntaxTree/Member/Auto property 08.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 08.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    member val P = 1 with get,
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 08.fs.bsl
@@ -1,0 +1,47 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 08.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P, None, PropertyGet,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,19--4,20)), (4,4--4,29),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,21--4,25)
+                           EqualsRange = Some (4,17--4,18)
+                           GetSetKeywords = Some (Get (4,26--4,29)) })],
+                     (4,4--4,29)), [], None, (3,5--4,29),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,29));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Possible incorrect indentation: this token is offside of context started at position (4:22). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in member definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 09.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 09.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    member val P1 = 1 with get,
+    member this.P2 = 1
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 09.fs.bsl
@@ -1,0 +1,70 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 09.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P1, None, PropertyGet,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,20--4,21)), (4,4--4,30),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,22--4,26)
+                           EqualsRange = Some (4,18--4,19)
+                           GetSetKeywords = Some (Get (4,27--4,30)) });
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None, None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(5,15--5,16)], [None; None]),
+                               None, None, Pats [], None, (5,11--5,18)), None,
+                            Const (Int32 1, (5,21--5,22)), (5,11--5,18),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (5,4--5,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (5,19--5,20) }), (5,4--5,22))],
+                     (4,4--5,22)), [], None, (3,5--5,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,22));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,10) parse error Possible incorrect indentation: this token is offside of context started at position (4:23). Try indenting this token further or using standard formatting conventions.
+(5,4)-(5,10) parse error Incomplete structured construct at or before this point in member definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 10.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 10.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    member val P = 1 with get,

--- a/tests/service/data/SyntaxTree/Member/Auto property 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 10.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 10.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P, None, PropertyGet,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,19--4,20)), (4,4--4,29),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,21--4,25)
+                           EqualsRange = Some (4,17--4,18)
+                           GetSetKeywords = Some (Get (4,26--4,29)) })],
+                     (4,4--4,29)), [], None, (3,5--4,29),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,29))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,29), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Possible incorrect indentation: this token is offside of context started at position (4:22). Try indenting this token further or using standard formatting conventions.
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in member definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 11.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 11.fs
@@ -1,0 +1,4 @@
+module Module
+
+type T =
+    member val P = 1 with get

--- a/tests/service/data/SyntaxTree/Member/Auto property 11.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 11.fs.bsl
@@ -1,0 +1,43 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 11.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P, None, PropertyGet,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,19--4,20)), (4,4--4,29),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,21--4,25)
+                           EqualsRange = Some (4,17--4,18)
+                           GetSetKeywords = Some (Get (4,26--4,29)) })],
+                     (4,4--4,29)), [], None, (3,5--4,29),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,29))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,29), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Auto property 12.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 12.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    member val P = 1 with
+
+()

--- a/tests/service/data/SyntaxTree/Member/Auto property 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 12.fs.bsl
@@ -1,0 +1,47 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 12.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,19--4,20)), (4,4--4,20),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,21--4,25)
+                           EqualsRange = Some (4,17--4,18)
+                           GetSetKeywords = None })], (4,4--4,20)), [], None,
+                  (3,5--4,20), { LeadingKeyword = Type (3,0--3,4)
+                                 EqualsRange = Some (3,7--3,8)
+                                 WithKeyword = None })], (3,0--4,20));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,21)-(4,25) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(6,0)-(6,1) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(4,21)-(4,25) parse error Identifier expected

--- a/tests/service/data/SyntaxTree/Member/Auto property 13.fs
+++ b/tests/service/data/SyntaxTree/Member/Auto property 13.fs
@@ -1,0 +1,5 @@
+module Module
+
+type T =
+    member val P = 1 with
+    member this.P2 = 2

--- a/tests/service/data/SyntaxTree/Member/Auto property 13.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 13.fs.bsl
@@ -1,0 +1,70 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Auto property 13.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [AutoProperty
+                        ([], false, P, None, Member,
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = Member },
+                         { IsInstance = true
+                           IsDispatchSlot = false
+                           IsOverrideOrExplicitImpl = false
+                           IsFinal = false
+                           GetterOrSetterIsCompilerGenerated = false
+                           MemberKind = PropertySet },
+                         PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                         None, Const (Int32 1, (4,19--4,20)), (4,4--4,20),
+                         { LeadingKeyword =
+                            MemberVal ((4,4--4,10), (4,11--4,14))
+                           WithKeyword = Some (4,21--4,25)
+                           EqualsRange = Some (4,17--4,18)
+                           GetSetKeywords = None });
+                      Member
+                        (SynBinding
+                           (None, Normal, false, false, [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            SynValData
+                              (Some { IsInstance = true
+                                      IsDispatchSlot = false
+                                      IsOverrideOrExplicitImpl = false
+                                      IsFinal = false
+                                      GetterOrSetterIsCompilerGenerated = false
+                                      MemberKind = Member },
+                               SynValInfo
+                                 ([[SynArgInfo ([], false, None)]; []],
+                                  SynArgInfo ([], false, None)), None, None),
+                            LongIdent
+                              (SynLongIdent
+                                 ([this; P2], [(5,15--5,16)], [None; None]),
+                               None, None, Pats [], None, (5,11--5,18)), None,
+                            Const (Int32 2, (5,21--5,22)), (5,11--5,18),
+                            NoneAtInvisible,
+                            { LeadingKeyword = Member (5,4--5,10)
+                              InlineKeyword = None
+                              EqualsRange = Some (5,19--5,20) }), (5,4--5,22))],
+                     (4,4--5,22)), [], None, (3,5--5,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,21)-(4,25) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(5,4)-(5,10) parse error Possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this token further or using standard formatting conventions.
+(4,21)-(4,25) parse error Identifier expected


### PR DESCRIPTION
Adds recovery for unfinished accessors clauses in properties:

```fsharp
type T =
    abstract P: int with get,
```

```fsharp
type T =
    abstract P: int with
```

```fsharp
type T =
    member val P = 1 with get,
```

```fsharp
type T =
    member val P = 1 with
```