### PR TITLE
Correctly colorize parameterized CE builders

### DIFF
--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -229,9 +229,9 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     // Give bespoke error messages for the FSharp.Core "query" builder
     let isQuery = 
         match stripDebugPoints interpExpr with 
-        // A non-generic custom builder, e.g., `query`, `async`.
+        // An unparameterized custom builder, e.g., `query`, `async`.
         | Expr.Val (vref, _, m)
-        // A custom builder with parameters, e.g., `builder<…>`, `builder ()`.
+        // A parameterized custom builder, e.g., `builder<…>`, `builder ()`.
         | Expr.App (funcExpr = Expr.Val (vref, _, m)) ->
             let item = Item.CustomBuilder (vref.DisplayName, vref)
             CallNameResolutionSink cenv.tcSink (m, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)

--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -229,10 +229,10 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     // Give bespoke error messages for the FSharp.Core "query" builder
     let isQuery = 
         match stripDebugPoints interpExpr with 
-        // A regular custom builder, e.g., async.
+        // A non-generic custom builder, e.g., `query`, `async`.
         | Expr.Val (vref, _, m)
-        // A custom builder with generic type parameters, e.g., builder<…>.
-        | Expr.App (funcExpr=Expr.Val (vref, _, m)) ->
+        // A custom builder with parameters, e.g., `builder<…>`, `builder ()`.
+        | Expr.App (funcExpr = Expr.Val (vref, _, m)) ->
             let item = Item.CustomBuilder (vref.DisplayName, vref)
             CallNameResolutionSink cenv.tcSink (m, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)
             valRefEq cenv.g vref cenv.g.query_value_vref 

--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -229,7 +229,10 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
     // Give bespoke error messages for the FSharp.Core "query" builder
     let isQuery = 
         match stripDebugPoints interpExpr with 
-        | Expr.Val (vref, _, m) -> 
+        // A regular custom builder, e.g., async.
+        | Expr.Val (vref, _, m)
+        // A custom builder with generic type parameters, e.g., builder<…>.
+        | Expr.App (funcExpr=Expr.Val (vref, _, m)) ->
             let item = Item.CustomBuilder (vref.DisplayName, vref)
             CallNameResolutionSink cenv.tcSink (m, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)
             valRefEq cenv.g vref cenv.g.query_value_vref 

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -967,17 +967,23 @@ let x = builder { return 3 }
 let y = builder
 """
 
-        match checkResults.GetSymbolUseAtLocation(6, 11, "let builder = Builder ()", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+        shouldEqual
+            [
+                // let builder = Builder ()
+                (6, 4), false
 
-        match checkResults.GetSymbolUseAtLocation(8, 15, "let x = builder { return 3 }", ["builder"]) with
-        | Some symbolUse -> Assert.True (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` in `builder { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let x = builder { return 3 }
+                (8, 8), false   // Item.Value _
+                (8, 8), true    // Item.CustomBuilder _
 
-        match checkResults.GetSymbolUseAtLocation(9, 15, "let y = builder", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let y = builder
+                (9, 8), false
+            ]
+            [
+                for symbolUse in checkResults.GetAllUsesOfAllSymbolsInFile() do
+                    if symbolUse.Symbol.DisplayName = "builder" then
+                        (symbolUse.Range.StartLine, symbolUse.Range.StartColumn), symbolUse.IsFromComputationExpression
+            ]
 
     [<Test>]
     let ``IsFromComputationExpression only returns true for 'builder' in 'builder<…> { … }'`` () =
@@ -995,29 +1001,34 @@ let p = builder<int>
 let q<'T> = builder<'T>
 """
 
-        match checkResults.GetSymbolUseAtLocation(6, 11, "let builder<'T> = Builder<'T> ()", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder<…> { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+        shouldEqual
+            [
+                // let builder<'T> = Builder<'T> ()
+                (6, 4), false
 
-        match checkResults.GetSymbolUseAtLocation(8, 15, "let x = builder { return 3 }", ["builder"]) with
-        | Some symbolUse -> Assert.True (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` in `builder<…> { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let x = builder { return 3 }
+                (8, 8), false   // Item.Value _
+                (8, 8), true    // Item.CustomBuilder _
 
-        match checkResults.GetSymbolUseAtLocation(9, 15, "let x = builder<int> { return 3 }", ["builder"]) with
-        | Some symbolUse -> Assert.True (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` in `builder<…> { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let y = builder<int> { return 3 }
+                (9, 8), false   // Item.Value _
+                (9, 8), true    // Item.CustomBuilder _
 
-        match checkResults.GetSymbolUseAtLocation(10, 15, "let x = builder<_> { return 3 }", ["builder"]) with
-        | Some symbolUse -> Assert.True (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` in `builder<…> { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let z = builder<_> { return 3 }
+                (10, 8), false  // Item.Value _
+                (10, 8), true   // Item.CustomBuilder _
 
-        match checkResults.GetSymbolUseAtLocation(11, 15, "let p = builder<int>", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder<…> { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let p = builder<int>
+                (11, 8), false
 
-        match checkResults.GetSymbolUseAtLocation(12, 15, "let q<'T> = builder<'T>", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder<…> { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let q<'T> = builder<'T>
+                (12, 12), false
+            ]
+            [
+                for symbolUse in checkResults.GetAllUsesOfAllSymbolsInFile() do
+                    if symbolUse.Symbol.DisplayName = "builder" then
+                        (symbolUse.Range.StartLine, symbolUse.Range.StartColumn), symbolUse.IsFromComputationExpression
+            ]
 
     [<Test>]
     let ``IsFromComputationExpression only returns true for 'builder' in 'builder () { … }'`` () =
@@ -1033,18 +1044,23 @@ let y = builder ()
 let z = builder
 """
 
-        match checkResults.GetSymbolUseAtLocation(6, 11, "let builder () = Builder ()", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder () { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+        shouldEqual
+            [
+                // let builder () = Builder ()
+                (6, 4), false
 
-        match checkResults.GetSymbolUseAtLocation(8, 15, "let x = builder () { return 3 }", ["builder"]) with
-        | Some symbolUse -> Assert.True (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` in `builder () { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let x = builder () { return 3 }
+                (8, 8), false   // Item.Value _
+                (8, 8), true    // Item.CustomBuilder _
 
-        match checkResults.GetSymbolUseAtLocation(9, 15, "let y = builder ()", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder () { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let y = builder ()
+                (9, 8), false
 
-        match checkResults.GetSymbolUseAtLocation(10, 15, "let z = builder", ["builder"]) with
-        | Some symbolUse -> Assert.False (symbolUse.IsFromComputationExpression, "IsFromComputationExpression should return true for `builder` only in `builder () { … }`.")
-        | None -> Assert.Fail "Symbol was not 'builder'."
+                // let z = builder
+                (10, 8), false
+            ]
+            [
+                for symbolUse in checkResults.GetAllUsesOfAllSymbolsInFile() do
+                    if symbolUse.Symbol.DisplayName = "builder" then
+                        (symbolUse.Range.StartLine, symbolUse.Range.StartColumn), symbolUse.IsFromComputationExpression
+            ]

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -965,11 +965,18 @@ let builder = Builder ()
 
 let x = builder { return 3 }
 let y = builder
+let z = Builder () { return 3 }
 """
 
         shouldEqual
             [
-                // let builder = Builder ()
+                // type Builder () =
+                (2, 5), false
+
+                // … = Builder ()
+                (6, 14), false
+
+                // let builder = …
                 (6, 4), false
 
                 // let x = builder { return 3 }
@@ -978,11 +985,15 @@ let y = builder
 
                 // let y = builder
                 (9, 8), false
+
+                // let z = Builder () { return 3 }
+                (10, 8), false
             ]
             [
                 for symbolUse in checkResults.GetAllUsesOfAllSymbolsInFile() do
-                    if symbolUse.Symbol.DisplayName = "builder" then
-                        (symbolUse.Range.StartLine, symbolUse.Range.StartColumn), symbolUse.IsFromComputationExpression
+                    match symbolUse.Symbol.DisplayName with
+                    | "Builder" | "builder" -> (symbolUse.Range.StartLine, symbolUse.Range.StartColumn), symbolUse.IsFromComputationExpression
+                    | _ -> ()
             ]
 
     [<Test>]


### PR DESCRIPTION
### Change

- Enable correct colorization of parameterized custom computation expression builders, e.g.:
  - `builder<…> { … }` (type application).
  - `builder () { … }` (function application).[^1]

### Example

In the following example, `builder` is now correctly colorized as a keyword (like `async` and any other custom builder that doesn't have generic type parameters).

```fsharp
type Builder<'T> () =
    member _.Return x = x
    member _.Run x = x

let builder<'T> = Builder<'T> ()

let x = builder { return 3 }
let y = builder<int> { return 3 }
let z = builder<_> { return 3 }
```

#### Before

<img src="https://github.com/dotnet/fsharp/assets/14795984/0975c94a-7692-489b-bb59-c04cd3769f3a.png" alt="image" width="700">

#### After

<img src="https://github.com/dotnet/fsharp/assets/14795984/b148fd11-0310-4be5-955f-aca924c1fcef.png" alt="image" width="700">

### Tests

`SyntacticClassificationServiceTests` seems to be too low-level to catch this change. I have added tests for `FSharpSymbolUse.IsFromComputationExpression` under `Tests.Service.Symbols.ComputationExpressions`.

[^1]: This does _not_ apply to direct invocations of constructors, e.g., `Builder () { … }`. I think this behavior makes sense, since a Pascal-case constructor doesn't "feel" like it should get keyword coloring, even in this context.

    I can think of even funkier valid cases where keyword coloring still does not apply and almost certainly (?) shouldn't…
    
    ```fsharp
    type System.Int32 with
        member _.Return x = x
        member _.Run x = x
    
    let uh = 99 { return 3 }
    ```
    
    ```fsharp
    type List<'T> with
        member _.Return x = x
        member _.Run x = x
    
    let yeah = [1..10] { return 3 }
    ```