### PR TITLE
Fix 15958: Missing warning FS3365 for SynLongIdent (dotless indexing vs application)

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/IndexingSyntax.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/IndexingSyntax.fs
@@ -14,7 +14,9 @@ namespace N
 
         let f (a: int list) = a
         
-        let g () = f[1]
+        let g () = f [1] // should not warn
+        
+        let h () = f[1] // should warn
         """
         |> FSharp
         |> withLangVersion70
@@ -22,9 +24,9 @@ namespace N
         |> shouldFail
         |> withResults [
             { Error = Information 3365
-              Range = { StartLine = 8
+              Range = { StartLine = 10
                         StartColumn = 20
-                        EndLine = 8
+                        EndLine = 10
                         EndColumn = 24 }
               Message =
                "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'." }
@@ -42,7 +44,8 @@ namespace N
 
         let g () =
             let c = C()
-            c.MyFunc[42]
+            let _ = c.MyFunc [23]   // should not warn
+            c.MyFunc[42]    // should warn
         """
         |> FSharp
         |> withLangVersion70
@@ -50,9 +53,9 @@ namespace N
         |> shouldFail
         |> withResults [
             { Error = Information 3365
-              Range = { StartLine = 11
+              Range = { StartLine = 12
                         StartColumn = 13
-                        EndLine = 11
+                        EndLine = 12
                         EndColumn = 25 }
               Message =
                "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'." }

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/IndexingSyntax.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/IndexingSyntax.fs
@@ -22,15 +22,21 @@ namespace N
         |> withLangVersion70
         |> compile
         |> shouldFail
-        |> withResults [
-            { Error = Information 3365
-              Range = { StartLine = 10
-                        StartColumn = 20
-                        EndLine = 10
-                        EndColumn = 24 }
-              Message =
-               "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'." }
-        ]
+        |> withResults
+            [
+                {
+                    Error = Information 3365
+                    Range =
+                        {
+                            StartLine = 10
+                            StartColumn = 20
+                            EndLine = 10
+                            EndColumn = 24
+                        }
+                    Message =
+                        "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'."
+                }
+            ]
 
     [<FSharp.Test.FactForNETCOREAPP>]
     let ``Warn successfully for SynExpr.LongIdent app`` () =
@@ -51,12 +57,18 @@ namespace N
         |> withLangVersion70
         |> compile
         |> shouldFail
-        |> withResults [
-            { Error = Information 3365
-              Range = { StartLine = 12
-                        StartColumn = 13
-                        EndLine = 12
-                        EndColumn = 25 }
-              Message =
-               "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'." }
-        ]
+        |> withResults
+            [
+                {
+                    Error = Information 3365
+                    Range =
+                        {
+                            StartLine = 12
+                            StartColumn = 13
+                            EndLine = 12
+                            EndColumn = 25
+                        }
+                    Message =
+                        "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'."
+                }
+            ]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/IndexingSyntax.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/IndexingSyntax.fs
@@ -1,0 +1,59 @@
+namespace FSharp.Compiler.ComponentTests.ErrorMessages
+
+open FSharp.Test.Compiler
+open FSharp.Test.Compiler.Assertions.StructuredResultsAsserts
+
+module ``Indexing Syntax`` =
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``Warn successfully for SynExpr.Ident app`` () =
+        """
+namespace N
+
+    module M =
+
+        let f (a: int list) = a
+        
+        let g () = f[1]
+        """
+        |> FSharp
+        |> withLangVersion70
+        |> compile
+        |> shouldFail
+        |> withResults [
+            { Error = Information 3365
+              Range = { StartLine = 8
+                        StartColumn = 20
+                        EndLine = 8
+                        EndColumn = 24 }
+              Message =
+               "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'." }
+        ]
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``Warn successfully for SynExpr.LongIdent app`` () =
+        """
+namespace N
+
+    module N =
+
+        type C () =
+            member _.MyFunc (inputList: int list) = inputList
+
+        let g () =
+            let c = C()
+            c.MyFunc[42]
+        """
+        |> FSharp
+        |> withLangVersion70
+        |> compile
+        |> shouldFail
+        |> withResults [
+            { Error = Information 3365
+              Range = { StartLine = 11
+                        StartColumn = 13
+                        EndLine = 11
+                        EndColumn = 25 }
+              Message =
+               "The syntax 'expr1[expr2]' is used for indexing. Consider adding a type annotation to enable indexing, or if calling a function add a space, e.g. 'expr1 [expr2]'." }
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -167,6 +167,7 @@
     <Compile Include="EmittedIL\FixedBindings\FixedBindings.fs" />
     <Compile Include="ErrorMessages\UnsupportedAttributes.fs" />
     <Compile Include="ErrorMessages\TailCallAttribute.fs" />
+    <Compile Include="ErrorMessages\IndexingSyntax.fs" />
     <Compile Include="ErrorMessages\TypeEqualsMissingTests.fs" />
     <Compile Include="ErrorMessages\AccessOfTypeAbbreviationTests.fs" />
     <Compile Include="ErrorMessages\AssignmentErrorTests.fs" />


### PR DESCRIPTION
This tries to fix #15958 

Although people are warming up to move new warnings to analyzers, I think this is still good to have in the compiler as it's related to a syntax change (dotless indexing).