### PR TITLE
VS checkbox for controlling the "Remove parens" diag+fix

### DIFF
--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -109,8 +109,8 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                     errors.Add(diagnostic) |> ignore
 
             let! unnecessaryParentheses =
-                match diagnosticType with                
-                | DiagnosticsType.Syntax when document.Project.IsFsharpRemoveParensEnabled  -> 
+                match diagnosticType with
+                | DiagnosticsType.Syntax when document.Project.IsFsharpRemoveParensEnabled ->
                     UnnecessaryParenthesesDiagnosticAnalyzer.GetDiagnostics document
                 | _ -> CancellableTask.singleton ImmutableArray.Empty
 

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -109,9 +109,10 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                     errors.Add(diagnostic) |> ignore
 
             let! unnecessaryParentheses =
-                match diagnosticType with
-                | DiagnosticsType.Semantic -> CancellableTask.singleton ImmutableArray.Empty
-                | DiagnosticsType.Syntax -> UnnecessaryParenthesesDiagnosticAnalyzer.GetDiagnostics document
+                match diagnosticType with                
+                | DiagnosticsType.Syntax when document.Project.IsFsharpRemoveParensEnabled  -> 
+                    UnnecessaryParenthesesDiagnosticAnalyzer.GetDiagnostics document
+                | _ -> CancellableTask.singleton ImmutableArray.Empty
 
             if errors.Count = 0 && unnecessaryParentheses.IsEmpty then
                 return ImmutableArray.Empty

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -252,8 +252,7 @@ module EditorOptionsExtensions =
         member this.IsFSharpCodeFixesUnusedOpensEnabled =
             this.EditorOptions.CodeFixes.UnusedOpens
 
-        member this.IsFsharpRemoveParensEnabled =
-            this.EditorOptions.CodeFixes.RemoveParens
+        member this.IsFsharpRemoveParensEnabled = this.EditorOptions.CodeFixes.RemoveParens
 
         member this.IsFSharpCodeFixesSuggestNamesForErrorsEnabled =
             this.EditorOptions.CodeFixes.SuggestNamesForErrors

--- a/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
+++ b/vsintegration/src/FSharp.Editor/Options/EditorOptions.fs
@@ -63,6 +63,7 @@ type CodeFixesOptions =
         UnusedOpens: bool
         UnusedDeclarations: bool
         SuggestNamesForErrors: bool
+        RemoveParens: bool
     }
 
     static member Default =
@@ -73,6 +74,7 @@ type CodeFixesOptions =
             UnusedOpens = true
             UnusedDeclarations = true
             SuggestNamesForErrors = true
+            RemoveParens = false
         }
 
 [<CLIMutable>]
@@ -249,6 +251,9 @@ module EditorOptionsExtensions =
 
         member this.IsFSharpCodeFixesUnusedOpensEnabled =
             this.EditorOptions.CodeFixes.UnusedOpens
+
+        member this.IsFsharpRemoveParensEnabled =
+            this.EditorOptions.CodeFixes.RemoveParens
 
         member this.IsFSharpCodeFixesSuggestNamesForErrorsEnabled =
             this.EditorOptions.CodeFixes.SuggestNamesForErrors

--- a/vsintegration/src/FSharp.UIResources/CodeFixesOptionControl.xaml
+++ b/vsintegration/src/FSharp.UIResources/CodeFixesOptionControl.xaml
@@ -31,6 +31,8 @@
 
                         <CheckBox x:Name="suggestNamesForErrors" IsChecked="{Binding SuggestNamesForErrors}"
                                   Content="{x:Static local:Strings.Suggest_names_for_errors_code_fix}"/>
+                        <CheckBox x:Name="removeParens" IsChecked="{Binding RemoveParens}"
+                                  Content="{x:Static local:Strings.Remove_parens_code_fix}"/>
                     </StackPanel>
                 </GroupBox>
             </StackPanel>

--- a/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
+++ b/vsintegration/src/FSharp.UIResources/Strings.Designer.cs
@@ -385,6 +385,15 @@ namespace Microsoft.VisualStudio.FSharp.UIResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove unnecessary parentheses (experimental, might affect typing performance).
+        /// </summary>
+        public static string Remove_parens_code_fix {
+            get {
+                return ResourceManager.GetString("Remove_parens_code_fix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Send additional performance telemetry.
         /// </summary>
         public static string Send_Additional_Telemetry {

--- a/vsintegration/src/FSharp.UIResources/Strings.resx
+++ b/vsintegration/src/FSharp.UIResources/Strings.resx
@@ -285,4 +285,7 @@
   <data name="Background_analysis" xml:space="preserve">
     <value>Background analysis</value>
   </data>
+  <data name="Remove_parens_code_fix" xml:space="preserve">
+    <value>Remove unnecessary parentheses (experimental, might affect typing performance)</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Upřednostňovaná šířka popisu ve znacích</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Odeslat další telemetrii výkonu</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Bevorzugte Beschreibungsbreite in Zeichen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Zusätzliche Leistungstelemetriedaten senden</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Anchura preferida de la descripción en caracteres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Enviar telemetría de rendimiento adicional</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Largeur de description préférée en caractères</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Envoyer une télémétrie de performances supplémentaire</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Larghezza descrizione preferita in caratteri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Invia dati di telemetria aggiuntivi per le prestazioni</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -127,6 +127,11 @@
         <target state="translated">優先する説明の文字幅</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">追加のパフォーマンス テレメトリを送信する</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -127,6 +127,11 @@
         <target state="translated">기본 설정 설명 너비(문자)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">추가 성능 원격 분석 보내기</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Preferowana szerokość opisu w znakach</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Wysyłanie dodatkowych danych telemetrycznych dotyczących wydajności</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Largura de descrição preferencial em caracteres</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Enviar telemetria de desempenho adicional</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Предпочитаемая ширина описания в символах</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Отправить дополнительные диагностические данные о производительности</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -127,6 +127,11 @@
         <target state="translated">Karakter olarak tercih edilen açıklama genişliği</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">Ek performans telemetrisi gönder</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -127,6 +127,11 @@
         <target state="translated">以字符为单位的首选说明宽度</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">发送其他性能遥测</target>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -127,6 +127,11 @@
         <target state="translated">慣用説明寬度 (以字元為單位)</target>
         <note />
       </trans-unit>
+      <trans-unit id="Remove_parens_code_fix">
+        <source>Remove unnecessary parentheses (experimental, might affect typing performance)</source>
+        <target state="new">Remove unnecessary parentheses (experimental, might affect typing performance)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Send_Additional_Telemetry">
         <source>Send additional performance telemetry</source>
         <target state="translated">傳送其他效能遙測</target>

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -16,7 +16,13 @@ module private TopLevel =
 
     let private tryFix (code: string) =
         cancellableTask {
-            let document = Document.create Auto code
+            let mode =
+                WithSettings
+                    { CodeFixesOptions.Default with
+                        RemoveParens = true
+                    }
+
+            let document = Document.create mode code
             let sourceText = SourceText.From code
 
             let! diagnostics = FSharpDocumentDiagnosticAnalyzer.GetDiagnostics(document, DiagnosticsType.Syntax)


### PR DESCRIPTION
At the moment, the RemoveParens diagnostic is hardcoded into the call for getting syntax diagnostics.
That happens with every keystroke and powers many basic features.

Like with other analyzers, this PR adds the checkbox to control it, with the default value of "false".
Once this analyzer has its own call from Roslyn, default can be changed to "true".

![image](https://github.com/dotnet/fsharp/assets/46543583/ac239154-e68e-4492-9aaa-fae5f692d908)
