### PR TITLE
Turn 3560 off by default, since it's hugely breaking

### DIFF
--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -387,6 +387,7 @@ type PhasedDiagnostic with
         | 3390 -> false // xmlDocBadlyFormed - off by default
         | 3395 -> false // tcImplicitConversionUsedForMethodArg - off by default
         | 3559 -> false // typrelNeverRefinedAwayFromTop - off by default
+        | 3560 -> false // tcCopyAndUpdateRecordChangesAllFields - off by default
         | 3579 -> false // alwaysUseTypedStringInterpolation - off by default
         | _ ->
             match x.Exception with

--- a/tests/FSharp.Compiler.ComponentTests/Diagnostics/Records.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Diagnostics/Records.fs
@@ -17,9 +17,9 @@ let updateOk r = { r with F1 = 1 }
 let updateWarn r = { r with F1 = 1; F2 = "" }
     """
     |> withLangVersion80
+    |> withOptions ["--warnon:FS3560"]
     |> typecheck
     |> shouldFail
-    |> withOptions ["--warnon:FS3560"]
     |> withDiagnostics [
         (Warning 3560, Line 7, Col 20, Line 7, Col 46, "This copy-and-update record expression changes all fields of record type 'Records.R'. Consider using the record construction syntax instead.")
     ]

--- a/tests/FSharp.Compiler.ComponentTests/Diagnostics/Records.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Diagnostics/Records.fs
@@ -19,6 +19,7 @@ let updateWarn r = { r with F1 = 1; F2 = "" }
     |> withLangVersion80
     |> typecheck
     |> shouldFail
+    |> withOptions ["--warnon:FS3560"]
     |> withDiagnostics [
         (Warning 3560, Line 7, Col 20, Line 7, Col 46, "This copy-and-update record expression changes all fields of record type 'Records.R'. Consider using the record construction syntax instead.")
     ]
@@ -46,7 +47,6 @@ type R = { F1: int; F2: string }
 let updateWarn r = { r with F1 = 1; F2 = "" }
     """
     |> withLangVersion80
-    |> withOptions ["--nowarn:3560"]
     |> typecheck
     |> shouldSucceed
 
@@ -86,6 +86,7 @@ let t2 (x: RecTy) (a: AnotherNestedRecTy) = { x with D.C.c = { a with A = 3 } }
 let t3 (x: RecTy) (a: AnotherNestedRecTy) = { x with D.C.c = { a with A = 3; B = 4 } }
     """
     |> withLangVersion80
+    |> withOptions ["--warnon:FS3560"]
     |> typecheck
     |> shouldFail
     |> withDiagnostics [


### PR DESCRIPTION
Heard it from multiple customers, it's producing thousands of warnings and breaking builds.