### PR TITLE
Making Remove Unused Opens remove all unused opens again

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnusedOpens.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/RemoveUnusedOpens.fs
@@ -3,12 +3,13 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Threading.Tasks
 open System.Collections.Immutable
 
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics
+
+open FSharp.Compiler.Text
 
 open CancellableTasks
 
@@ -30,14 +31,20 @@ type internal RemoveUnusedOpensCodeFixProvider [<ImportingConstructor>] () =
             cancellableTask {
                 let! sourceText = context.GetSourceTextAsync()
 
-                let span =
-                    sourceText.Lines.GetLineFromPosition(context.Span.Start).SpanIncludingLineBreak
+                let! unusedOpensOpt = UnusedOpensDiagnosticAnalyzer.GetUnusedOpenRanges context.Document
 
                 return
-                    ValueSome
+                    unusedOpensOpt
+                    |> ValueOption.ofOption
+                    |> ValueOption.map (
+                        List.map (fun m ->
+                            let span = sourceText.Lines[Line.toZ m.StartLine].SpanIncludingLineBreak
+                            TextChange(span, ""))
+                    )
+                    |> ValueOption.map (fun changes ->
                         {
                             Name = CodeFix.RemoveUnusedOpens
                             Message = title
-                            Changes = [ TextChange(span, "") ]
-                        }
+                            Changes = changes
+                        })
             }

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnusedOpensTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnusedOpensTests.fs
@@ -10,7 +10,7 @@ open CodeFixTestFramework
 let private codeFix = RemoveUnusedOpensCodeFixProvider()
 
 [<Fact>]
-let ``Fixes IDE0005`` () =
+let ``Fixes IDE0005 - one unused declaration`` () =
     let code =
         """
 open System
@@ -26,5 +26,30 @@ open System
             }
 
     let actual = codeFix |> tryFix code (Manual("open System", "IDE0005"))
+
+    Assert.Equal(expected, actual)
+
+[<Theory>]
+[<InlineData "open System.Buffers">]
+[<InlineData "open System.IO">]
+[<InlineData "open System.Text">]
+let ``Fixes IDE0005 - multiple unused declarations`` focus =
+    let code =
+        """
+open System.Buffers
+open System.IO
+open System.Text
+"""
+
+    let expected =
+        Some
+            {
+                Message = "Remove unused open declarations"
+                FixedCode =
+                    """
+"""
+            }
+
+    let actual = codeFix |> tryFix code (Manual(focus, "IDE0005"))
 
     Assert.Equal(expected, actual)


### PR DESCRIPTION
Fixes #15932

This got broken in [this PR](https://github.com/dotnet/fsharp/pull/15082/files#diff-fa5e1d76c141cf6bc69bbd1eb5830ca6c660c8e722c36ae520107be70fcb72be), I am basically returning the previous implementation here.

Thanks @atsapura for noticing the regression.