### PR TITLE
fix16014 - Update package versions for fsharp.core and fsharp.compiler.service

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>7</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>401</FSBuildVersion>
+    <FSBuildVersion>402</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->


### PR DESCRIPTION
Fix #16014 FSharp.Core package versions aren't incrementing with each SDK release

We have failed to update the compiler service and fsharp.core releases to match sdk releases.

**Description**
When the dotnet sdk ships and releases it includes an updated FSharp Compiler and FSharp.Core nuget package.  The latest release of the dotnet sdk 7.0.401 includes updated compilers and cores, however, the nuget package version was not updated, ordinarily this is not a significant issue, however, the SDK also includes an embedded fsharp.core nuget package, this enables fsharp builds to succeed offline from nuget.  This behaviour works well, however, when using nuget lock files the hash of the nuget package in SDK 7.0.401, differs from that shipped with sdk 7.0.400 and shipped to nuget.  Which means that developers using nuget lock files get a warning message during build.

Regression? yes
Risk: very low

Original issue: #16014 - FSharp.Core package versions aren't incrementing with each SDK release.

The impacted nuget packages: FSharp.Compiler.Service and FSharp.Core are shipped automatically as part of the SDK release process

**How to prevent this moving forward:**  it is quite tough to figure out how to prevent this, because in fact the version number had been changed in our branch (I.e. we remembered to make the necessary change) ... but the change didn't flow to the Sdk repo.  We are considering an automatic tool to update it and ensure we push it into the sdk
