### PR TITLE
Ad-hoc fix for `ref readonly` parameters

### DIFF
--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -1423,6 +1423,7 @@ type TcGlobals(
   member val attrib_ParamArrayAttribute = findSysAttrib "System.ParamArrayAttribute"
   member val attrib_IDispatchConstantAttribute = tryFindSysAttrib "System.Runtime.CompilerServices.IDispatchConstantAttribute"
   member val attrib_IUnknownConstantAttribute = tryFindSysAttrib "System.Runtime.CompilerServices.IUnknownConstantAttribute"
+  member val attrib_RequiresLocationAttribute = findSysAttrib "System.Runtime.CompilerServices.RequiresLocationAttribute"
 
   // We use 'findSysAttrib' here because lookup on attribute is done by name comparison, and can proceed
   // even if the type is not found in a system assembly.

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <Compile Include="..\service\FsUnit.fs">
       <Link>FsUnit.fs</Link>
-    </Compile>  
+    </Compile>
     <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\Basic\Basic.fs" />
     <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\OnOverridesAndIFaceImpl\OnOverridesAndIFaceImpl.fs" />
     <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\OnTypeMembers\OnTypeMembers.fs" />
@@ -112,7 +112,7 @@
     <Compile Include="Conformance\Types\RecordTypes\AnonymousRecords.fs" />
     <Compile Include="Conformance\Types\RecordTypes\RecordTypes.fs" />
     <Compile Include="Conformance\Types\StructTypes\StructTypes.fs" />
-    <Compile Include="Conformance\Types\StructTypes\StructActivePatterns.fs" />	  
+    <Compile Include="Conformance\Types\StructTypes\StructActivePatterns.fs" />
     <Compile Include="Conformance\Types\TypeConstraints\CheckingSyntacticTypes\CheckingSyntacticTypes.fs" />
     <Compile Include="Conformance\Types\TypeConstraints\LogicalPropertiesOfTypes\LogicalPropertiesOfTypes.fs" />
     <Compile Include="Conformance\Types\TypeConstraints\IWSAMsAndSRTPs\IWSAMsAndSRTPsTests.fs" />
@@ -175,7 +175,7 @@
     <Compile Include="ErrorMessages\DontSuggestTests.fs" />
     <Compile Include="ErrorMessages\ElseBranchHasWrongTypeTests.fs" />
     <Compile Include="ErrorMessages\InvalidLiteralTests.fs" />
-    <Compile Include="ErrorMessages\InvalidNumericLiteralTests.fs" />    
+    <Compile Include="ErrorMessages\InvalidNumericLiteralTests.fs" />
     <Compile Include="ErrorMessages\MissingElseBranch.fs" />
     <Compile Include="ErrorMessages\MissingExpressionTests.fs" />
     <Compile Include="ErrorMessages\ModuleTests.fs" />
@@ -191,7 +191,7 @@
     <Compile Include="ErrorMessages\Repro1548.fs" />
     <Compile Include="ErrorMessages\WarnIfDiscardedInList.fs" />
     <Compile Include="ErrorMessages\UnionCasePatternMatchingErrors.fs" />
-    <Compile Include="ErrorMessages\InterfaceImplInAugmentationsTests.fs" />	
+    <Compile Include="ErrorMessages\InterfaceImplInAugmentationsTests.fs" />
     <Compile Include="ErrorMessages\ExtendedDiagnosticDataTests.fs" />
     <Compile Include="Language\IndexerSetterParamArray.fs" />
     <Compile Include="Language\MultiDimensionalArrayTests.fs" />
@@ -225,6 +225,7 @@
     <Compile Include="Interop\RequiredAndInitOnlyProperties.fs" />
     <Compile Include="Interop\StaticsInInterfaces.fs" />
     <Compile Include="Interop\VisibilityTests.fs" />
+    <Compile Include="Interop\ByrefTests.fs" />
     <Compile Include="Scripting\Interactive.fs" />
     <Compile Include="TypeChecks\SeqTypeCheckTests.fs" />
     <Compile Include="TypeChecks\CheckDeclarationsTests.fs" />
@@ -323,5 +324,5 @@
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
   </ItemGroup>
-	
+
 </Project>

--- a/tests/FSharp.Compiler.ComponentTests/Interop/ByrefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/ByrefTests.fs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Interop
+
+open Xunit
+open FSharp.Test
+open FSharp.Test.Compiler
+
+module ``Byref interop verification tests`` =
+
+    [<FactForNETCOREAPP>]
+    let ``Test that ref readonly is treated as ref`` () =
+
+        FSharp """
+        namespace ByrefTest
+        open System.Runtime.CompilerServices
+        type MyRecord = { Value : int } with
+            member this.SetValue(v: int) = (Unsafe.AsRef<int> &this.Value) <- v
+        """
+        |> compile
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Interop/ByrefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/ByrefTests.fs
@@ -2,20 +2,54 @@
 
 namespace Interop
 
-open Xunit
 open FSharp.Test
 open FSharp.Test.Compiler
 
 module ``Byref interop verification tests`` =
 
     [<FactForNETCOREAPP>]
-    let ``Test that ref readonly is treated as ref`` () =
+    let ``Test that ref readonly is treated as inref`` () =
 
         FSharp """
-        namespace ByrefTest
+        module ByrefTest
         open System.Runtime.CompilerServices
         type MyRecord = { Value : int } with
             member this.SetValue(v: int) = (Unsafe.AsRef<int> &this.Value) <- v
+
+        let check mr =
+            if mr.Value <> 1 then
+                failwith "Value should be 1"
+
+            mr.SetValue(42)
+
+            if mr.Value <> 42 then
+                failwith $"Value should be 42, but is {mr.Value}"
+            0
+
+        [<EntryPoint>]
+        let main _ =
+            let mr = { Value = 1 }
+            check mr
         """
-        |> compile
+        |> asExe
+        |> compileAndRun
+        |> shouldSucceed
+
+    [<FactForNETCOREAPP>]
+    let ``Test that ref readonly is treated as inref for ROS .ctor`` () =
+        FSharp """
+        module Foo
+        open System
+
+        [<EntryPoint>]
+        let main _ =
+            let mutable bt: int = 42
+            let ros = ReadOnlySpan<int>(&bt)
+
+            if ros.Length <> 0 && ros[0] <> 42 then
+                failwith "Unexpected result"
+            0
+        """
+        |> asExe
+        |> compileAndRun
         |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Interop/ByrefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/ByrefTests.fs
@@ -41,12 +41,13 @@ module ``Byref interop verification tests`` =
         module Foo
         open System
 
+
         [<EntryPoint>]
         let main _ =
             let mutable bt: int = 42
             let ros = ReadOnlySpan<int>(&bt)
 
-            if ros.Length <> 0 && ros[0] <> 42 then
+            if ros.Length <> 1 || ros[0] <> 42 then
                 failwith "Unexpected result"
             0
         """


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94317

**Note that this is an ad-hoc fix which will just treat `ref readonly` as `inref` during parameters import, for long-term fix, please refer to https://github.com/dotnet/fsharp/issues/16222**


`ref readonly` is encoded as `[in]&T` with `RequiresLocationAttribute`, we import `inref<_>` only from `[in]&T` with `IsReadOnlyAttribute`, this PR adds a second check.