### PR TITLE
Lexer: report missing error on `~`

### DIFF
--- a/src/Compiler/lex.fsl
+++ b/src/Compiler/lex.fsl
@@ -939,7 +939,9 @@ rule token (args: LexArgs) (skip: bool) = parse
 
  | "-" { MINUS }
 
- | "~" { RESERVED }
+ | "~"
+     { errorR (Error(FSComp.SR.lexInvalidIdentifier(), lexbuf.LexemeRange))
+       RESERVED }
 
  | ignored_op_char* '*' '*'                    op_char* { checkExprOp lexbuf; INFIX_STAR_STAR_OP(lexeme lexbuf) }
 

--- a/tests/service/data/SyntaxTree/Expression/Unary - Reserved 01.fs
+++ b/tests/service/data/SyntaxTree/Expression/Unary - Reserved 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+~x

--- a/tests/service/data/SyntaxTree/Expression/Unary - Reserved 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Unary - Reserved 01.fs.bsl
@@ -1,0 +1,17 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Unary - Reserved 01.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (App
+                (NonAtomic, false,
+                 ArbitraryAfterError ("unfinished identifier", (3,0--3,1)),
+                 Ident x, (3,0--3,2)), (3,0--3,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,0)-(3,1) parse error This is not a valid identifier

--- a/tests/service/data/SyntaxTree/Expression/Unary - Reserved 02.fs
+++ b/tests/service/data/SyntaxTree/Expression/Unary - Reserved 02.fs
@@ -1,0 +1,3 @@
+module Module
+
+x ~ y

--- a/tests/service/data/SyntaxTree/Expression/Unary - Reserved 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Unary - Reserved 02.fs.bsl
@@ -1,0 +1,19 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Unary - Reserved 02.fs", false,
+      QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (App
+                (NonAtomic, false,
+                 App
+                   (NonAtomic, false, Ident x,
+                    ArbitraryAfterError ("unfinished identifier", (3,2--3,3)),
+                    (3,0--3,3)), Ident y, (3,0--3,5)), (3,0--3,5))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--3,5), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(3,2)-(3,3) parse error This is not a valid identifier


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/16135.

Previously, the parser would fail on 'reserved' identifiers : `~` and unfinished backticked identifiers. https://github.com/dotnet/fsharp/pull/15030 added recovery by parsing these as normal identifiers and added a proper error reporting about the backticked identifiers to the lexer.  The `~` case was overlooked in the lexer, so there was no additional error after the parser one was gone. The same error is reported now.