### PR TITLE
Add GetSubTextFromRange to ISourceText

### DIFF
--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -120,7 +120,12 @@ type StringText(str: string) =
                 line.Substring(range.StartColumn, length)
             else
                 let firstLineContent = line.Substring(range.StartColumn)
-                let sb = System.Text.StringBuilder().AppendLine(firstLineContent)
+
+                let capacity =
+                    [ (range.StartLine - 1) .. (range.EndLine - 1) ]
+                    |> List.sumBy (fun lineIdx -> (sourceText.GetLineString lineIdx).Length)
+
+                let sb = System.Text.StringBuilder(capacity).AppendLine(firstLineContent)
 
                 (sb, [ range.StartLine .. range.EndLine - 2 ])
                 ||> List.fold (fun sb lineNumber -> sb.AppendLine(sourceText.GetLineString lineNumber))

--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -127,11 +127,11 @@ type StringText(str: string) =
 
                 let sb = System.Text.StringBuilder(capacity).AppendLine(firstLineContent)
 
-                (sb, [ range.StartLine .. range.EndLine - 2 ])
-                ||> List.fold (fun sb lineNumber -> sb.AppendLine(sourceText.GetLineString lineNumber))
-                |> fun sb ->
-                    let lastLine = sourceText.GetLineString(range.EndLine - 1)
-                    sb.Append(lastLine.Substring(0, range.EndColumn)).ToString()
+                for lineNumber in [ range.StartLine .. range.EndLine - 2 ] do
+                    sb.AppendLine(sourceText.GetLineString lineNumber) |> ignore
+
+                let lastLine = sourceText.GetLineString(range.EndLine - 1)
+                sb.Append(lastLine.Substring(0, range.EndColumn)).ToString()
 
 module SourceText =
 

--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -136,14 +136,9 @@ type StringText(str: string) =
                     line.Substring(range.StartColumn, length)
                 else
                     let firstLineContent = line.Substring(range.StartColumn)
+                    let sb = System.Text.StringBuilder().AppendLine(firstLineContent)
 
-                    let capacity =
-                        [ (range.StartLine - 1) .. (range.EndLine - 1) ]
-                        |> List.sumBy (fun lineIdx -> (sourceText.GetLineString lineIdx).Length)
-
-                    let sb = System.Text.StringBuilder(capacity).AppendLine(firstLineContent)
-
-                    for lineNumber in [ range.StartLine .. range.EndLine - 2 ] do
+                    for lineNumber in range.StartLine .. range.EndLine - 2 do
                         sb.AppendLine(sourceText.GetLineString lineNumber) |> ignore
 
                     let lastLine = sourceText.GetLineString(range.EndLine - 1)

--- a/src/Compiler/Facilities/prim-lexing.fsi
+++ b/src/Compiler/Facilities/prim-lexing.fsi
@@ -36,6 +36,7 @@ type ISourceText =
     abstract CopyTo: sourceIndex: int * destination: char[] * destinationIndex: int * count: int -> unit
 
     /// Gets a section of the input based on a given range.
+    /// <exception cref="System.ArgumentException">Throws an exception when the input range is outside the file boundaries.</exception>
     abstract GetSubTextFromRange: range: range -> string
 
 /// Functions related to ISourceText objects

--- a/src/Compiler/Facilities/prim-lexing.fsi
+++ b/src/Compiler/Facilities/prim-lexing.fsi
@@ -35,6 +35,9 @@ type ISourceText =
     /// Copies a section of the input to the given destination ad the given index
     abstract CopyTo: sourceIndex: int * destination: char[] * destinationIndex: int * count: int -> unit
 
+    /// Gets a section of the input based on a given range.
+    abstract GetSubTextFromRange: range: range -> string
+
 /// Functions related to ISourceText objects
 module SourceText =
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -10179,6 +10179,7 @@ FSharp.Compiler.Text.ISourceText: Int32 GetLineCount()
 FSharp.Compiler.Text.ISourceText: Int32 Length
 FSharp.Compiler.Text.ISourceText: Int32 get_Length()
 FSharp.Compiler.Text.ISourceText: System.String GetLineString(Int32)
+FSharp.Compiler.Text.ISourceText: System.String GetSubTextFromRange(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Text.ISourceText: System.String GetSubTextString(Int32, Int32)
 FSharp.Compiler.Text.ISourceText: System.Tuple`2[System.Int32,System.Int32] GetLastCharacterPosition()
 FSharp.Compiler.Text.ISourceText: Void CopyTo(Int32, Char[], Int32, Int32)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -10179,6 +10179,7 @@ FSharp.Compiler.Text.ISourceText: Int32 GetLineCount()
 FSharp.Compiler.Text.ISourceText: Int32 Length
 FSharp.Compiler.Text.ISourceText: Int32 get_Length()
 FSharp.Compiler.Text.ISourceText: System.String GetLineString(Int32)
+FSharp.Compiler.Text.ISourceText: System.String GetSubTextFromRange(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Text.ISourceText: System.String GetSubTextString(Int32, Int32)
 FSharp.Compiler.Text.ISourceText: System.Tuple`2[System.Int32,System.Int32] GetLastCharacterPosition()
 FSharp.Compiler.Text.ISourceText: Void CopyTo(Int32, Char[], Int32, Int32)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -89,6 +89,7 @@
       <Link>RangeTests.fs</Link>
     </Compile>
     <Compile Include="TooltipTests.fs" />
+    <Compile Include="SourceTextTests.fs" />
     <Compile Include="..\service\Program.fs">
       <Link>Program.fs</Link>
     </Compile>

--- a/tests/FSharp.Compiler.Service.Tests/SourceTextTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SourceTextTests.fs
@@ -23,3 +23,11 @@ let a b c =
     let v = sourceText.GetSubTextFromRange m
     let sanitized = v.Replace("\r", "")
     Assert.AreEqual("a b c =\n    // comment\n    2", sanitized)
+
+[<Test>]
+let ``Inconsistent return carriage return correct text`` () =
+    let sourceText =  SourceText.ofString "let a =\r\n    // foo\n    43"
+    let m = Range.mkRange "Sample.fs" (Position.mkPos 1 4) (Position.mkPos 3 6)
+    let v = sourceText.GetSubTextFromRange m
+    let sanitized = v.Replace("\r", "")
+    Assert.AreEqual("a =\n    // foo\n    43", sanitized)

--- a/tests/FSharp.Compiler.Service.Tests/SourceTextTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SourceTextTests.fs
@@ -1,5 +1,6 @@
 ﻿module FSharp.Compiler.Service.Tests.SourceTextTests
 
+open System
 open FSharp.Compiler.Text
 open NUnit.Framework
 
@@ -27,7 +28,20 @@ let a b c =
 [<Test>]
 let ``Inconsistent return carriage return correct text`` () =
     let sourceText =  SourceText.ofString "let a =\r\n    // foo\n    43"
-    let m = Range.mkRange "Sample.fs" (Position.mkPos 1 4) (Position.mkPos 3 6)
+    let m = Range.mkRange "Sample.fs" (Position.mkPos 1 4) (Position.mkPos 3 6) 
     let v = sourceText.GetSubTextFromRange m
     let sanitized = v.Replace("\r", "")
     Assert.AreEqual("a =\n    // foo\n    43", sanitized)
+
+[<Test>]
+let ``Zero range should return empty string`` () =
+    let sourceText = SourceText.ofString "a"
+    let v = sourceText.GetSubTextFromRange Range.Zero
+    Assert.AreEqual(String.Empty, v)
+    
+[<Test>]
+let ``Invalid range should throw argument exception`` () =
+    let sourceText = SourceText.ofString "a"
+    let mInvalid = Range.mkRange "Sample.fs" (Position.mkPos 3 6) (Position.mkPos 1 4)
+    Assert.Throws<ArgumentException>(fun () -> sourceText.GetSubTextFromRange mInvalid |> ignore)
+    |> ignore

--- a/tests/FSharp.Compiler.Service.Tests/SourceTextTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SourceTextTests.fs
@@ -1,0 +1,25 @@
+﻿module FSharp.Compiler.Service.Tests.SourceTextTests
+
+open FSharp.Compiler.Text
+open NUnit.Framework
+
+[<Test>]
+let ``Select text from a single line via the range`` () =
+    let sourceText = SourceText.ofString """
+let a = 2
+"""
+    let m = Range.mkRange "Sample.fs" (Position.mkPos 2 4) (Position.mkPos 2 5)
+    let v = sourceText.GetSubTextFromRange m
+    Assert.AreEqual("a", v)
+
+[<Test>]
+let ``Select text from multiple lines via the range`` () =
+    let sourceText = SourceText.ofString """
+let a b c =
+    // comment
+    2
+"""
+    let m = Range.mkRange "Sample.fs" (Position.mkPos 2 4) (Position.mkPos 4 5)
+    let v = sourceText.GetSubTextFromRange m
+    let sanitized = v.Replace("\r", "")
+    Assert.AreEqual("a b c =\n    // comment\n    2", sanitized)

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/SourceText.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/SourceText.fs
@@ -65,7 +65,39 @@ module internal SourceText =
                 member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
                     sourceText.CopyTo(sourceIndex, destination, destinationIndex, count)
 
-                member __.GetSubTextFromRange _ = failwith "Not implemented"
+                member this.GetSubTextFromRange range =
+                    let totalAmountOfLines = sourceText.Lines.Count
+
+                    if
+                        range.StartLine = 0
+                        && range.StartColumn = 0
+                        && range.EndLine = 0
+                        && range.EndColumn = 0
+                    then
+                        String.Empty
+                    elif
+                        range.StartLine < 1
+                        || (range.StartLine - 1) > totalAmountOfLines
+                        || range.EndLine < 1
+                        || (range.EndLine - 1) > totalAmountOfLines
+                    then
+                        invalidArg (nameof range) "The range is outside the file boundaries"
+                    else
+                        let startLine = range.StartLine - 1
+                        let line = this.GetLineString startLine
+
+                        if range.StartLine = range.EndLine then
+                            let length = range.EndColumn - range.StartColumn
+                            line.Substring(range.StartColumn, length)
+                        else
+                            let firstLineContent = line.Substring(range.StartColumn)
+                            let sb = System.Text.StringBuilder().AppendLine(firstLineContent)
+
+                            for lineNumber in range.StartLine .. range.EndLine - 2 do
+                                sb.AppendLine(this.GetLineString lineNumber) |> ignore
+
+                            let lastLine = this.GetLineString(range.EndLine - 1)
+                            sb.Append(lastLine.Substring(0, range.EndColumn)).ToString()
             }
 
         sourceText

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/SourceText.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/SourceText.fs
@@ -64,6 +64,8 @@ module internal SourceText =
 
                 member __.CopyTo(sourceIndex, destination, destinationIndex, count) =
                     sourceText.CopyTo(sourceIndex, destination, destinationIndex, count)
+
+                member __.GetSubTextFromRange _ = failwith "Not implemented"
             }
 
         sourceText

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -163,6 +163,8 @@ module private SourceText =
 
                   member _.CopyTo(sourceIndex, destination, destinationIndex, count) =
                       sourceText.CopyTo(sourceIndex, destination, destinationIndex, count)
+
+                  member _.GetSubTextFromRange(range) = failwith "Not implemented"
             }
 
         sourceText

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -164,7 +164,39 @@ module private SourceText =
                   member _.CopyTo(sourceIndex, destination, destinationIndex, count) =
                       sourceText.CopyTo(sourceIndex, destination, destinationIndex, count)
 
-                  member _.GetSubTextFromRange(range) = failwith "Not implemented"
+                  member this.GetSubTextFromRange range =
+                      let totalAmountOfLines = sourceText.Lines.Count
+
+                      if
+                          range.StartLine = 0
+                          && range.StartColumn = 0
+                          && range.EndLine = 0
+                          && range.EndColumn = 0
+                      then
+                          String.Empty
+                      elif
+                          range.StartLine < 1
+                          || (range.StartLine - 1) > totalAmountOfLines
+                          || range.EndLine < 1
+                          || (range.EndLine - 1) > totalAmountOfLines
+                      then
+                          invalidArg (nameof range) "The range is outside the file boundaries"
+                      else
+                          let startLine = range.StartLine - 1
+                          let line = this.GetLineString startLine
+
+                          if range.StartLine = range.EndLine then
+                              let length = range.EndColumn - range.StartColumn
+                              line.Substring(range.StartColumn, length)
+                          else
+                              let firstLineContent = line.Substring(range.StartColumn)
+                              let sb = System.Text.StringBuilder().AppendLine(firstLineContent)
+
+                              for lineNumber in range.StartLine .. range.EndLine - 2 do
+                                  sb.AppendLine(this.GetLineString lineNumber) |> ignore
+
+                              let lastLine = this.GetLineString(range.EndLine - 1)
+                              sb.Append(lastLine.Substring(0, range.EndColumn)).ToString()
             }
 
         sourceText


### PR DESCRIPTION
In Fantomas, we have [an extension](https://github.com/fsprojects/fantomas/blob/e671f3d7c68a258d80f6440ea82aaada2c48a34d/src/Fantomas.Core/ISourceTextExtensions.fs) for `ISourceText` to grab the text based on a `range`.

I find myself copying this over to other projects that consume FCS quite often, and I would like to have this in `FCS`.