### PR TITLE
add gnupg installation to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     # Verify bash, git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install bash git openssh-client less iproute2 procps lsb-release \
+    && apt-get -y install gnupg \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
The VS Code Dev Containers extensions has great support for git signing (automated setup of gpg agent etc). However, this needs gnupg which is currently not installed. I propose to add gnupg installation to the Dockerfile. This will enable signed contributions to github out of the Dev Container using the keys stored on the local VS Code host.