### PR TITLE
IL: don't keep ILPreTypeDefImpl storage after it was evaluated

### DIFF
--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -2887,6 +2887,7 @@ and [<Sealed>] ILPreTypeDefImpl(nameSpace: string list, name: string, metadataIn
             | null ->
                 let syncObj = storage
                 Monitor.Enter(syncObj)
+
                 try
                     match box store with
                     | null ->
@@ -2895,6 +2896,7 @@ and [<Sealed>] ILPreTypeDefImpl(nameSpace: string list, name: string, metadataIn
                             | ILTypeDefStored.Given td -> td
                             | ILTypeDefStored.Computed f -> f ()
                             | ILTypeDefStored.Reader f -> f metadataIndex
+
                         store <- value
                         storage <- Unchecked.defaultof<_>
                         value

--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -2876,6 +2876,7 @@ and [<NoEquality; NoComparison>] ILPreTypeDef =
 /// This is a memory-critical class. Very many of these objects get allocated and held to represent the contents of .NET assemblies.
 and [<Sealed>] ILPreTypeDefImpl(nameSpace: string list, name: string, metadataIndex: int32, storage: ILTypeDefStored) =
     let mutable store: ILTypeDef = Unchecked.defaultof<_>
+    let mutable storage = storage
 
     interface ILPreTypeDef with
         member _.Namespace = nameSpace
@@ -2884,12 +2885,22 @@ and [<Sealed>] ILPreTypeDefImpl(nameSpace: string list, name: string, metadataIn
         member x.GetTypeDef() =
             match box store with
             | null ->
-                match storage with
-                | ILTypeDefStored.Given td ->
-                    store <- td
-                    td
-                | ILTypeDefStored.Computed f -> LazyInitializer.EnsureInitialized<ILTypeDef>(&store, Func<_>(fun () -> f ()))
-                | ILTypeDefStored.Reader f -> LazyInitializer.EnsureInitialized<ILTypeDef>(&store, Func<_>(fun () -> f metadataIndex))
+                let syncObj = storage
+                Monitor.Enter(syncObj)
+                try
+                    match box store with
+                    | null ->
+                        let value =
+                            match storage with
+                            | ILTypeDefStored.Given td -> td
+                            | ILTypeDefStored.Computed f -> f ()
+                            | ILTypeDefStored.Reader f -> f metadataIndex
+                        store <- value
+                        storage <- Unchecked.defaultof<_>
+                        value
+                    | _ -> store
+                finally
+                    Monitor.Exit(syncObj)
             | _ -> store
 
 and ILTypeDefStored =


### PR DESCRIPTION
Fixes `f` closures are kept in memory after they aren't needed.
Fixes `f` functions could be evaluated multiple times if accessed concurrently.