### PR TITLE
Allow merging of Namespace and Module in TrieMapping

### DIFF
--- a/src/Compiler/Driver/GraphChecking/TrieMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/TrieMapping.fs
@@ -70,6 +70,14 @@ let mergeTrieNodes (defaultChildSize: int) (tries: TrieNode array) =
               TrieNodeInfo.Namespace (filesThatExposeTypes = otherFiles; filesDefiningNamespaceWithoutTypes = otherFilesWithoutTypes) ->
                 currentFilesThatExposeTypes.UnionWith otherFiles
                 currentFilesWithoutTypes.UnionWith otherFilesWithoutTypes
+            // Edge case scenario detected in https://github.com/dotnet/fsharp/issues/15985
+            | TrieNodeInfo.Namespace (filesThatExposeTypes = currentFilesThatExposeTypes), TrieNodeInfo.Module (_name, file) ->
+                // Keep the namespace (as it can still have nested children).
+                currentFilesThatExposeTypes.Add file |> ignore
+            | TrieNodeInfo.Module (_name, file), TrieNodeInfo.Namespace (filesThatExposeTypes = currentFilesThatExposeTypes) ->
+                currentFilesThatExposeTypes.Add file |> ignore
+                // Replace the module in favour of the namespace (which can hold nested children).
+                root.Children[ k ] <- v
             | _ -> ()
 
             for kv in v.Children do

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -688,4 +688,66 @@ module ColdTasks =
 """
                     (set [| 0; 2 |])
             ]
+        scenario
+            "ModuleSuffix clash"
+            [
+                sourceFile
+                    "A.fs"
+                    """
+namespace F.General
+"""
+                    Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module F
+
+let br () = ()
+"""
+                    Set.empty
+
+                sourceFile
+                    "C.fs"
+                    """
+module S
+
+[<EntryPoint>]
+let main _ =
+    F.br ()
+    0
+"""
+                    (set [| 1 |])
+            ]
+        scenario
+            "ModuleSuffix clash, module before namespace"
+            [
+                sourceFile
+                    "A.fs"
+                    """
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module F
+
+let br () = ()
+"""
+                    Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+namespace F.General
+"""
+                    Set.empty
+
+                sourceFile
+                    "C.fs"
+                    """
+module S
+
+[<EntryPoint>]
+let main _ =
+    F.br ()
+    0
+"""
+                    (set [| 0 |])
+            ]
     ]


### PR DESCRIPTION
Fixes #15985.

@safesparrow would you mind taking a look at this change?
The problem was in constructing the Trie. We didn't anticipate that a name could be used for both a module and a namespace. My fix is to treat the module as it exposes a type inside the namespace.
I think this is acceptable but would like to hear your opinion here.