### PR TITLE
Add regression test for unused open.

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -772,4 +772,32 @@ type DiGraph = obj
 """
                     (set [| 0 |])
             ]
+        scenario
+            "Unused namespace should be detected"
+            [
+                sourceFile
+                    "File1.fs"
+                    """
+namespace My.Great.Namespace
+"""
+                    Set.empty
+
+                sourceFile
+                    "File2.fs"
+                    """
+namespace My.Great.Namespace
+
+open My.Great.Namespace
+
+type Foo = class end
+"""
+                    (set [| 0 |])
+                    
+                sourceFile
+                    "Program"
+                    """
+printfn "Hello"
+"""
+                    Set.empty
+            ]
     ]


### PR DESCRIPTION
I'm unable to reproduce the problem https://github.com/dotnet/fsharp/issues/16225 locally.

The problem goes away when I hook in my local compiler: `<DotnetFscCompilerPath>C:\Users\nojaf\Projects\fsharp\artifacts\bin\fsc\Debug\net8.0\fsc.dll</DotnetFscCompilerPath>`.

I'd like to see what CI says.