### PR TITLE
Update xcopy-msbuild

### DIFF
--- a/global.json
+++ b/global.json
@@ -12,7 +12,7 @@
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.6.0-2"
+    "xcopy-msbuild": "17.7.0"
   },
   "native-tools": {
     "perl": "5.38.0.1"


### PR DESCRIPTION
Minimal version required is 17.7 since we've updated to rc2