### PR TITLE
Allow using __SOURCE_DIRECTORY__ in #i directive

### DIFF
--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -874,6 +874,11 @@ let ProcessMetaCommandsFromInput
             errorR (HashReferenceNotAllowedInNonScript m)
 
         match args with
+        | paths when directive = Directive.Include ->
+            let p = paths |> String.concat ""
+
+            hashReferenceF state (m, p, directive)
+
         | [ path ] ->
             let p = if String.IsNullOrWhiteSpace(path) then "" else path
 

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -3743,7 +3743,8 @@ type FsiInteractionProcessor
         | ParsedHashDirective (("reference" | "r"), ParsedHashDirectiveArguments [ path ], m) ->
             fsiDynamicCompiler.PartiallyProcessReferenceOrPackageIncudePathDirective(ctok, istate, Directive.Resolution, path, true, m)
 
-        | ParsedHashDirective ("i", ParsedHashDirectiveArguments [ path ], m) ->
+        | ParsedHashDirective ("i", ParsedHashDirectiveArguments args, m) ->
+            let path = String.concat "" args
             fsiDynamicCompiler.PartiallyProcessReferenceOrPackageIncudePathDirective(ctok, istate, Directive.Include, path, true, m)
 
         | ParsedHashDirective ("I", ParsedHashDirectiveArguments [ path ], m) ->

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -3743,7 +3743,7 @@ type FsiInteractionProcessor
         | ParsedHashDirective (("reference" | "r"), ParsedHashDirectiveArguments [ path ], m) ->
             fsiDynamicCompiler.PartiallyProcessReferenceOrPackageIncudePathDirective(ctok, istate, Directive.Resolution, path, true, m)
 
-        | ParsedHashDirective ("i", ParsedHashDirectiveArguments args, m) ->
+        | ParsedHashDirective ("i", ParsedHashDirectiveArguments args, m) when not (List.isEmpty args) ->
             let path = String.concat "" args
             fsiDynamicCompiler.PartiallyProcessReferenceOrPackageIncudePathDirective(ctok, istate, Directive.Include, path, true, m)
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/CompilerDirectiveTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CompilerDirectiveTests.fs
@@ -24,6 +24,14 @@ module ``Test Compiler Directives`` =
             |> shouldFail
             |> withSingleDiagnostic (Warning 213, Line 2, Col 1, Line 2, Col 10, "'' is not a valid assembly name")
 
+    [<Fact>]
+    let ``#i works with __SOURCE_DIRECTORY__ and string literals`` () =
+        Fsx """
+#i "nuget:" __SOURCE_DIRECTORY__
+        """
+        |> compile
+        |> shouldSucceed
+
 module ``Test compiler directives in FSI`` =
     [<Fact>]
     let ``r# "" is invalid`` () =
@@ -33,3 +41,11 @@ module ``Test compiler directives in FSI`` =
             |> eval
             |> shouldFail
             |> withSingleDiagnostic (Error 2301, Line 2, Col 1, Line 2, Col 6, "'' is not a valid assembly name")
+
+    [<Fact>]
+    let ``#i works with __SOURCE_DIRECTORY__ and string literals`` () =
+        Fsx """
+#i "nuget:" __SOURCE_DIRECTORY__
+        """
+        |> eval
+        |> shouldSucceed


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/12969

Alternative to https://github.com/dotnet/fsharp/pull/16123

This will allow to pass multiple arguments to `#i` and concatenate them. Arguments will be allowed to be string literals or [special identifiers](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/source-line-file-path-identifiers).