### PR TITLE
Take the current index into account in the QueryTrieNodeResult.

### DIFF
--- a/src/Compiler/Driver/GraphChecking/DependencyResolution.fsi
+++ b/src/Compiler/Driver/GraphChecking/DependencyResolution.fsi
@@ -1,9 +1,12 @@
 /// Logic for constructing a file dependency graph for the purposes of parallel type-checking.
 module internal FSharp.Compiler.GraphChecking.DependencyResolution
 
-/// <summary>Query a TrieNode to find a certain path.</summary>
+/// <summary>
+/// Query a TrieNode to find a certain path.
+/// The result will take the current file index into account to determine if the result node contains data.
+/// </summary>
 /// <remarks>This code is only used directly in unit tests.</remarks>
-val queryTrie: trie: TrieNode -> path: LongIdentifier -> QueryTrieNodeResult
+val queryTrie: currentFileIndex: FileIndex -> trie: TrieNode -> path: LongIdentifier -> QueryTrieNodeResult
 
 /// <summary>Process an open path (found in the ParsedInput) with a given FileContentQueryState.</summary>
 /// <remarks>This code is only used directly in unit tests.</remarks>

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/QueryTrieTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/QueryTrieTests.fs
@@ -762,7 +762,7 @@ let private fantomasCoreTrie: TrieNode =
 [<Test>]
 let ``Query non existing node in trie`` () =
     let result =
-        queryTrie fantomasCoreTrie [ "System"; "System"; "Runtime"; "CompilerServices" ]
+        queryTrie 7 fantomasCoreTrie [ "System"; "System"; "Runtime"; "CompilerServices" ]
 
     match result with
     | QueryTrieNodeResult.NodeDoesNotExist -> Assert.Pass()
@@ -770,7 +770,7 @@ let ``Query non existing node in trie`` () =
 
 [<Test>]
 let ``Query node that does not expose data in trie`` () =
-    let result = queryTrie fantomasCoreTrie [ "Fantomas"; "Core" ]
+    let result = queryTrie 7 fantomasCoreTrie [ "Fantomas"; "Core" ]
 
     match result with
     | QueryTrieNodeResult.NodeDoesNotExposeData -> Assert.Pass()
@@ -779,7 +779,7 @@ let ``Query node that does not expose data in trie`` () =
 [<Test>]
 let ``Query module node that exposes one file`` () =
     let result =
-        queryTrie fantomasCoreTrie [ "Fantomas"; "Core"; "ISourceTextExtensions" ]
+        queryTrie 7 fantomasCoreTrie [ "Fantomas"; "Core"; "ISourceTextExtensions" ]
 
     match result with
     | QueryTrieNodeResult.NodeExposesData file ->

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -750,4 +750,26 @@ let main _ =
 """
                     (set [| 0 |])
             ]
+        scenario
+            "Ghost dependency via top-level namespace"
+            [
+                sourceFile
+                    "Graph.fs"
+                    """
+namespace Graphoscope.Graph
+
+type UndirectedGraph = obj
+"""
+                    Set.empty
+                sourceFile
+                    "DiGraph.fs"
+                    """
+namespace Graphoscope
+
+open Graphoscope
+
+type DiGraph = obj
+"""
+                    (set [| 0 |])
+            ]
     ]


### PR DESCRIPTION
When playing around with GBC in https://github.com/fslaborg/Graphoscope/blob/developer/src/Graphoscope/Graphoscope.fsproj I discovered another edge case.

Consider the following setup:

```fsharp
        scenario
            "Ghost dependency via top-level namespace"
            [
                sourceFile
                    "Graph.fs"
                    """
namespace Graphoscope.Graph
type UndirectedGraph = obj
"""
                    Set.empty
                sourceFile
                    "DiGraph.fs"
                    """
namespace Graphoscope
open Graphoscope
type DiGraph = obj 
"""
                    (set [| 0 |])
            ]
```

`DiGraph.fs` should depend on `Graph.fs` to satisfy the `open Graphoscope`.
The open statement can safely be removed in the actual code but is valid nonetheless given the file order.

The Trie:

```mermaid
classDiagram

class root

root <|-- ns_Graphoscope
class ns_Graphoscope {
    DiGraph.fs[1]

    Graph.fs(0)
}

ns_Graphoscope <|-- ns_Graph
class ns_Graph {
    Graph.fs[0]

}
```

`DiGraph.fs` adds data to `ns_Graphoscope`, but `Graph.fs` does not.
Out of necessity to resolve the `open Graphoscope` we need to establish that from `DiGraph.fs` point of view the node (`ns_Graphoscope`) does not expose data and thus the ghost dependency resolution should kick in.

In practice, the more obvious thing to do is of course to remove the unused open statement, but we will want to be able to type-check the project using GBC.

@safesparrow could you take a look at this one as well, please?