### PR TITLE
IL: make ILTypeDefs, ILMethodDefs thread-safe

### DIFF
--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -2855,7 +2855,7 @@ and [<Sealed>] ILTypeDefs(f: unit -> ILPreTypeDef[]) =
 
     member x.FindByName nm =
         let ns, n = splitILTypeName nm
-        x.GetDictionary().[ (ns, n) ].GetTypeDef()
+        x.GetDictionary().[(ns, n)].GetTypeDef()
 
     member x.ExistsByName nm =
         let ns, n = splitILTypeName nm

--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -2142,24 +2142,21 @@ type ILMethodDef
 type MethodDefMap = Map<string, ILMethodDef list>
 
 [<Sealed>]
-type ILMethodDefs(f: unit -> ILMethodDef[]) =
+type ILMethodDefs(f) =
+    inherit DelayInitArrayMap<ILMethodDef, string, ILMethodDef list>(f)
 
-    let mutable array = InlineDelayInit<_>(f)
+    override this.CreateDictionary(arr) =
+        let t = Dictionary(arr.Length)
 
-    let mutable dict =
-        InlineDelayInit<_>(fun () ->
-            let arr = array.Value
-            let t = Dictionary<_, _>()
+        for i = arr.Length - 1 downto 0 do
+            let y = arr[i]
+            let key = y.Name
 
-            for i = arr.Length - 1 downto 0 do
-                let y = arr[i]
-                let key = y.Name
+            match t.TryGetValue key with
+            | true, m -> t[key] <- y :: m
+            | _ -> t[key] <- [ y ]
 
-                match t.TryGetValue key with
-                | true, m -> t[key] <- y :: m
-                | _ -> t[key] <- [ y ]
-
-            t)
+        t
 
     interface IEnumerable with
         member x.GetEnumerator() =
@@ -2167,14 +2164,13 @@ type ILMethodDefs(f: unit -> ILMethodDef[]) =
 
     interface IEnumerable<ILMethodDef> with
         member x.GetEnumerator() =
-            (array.Value :> IEnumerable<ILMethodDef>).GetEnumerator()
+            (x.GetArray() :> IEnumerable<ILMethodDef>).GetEnumerator()
 
-    member x.AsArray() = array.Value
-
-    member x.AsList() = array.Value |> Array.toList
+    member x.AsArray() = x.GetArray()
+    member x.AsList() = x.GetArray() |> Array.toList
 
     member x.FindByName nm =
-        match dict.Value.TryGetValue nm with
+        match x.GetDictionary().TryGetValue nm with
         | true, m -> m
         | _ -> []
 
@@ -2830,25 +2826,22 @@ type ILTypeDef
     override x.ToString() = "type " + x.Name
 
 and [<Sealed>] ILTypeDefs(f: unit -> ILPreTypeDef[]) =
+    inherit DelayInitArrayMap<ILPreTypeDef, string list * string, ILPreTypeDef>(f)
 
-    let mutable array = InlineDelayInit<_>(f)
+    override this.CreateDictionary(arr) =
+        let t = Dictionary(arr.Length, HashIdentity.Structural)
 
-    let mutable dict =
-        InlineDelayInit<_>(fun () ->
-            let arr = array.Value
-            let t = Dictionary<_, _>(HashIdentity.Structural)
+        for pre in arr do
+            let key = pre.Namespace, pre.Name
+            t[key] <- pre
 
-            for pre in arr do
-                let key = pre.Namespace, pre.Name
-                t[key] <- pre
+        ReadOnlyDictionary t
 
-            ReadOnlyDictionary t)
+    member x.AsArray() =
+        [| for pre in x.GetArray() -> pre.GetTypeDef() |]
 
-    member _.AsArray() =
-        [| for pre in array.Value -> pre.GetTypeDef() |]
-
-    member _.AsList() =
-        [ for pre in array.Value -> pre.GetTypeDef() ]
+    member x.AsList() =
+        [ for pre in x.GetArray() -> pre.GetTypeDef() ]
 
     interface IEnumerable with
         member x.GetEnumerator() =
@@ -2856,17 +2849,17 @@ and [<Sealed>] ILTypeDefs(f: unit -> ILPreTypeDef[]) =
 
     interface IEnumerable<ILTypeDef> with
         member x.GetEnumerator() =
-            (seq { for pre in array.Value -> pre.GetTypeDef() }).GetEnumerator()
+            (seq { for pre in x.GetArray() -> pre.GetTypeDef() }).GetEnumerator()
 
-    member _.AsArrayOfPreTypeDefs() = array.Value
+    member x.AsArrayOfPreTypeDefs() = x.GetArray()
 
-    member _.FindByName nm =
+    member x.FindByName nm =
         let ns, n = splitILTypeName nm
-        dict.Value[ (ns, n) ].GetTypeDef()
+        x.GetDictionary().[ (ns, n) ].GetTypeDef()
 
-    member _.ExistsByName nm =
+    member x.ExistsByName nm =
         let ns, n = splitILTypeName nm
-        dict.Value.ContainsKey((ns, n))
+        x.GetDictionary().ContainsKey((ns, n))
 
 and [<NoEquality; NoComparison>] ILPreTypeDef =
     abstract Namespace: string list

--- a/src/Compiler/AbstractIL/il.fsi
+++ b/src/Compiler/AbstractIL/il.fsi
@@ -7,6 +7,7 @@ module rec FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.IO
 open System.Collections.Generic
 open System.Reflection
+open Internal.Utilities.Library
 
 /// Represents the target primary assembly
 [<RequireQualifiedAccess>]
@@ -1179,8 +1180,9 @@ type ILMethodDef =
 /// Tables of methods.  Logically equivalent to a list of methods but
 /// the table is kept in a form optimized for looking up methods by
 /// name and arity.
-[<NoEquality; NoComparison; Sealed>]
+[<NoEquality; NoComparison; Class; Sealed>]
 type ILMethodDefs =
+    inherit DelayInitArrayMap<ILMethodDef, string, ILMethodDef list>
 
     interface IEnumerable<ILMethodDef>
 
@@ -1458,8 +1460,10 @@ type ILTypeDefKind =
     | Delegate
 
 /// Tables of named type definitions.
-[<NoEquality; NoComparison; Sealed>]
+[<NoEquality; NoComparison; Class; Sealed>]
 type ILTypeDefs =
+    inherit DelayInitArrayMap<ILPreTypeDef, string list * string, ILPreTypeDef>
+
     interface IEnumerable<ILTypeDef>
 
     member internal AsArray: unit -> ILTypeDef[]

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -120,7 +120,7 @@ module internal PervasiveAutoOpens =
 
 [<AbstractClass>]
 type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
-    let syncObj = obj()
+    let syncObj = obj ()
 
     let mutable arrayStore = null
     let mutable dictStore = null
@@ -132,15 +132,16 @@ type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
         | NonNull value -> value
         | _ ->
             Monitor.Enter(syncObj)
+
             try
                 match arrayStore with
                 | NonNull value -> value
                 | _ ->
-            
-                arrayStore <- func ()
 
-                func <- Unchecked.defaultof<_>
-                arrayStore
+                    arrayStore <- func ()
+
+                    func <- Unchecked.defaultof<_>
+                    arrayStore
             finally
                 Monitor.Exit(syncObj)
 
@@ -150,18 +151,18 @@ type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
         | _ ->
             let array = this.GetArray()
             Monitor.Enter(syncObj)
+
             try
                 match dictStore with
                 | NonNull value -> value
                 | _ ->
-            
-                dictStore <- this.CreateDictionary(array)
-                dictStore
+
+                    dictStore <- this.CreateDictionary(array)
+                    dictStore
             finally
                 Monitor.Exit(syncObj)
 
     abstract CreateDictionary: 'T[] -> IDictionary<'TDictKey, 'TDictValue>
-
 
 //-------------------------------------------------------------------------
 // Library: projections

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -70,13 +70,14 @@ module internal PervasiveAutoOpens =
 
     val notFound: unit -> 'a
 
-[<Struct>]
-type internal InlineDelayInit<'T when 'T: not struct> =
+[<AbstractClass>]
+type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue> =
+    new: f: (unit -> 'T[]) -> DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>
 
-    new: f: (unit -> 'T) -> InlineDelayInit<'T>
-    val mutable store: 'T
-    val mutable func: Func<'T>
-    member Value: 'T
+    member GetArray: unit -> 'T[]
+    member GetDictionary: unit -> IDictionary<'TDictKey, 'TDictValue>
+
+    abstract CreateDictionary: 'T[] -> IDictionary<'TDictKey, 'TDictValue>
 
 module internal Order =
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -799,6 +799,7 @@ FSharp.Compiler.AbstractIL.IL+ILMethodDefs: ILMethodDef[] AsArray()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] AsList()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] FindByName(System.String)
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] TryFindInstanceByNameAndCallingSignature(System.String, ILCallingSignature)
+FSharp.Compiler.AbstractIL.IL+ILMethodDefs: System.Collections.Generic.IDictionary`2[System.String,Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef]] CreateDictionary(ILMethodDef[])
 FSharp.Compiler.AbstractIL.IL+ILMethodImplDef: Boolean Equals(ILMethodImplDef)
 FSharp.Compiler.AbstractIL.IL+ILMethodImplDef: Boolean Equals(System.Object)
 FSharp.Compiler.AbstractIL.IL+ILMethodImplDef: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
@@ -1619,6 +1620,7 @@ FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: Int32 GetHashCode(System.Collecti
 FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: Int32 Tag
 FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: Int32 get_Tag()
 FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: System.String ToString()
+FSharp.Compiler.AbstractIL.IL+ILTypeDefs: System.Collections.Generic.IDictionary`2[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[System.String],System.String],FSharp.Compiler.AbstractIL.IL+ILPreTypeDef] CreateDictionary(ILPreTypeDef[])
 FSharp.Compiler.AbstractIL.IL+ILTypeInit+Tags: Int32 BeforeField
 FSharp.Compiler.AbstractIL.IL+ILTypeInit+Tags: Int32 OnAny
 FSharp.Compiler.AbstractIL.IL+ILTypeInit: Boolean Equals(ILTypeInit)
@@ -11708,3 +11710,7 @@ FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
 FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
 FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
 FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Collections.Generic.IDictionary`2[TDictKey,TDictValue] CreateDictionary(T[])
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Collections.Generic.IDictionary`2[TDictKey,TDictValue] GetDictionary()
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: T[] GetArray()
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,T[]])

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -799,6 +799,7 @@ FSharp.Compiler.AbstractIL.IL+ILMethodDefs: ILMethodDef[] AsArray()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] AsList()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] FindByName(System.String)
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] TryFindInstanceByNameAndCallingSignature(System.String, ILCallingSignature)
+FSharp.Compiler.AbstractIL.IL+ILMethodDefs: System.Collections.Generic.IDictionary`2[System.String,Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef]] CreateDictionary(ILMethodDef[])
 FSharp.Compiler.AbstractIL.IL+ILMethodImplDef: Boolean Equals(ILMethodImplDef)
 FSharp.Compiler.AbstractIL.IL+ILMethodImplDef: Boolean Equals(System.Object)
 FSharp.Compiler.AbstractIL.IL+ILMethodImplDef: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
@@ -1619,6 +1620,7 @@ FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: Int32 GetHashCode(System.Collecti
 FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: Int32 Tag
 FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: Int32 get_Tag()
 FSharp.Compiler.AbstractIL.IL+ILTypeDefLayout: System.String ToString()
+FSharp.Compiler.AbstractIL.IL+ILTypeDefs: System.Collections.Generic.IDictionary`2[System.Tuple`2[Microsoft.FSharp.Collections.FSharpList`1[System.String],System.String],FSharp.Compiler.AbstractIL.IL+ILPreTypeDef] CreateDictionary(ILPreTypeDef[])
 FSharp.Compiler.AbstractIL.IL+ILTypeInit+Tags: Int32 BeforeField
 FSharp.Compiler.AbstractIL.IL+ILTypeInit+Tags: Int32 OnAny
 FSharp.Compiler.AbstractIL.IL+ILTypeInit: Boolean Equals(ILTypeInit)
@@ -11708,3 +11710,7 @@ FSharp.Compiler.Xml.XmlDoc: System.String[] GetElaboratedXmlLines()
 FSharp.Compiler.Xml.XmlDoc: System.String[] UnprocessedLines
 FSharp.Compiler.Xml.XmlDoc: System.String[] get_UnprocessedLines()
 FSharp.Compiler.Xml.XmlDoc: Void .ctor(System.String[], FSharp.Compiler.Text.Range)
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Collections.Generic.IDictionary`2[TDictKey,TDictValue] CreateDictionary(T[])
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Collections.Generic.IDictionary`2[TDictKey,TDictValue] GetDictionary()
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: T[] GetArray()
+Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,T[]])


### PR DESCRIPTION
`InlineDelayInit` is used in `ILTypeDefs` and `ILMethodDefs`. It's not thread safe and creates unneeded closured for all types and methods to be possibly imported.

The thread safety problem can be seen here:
```fsharp
    member x.Value =
        match x.func with
        | null -> x.store
        | _ ->
            let res = LazyInitializer.EnsureInitialized(&x.store, x.func)
            x.func <- null
            res
```
There's a chance that `x.func` may be set to `null` on another thread before `EnsureInitialized` is executed, leading to exception and possibly corrupted compiler state.

It wasn't a problem before, as all this compiler logic was single-threaded. Nowadays we try to move parts of the analysis to separate threads (think about 1) skipping implementation files and then analyzing them concurrently, 2) sharing `ILModuleDef` between multiple background builders in an IDE, 3) moving some parts of the analysis like pattern match compilation to a later parallel stage). All of this makes it possible for this problem to occur if two threads try to import the same namespace or methods at the same time.

In addition to not being thread-safe, `InlineDelayInit` always allocated another closure for the dictionary factory as it used array value. It also allocated `Func` and kept delegates to store the factories.

The current implementation uses a monitor to fix thread safety, doesn't allocate `Func` delegates, and stores a single array factory lambda instead of two.

Since there're many instances created and we want to use less memory here, we can also shave another empty object and a reference field from the type if we decide that it's fine to lock on `this`, but that's a questionable trick. Or we could pass/use some shared object instead.

It's also possible to remove some added repetition, but I've only managed to do it at the expense of additional allocations when creating the array or dictionary, so I didn't commit these changes.