### PR TITLE
Add separate step checking no strict indentation specifically

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -383,6 +383,29 @@ stages:
                 ArtifactType: Container
                 parallel: true
 
+        - job: WindowsNoStrictIndentation
+          pool:
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals $(WindowsMachineQueueName)
+          timeoutInMinutes: 120
+          steps:
+          - checkout: self
+            clean: true
+
+          - script: eng\CIBuild.cmd -compressallmetadata -configuration Release /p:AdditionalFscCmdFlags=--strict-indentation-
+            env:
+              NativeToolsOnMachine: true
+            displayName: Build
+
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Build BinLog
+            condition: always()
+            continueOnError: true
+            inputs:
+                PathToPublish: '$(Build.SourcesDirectory)\artifacts\log/Release\Build.VisualFSharp.sln.binlog'
+                ArtifactName: 'Windows Release build binlogs'
+                ArtifactType: Container
+                parallel: true
 
         # Windows With Compressed Metadata
         - job: WindowsCompressedMetadata


### PR DESCRIPTION
Adding this since all of ci steps in 17.8 are running on version 8, which includes strict indentation changes.