### PR TITLE
Making code fixes generate multiple suggestions again

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
@@ -82,10 +82,7 @@ module internal CodeFixHelpers =
                     reportCodeFixTelemetry context.Diagnostics context.Document codeFix.Name [||]
                     return doc
                 }
-                |> CancellableTask.start cancellationToken),
-            // Equivalence key - should be unique!
-            // Otherwise VS will only show the first registered code fix.
-            codeFix.Message
+                |> CancellableTask.start cancellationToken)
         )
 
 [<AutoOpen>]

--- a/vsintegration/src/FSharp.Editor/CodeFixes/IFSharpCodeFix.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/IFSharpCodeFix.fs
@@ -14,5 +14,10 @@ type FSharpCodeFix =
         Changes: TextChange list
     }
 
+/// Provider can generate at most 1 suggestion.
 type IFSharpCodeFixProvider =
     abstract member GetCodeFixIfAppliesAsync: context: CodeFixContext -> CancellableTask<FSharpCodeFix voption>
+
+/// Provider can generate multiple suggestions.
+type IFSharpMultiCodeFixProvider =
+    abstract member GetCodeFixesAsync: context: CodeFixContext -> CancellableTask<FSharpCodeFix seq>

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ReplaceWithSuggestionTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/ReplaceWithSuggestionTests.fs
@@ -19,7 +19,7 @@ let song = { Titel = "Jigsaw Falling Into Place" }
 """
 
     let expected =
-        Some
+        [
             {
                 Message = "Replace with 'Title'"
                 FixedCode =
@@ -29,8 +29,9 @@ type Song = { Title : string }
 let song = { Title = "Jigsaw Falling Into Place" }
 """
             }
+        ]
 
-    let actual = codeFix |> tryFix code Auto
+    let actual = codeFix |> multiFix code Auto
 
     Assert.Equal(expected, actual)
 
@@ -44,7 +45,7 @@ let someSong : Wrong = { Title = "The Narcissist" }
 """
 
     let expected =
-        Some
+        [
             {
                 Message = "Replace with 'Song'"
                 FixedCode =
@@ -54,8 +55,47 @@ type Song = { Title : string }
 let someSong : Song = { Title = "The Narcissist" }
 """
             }
+        ]
 
-    let actual = codeFix |> tryFix code Auto
+    let actual = codeFix |> multiFix code Auto
+
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Fixes FS0039 - multiple suggestions`` () =
+    let code =
+        """
+type TheType1() = class end
+type TheType3() = class end
+
+let test = TheType2()
+"""
+
+    let expected =
+        [
+            {
+                Message = "Replace with 'TheType1'"
+                FixedCode =
+                    """
+type TheType1() = class end
+type TheType3() = class end
+
+let test = TheType1()
+"""
+            }
+            {
+                Message = "Replace with 'TheType3'"
+                FixedCode =
+                    """
+type TheType1() = class end
+type TheType3() = class end
+
+let test = TheType3()
+"""
+            }
+        ]
+
+    let actual = codeFix |> multiFix code Auto
 
     Assert.Equal(expected, actual)
 
@@ -70,9 +110,9 @@ module Module2 =
     let song = { Titel = "Jigsaw Falling Into Place" }
 """
 
-    let expected = None
+    let expected = []
 
-    let actual = codeFix |> tryFix code Auto
+    let actual = codeFix |> multiFix code Auto
 
     Assert.Equal(expected, actual)
 
@@ -83,9 +123,9 @@ let ``Doesn't fix FS0039 for random undefined stuff`` () =
 let f = g
 """
 
-    let expected = None
+    let expected = []
 
-    let actual = codeFix |> tryFix code Auto
+    let actual = codeFix |> multiFix code Auto
 
     Assert.Equal(expected, actual)
 
@@ -100,7 +140,7 @@ let song = Song(titel = "Under The Milky Way")
 """
 
     let expected =
-        Some
+        [
             {
                 Message = "Replace with 'title'"
                 FixedCode =
@@ -111,7 +151,8 @@ type Song(title: string) =
 let song = Song(title = "Under The Milky Way")
 """
             }
+        ]
 
-    let actual = codeFix |> tryFix code Auto
+    let actual = codeFix |> multiFix code Auto
 
     Assert.Equal(expected, actual)


### PR DESCRIPTION
Fixes #15890

I think this is the last addition to the code fix framework. **A few** code fixes can generate multiple suggestions, so here I add a notion of this. Technically we could generalize the existing interface (`IFSharpCodeFixProvider`), but I decided to create another one - to keep the intention clear and to not complicate the code for the majority of code fixes which do not need this.

Note, this used to work, but got broken [here](https://github.com/dotnet/fsharp/pull/15082/files#diff-4aa4daee5ebb0cea1bf021781111592bec1b1f55f447df9cd1acd5a34f0e0198) when we changed [the equivalence key](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.codeactions.codeaction.equivalencekey?view=roslyn-dotnet-4.6.0#microsoft-codeanalysis-codeactions-codeaction-equivalencekey) - it used to be the code fix message (different for suggestions) to the code fix name (same for suggestions). In fact, we don't need any equivalence key now - we don't have equivalent code fixes yet.

Demo:

https://github.com/dotnet/fsharp/assets/5451366/ed768c94-19e7-4c51-83ad-cde33f9a5975


