### PR TITLE
Workaround for #15972

### DIFF
--- a/vsintegration/tests/FSharp.Editor.Tests/DocumentDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/DocumentDiagnosticAnalyzerTests.fs
@@ -126,7 +126,12 @@ type DocumentDiagnosticAnalyzerTests() =
         // TODO: once workaround (https://github.com/dotnet/fsharp/pull/15982) will not be needed, this should be reverted back to normal method (see PR)
         this.VerifyDiagnosticBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(fileContents, expectedMessage, DiagnosticSeverity.Error)
 
-    member private this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(fileContents: string, expectedMarker: string, ?expectedMessage: string) =
+    member private this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE
+        (
+            fileContents: string,
+            expectedMarker: string,
+            ?expectedMessage: string
+        ) =
         let errors =
             getDiagnostics fileContents
             |> Seq.filter (fun e -> e.Severity = DiagnosticSeverity.Error)

--- a/vsintegration/tests/FSharp.Editor.Tests/DocumentDiagnosticAnalyzerTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/DocumentDiagnosticAnalyzerTests.fs
@@ -91,6 +91,67 @@ type DocumentDiagnosticAnalyzerTests() =
         actualError.Location.SourceSpan.End
         |> Assert.shouldBeEqualWith expectedEnd "Error end positions should match"
 
+    member private this.VerifyDiagnosticBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE
+        (
+            fileContents: string,
+            expectedMessage: string,
+            expectedSeverity: DiagnosticSeverity
+        ) =
+        // TODO: once workaround (https://github.com/dotnet/fsharp/pull/15982) will not be needed, this should be reverted back to normal method (see PR)
+        let errors =
+            getDiagnostics fileContents
+            |> Seq.filter (fun e -> e.Severity = expectedSeverity)
+            |> Seq.toArray
+
+        errors.Length
+        |> Assert.shouldBeEqualWith 2 "There should be two errors generated"
+
+        let actualError = errors.[0]
+        Assert.Equal(expectedSeverity, actualError.Severity)
+
+        actualError.GetMessage()
+        |> Assert.shouldBeEqualWith expectedMessage "Error messages should match"
+
+        let expectedStart = fileContents.IndexOf(startMarker) + startMarker.Length
+
+        actualError.Location.SourceSpan.Start
+        |> Assert.shouldBeEqualWith expectedStart "Error start positions should match"
+
+        let expectedEnd = fileContents.IndexOf(endMarker)
+
+        actualError.Location.SourceSpan.End
+        |> Assert.shouldBeEqualWith expectedEnd "Error end positions should match"
+
+    member private this.VerifyErrorBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(fileContents: string, expectedMessage: string) =
+        // TODO: once workaround (https://github.com/dotnet/fsharp/pull/15982) will not be needed, this should be reverted back to normal method (see PR)
+        this.VerifyDiagnosticBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(fileContents, expectedMessage, DiagnosticSeverity.Error)
+
+    member private this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(fileContents: string, expectedMarker: string, ?expectedMessage: string) =
+        let errors =
+            getDiagnostics fileContents
+            |> Seq.filter (fun e -> e.Severity = DiagnosticSeverity.Error)
+            |> Seq.toArray
+
+        errors.Length
+        |> Assert.shouldBeEqualWith 2 "There should be exactly two errors generated"
+
+        let actualError = errors.[0]
+
+        if expectedMessage.IsSome then
+            actualError.GetMessage()
+            |> Assert.shouldBeEqualWith expectedMessage.Value "Error messages should match"
+
+        Assert.Equal(DiagnosticSeverity.Error, actualError.Severity)
+        let expectedStart = fileContents.IndexOf(expectedMarker)
+
+        actualError.Location.SourceSpan.Start
+        |> Assert.shouldBeEqualWith expectedStart "Error start positions should match"
+
+        let expectedEnd = expectedStart + expectedMarker.Length
+
+        actualError.Location.SourceSpan.End
+        |> Assert.shouldBeEqualWith expectedEnd "Error end positions should match"
+
     member private this.VerifyErrorBetweenMarkers(fileContents: string, expectedMessage: string) =
         this.VerifyDiagnosticBetweenMarkers(fileContents, expectedMessage, DiagnosticSeverity.Error)
 
@@ -99,7 +160,7 @@ type DocumentDiagnosticAnalyzerTests() =
 
     [<Fact>]
     member public this.Error_Expression_IllegalIntegerLiteral() =
-        this.VerifyErrorBetweenMarkers(
+        this.VerifyErrorBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 let _ = 1
@@ -110,7 +171,7 @@ let a = 0.1(*start*).(*end*)0
 
     [<Fact>]
     member public this.Error_Expression_IncompleteDefine() =
-        this.VerifyErrorBetweenMarkers(
+        this.VerifyErrorBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 let a = (*start*);(*end*)
@@ -120,7 +181,7 @@ let a = (*start*);(*end*)
 
     [<Fact>]
     member public this.Error_Expression_KeywordAsValue() =
-        this.VerifyErrorBetweenMarkers(
+        this.VerifyErrorBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 let b =
@@ -255,7 +316,7 @@ let f () =
 
     [<Fact>]
     member public this.Error_Identifer_IllegalFloatPointLiteral() =
-        this.VerifyErrorBetweenMarkers(
+        this.VerifyErrorBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 let x: float = 1.2(*start*).(*end*)3
@@ -368,7 +429,7 @@ async { if true then return 1 } |> ignore
 
     [<Fact>]
     member public this.ExtraEndif() =
-        this.VerifyErrorBetweenMarkers(
+        this.VerifyErrorBetweenMarkers_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 #if UNDEFINED
@@ -383,7 +444,7 @@ async { if true then return 1 } |> ignore
 
     [<Fact>]
     member public this.Squiggles_HashNotFirstSymbol_If() =
-        this.VerifyErrorAtMarker(
+        this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 (*comment*) #if UNDEFINED
@@ -398,7 +459,7 @@ async { if true then return 1 } |> ignore
 
     [<Fact>]
     member public this.Squiggles_HashNotFirstSymbol_Endif() =
-        this.VerifyErrorAtMarker(
+        this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 #if DEBUG
@@ -413,7 +474,7 @@ async { if true then return 1 } |> ignore
 
     [<Fact>]
     member public this.Squiggles_HashIfWithMultilineComment() =
-        this.VerifyErrorAtMarker(
+        this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 #if DEBUG (*comment*)
@@ -425,7 +486,7 @@ async { if true then return 1 } |> ignore
 
     [<Fact>]
     member public this.Squiggles_HashIfWithUnexpected() =
-        this.VerifyErrorAtMarker(
+        this.VerifyErrorAtMarker_HACK_PLEASE_REFER_TO_COMMENT_INSIDE(
             fileContents =
                 """
 #if DEBUG TEST


### PR DESCRIPTION
After talking to @0101, we decided to make a workaround for https://github.com/dotnet/fsharp/issues/15972 by not excluding parsing/syntax errors from semantic ones, just in case if proper fix doesn't make it to P3.

Worst case scenario, parsing errors will be doubled.

It shows errors right now:

<img width="260" alt="image_2023-09-15_15-23-26" src="https://github.com/dotnet/fsharp/assets/1260985/e2d95a51-abf7-4de7-87b3-5456150ae691">
