### PR TITLE
Add InterruptibleLazy

### DIFF
--- a/src/Compiler/AbstractIL/il.fsi
+++ b/src/Compiler/AbstractIL/il.fsi
@@ -984,7 +984,7 @@ type internal ILOverridesSpec =
 
 [<RequireQualifiedAccess>]
 type MethodBody =
-    | IL of Lazy<ILMethodBody>
+    | IL of InterruptibleLazy<ILMethodBody>
     | PInvoke of Lazy<PInvokeMethod>
     | Abstract
     | Native
@@ -1033,7 +1033,7 @@ type ILMethodDef =
         callingConv: ILCallingConv *
         parameters: ILParameters *
         ret: ILReturn *
-        body: Lazy<MethodBody> *
+        body: InterruptibleLazy<MethodBody> *
         isEntryPoint: bool *
         genericParams: ILGenericParameterDefs *
         securityDeclsStored: ILSecurityDeclsStored *
@@ -1049,7 +1049,7 @@ type ILMethodDef =
         callingConv: ILCallingConv *
         parameters: ILParameters *
         ret: ILReturn *
-        body: Lazy<MethodBody> *
+        body: InterruptibleLazy<MethodBody> *
         isEntryPoint: bool *
         genericParams: ILGenericParameterDefs *
         securityDecls: ILSecurityDecls *
@@ -1140,7 +1140,7 @@ type ILMethodDef =
         ?callingConv: ILCallingConv *
         ?parameters: ILParameters *
         ?ret: ILReturn *
-        ?body: Lazy<MethodBody> *
+        ?body: InterruptibleLazy<MethodBody> *
         ?securityDecls: ILSecurityDecls *
         ?isEntryPoint: bool *
         ?genericParams: ILGenericParameterDefs *
@@ -2075,11 +2075,11 @@ val internal mkILMethodBody:
 
 val internal mkMethodBody: bool * ILLocals * int * ILCode * ILDebugPoint option * ILDebugImports option -> MethodBody
 
-val internal methBodyNotAvailable: Lazy<MethodBody>
+val internal methBodyNotAvailable: InterruptibleLazy<MethodBody>
 
-val internal methBodyAbstract: Lazy<MethodBody>
+val internal methBodyAbstract: InterruptibleLazy<MethodBody>
 
-val internal methBodyNative: Lazy<MethodBody>
+val internal methBodyNative: InterruptibleLazy<MethodBody>
 
 val internal mkILCtor: ILMemberAccess * ILParameter list * MethodBody -> ILMethodDef
 
@@ -2217,11 +2217,11 @@ val storeILSecurityDecls: ILSecurityDecls -> ILSecurityDeclsStored
 val internal mkILSecurityDeclsReader: (int32 -> ILSecurityDecl[]) -> ILSecurityDeclsStored
 
 val mkILEvents: ILEventDef list -> ILEventDefs
-val mkILEventsLazy: Lazy<ILEventDef list> -> ILEventDefs
+val mkILEventsLazy: InterruptibleLazy<ILEventDef list> -> ILEventDefs
 val emptyILEvents: ILEventDefs
 
 val mkILProperties: ILPropertyDef list -> ILPropertyDefs
-val mkILPropertiesLazy: Lazy<ILPropertyDef list> -> ILPropertyDefs
+val mkILPropertiesLazy: InterruptibleLazy<ILPropertyDef list> -> ILPropertyDefs
 val emptyILProperties: ILPropertyDefs
 
 val mkILMethods: ILMethodDef list -> ILMethodDefs
@@ -2230,7 +2230,7 @@ val mkILMethodsComputed: (unit -> ILMethodDef[]) -> ILMethodDefs
 val emptyILMethods: ILMethodDefs
 
 val mkILFields: ILFieldDef list -> ILFieldDefs
-val mkILFieldsLazy: Lazy<ILFieldDef list> -> ILFieldDefs
+val mkILFieldsLazy: InterruptibleLazy<ILFieldDef list> -> ILFieldDefs
 val emptyILFields: ILFieldDefs
 
 val mkILMethodImpls: ILMethodImplDef list -> ILMethodImplDefs

--- a/src/Compiler/AbstractIL/ilmorph.fs
+++ b/src/Compiler/AbstractIL/ilmorph.fs
@@ -305,7 +305,7 @@ let morphILMethodBody fMethBody (x: MethodBody) =
     match x with
     | MethodBody.IL il ->
         let ilCode = fMethBody il.Value // Eager
-        MethodBody.IL(lazy ilCode)
+        MethodBody.IL(InterruptibleLazy.FromValue ilCode)
     | x -> x
 
 let ospec_ty2ty f (OverridesSpec (mref, ty)) = OverridesSpec(mref_ty2ty f mref, f ty)

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -1129,7 +1129,7 @@ type ILMetadataReader =
         mdfile: BinaryFile
         pectxtCaptured: PEReader option // only set when reading full PE including code etc. for static linking
         entryPointToken: TableName * int
-        dataEndPoints: Lazy<int32 list>
+        dataEndPoints: InterruptibleLazy<int32 list>
         fileName: string
         getNumRows: TableName -> int
         userStringsStreamPhysicalLoc: int32
@@ -1766,7 +1766,7 @@ let readNativeResources (pectxt: PEReader) =
     ]
 
 let getDataEndPointsDelayed (pectxt: PEReader) ctxtH =
-    lazy
+    InterruptibleLazy(fun _ ->
         let (ctxt: ILMetadataReader) = getHole ctxtH
         let mdv = ctxt.mdfile.GetView()
 
@@ -1826,14 +1826,14 @@ let getDataEndPointsDelayed (pectxt: PEReader) ctxtH =
                                    [ ("managed vtable_fixups", pectxt.vtableFixupsAddr) ])
                               @ methodRVAs)))
             |> List.distinct
-            |> List.sort
+            |> List.sort)
 
 let rvaToData (ctxt: ILMetadataReader) (pectxt: PEReader) nm rva =
     if rva = 0x0 then
         failwith "rva is zero"
 
     let start = pectxt.anyV2P (nm, rva)
-    let endPoints = (Lazy.force ctxt.dataEndPoints)
+    let endPoints = ctxt.dataEndPoints.Value
 
     let rec look l =
         match l with
@@ -2424,14 +2424,14 @@ and seekReadField ctxt mdv (numTypars, hasLayout) (idx: int) =
 
 and seekReadFields (ctxt: ILMetadataReader) (numTypars, hasLayout) fidx1 fidx2 =
     mkILFieldsLazy (
-        lazy
+        InterruptibleLazy(fun _ ->
             let mdv = ctxt.mdfile.GetView()
 
             [
                 if fidx1 > 0 then
                     for i = fidx1 to fidx2 - 1 do
                         yield seekReadField ctxt mdv (numTypars, hasLayout) i
-            ]
+            ])
     )
 
 and seekReadMethods (ctxt: ILMetadataReader) numTypars midx1 midx2 =
@@ -3064,7 +3064,7 @@ and seekReadEvent ctxt mdv numTypars idx =
 (* REVIEW: can substantially reduce numbers of EventMap and PropertyMap reads by first checking if the whole table mdv sorted according to ILTypeDef tokens and then doing a binary chop *)
 and seekReadEvents (ctxt: ILMetadataReader) numTypars tidx =
     mkILEventsLazy (
-        lazy
+        InterruptibleLazy(fun _ ->
             let mdv = ctxt.mdfile.GetView()
 
             match
@@ -3090,7 +3090,7 @@ and seekReadEvents (ctxt: ILMetadataReader) numTypars tidx =
                     if beginEventIdx > 0 then
                         for i in beginEventIdx .. endEventIdx - 1 do
                             yield seekReadEvent ctxt mdv numTypars i
-                ]
+                ])
     )
 
 and seekReadProperty ctxt mdv numTypars idx =
@@ -3131,7 +3131,7 @@ and seekReadProperty ctxt mdv numTypars idx =
 
 and seekReadProperties (ctxt: ILMetadataReader) numTypars tidx =
     mkILPropertiesLazy (
-        lazy
+        InterruptibleLazy(fun _ ->
             let mdv = ctxt.mdfile.GetView()
 
             match
@@ -3157,7 +3157,7 @@ and seekReadProperties (ctxt: ILMetadataReader) numTypars tidx =
                     if beginPropIdx > 0 then
                         for i in beginPropIdx .. endPropIdx - 1 do
                             yield seekReadProperty ctxt mdv numTypars i
-                ]
+                ])
     )
 
 and customAttrsReader ctxtH tag : ILAttributesStored =
@@ -3251,7 +3251,7 @@ and seekReadConstant (ctxt: ILMetadataReader) idx =
     | _ -> ILFieldInit.Null
 
 and seekReadImplMap (ctxt: ILMetadataReader) nm midx =
-    lazy
+    InterruptibleLazy(fun _ ->
         MethodBody.PInvoke(
             lazy
                 let mdv = ctxt.mdfile.GetView()
@@ -3339,7 +3339,7 @@ and seekReadImplMap (ctxt: ILMetadataReader) nm midx =
                          | Some nm2 -> nm2)
                     Where = seekReadModuleRef ctxt mdv scopeIdx
                 }
-        )
+        ))
 
 and seekReadTopCode (ctxt: ILMetadataReader) pev mdv numTypars (sz: int) start =
     let labelsOfRawOffsets = Dictionary<_, _>(sz / 2)
@@ -3633,7 +3633,7 @@ and seekReadTopCode (ctxt: ILMetadataReader) pev mdv numTypars (sz: int) start =
     instrs, rawToLabel, lab2pc
 
 and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (nm, noinline, aggressiveinline, numTypars) rva =
-    lazy
+    InterruptibleLazy(fun _ ->
         let pev = pectxt.pefile.GetView()
         let baseRVA = pectxt.anyV2P ("method rva", rva)
         // ": reading body of method "+nm+" at rva "+string rva+", phys "+string baseRVA
@@ -3650,7 +3650,7 @@ and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (nm, noinline,
         else
 
             MethodBody.IL(
-                lazy
+                InterruptibleLazy(fun _ ->
                     let pev = pectxt.pefile.GetView()
                     let mdv = ctxt.mdfile.GetView()
 
@@ -3824,8 +3824,8 @@ and seekReadMethodRVA (pectxt: PEReader) (ctxt: ILMetadataReader) (nm, noinline,
                             Code = code
                             DebugRange = None
                             DebugImports = None
-                        }
-            )
+                        })
+            ))
 
 and int32AsILVariantType (ctxt: ILMetadataReader) (n: int32) =
     if List.memAssoc n (Lazy.force ILVariantTypeRevMap) then

--- a/src/Compiler/AbstractIL/ilx.fs
+++ b/src/Compiler/AbstractIL/ilx.fs
@@ -167,7 +167,7 @@ type IlxClosureInfo =
     {
         cloStructure: IlxClosureLambdas
         cloFreeVars: IlxClosureFreeVar[]
-        cloCode: Lazy<ILMethodBody>
+        cloCode: InterruptibleLazy<ILMethodBody>
         cloUseStaticField: bool
     }
 

--- a/src/Compiler/AbstractIL/ilx.fsi
+++ b/src/Compiler/AbstractIL/ilx.fsi
@@ -4,6 +4,7 @@
 module internal FSharp.Compiler.AbstractIL.ILX.Types
 
 open FSharp.Compiler.AbstractIL.IL
+open Internal.Utilities.Library
 
 /// Union case field
 [<Sealed>]
@@ -118,7 +119,7 @@ type IlxClosureApps =
 type IlxClosureInfo =
     { cloStructure: IlxClosureLambdas
       cloFreeVars: IlxClosureFreeVar[]
-      cloCode: Lazy<ILMethodBody>
+      cloCode: InterruptibleLazy<ILMethodBody>
       cloUseStaticField: bool }
 
 /// Represents a discriminated union type prior to erasure

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -1160,7 +1160,7 @@ and IlxGenEnv =
         imports: ILDebugImports option
 
         /// All values in scope
-        valsInScope: ValMap<Lazy<ValStorage>>
+        valsInScope: ValMap<InterruptibleLazy<ValStorage>>
 
         /// All witnesses in scope and their mapping to storage for the witness value.
         witnessesInScope: TraitWitnessInfoHashMap<ValStorage>
@@ -1614,7 +1614,7 @@ let rec AddStorageForNonLocalModuleOrNamespaceRef cenv g cloc acc (modref: Modul
 
     let acc =
         (acc, modul.ModuleOrNamespaceType.AllValsAndMembers)
-        ||> Seq.fold (fun acc v -> AddStorageForVal g (v, lazy (ComputeStorageForNonLocalVal cenv g cloc modref v)) acc)
+        ||> Seq.fold (fun acc v -> AddStorageForVal g (v, InterruptibleLazy(fun _ -> ComputeStorageForNonLocalVal cenv g cloc modref v)) acc)
 
     acc
 
@@ -1638,7 +1638,8 @@ let AddStorageForExternalCcu cenv g eenv (ccu: CcuThunk) =
             let eref = ERefNonLocalPreResolved ccu.Contents (mkNonLocalEntityRef ccu [||])
 
             (eenv, ccu.Contents.ModuleOrNamespaceType.AllValsAndMembers)
-            ||> Seq.fold (fun acc v -> AddStorageForVal g (v, lazy (ComputeStorageForNonLocalVal cenv g cloc eref v)) acc)
+            ||> Seq.fold (fun acc v ->
+                AddStorageForVal g (v, InterruptibleLazy(fun _ -> ComputeStorageForNonLocalVal cenv g cloc eref v)) acc)
 
         eenv
 
@@ -3082,7 +3083,9 @@ and DelayCodeGenMethodForExpr cenv mgbuf ((_, _, eenv, _, _, _, _) as args) =
         // Once this is lazily-evaluated later, it should not put things in queue. They would not be picked up by anyone.
         let newArgs = change3rdOutOf7 args { eenv with delayCodeGen = false }
 
-        let lazyMethodBody = lazy (CodeGenMethodForExpr cenv mgbuf newArgs)
+        let lazyMethodBody =
+            InterruptibleLazy(fun _ -> CodeGenMethodForExpr cenv mgbuf newArgs)
+
         cenv.delayedGenMethods.Enqueue(fun () -> lazyMethodBody.Force() |> ignore)
         lazyMethodBody
     else
@@ -5861,7 +5864,7 @@ and GenObjectExprMethod cenv eenvinner (cgbuf: CodeGenBuffer) useMethodImpl tmet
                 GenGenericParams cenv eenvUnderTypars methTyparsOfOverridingMethod,
                 ilParamsOfOverridingMethod,
                 ilReturnOfOverridingMethod,
-                MethodBody.IL(lazy ilMethodBody)
+                MethodBody.IL(InterruptibleLazy.FromValue ilMethodBody)
             )
         // fixup attributes to generate a method impl
         let mdef = if useMethodImpl then fixupMethodImplFlags mdef else mdef
@@ -6410,7 +6413,7 @@ and GenSequenceExpr
             ILMemberAccess.Public,
             [],
             mkILReturn ilCloEnumeratorTy,
-            MethodBody.IL(lazy mbody)
+            MethodBody.IL(InterruptibleLazy.FromValue mbody)
         )
         |> AddNonUserCompilerGeneratedAttribs g
 
@@ -6418,7 +6421,13 @@ and GenSequenceExpr
         let ilCode =
             CodeGenMethodForExpr cenv cgbuf.mgbuf ([], "Close", eenvinner, 1, None, closeExpr, discardAndReturnVoid)
 
-        mkILNonGenericVirtualInstanceMethod ("Close", ILMemberAccess.Public, [], mkILReturn ILType.Void, MethodBody.IL(lazy ilCode))
+        mkILNonGenericVirtualInstanceMethod (
+            "Close",
+            ILMemberAccess.Public,
+            [],
+            mkILReturn ILType.Void,
+            MethodBody.IL(InterruptibleLazy.FromValue ilCode)
+        )
 
     let checkCloseMethod =
         let ilCode =
@@ -6429,7 +6438,7 @@ and GenSequenceExpr
             ILMemberAccess.Public,
             [],
             mkILReturn g.ilg.typ_Bool,
-            MethodBody.IL(lazy ilCode)
+            MethodBody.IL(InterruptibleLazy.FromValue ilCode)
         )
 
     let generateNextMethod =
@@ -6441,7 +6450,10 @@ and GenSequenceExpr
         let ilReturn = mkILReturn g.ilg.typ_Int32
 
         let ilCode =
-            MethodBody.IL(lazy (CodeGenMethodForExpr cenv cgbuf.mgbuf ([], "GenerateNext", eenvinner, 2, None, generateNextExpr, Return)))
+            MethodBody.IL(
+                InterruptibleLazy(fun _ ->
+                    CodeGenMethodForExpr cenv cgbuf.mgbuf ([], "GenerateNext", eenvinner, 2, None, generateNextExpr, Return))
+            )
 
         mkILNonGenericVirtualInstanceMethod ("GenerateNext", ILMemberAccess.Public, ilParams, ilReturn, ilCode)
 
@@ -6454,7 +6466,7 @@ and GenSequenceExpr
             ILMemberAccess.Public,
             [],
             mkILReturn ilCloSeqElemTy,
-            MethodBody.IL(lazy ilCode)
+            MethodBody.IL(InterruptibleLazy.FromValue ilCode)
         )
         |> AddNonUserCompilerGeneratedAttribs g
 
@@ -6656,7 +6668,7 @@ and GenClosureAsLocalTypeFunction cenv (cgbuf: CodeGenBuffer) eenv thisVars expr
                 ilDirectGenericParams,
                 ilDirectWitnessParams,
                 mkILReturn ilCloFormalReturnTy,
-                MethodBody.IL(lazy ilCloBody)
+                MethodBody.IL(InterruptibleLazy.FromValue ilCloBody)
             )
         ]
 
@@ -7072,7 +7084,7 @@ and GenDelegateExpr cenv cgbuf eenvouter expr (TObjExprMethod (slotsig, _attribs
                 ILMemberAccess.Assembly,
                 ilDelegeeParams,
                 ilDelegeeRet,
-                MethodBody.IL(lazy ilMethodBody)
+                MethodBody.IL(InterruptibleLazy.FromValue ilMethodBody)
             )
 
     let delegeeCtorMeth =
@@ -10202,7 +10214,9 @@ and GenImplFile cenv (mgbuf: AssemblyBuilder) mainInfoOpt eenv (implFile: Checke
                         seqpt
                     ))
 
-                let cctorMethDef = mkILClassCtor (MethodBody.IL(lazy topCode))
+                let cctorMethDef =
+                    mkILClassCtor (MethodBody.IL(InterruptibleLazy.FromValue topCode))
+
                 mgbuf.AddMethodDef(initClassTy.TypeRef, cctorMethDef)
 
         // Final file, implicit entry point. We generate no .cctor.
@@ -10224,7 +10238,7 @@ and GenImplFile cenv (mgbuf: AssemblyBuilder) mainInfoOpt eenv (implFile: Checke
                         ILMemberAccess.Public,
                         [],
                         mkILReturn ILType.Void,
-                        MethodBody.IL(lazy topCode)
+                        MethodBody.IL(InterruptibleLazy.FromValue topCode)
                     )
 
                 mdef.With(isEntryPoint = true, customAttrs = ilAttrs)
@@ -10235,7 +10249,9 @@ and GenImplFile cenv (mgbuf: AssemblyBuilder) mainInfoOpt eenv (implFile: Checke
     | None ->
         if doesSomething then
             // Add the cctor
-            let cctorMethDef = mkILClassCtor (MethodBody.IL(lazy topCode))
+            let cctorMethDef =
+                mkILClassCtor (MethodBody.IL(InterruptibleLazy.FromValue topCode))
+
             mgbuf.AddMethodDef(initClassTy.TypeRef, cctorMethDef)
 
     // Commit the directed initializations
@@ -10453,8 +10469,8 @@ and GenPrintingMethod cenv eenv methName ilThisTy m =
     [
         if not g.useReflectionFreeCodeGen then
             match (eenv.valsInScope.TryFind g.sprintf_vref.Deref, eenv.valsInScope.TryFind g.new_format_vref.Deref) with
-            | Some (Lazy (Method (_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
-              Some (Lazy (Method (_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
+            | Some (InterruptibleLazy (Method (_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
+              Some (InterruptibleLazy (Method (_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
                 // The type returned by the 'sprintf' call
                 let funcTy = EraseClosures.mkILFuncTy cenv.ilxPubCloEnv ilThisTy g.ilg.typ_String
 
@@ -10937,11 +10953,9 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) =
                             yield ilMethodDef.WithSpecialName
 
                     if generateDebugDisplayAttribute then
-                        let (|Lazy|) (x: Lazy<_>) = x.Force()
-
                         match (eenv.valsInScope.TryFind g.sprintf_vref.Deref, eenv.valsInScope.TryFind g.new_format_vref.Deref) with
-                        | Some (Lazy (Method (_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
-                          Some (Lazy (Method (_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
+                        | Some (InterruptibleLazy (Method (_, _, sprintfMethSpec, _, _, _, _, _, _, _, _, _))),
+                          Some (InterruptibleLazy (Method (_, _, newFormatMethSpec, _, _, _, _, _, _, _, _, _))) ->
                             // The type returned by the 'sprintf' call
                             let funcTy = EraseClosures.mkILFuncTy cenv.ilxPubCloEnv ilThisTy g.ilg.typ_String
                             // Give the instantiation of the printf format object, i.e. a Format`5 object compatible with StringFormat<ilThisTy>

--- a/src/Compiler/Driver/CompilerImports.fsi
+++ b/src/Compiler/Driver/CompilerImports.fsi
@@ -116,7 +116,7 @@ type ImportedAssembly =
       IsProviderGenerated: bool
       mutable TypeProviders: Tainted<ITypeProvider> list
 #endif
-      FSharpOptimizationData: Lazy<LazyModuleInfo option> }
+      FSharpOptimizationData: InterruptibleLazy<LazyModuleInfo option> }
 
 /// Tables of assembly resolutions
 [<Sealed>]

--- a/src/Compiler/Driver/OptimizeInputs.fs
+++ b/src/Compiler/Driver/OptimizeInputs.fs
@@ -146,7 +146,9 @@ module private ParallelOptimization =
                 FirstLoopRes =
                     {
                         OptEnv = env0
-                        OptInfo = lazy failwith "This dummy value wrapped in a Lazy was not expected to be evaluated before being replaced."
+                        OptInfo =
+                            InterruptibleLazy(fun _ ->
+                                failwith "This dummy value wrapped in a Lazy was not expected to be evaluated before being replaced.")
                         HidingInfo = SignatureHidingInfo.Empty
                         // A no-op optimizer
                         OptDuringCodeGen = fun _ expr -> expr
@@ -265,9 +267,9 @@ let optimizeFilesSequentially optEnv (phases: PhaseInfo[]) implFiles =
                             {
                                 OptEnv = optEnvFirstLoop
                                 OptInfo =
-                                    lazy
+                                    InterruptibleLazy(fun _ ->
                                         failwith
-                                            "This dummy value wrapped in a Lazy was not expected to be evaluated before being replaced."
+                                            "This dummy value wrapped in a Lazy was not expected to be evaluated before being replaced.")
                                 HidingInfo = hidden
                                 // A no-op optimizer
                                 OptDuringCodeGen = fun _ expr -> expr

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -46,13 +46,6 @@ exception ReportedError of exn option with
         | ReportedError (Some exn) -> msg + " Original message: " + exn.Message + ")"
         | _ -> msg
 
-[<return: Struct>]
-let (|RecoverableException|_|) (exn: Exception) =
-    if exn.IsOperationCancelled then
-        ValueNone
-    else
-        ValueSome exn
-
 let rec findOriginalException err =
     match err with
     | ReportedError (Some err) -> err

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -28,8 +28,6 @@ exception WrappedError of exn * range
 /// when a lazy thunk is re-evaluated.
 exception ReportedError of exn option
 
-val (|RecoverableException|_|): exn: Exception -> Exception voption
-
 val findOriginalException: err: exn -> exn
 
 type Suggestions = (string -> unit) -> unit

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1622,7 +1622,13 @@ let internal mkBoundValueTypedImpl tcGlobals m moduleName name ty =
     let mutable mty = Unchecked.defaultof<_>
 
     let entity =
-        Construct.NewModuleOrNamespace (Some compPath) vis (Ident(moduleName, m)) XmlDoc.Empty [] (MaybeLazy.Lazy(lazy mty))
+        Construct.NewModuleOrNamespace
+            (Some compPath)
+            vis
+            (Ident(moduleName, m))
+            XmlDoc.Empty
+            []
+            (MaybeLazy.Lazy(InterruptibleLazy(fun _ -> mty)))
 
     let v =
         Construct.NewVal(

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -172,7 +172,7 @@ type ModuleInfo =
     { ValInfos: ValInfos
       ModuleOrNamespaceInfos: NameMap<LazyModuleInfo> }
           
-and LazyModuleInfo = Lazy<ModuleInfo>
+and LazyModuleInfo = InterruptibleLazy<ModuleInfo>
 
 type ImplFileOptimizationInfo = LazyModuleInfo
 
@@ -1393,10 +1393,10 @@ let AbstractLazyModulInfoByHiding isAssemblyBoundary mhi =
 let AbstractOptimizationInfoToEssentials =
 
     let rec abstractModulInfo (ss: ModuleInfo) =
-         { ModuleOrNamespaceInfos = NameMap.map (Lazy.force >> abstractModulInfo >> notlazy) ss.ModuleOrNamespaceInfos
+         { ModuleOrNamespaceInfos = NameMap.map (InterruptibleLazy.force >> abstractModulInfo >> notlazy) ss.ModuleOrNamespaceInfos
            ValInfos = ss.ValInfos.Filter (fun (v, _) -> v.MustInline) }
 
-    and abstractLazyModulInfo ss = ss |> Lazy.force |> abstractModulInfo |> notlazy
+    and abstractLazyModulInfo ss = ss |> InterruptibleLazy.force |> abstractModulInfo |> notlazy
       
     abstractLazyModulInfo
 
@@ -1459,7 +1459,7 @@ let AbstractExprInfoByVars (boundVars: Val list, boundTyVars) ivalue =
             ValMakesNoCriticalTailcalls=v.ValMakesNoCriticalTailcalls }
 
       and abstractModulInfo ss =
-         { ModuleOrNamespaceInfos = ss.ModuleOrNamespaceInfos |> NameMap.map (Lazy.force >> abstractModulInfo >> notlazy) 
+         { ModuleOrNamespaceInfos = ss.ModuleOrNamespaceInfos |> NameMap.map (InterruptibleLazy.force >> abstractModulInfo >> notlazy) 
            ValInfos = ss.ValInfos.Map (fun (vref, e) -> 
                check vref (abstractValInfo e) ) }
 
@@ -1496,7 +1496,7 @@ let RemapOptimizationInfo g tmenv =
                (vrefR, vinfo)) } 
 
     and remapLazyModulInfo ss =
-         ss |> Lazy.force |> remapModulInfo |> notlazy
+         ss |> InterruptibleLazy.force |> remapModulInfo |> notlazy
            
     remapLazyModulInfo
 

--- a/src/Compiler/Optimize/Optimizer.fsi
+++ b/src/Compiler/Optimize/Optimizer.fsi
@@ -8,6 +8,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 open FSharp.Compiler.TypedTreePickle
+open Internal.Utilities.Library
 
 [<RequireQualifiedAccess>]
 type OptimizationProcessingMode =
@@ -61,7 +62,7 @@ type OptimizationSettings =
 /// Optimization information
 type ModuleInfo
 
-type LazyModuleInfo = Lazy<ModuleInfo>
+type LazyModuleInfo = InterruptibleLazy<ModuleInfo>
 
 type ImplFileOptimizationInfo = LazyModuleInfo
 

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -5878,7 +5878,7 @@ type Construct() =
             entity_typars= LazyWithContext.NotLazy []
             entity_tycon_repr = repr
             entity_tycon_tcaug=TyconAugmentation.Create()
-            entity_modul_type = MaybeLazy.Lazy (lazy ModuleOrNamespaceType(Namespace true, QueueList.ofList [], QueueList.ofList []))
+            entity_modul_type = MaybeLazy.Lazy(InterruptibleLazy(fun _ -> ModuleOrNamespaceType(Namespace true, QueueList.ofList [], QueueList.ofList [])))
             // Generated types get internal accessibility
             entity_pubpath = Some pubpath
             entity_cpath = Some cpath

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -3077,7 +3077,7 @@ type GenericParameterStyle =
 [<NoEquality; NoComparison>]
 type DisplayEnv = 
     { includeStaticParametersInTypeNames: bool
-      openTopPathsSorted: Lazy<string list list>
+      openTopPathsSorted: InterruptibleLazy<string list list>
       openTopPathsRaw: string list list
       shortTypeNames: bool
       suppressNestedTypes: bool
@@ -3107,7 +3107,7 @@ type DisplayEnv =
 
     member x.SetOpenPaths paths = 
         { x with 
-             openTopPathsSorted = (lazy (paths |> List.sortWith (fun p1 p2 -> -(compare p1 p2))))
+             openTopPathsSorted = (InterruptibleLazy(fun _ -> paths |> List.sortWith (fun p1 p2 -> -(compare p1 p2))))
              openTopPathsRaw = paths 
         }
 
@@ -10249,7 +10249,7 @@ let CombineCcuContentFragments l =
             let xml = XmlDoc.Merge entity1.XmlDoc entity2.XmlDoc
             { data1 with 
                 entity_attribs = entity1.Attribs @ entity2.Attribs
-                entity_modul_type = MaybeLazy.Lazy (lazy (CombineModuleOrNamespaceTypes path2 entity1.ModuleOrNamespaceType entity2.ModuleOrNamespaceType))
+                entity_modul_type = MaybeLazy.Lazy (InterruptibleLazy(fun _ -> CombineModuleOrNamespaceTypes path2 entity1.ModuleOrNamespaceType entity2.ModuleOrNamespaceType))
                 entity_opt_data = 
                 match data1.entity_opt_data with
                 | Some optData -> Some { optData with entity_xmldoc = xml }

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -1048,7 +1048,7 @@ type GenericParameterStyle =
 type DisplayEnv =
     {
         includeStaticParametersInTypeNames: bool
-        openTopPathsSorted: Lazy<string list list>
+        openTopPathsSorted: InterruptibleLazy<string list list>
         openTopPathsRaw: string list list
         shortTypeNames: bool
         suppressNestedTypes: bool

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -501,7 +501,7 @@ let private p_lazy_impl p v st =
     st.os.FixupInt32 fixupPos7 ovalsIdx2
 
 let p_lazy p x st =
-    p_lazy_impl p (Lazy.force x) st
+    p_lazy_impl p (InterruptibleLazy.force x) st
 
 let p_maybe_lazy p (x: MaybeLazy<_>) st =
     p_lazy_impl p x.Value st
@@ -604,7 +604,7 @@ let u_lazy u st =
     res
 #else
     ignore (len, otyconsIdx1, otyconsIdx2, otyparsIdx1, otyparsIdx2, ovalsIdx1, ovalsIdx2)
-    Lazy.CreateFromValue(u st)
+    InterruptibleLazy.FromValue(u st)
 #endif
 
 

--- a/src/Compiler/TypedTree/TypedTreePickle.fsi
+++ b/src/Compiler/TypedTree/TypedTreePickle.fsi
@@ -44,7 +44,7 @@ val internal p_int: int -> WriterState -> unit
 val internal p_string: string -> WriterState -> unit
 
 /// Serialize a lazy value (eagerly)
-val internal p_lazy: pickler<'T> -> Lazy<'T> pickler
+val internal p_lazy: pickler<'T> -> InterruptibleLazy<'T> pickler
 
 /// Serialize a tuple of data
 val inline internal p_tup2: pickler<'T1> -> pickler<'T2> -> pickler<'T1 * 'T2>
@@ -106,7 +106,7 @@ val internal u_int: ReaderState -> int
 val internal u_string: ReaderState -> string
 
 /// Deserialize a lazy value (eagerly)
-val internal u_lazy: unpickler<'T> -> unpickler<Lazy<'T>>
+val internal u_lazy: unpickler<'T> -> unpickler<InterruptibleLazy<'T>>
 
 /// Deserialize a tuple
 val inline internal u_tup2: unpickler<'T2> -> unpickler<'T3> -> unpickler<'T2 * 'T3>

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -38,15 +38,6 @@ type Cancellable =
         | [] -> ()
         | token :: _ -> token.ThrowIfCancellationRequested()
 
-[<AutoOpen>]
-module Cancellable =
-    type Exception with
-
-        member this.IsOperationCancelled =
-            match this with
-            | :? OperationCanceledException -> true
-            | _ -> false
-
 namespace Internal.Utilities.Library
 
 open System

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -9,12 +9,6 @@ type Cancellable =
     static member Token: CancellationToken
     static member CheckAndThrow: unit -> unit
 
-[<AutoOpen>]
-module internal Cancellable =
-    type Exception with
-
-        member IsOperationCancelled: bool
-
 namespace Internal.Utilities.Library
 
 open System

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -7,13 +7,31 @@ open System.Threading
 open System.Collections.Generic
 open System.Runtime.CompilerServices
 
+[<Class>]
+type InterruptibleLazy<'T> =
+    new: valueFactory: (unit -> 'T) -> InterruptibleLazy<'T>
+
+    member IsValueCreated: bool
+
+    member Value: 'T
+    member Force: unit -> 'T
+
+    static member FromValue: value: 'T -> InterruptibleLazy<'T>
+
+module InterruptibleLazy =
+    val force: InterruptibleLazy<'T> -> 'T
+
 [<AutoOpen>]
 module internal PervasiveAutoOpens =
     /// Logical shift right treating int32 as unsigned integer.
     /// Code that uses this should probably be adjusted to use unsigned integer types.
     val (>>>&): x: int32 -> n: int32 -> int32
 
-    val notlazy: v: 'a -> Lazy<'a>
+    val notlazy: v: 'a -> InterruptibleLazy<'a>
+
+    val (|InterruptibleLazy|): l: InterruptibleLazy<'T> -> 'T
+
+    val (|RecoverableException|_|): exn: Exception -> Exception voption
 
     val inline isNil: l: 'a list -> bool
 

--- a/src/Compiler/Utilities/lib.fs
+++ b/src/Compiler/Utilities/lib.fs
@@ -383,7 +383,7 @@ type Dumper(x:obj) =
 [<RequireQualifiedAccess>]
 type MaybeLazy<'T> =
     | Strict of 'T
-    | Lazy of Lazy<'T>
+    | Lazy of InterruptibleLazy<'T>
 
     member this.Value: 'T =
         match this with

--- a/src/Compiler/Utilities/lib.fsi
+++ b/src/Compiler/Utilities/lib.fsi
@@ -250,7 +250,7 @@ val inline tryGetCacheValue: cache: cache<'a> -> NonNullSlot<'a> voption
 [<RequireQualifiedAccess>]
 type MaybeLazy<'T> =
     | Strict of 'T
-    | Lazy of System.Lazy<'T>
+    | Lazy of InterruptibleLazy<'T>
 
     member Force: unit -> 'T
     member Value: 'T

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -794,7 +794,7 @@ FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.Reflection.MethodImplAttribute
 FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.String Name
 FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.String ToString()
 FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.String get_Name()
-FSharp.Compiler.AbstractIL.IL+ILMethodDef: Void .ctor(System.String, System.Reflection.MethodAttributes, System.Reflection.MethodImplAttributes, ILCallingConv, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILParameter], ILReturn, System.Lazy`1[FSharp.Compiler.AbstractIL.IL+MethodBody], Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILGenericParameterDef], ILSecurityDecls, ILAttributes)
+FSharp.Compiler.AbstractIL.IL+ILMethodDef: Void .ctor(System.String, System.Reflection.MethodAttributes, System.Reflection.MethodImplAttributes, ILCallingConv, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILParameter], ILReturn, Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+MethodBody], Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILGenericParameterDef], ILSecurityDecls, ILAttributes)
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: ILMethodDef[] AsArray()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] AsList()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] FindByName(System.String)
@@ -1699,8 +1699,8 @@ FSharp.Compiler.AbstractIL.IL+ILVersionInfo: UInt16 get_Major()
 FSharp.Compiler.AbstractIL.IL+ILVersionInfo: UInt16 get_Minor()
 FSharp.Compiler.AbstractIL.IL+ILVersionInfo: UInt16 get_Revision()
 FSharp.Compiler.AbstractIL.IL+ILVersionInfo: Void .ctor(UInt16, UInt16, UInt16, UInt16)
-FSharp.Compiler.AbstractIL.IL+MethodBody+IL: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] Item
-FSharp.Compiler.AbstractIL.IL+MethodBody+IL: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] get_Item()
+FSharp.Compiler.AbstractIL.IL+MethodBody+IL: Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] Item
+FSharp.Compiler.AbstractIL.IL+MethodBody+IL: Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] get_Item()
 FSharp.Compiler.AbstractIL.IL+MethodBody+PInvoke: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+PInvokeMethod] Item
 FSharp.Compiler.AbstractIL.IL+MethodBody+PInvoke: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+PInvokeMethod] get_Item()
 FSharp.Compiler.AbstractIL.IL+MethodBody+Tags: Int32 Abstract
@@ -1730,7 +1730,7 @@ FSharp.Compiler.AbstractIL.IL+MethodBody: Int32 Tag
 FSharp.Compiler.AbstractIL.IL+MethodBody: Int32 get_Tag()
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody Abstract
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody Native
-FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NewIL(System.Lazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody])
+FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NewIL(Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody])
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NewPInvoke(System.Lazy`1[FSharp.Compiler.AbstractIL.IL+PInvokeMethod])
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NotAvailable
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody get_Abstract()
@@ -1842,12 +1842,12 @@ FSharp.Compiler.AbstractIL.IL: ILAttributesStored storeILCustomAttrs(ILAttribute
 FSharp.Compiler.AbstractIL.IL: ILEventDefs emptyILEvents
 FSharp.Compiler.AbstractIL.IL: ILEventDefs get_emptyILEvents()
 FSharp.Compiler.AbstractIL.IL: ILEventDefs mkILEvents(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILEventDef])
-FSharp.Compiler.AbstractIL.IL: ILEventDefs mkILEventsLazy(System.Lazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILEventDef]])
+FSharp.Compiler.AbstractIL.IL: ILEventDefs mkILEventsLazy(Internal.Utilities.Library.InterruptibleLazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILEventDef]])
 FSharp.Compiler.AbstractIL.IL: ILExportedTypesAndForwarders mkILExportedTypes(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILExportedTypeOrForwarder])
 FSharp.Compiler.AbstractIL.IL: ILFieldDefs emptyILFields
 FSharp.Compiler.AbstractIL.IL: ILFieldDefs get_emptyILFields()
 FSharp.Compiler.AbstractIL.IL: ILFieldDefs mkILFields(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILFieldDef])
-FSharp.Compiler.AbstractIL.IL: ILFieldDefs mkILFieldsLazy(System.Lazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILFieldDef]])
+FSharp.Compiler.AbstractIL.IL: ILFieldDefs mkILFieldsLazy(Internal.Utilities.Library.InterruptibleLazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILFieldDef]])
 FSharp.Compiler.AbstractIL.IL: ILMethodDefs emptyILMethods
 FSharp.Compiler.AbstractIL.IL: ILMethodDefs get_emptyILMethods()
 FSharp.Compiler.AbstractIL.IL: ILMethodDefs mkILMethods(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef])
@@ -1862,7 +1862,7 @@ FSharp.Compiler.AbstractIL.IL: ILNestedExportedTypes mkILNestedExportedTypes(Mic
 FSharp.Compiler.AbstractIL.IL: ILPropertyDefs emptyILProperties
 FSharp.Compiler.AbstractIL.IL: ILPropertyDefs get_emptyILProperties()
 FSharp.Compiler.AbstractIL.IL: ILPropertyDefs mkILProperties(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILPropertyDef])
-FSharp.Compiler.AbstractIL.IL: ILPropertyDefs mkILPropertiesLazy(System.Lazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILPropertyDef]])
+FSharp.Compiler.AbstractIL.IL: ILPropertyDefs mkILPropertiesLazy(Internal.Utilities.Library.InterruptibleLazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILPropertyDef]])
 FSharp.Compiler.AbstractIL.IL: ILResources emptyILResources
 FSharp.Compiler.AbstractIL.IL: ILResources get_emptyILResources()
 FSharp.Compiler.AbstractIL.IL: ILReturn mkILReturn(ILType)
@@ -11717,3 +11717,11 @@ Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Co
 Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Collections.Generic.IDictionary`2[TDictKey,TDictValue] GetDictionary()
 Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: T[] GetArray()
 Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,T[]])
+Internal.Utilities.Library.InterruptibleLazy: T force[T](Internal.Utilities.Library.InterruptibleLazy`1[T])
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Boolean IsValueCreated
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Boolean get_IsValueCreated()
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Internal.Utilities.Library.InterruptibleLazy`1[T] FromValue(T)
+Internal.Utilities.Library.InterruptibleLazy`1[T]: T Force()
+Internal.Utilities.Library.InterruptibleLazy`1[T]: T Value
+Internal.Utilities.Library.InterruptibleLazy`1[T]: T get_Value()
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,T])

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -794,7 +794,7 @@ FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.Reflection.MethodImplAttribute
 FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.String Name
 FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.String ToString()
 FSharp.Compiler.AbstractIL.IL+ILMethodDef: System.String get_Name()
-FSharp.Compiler.AbstractIL.IL+ILMethodDef: Void .ctor(System.String, System.Reflection.MethodAttributes, System.Reflection.MethodImplAttributes, ILCallingConv, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILParameter], ILReturn, System.Lazy`1[FSharp.Compiler.AbstractIL.IL+MethodBody], Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILGenericParameterDef], ILSecurityDecls, ILAttributes)
+FSharp.Compiler.AbstractIL.IL+ILMethodDef: Void .ctor(System.String, System.Reflection.MethodAttributes, System.Reflection.MethodImplAttributes, ILCallingConv, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILParameter], ILReturn, Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+MethodBody], Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILGenericParameterDef], ILSecurityDecls, ILAttributes)
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: ILMethodDef[] AsArray()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] AsList()
 FSharp.Compiler.AbstractIL.IL+ILMethodDefs: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef] FindByName(System.String)
@@ -1699,8 +1699,8 @@ FSharp.Compiler.AbstractIL.IL+ILVersionInfo: UInt16 get_Major()
 FSharp.Compiler.AbstractIL.IL+ILVersionInfo: UInt16 get_Minor()
 FSharp.Compiler.AbstractIL.IL+ILVersionInfo: UInt16 get_Revision()
 FSharp.Compiler.AbstractIL.IL+ILVersionInfo: Void .ctor(UInt16, UInt16, UInt16, UInt16)
-FSharp.Compiler.AbstractIL.IL+MethodBody+IL: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] Item
-FSharp.Compiler.AbstractIL.IL+MethodBody+IL: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] get_Item()
+FSharp.Compiler.AbstractIL.IL+MethodBody+IL: Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] Item
+FSharp.Compiler.AbstractIL.IL+MethodBody+IL: Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody] get_Item()
 FSharp.Compiler.AbstractIL.IL+MethodBody+PInvoke: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+PInvokeMethod] Item
 FSharp.Compiler.AbstractIL.IL+MethodBody+PInvoke: System.Lazy`1[FSharp.Compiler.AbstractIL.IL+PInvokeMethod] get_Item()
 FSharp.Compiler.AbstractIL.IL+MethodBody+Tags: Int32 Abstract
@@ -1730,7 +1730,7 @@ FSharp.Compiler.AbstractIL.IL+MethodBody: Int32 Tag
 FSharp.Compiler.AbstractIL.IL+MethodBody: Int32 get_Tag()
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody Abstract
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody Native
-FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NewIL(System.Lazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody])
+FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NewIL(Internal.Utilities.Library.InterruptibleLazy`1[FSharp.Compiler.AbstractIL.IL+ILMethodBody])
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NewPInvoke(System.Lazy`1[FSharp.Compiler.AbstractIL.IL+PInvokeMethod])
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody NotAvailable
 FSharp.Compiler.AbstractIL.IL+MethodBody: MethodBody get_Abstract()
@@ -1842,12 +1842,12 @@ FSharp.Compiler.AbstractIL.IL: ILAttributesStored storeILCustomAttrs(ILAttribute
 FSharp.Compiler.AbstractIL.IL: ILEventDefs emptyILEvents
 FSharp.Compiler.AbstractIL.IL: ILEventDefs get_emptyILEvents()
 FSharp.Compiler.AbstractIL.IL: ILEventDefs mkILEvents(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILEventDef])
-FSharp.Compiler.AbstractIL.IL: ILEventDefs mkILEventsLazy(System.Lazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILEventDef]])
+FSharp.Compiler.AbstractIL.IL: ILEventDefs mkILEventsLazy(Internal.Utilities.Library.InterruptibleLazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILEventDef]])
 FSharp.Compiler.AbstractIL.IL: ILExportedTypesAndForwarders mkILExportedTypes(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILExportedTypeOrForwarder])
 FSharp.Compiler.AbstractIL.IL: ILFieldDefs emptyILFields
 FSharp.Compiler.AbstractIL.IL: ILFieldDefs get_emptyILFields()
 FSharp.Compiler.AbstractIL.IL: ILFieldDefs mkILFields(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILFieldDef])
-FSharp.Compiler.AbstractIL.IL: ILFieldDefs mkILFieldsLazy(System.Lazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILFieldDef]])
+FSharp.Compiler.AbstractIL.IL: ILFieldDefs mkILFieldsLazy(Internal.Utilities.Library.InterruptibleLazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILFieldDef]])
 FSharp.Compiler.AbstractIL.IL: ILMethodDefs emptyILMethods
 FSharp.Compiler.AbstractIL.IL: ILMethodDefs get_emptyILMethods()
 FSharp.Compiler.AbstractIL.IL: ILMethodDefs mkILMethods(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILMethodDef])
@@ -1862,7 +1862,7 @@ FSharp.Compiler.AbstractIL.IL: ILNestedExportedTypes mkILNestedExportedTypes(Mic
 FSharp.Compiler.AbstractIL.IL: ILPropertyDefs emptyILProperties
 FSharp.Compiler.AbstractIL.IL: ILPropertyDefs get_emptyILProperties()
 FSharp.Compiler.AbstractIL.IL: ILPropertyDefs mkILProperties(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILPropertyDef])
-FSharp.Compiler.AbstractIL.IL: ILPropertyDefs mkILPropertiesLazy(System.Lazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILPropertyDef]])
+FSharp.Compiler.AbstractIL.IL: ILPropertyDefs mkILPropertiesLazy(Internal.Utilities.Library.InterruptibleLazy`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.AbstractIL.IL+ILPropertyDef]])
 FSharp.Compiler.AbstractIL.IL: ILResources emptyILResources
 FSharp.Compiler.AbstractIL.IL: ILResources get_emptyILResources()
 FSharp.Compiler.AbstractIL.IL: ILReturn mkILReturn(ILType)
@@ -11717,3 +11717,11 @@ Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Co
 Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: System.Collections.Generic.IDictionary`2[TDictKey,TDictValue] GetDictionary()
 Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: T[] GetArray()
 Internal.Utilities.Library.DelayInitArrayMap`3[T,TDictKey,TDictValue]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,T[]])
+Internal.Utilities.Library.InterruptibleLazy: T force[T](Internal.Utilities.Library.InterruptibleLazy`1[T])
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Boolean IsValueCreated
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Boolean get_IsValueCreated()
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Internal.Utilities.Library.InterruptibleLazy`1[T] FromValue(T)
+Internal.Utilities.Library.InterruptibleLazy`1[T]: T Force()
+Internal.Utilities.Library.InterruptibleLazy`1[T]: T Value
+Internal.Utilities.Library.InterruptibleLazy`1[T]: T get_Value()
+Internal.Utilities.Library.InterruptibleLazy`1[T]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Core.Unit,T])

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -38,6 +38,9 @@
     <Compile Include="..\service\AssemblyReaderShim.fs">
       <Link>AssemblyReaderShim.fs</Link>
     </Compile>
+    <Compile Include="..\service\ModuleReaderCancellationTests.fs">
+      <Link>ModuleReaderCancellationTests.fs</Link>
+    </Compile>
     <Compile Include="..\service\EditorTests.fs">
       <Link>EditorTests.fs</Link>
     </Compile>

--- a/tests/service/ModuleReaderCancellationTests.fs
+++ b/tests/service/ModuleReaderCancellationTests.fs
@@ -1,0 +1,254 @@
+module FSharp.Compiler.Service.Tests.ModuleReaderCancellationTests
+
+open System
+open System.IO
+open System.Reflection
+open System.Threading
+open FSharp.Compiler.AbstractIL.IL
+open FSharp.Compiler.AbstractIL.ILBinaryReader
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Text
+open FsUnit
+open Internal.Utilities.Library
+open NUnit.Framework
+
+let mutable private cts = new CancellationTokenSource()
+let mutable private wasCancelled = false
+
+let runCancelFirstTime f =
+    let mutable requestCount = 0
+    fun () ->
+        if requestCount = 0 then
+            cts.Cancel()
+
+        requestCount <- requestCount + 1
+        cts.Token.ThrowIfCancellationRequested()
+
+        f ()
+
+
+module ModuleReader =
+    let subsystemVersion = 4, 0
+    let useHighEntropyVA = false
+    let metadataVersion = String.Empty
+    let flags = 0
+    let exportedTypes = mkILExportedTypes []
+
+    let mkCtor () =
+        let name = ".ctor"
+        let methodAttrs =
+            MethodAttributes.Public |||
+            MethodAttributes.HideBySig |||
+            MethodAttributes.NewSlot |||
+            MethodAttributes.SpecialName
+
+        let callingConv = Callconv(ILThisConvention.Instance, ILArgConvention.Default)
+        let parameters = []
+        let ret = mkILReturn ILType.Void
+        let genericParams = []
+        let customAttrs = mkILCustomAttrs [] 
+
+        let implAttributes = MethodImplAttributes.Managed
+        let body = InterruptibleLazy.FromValue MethodBody.NotAvailable
+        let securityDecls = emptyILSecurityDecls
+        let isEntryPoint = false
+
+        ILMethodDef(name, methodAttrs, implAttributes, callingConv, parameters, ret, body, isEntryPoint, genericParams,
+             securityDecls, customAttrs)
+
+
+type ModuleReader(name, typeDefs) =
+    let assemblyName = $"{name}.dll"
+    let moduleName = name
+    let isDll = true
+
+    let ilModuleDef =
+        mkILSimpleModule
+            assemblyName moduleName isDll
+            ModuleReader.subsystemVersion
+            ModuleReader.useHighEntropyVA
+            typeDefs
+            None None
+            ModuleReader.flags
+            ModuleReader.exportedTypes
+            ""
+
+    member val Timestamp = DateTime.UtcNow
+    member val Path = Path.Combine(Path.GetTempPath(), assemblyName)
+
+    interface ILModuleReader with
+        member x.ILModuleDef = ilModuleDef
+        member x.ILAssemblyRefs = []
+        member x.Dispose() = ()
+
+
+type PreTypeDefData =
+    { Name: string
+      Namespace: string list
+      HasCtor: bool
+      CancelOnImport: bool }
+
+    member this.TypeDef =
+        let name =
+            match this.Namespace with
+            | [] -> this.Name
+            | ns ->
+                let ns = ns |> String.concat "."
+                $"{ns}.{this.Name}"
+
+        let methodsDefs =
+            if this.HasCtor then
+                let mkCtor = runCancelFirstTime (fun _ -> [| ModuleReader.mkCtor () |])
+                mkILMethodsComputed mkCtor
+            else
+                mkILMethods []
+
+        let typeAttributes = TypeAttributes.Public
+        let customAttrs = mkILCustomAttrs []
+        ILTypeDef(this.Name, typeAttributes, ILTypeDefLayout.Auto, [], [],
+            None, methodsDefs, mkILTypeDefs [], mkILFields [], emptyILMethodImpls, mkILEvents [], mkILProperties [], false,
+            emptyILSecurityDecls, customAttrs)
+
+type PreTypeDef(data: PreTypeDefData) =
+    let typeDef = data.TypeDef
+    let getTypeDef =
+        if data.CancelOnImport then runCancelFirstTime (fun _ -> typeDef) else (fun _ -> typeDef)
+
+    interface ILPreTypeDef with
+        member x.Name = data.Name
+        member x.Namespace = data.Namespace
+        member x.GetTypeDef() = getTypeDef ()
+
+
+let createPreTypeDefs typeData =
+    typeData
+    |> Array.ofList
+    |> Array.map (fun data -> PreTypeDef data :> ILPreTypeDef)
+
+let referenceReaderProject getPreTypeDefs options =
+    let reader = new ModuleReader("Reference", mkILTypeDefsComputed getPreTypeDefs)
+
+    let project = FSharpReferencedProject.ILModuleReference(
+        reader.Path, (fun _ -> reader.Timestamp), (fun _ -> reader)
+    )
+
+    { options with ReferencedProjects = [| project |]; OtherOptions = Array.append options.OtherOptions [| $"-r:{reader.Path}"|] }
+
+let parseAndCheck path source options =
+    cts <- new CancellationTokenSource()
+    wasCancelled <- false
+
+    try
+        match Async.RunSynchronously(checker.ParseAndCheckFileInProject(path, 0, SourceText.ofString source, options), cancellationToken = cts.Token) with
+        | fileResults, FSharpCheckFileAnswer.Aborted -> None
+        | fileResults, FSharpCheckFileAnswer.Succeeded results -> Some results
+    with :? OperationCanceledException ->
+        wasCancelled <- true
+        None
+
+
+
+let source1 = """
+module Module
+
+let t: T = T()
+"""
+
+let source2 = """
+module Module
+
+open Ns1.Ns2
+
+let t: T = T()
+"""
+
+
+[<Test>]
+let ``Type defs 01 - assembly import`` () =
+    let source = source1
+
+    let getPreTypeDefs typeData = runCancelFirstTime (fun _ -> createPreTypeDefs typeData)
+    let typeDefs = getPreTypeDefs [ { Name = "T"; Namespace = []; HasCtor = false; CancelOnImport = false } ]
+    let path, options = mkTestFileAndOptions source [||]
+    let options = referenceReaderProject typeDefs options
+
+    // First request, should be cancelled inside getPreTypeDefs
+    // The cancellation happens in side CombineImportedAssembliesTask, so background builder node fails to be evaluated
+    parseAndCheck path source options |> ignore
+    wasCancelled |> shouldEqual true
+
+    // Second request, should succeed, with complete analysis
+    match parseAndCheck path source options with
+    | Some results ->
+        wasCancelled |> shouldEqual false
+
+        results.Diagnostics
+        |> Array.map (fun e -> e.Message)
+        |> shouldEqual [| "No constructors are available for the type 'T'" |]
+
+    | None -> failwith "Expecting results"
+
+
+[<Test; Explicit("Type shouldn't be imported, see dotnet/fsharp#16166")>]
+let ``Type defs 02 - assembly import`` () =
+    let source = source1
+
+    let typeDefs = fun _ -> createPreTypeDefs [ { Name = "T"; Namespace = ["Ns"]; HasCtor = false; CancelOnImport = true } ]
+    let path, options = mkTestFileAndOptions source [||]
+    let options = referenceReaderProject typeDefs options
+
+    parseAndCheck path source options |> ignore
+    wasCancelled |> shouldEqual false
+
+    match parseAndCheck path source options with
+    | Some results ->
+        wasCancelled |> shouldEqual false
+        results.Diagnostics |> Array.isEmpty |> shouldEqual false
+    | None -> failwith "Expecting results"
+
+
+[<Test>]
+let ``Type defs 03 - type import`` () =
+    let source = source2
+
+    let typeDefs = fun _ -> createPreTypeDefs [ { Name = "T"; Namespace = ["Ns1"; "Ns2"]; HasCtor = false; CancelOnImport = true } ]
+    let path, options = mkTestFileAndOptions source [||]
+    let options = referenceReaderProject typeDefs options
+
+    // First request, should be cancelled inside GetTypeDef
+    // This shouldn't be cached due to InterruptibleLazy
+    parseAndCheck path source options |> ignore
+    wasCancelled |> shouldEqual true
+
+    // Second request, should succeed, with complete analysis
+    match parseAndCheck path source options with
+    | Some results ->
+        wasCancelled |> shouldEqual false
+
+        results.Diagnostics
+        |> Array.map (fun e -> e.Message)
+        |> shouldEqual [| "No constructors are available for the type 'T'" |]
+
+    | None -> failwith "Expecting results"
+
+
+[<Test>]
+let ``Type defs 04 - ctor import`` () =
+    let source = source1
+
+    let typeDefs = fun _ -> createPreTypeDefs [ { Name = "T"; Namespace = []; HasCtor = true; CancelOnImport = false } ]
+    let path, options = mkTestFileAndOptions source [||]
+    let options = referenceReaderProject typeDefs options
+
+    // First request, should be cancelled inside ILMethodDefs
+    // This shouldn't be cached due to InterruptibleLazy
+    parseAndCheck path source options |> ignore
+    wasCancelled |> shouldEqual true
+
+    // Second request, should succeed, with complete analysis
+    match parseAndCheck path source options with
+    | Some results ->
+        wasCancelled |> shouldEqual false
+        results.Diagnostics |> Array.isEmpty |> shouldEqual true
+
+    | None -> failwith "Expecting results"

--- a/tests/service/ModuleReaderCancellationTests.fs
+++ b/tests/service/ModuleReaderCancellationTests.fs
@@ -4,6 +4,7 @@ open System
 open System.IO
 open System.Reflection
 open System.Threading
+open FSharp.Compiler
 open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.CodeAnalysis
@@ -22,7 +23,7 @@ let runCancelFirstTime f =
             cts.Cancel()
 
         requestCount <- requestCount + 1
-        cts.Token.ThrowIfCancellationRequested()
+        Cancellable.CheckAndThrow()
 
         f ()
 


### PR DESCRIPTION
Continues #16137 and adds Lazy implementation that doesn't cache exceptions, allowing it to be used when `OperationCancelledException` may be raised inside the factory function. I've initially added it to various IL types, but ended up transitively updating other places, so no conversion between lazy types is needed. It also allows to cancel in more places in future if we decide to add more cancellation points via `Cancellable` or other way.

It also adds tests for cancellation inside metadata reading in various places during project analysis startup and during code analysis. These tests show that previously cancelled requests now don't have any impact on subsequent requests and these requests return correct info. These tests have also shown some performance issues in metadata reading (see https://github.com/dotnet/fsharp/issues/16166), which is good, since we can improve these parts of the compiler too and even assert it with these tests.

Next steps may be these:
* Check `LazyWithContext`. It seems it's redundant to create it just for keeping the exception ranges, as `errorRecovery` also attaches relatively good range to errors. It needs to be checked and evaluated, though.