### PR TITLE
Respect line limit in QuickInfo

### DIFF
--- a/vsintegration/src/FSharp.Editor/DocComments/XMLDocumentation.fs
+++ b/vsintegration/src/FSharp.Editor/DocComments/XMLDocumentation.fs
@@ -78,10 +78,12 @@ type internal TextSanitizingCollector(collector, ?lineLimit: int) =
 
     interface ITaggedTextCollector with
         member _.Add taggedText =
-            // TODO: bail out early if line limit is already hit
-            match taggedText.Tag with
-            | TextTag.Text -> reportTextLines taggedText.Text
-            | _ -> addTaggedTextEntry taggedText
+            match lineLimit with
+            | Some lineLimit when lineLimit < count -> ()
+            | _ ->
+                match taggedText.Tag with
+                | TextTag.Text -> reportTextLines taggedText.Text
+                | _ -> addTaggedTextEntry taggedText
 
         member _.IsEmpty = isEmpty
         member _.EndsWithLineBreak = isEmpty || endsWithLineBreak


### PR DESCRIPTION
Fixes problem with the ellipsis as seen in #7783:

Before:
![image](https://github.com/dotnet/fsharp/assets/1760221/55aa53f5-416a-42ea-a84d-e636844de546)

After:
<img width="572" alt="image" src="https://github.com/dotnet/fsharp/assets/1760221/86fbeb89-a4a6-4ee4-854c-b03ed122b31a">
