### PR TITLE
Fix 16009 - wrong order of static init in recursive module

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -1840,7 +1840,10 @@ let TcMutRecDefns_Phase2 (cenv: cenv) envInitial mBinds scopem mutRecNSInfo (env
           | SynMemberDefn.ImplicitCtor _ :: _ -> ()
           | _ ->
             if not tcref.IsFSharpEnumTycon && not tcref.IsFSharpDelegateTycon && not tcref.IsFSharpException && not tcref.IsTypeAbbrev then
-                TyconBindingDefn(containerInfo, newslotsOK, declKind, None, tcref.Range)
+                if members |> List.exists (function | SynMemberDefn.LetBindings(isStatic=true) -> true | _ -> false ) then
+                    // Introduction of this member has caused the regression #16009, due to a missed Lazy<>.Force access from a member to a value in recursive module
+                    // Minimizing the impact by only yielding in case of actually emitting static let bindings.
+                    TyconBindingDefn(containerInfo, newslotsOK, declKind, None, tcref.Range)
 
           // Yield the other members
           for memb in members do

--- a/src/Compiler/Checking/CheckIncrementalClasses.fs
+++ b/src/Compiler/Checking/CheckIncrementalClasses.fs
@@ -756,7 +756,6 @@ let MakeCtorForIncrClassConstructionPhase2C(
     /// binding in the implicit class construction sequence 
     let TransTrueDec isCtorArg (reps: IncrClassReprInfo) dec = 
             match dec with 
-            // Pokud to neni staticke, a zaroven to nema construktor info, tak zkusit vyhnout se TransBind mozna?
             | IncrClassBindingGroup(binds, isStatic, isRec) ->
                 let actions, reps, methodBinds = 
                     let reps = (reps, binds) ||> List.fold (fun rep bind -> rep.ChooseAndAddRepresentation(cenv, env, isStatic, isCtorArg, staticCtorInfo, ctorInfoOpt, staticForcedFieldVars, instanceForcedFieldVars, bind)) // extend

--- a/tests/fsharp/typecheck/sigs/neg04.bsl
+++ b/tests/fsharp/typecheck/sigs/neg04.bsl
@@ -45,15 +45,11 @@ neg04.fs(70,21,70,36): typecheck error FS0064: This construct causes code to be 
 
 neg04.fs(70,12,70,14): typecheck error FS0663: This type parameter has been used in a way that constrains it to always be 'c<string>'
 
-neg04.fs(70,12,70,14): typecheck error FS0660: This code is less generic than required by its annotations because the explicit type variable 'a' could not be generalized. It was constrained to be 'c<string>'.
-
 neg04.fs(76,19,76,26): typecheck error FS0698: Invalid constraint: the type used for the constraint is sealed, which means the constraint could only be satisfied by at most one solution
 
 neg04.fs(76,19,76,26): typecheck error FS0064: This construct causes code to be less generic than indicated by the type annotations. The type variable 'a has been constrained to be type 'd'.
 
 neg04.fs(76,10,76,12): typecheck error FS0663: This type parameter has been used in a way that constrains it to always be 'd'
-
-neg04.fs(76,10,76,12): typecheck error FS0660: This code is less generic than required by its annotations because the explicit type variable 'a' could not be generalized. It was constrained to be 'd'.
 
 neg04.fs(81,58,81,61): typecheck error FS0001: This expression was expected to have type
     'int'    


### PR DESCRIPTION
Fixes issue #16009 .

This was happening after introduction of `static let`.
However, for incremental classes, the error was always there: https://sharplab.io/#v2:DYLgZgzgNALiCWwA+A7AhgWwKYQA5oGMsACAWQE8AFAJwHsBzazAWACg2NaATAV2BOpYCZbnxIBeYmzbFZxWriwpiAZXIQYWDNNZzi/GMQBG8FF1P1ikgGK1aAdQAW8Ao+tpEEAHQqYaGC6kWkZY1Dp6nLz8xAByOJpcpKLR4jJ6cgbEAEKm5iiWkihYAO7yRgBWABQAlGnpUrpyMOSKxLYOzq72tNQA1hBWdeka/i7E2Bgh1Kp+AQRBk6FWsfFYiclYXjlmFuFNLSTtTi5uHsAQlWgIKDDVg431maYjKEQAgsto6UN6I3PjwSWvlG80B00kcQ0aySUU22zy9B+9QakTExDeBBgPDQwBoDCYGGWQwUShEsOJimUaih2geDT0Jh2+S8ABVaL5qBYasQkAA+YgAYVoKAgtH4XnsnM0ABlTFggA 


This minimizes the impact by skipping a fake member generation in case it is not needed for `static let` purposes.

The error remains for the (hopefully rare) combination of:
`module rec`
forward-usage of declared static members
having a static member on a type which needs incremental constructor


Also, the existing failing code does emit the `diagnostics 40` warning about a recursive issue -> but it is not an error.