### PR TITLE
Mark attributes we codegen as CompilerGenerated

### DIFF
--- a/src/Compiler/CodeGen/IlxGenSupport.fs
+++ b/src/Compiler/CodeGen/IlxGenSupport.fs
@@ -38,6 +38,8 @@ let mkLocalPrivateAttributeWithDefaultConstructor (g: TcGlobals, name: string) =
                 g.AddMethodGeneratedAttributes(mkILNonGenericEmptyCtor (g.ilg.typ_Attribute, None, None))
             ]
 
+    let ilCustomAttrs = mkILCustomAttrsFromArray [| g.CompilerGeneratedAttribute |]
+
     mkILGenericClass (
         name,
         ILTypeDefAccess.Private,
@@ -49,7 +51,7 @@ let mkLocalPrivateAttributeWithDefaultConstructor (g: TcGlobals, name: string) =
         emptyILTypeDefs,
         emptyILProperties,
         emptyILEvents,
-        emptyILCustomAttrs,
+        ilCustomAttrs,
         ILTypeInit.BeforeField
     )
 

--- a/src/Compiler/CodeGen/IlxGenSupport.fs
+++ b/src/Compiler/CodeGen/IlxGenSupport.fs
@@ -220,7 +220,7 @@ let GetDynamicDependencyAttribute (g: TcGlobals) memberTypes (ilType: ILType) =
             let properties =
                 Some [ "MemberType", GetDynamicallyAccessedMemberTypes g; "Type", g.ilg.typ_Type ]
 
-            mkLocalPrivateAttributeWithPropertyConstr   uctors (g, tref.Name, properties))
+            mkLocalPrivateAttributeWithPropertyConstructors (g, tref.Name, properties))
     )
 
     let typIlMemberTypes =

--- a/src/Compiler/CodeGen/IlxGenSupport.fs
+++ b/src/Compiler/CodeGen/IlxGenSupport.fs
@@ -106,6 +106,8 @@ let mkLocalPrivateAttributeWithPropertyConstructors (g: TcGlobals, name: string,
             )
         )
 
+    let ilCustomAttrs = mkILCustomAttrsFromArray [| g.CompilerGeneratedAttribute |]
+
     mkILGenericClass (
         name,
         ILTypeDefAccess.Private,
@@ -120,7 +122,7 @@ let mkLocalPrivateAttributeWithPropertyConstructors (g: TcGlobals, name: string,
         emptyILTypeDefs,
         mkILProperties (ilElements |> List.map (fun (_, _, property, _) -> property)),
         emptyILEvents,
-        emptyILCustomAttrs,
+        ilCustomAttrs,
         ILTypeInit.BeforeField
     )
 
@@ -218,7 +220,7 @@ let GetDynamicDependencyAttribute (g: TcGlobals) memberTypes (ilType: ILType) =
             let properties =
                 Some [ "MemberType", GetDynamicallyAccessedMemberTypes g; "Type", g.ilg.typ_Type ]
 
-            mkLocalPrivateAttributeWithPropertyConstructors (g, tref.Name, properties))
+            mkLocalPrivateAttributeWithPropertyConstr   uctors (g, tref.Name, properties))
     )
 
     let typIlMemberTypes =

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
@@ -279,12 +279,12 @@ type C() =
         let verifyProperty = """.property instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
                 X()
         {
-          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) 
+          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
           .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname 
-                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) 
+        let verifyMethod = """.method public hidebysig specialname
+                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
                 get_X() cil managed
         {
           .param [0]
@@ -309,12 +309,12 @@ type C() =
         let verifyProperty = """.property instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
                 X()
         {
-          .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) 
+          .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
           .get instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname 
-                instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) 
+        let verifyMethod = """.method public hidebysig specialname
+                instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
                 get_X() cil managed
         {
           .param [0]
@@ -324,11 +324,12 @@ type C() =
 .class private auto ansi beforefieldinit System.Runtime.CompilerServices.IsReadOnlyAttribute
        extends [System.Runtime]System.Attribute
 {
-  .method public specialname rtspecialname 
+  .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+  .method public specialname rtspecialname
           instance void  .ctor() cil managed
   {
-    .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .custom instance void [netstandard]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+    .custom instance void [netstandard]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
     // Code size       7 (0x7)
     .maxstack  8
     IL_0000:  ldarg.0
@@ -361,7 +362,7 @@ type C() =
         let verifyProperty = """.property instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
                 X()
         {
-          .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) 
+          .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
           .get instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) System.Runtime.CompilerServices.C::get_X()
         }"""
 
@@ -375,18 +376,18 @@ type C() =
 .class public auto ansi serializable System.Runtime.CompilerServices.IsReadOnlyAttribute
        extends [netstandard]System.Attribute
 {
-  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
-  .method public specialname rtspecialname 
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
+  .method public specialname rtspecialname
           instance void  .ctor() cil managed
   {
-    
+
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  callvirt   instance void [netstandard]System.Attribute::.ctor()
     IL_0006:  ldarg.0
     IL_0007:  pop
     IL_0008:  ret
-  } 
+  }
 
 }"""
 
@@ -407,7 +408,7 @@ type C<'T>() =
     member _.X<'U>(): inref<'T> = &x
             """
 
-        let verifyMethod = """.method public hidebysig instance !T& modreq([runtime]System.Runtime.InteropServices.InAttribute) 
+        let verifyMethod = """.method public hidebysig instance !T& modreq([runtime]System.Runtime.InteropServices.InAttribute)
                 X<U>() cil managed
         {
           .param [0]
@@ -434,7 +435,7 @@ module Test =
         member _.X<'U>(): inref<'T> = &x
             """
 
-        let verifyMethod = """.method public hidebysig instance !T& modreq([netstandard]System.Runtime.InteropServices.InAttribute) 
+        let verifyMethod = """.method public hidebysig instance !T& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
                 X<U>() cil managed
         {
           .param [0]
@@ -457,8 +458,8 @@ type C<'T>() =
     abstract X<'U> : unit -> inref<'U>
             """
 
-        let verifyMethod = """.method public hidebysig abstract virtual 
-                instance !!U& modreq([runtime]System.Runtime.InteropServices.InAttribute) 
+        let verifyMethod = """.method public hidebysig abstract virtual
+                instance !!U& modreq([runtime]System.Runtime.InteropServices.InAttribute)
                 X<U>() cil managed
         {
           .param [0]
@@ -476,18 +477,18 @@ type C<'T>() =
 module Test
 
 type C =
-    abstract X: inref<int> 
+    abstract X: inref<int>
             """
 
         let verifyProperty = """.property instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
                 X()
         {
-          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) 
+          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
           .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
         let verifyMethod = """.method public hidebysig specialname abstract virtual
-                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) 
+                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
                 get_X() cil managed
         {
           .param [0]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CCtorDUWithMember/CCtorDUWithMember01a.fs.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CCtorDUWithMember/CCtorDUWithMember01a.fs.il.net472.bsl
@@ -579,6 +579,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare05.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare05.fsx.il.net472.bsl
@@ -651,6 +651,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare06.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare06.fsx.il.net472.bsl
@@ -549,6 +549,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare07.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare07.fsx.il.net472.bsl
@@ -695,6 +695,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare10.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Compare10.fsx.il.net472.bsl
@@ -1317,6 +1317,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals04.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals04.fsx.il.net472.bsl
@@ -653,6 +653,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals05.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals05.fsx.il.net472.bsl
@@ -551,6 +551,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals06.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals06.fsx.il.net472.bsl
@@ -697,6 +697,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals09.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals09.fsx.il.net472.bsl
@@ -1319,6 +1319,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash05.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash05.fsx.il.net472.bsl
@@ -640,6 +640,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash06.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash06.fsx.il.net472.bsl
@@ -639,6 +639,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash08.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash08.fsx.il.net472.bsl
@@ -539,6 +539,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash09.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash09.fsx.il.net472.bsl
@@ -683,6 +683,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash12.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Hash12.fsx.il.net472.bsl
@@ -1298,6 +1298,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.il.net472.debug.bsl
@@ -1465,6 +1465,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.il.net472.release.bsl
@@ -1468,6 +1468,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/AnonRecd.fs.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/AnonRecd.fs.il.net472.bsl
@@ -525,6 +525,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/EqualsOnUnions01.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/EqualsOnUnions01.fs.il.net472.debug.bsl
@@ -917,6 +917,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/EqualsOnUnions01.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/EqualsOnUnions01.fs.il.net472.release.bsl
@@ -884,6 +884,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/GeneralizationOnUnions01.fs.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/GeneralizationOnUnions01.fs.il.net472.bsl
@@ -450,6 +450,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs02_asNetStandard20.fs.il.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs02_asNetStandard20.fs.il.debug.bsl
@@ -380,6 +380,7 @@
 .class private auto ansi beforefieldinit System.Runtime.CompilerServices.IsReadOnlyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public specialname rtspecialname 
           instance void  .ctor() cil managed
   {

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs02_asNetStandard20.fs.il.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Misc/Structs02_asNetStandard20.fs.il.release.bsl
@@ -347,6 +347,7 @@
 .class private auto ansi beforefieldinit System.Runtime.CompilerServices.IsReadOnlyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public specialname rtspecialname 
           instance void  .ctor() cil managed
   {

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule.fs.il.net472.debug.bsl
@@ -1624,6 +1624,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule.fs.il.net472.release.bsl
@@ -1528,6 +1528,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule60.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule60.fs.il.net472.debug.bsl
@@ -1596,6 +1596,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule60.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelModule60.fs.il.net472.release.bsl
@@ -1500,6 +1500,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace.fs.il.net472.debug.bsl
@@ -2357,6 +2357,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace.fs.il.net472.release.bsl
@@ -2213,6 +2213,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace60.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace60.fs.il.net472.debug.bsl
@@ -2315,6 +2315,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace60.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/ToplevelNamespace60.fs.il.net472.release.bsl
@@ -2171,6 +2171,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.net472.debug.bsl
@@ -543,6 +543,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch06.fs.il.net472.release.bsl
@@ -543,6 +543,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.net472.debug.bsl
@@ -543,6 +543,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SteppingMatch/SteppingMatch07.fs.il.net472.release.bsl
@@ -543,6 +543,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction16.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction16.fs.il.net472.debug.bsl
@@ -714,6 +714,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction16.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction16.fs.il.net472.release.bsl
@@ -648,6 +648,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.debug.bsl
@@ -616,6 +616,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction17.fs.il.net472.release.bsl
@@ -550,6 +550,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction21.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction21.fs.il.net472.debug.bsl
@@ -804,6 +804,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction21.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction21.fs.il.net472.release.bsl
@@ -738,6 +738,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.debug.bsl
@@ -965,6 +965,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction24.fs.il.net472.release.bsl
@@ -851,6 +851,7 @@
 .class private auto ansi beforefieldinit System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
        extends [runtime]System.Attribute
 {
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 


### PR DESCRIPTION
Fixes #16141


**Update:** actually, we might already generate compgen attribute
**Update 2:** we generate for some, and not for others:

![image](https://github.com/dotnet/fsharp/assets/1260985/a7dfedd1-1ff0-499a-a4fc-e67ab03a3eb4)
![image](https://github.com/dotnet/fsharp/assets/1260985/bfe1e4fc-3dd8-41ee-9d2f-b24420b64e4e)
