### PR TITLE
Checker: invalidate type check cache when clearing project

### DIFF
--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -1246,12 +1246,10 @@ type BackgroundCompiler
             options
             |> Seq.iter (fun options ->
                 incrementalBuildersCache.RemoveAnySimilar(AnyCallerThread, options)
-                
+
                 parseCacheLock.AcquireLock(fun ltok ->
                     for sourceFile in options.SourceFiles do
-                        checkFileInProjectCache.RemoveAnySimilar(ltok, (sourceFile, 0L, options)))
-            )
-        )
+                        checkFileInProjectCache.RemoveAnySimilar(ltok, (sourceFile, 0L, options)))))
 
     member _.NotifyProjectCleaned(options: FSharpProjectOptions, userOpName) =
         use _ =

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -1244,7 +1244,14 @@ type BackgroundCompiler
 
         lock gate (fun () ->
             options
-            |> Seq.iter (fun options -> incrementalBuildersCache.RemoveAnySimilar(AnyCallerThread, options)))
+            |> Seq.iter (fun options ->
+                incrementalBuildersCache.RemoveAnySimilar(AnyCallerThread, options)
+                
+                parseCacheLock.AcquireLock(fun ltok ->
+                    for sourceFile in options.SourceFiles do
+                        checkFileInProjectCache.RemoveAnySimilar(ltok, (sourceFile, 0L, options)))
+            )
+        )
 
     member _.NotifyProjectCleaned(options: FSharpProjectOptions, userOpName) =
         use _ =


### PR DESCRIPTION
Applies the same fix as in https://github.com/dotnet/fsharp/pull/12853, but in `ClearCache` in addition to `InvalidateConfiguration`.