### PR TITLE
Handle special parsing of `new T…` & `inherit T…`

### DIFF
--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -1167,7 +1167,7 @@ module UnnecessaryParentheses =
             | SynExpr.Paren (expr = AtomicExprAfterType; range = range), SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
                 ValueSome range
 
-            // Parens are otherwise required in inherit T(x), etc. (see atomicExprAfterType in pars.fsy).
+            // Parens are otherwise required in inherit T(x), etc.
             | SynExpr.Paren _, SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ -> ValueNone
 
             // We can't remove parens when they're required for fluent calls:

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -704,8 +704,8 @@ module UnnecessaryParentheses =
             | SynExpr.AnonRecd _
             | SynExpr.InterpolatedString _
             | SynExpr.Null _
-            | SynExpr.ArrayOrList _
-            | SynExpr.ArrayOrListComputed _ -> ValueSome AtomicExprAfterType
+            | SynExpr.ArrayOrList (isArray = true)
+            | SynExpr.ArrayOrListComputed (isArray = true) -> ValueSome AtomicExprAfterType
             | _ -> ValueNone
 
         /// Matches if the given expression represents a high-precedence

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -1164,12 +1164,11 @@ module UnnecessaryParentheses =
             //     inherit T(null)
             //     inherit T("")
             //     …
-            | SynExpr.Paren(expr = AtomicExprAfterType; range = range), SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
+            | SynExpr.Paren (expr = AtomicExprAfterType; range = range), SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
                 ValueSome range
 
             // Parens are otherwise required in inherit T(x), etc. (see atomicExprAfterType in pars.fsy).
-            | SynExpr.Paren _, SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
-                ValueNone
+            | SynExpr.Paren _, SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ -> ValueNone
 
             // We can't remove parens when they're required for fluent calls:
             //
@@ -1318,8 +1317,8 @@ module UnnecessaryParentheses =
                 | SynExpr.New _, _ -> ValueNone
 
                 // { inherit T(expr); … }
-                | SynExpr.Record (baseInfo = Some (_, SynExpr.Paren (expr = Is inner), _, _, _)), AtomicExprAfterType -> ValueSome range
-                | SynExpr.Record (baseInfo = Some (_, SynExpr.Paren (expr = Is inner), _, _, _)), _ -> ValueNone
+                | SynExpr.Record(baseInfo = Some (_, SynExpr.Paren(expr = Is inner), _, _, _)), AtomicExprAfterType -> ValueSome range
+                | SynExpr.Record(baseInfo = Some (_, SynExpr.Paren(expr = Is inner), _, _, _)), _ -> ValueNone
 
                 | _, SynExpr.Paren _
                 | _, SynExpr.Quote _

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -704,8 +704,8 @@ module UnnecessaryParentheses =
             | SynExpr.AnonRecd _
             | SynExpr.InterpolatedString _
             | SynExpr.Null _
-            | SynExpr.ArrayOrList (isArray = true)
-            | SynExpr.ArrayOrListComputed (isArray = true) -> ValueSome AtomicExprAfterType
+            | SynExpr.ArrayOrList(isArray = true)
+            | SynExpr.ArrayOrListComputed(isArray = true) -> ValueSome AtomicExprAfterType
             | _ -> ValueNone
 
         /// Matches if the given expression represents a high-precedence

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -692,6 +692,22 @@ module UnnecessaryParentheses =
     module SynExpr =
         open FSharp.Compiler.SyntaxTrivia
 
+        /// See atomicExprAfterType in pars.fsy.
+        [<return: Struct>]
+        let (|AtomicExprAfterType|_|) expr =
+            match expr with
+            | SynExpr.Paren _
+            | SynExpr.Quote _
+            | SynExpr.Const _
+            | SynExpr.Tuple(isStruct = true)
+            | SynExpr.Record _
+            | SynExpr.AnonRecd _
+            | SynExpr.InterpolatedString _
+            | SynExpr.Null _
+            | SynExpr.ArrayOrList _
+            | SynExpr.ArrayOrListComputed _ -> ValueSome AtomicExprAfterType
+            | _ -> ValueNone
+
         /// Matches if the given expression represents a high-precedence
         /// function application, e.g.,
         ///
@@ -1142,6 +1158,19 @@ module UnnecessaryParentheses =
             | SynExpr.Paren(expr = SynExpr.App _), SyntaxNode.SynExpr (SynExpr.App _) :: SyntaxNode.SynExpr (SynExpr.JoinIn _) :: _ ->
                 ValueNone
 
+            // Parens are not required around a few anointed expressions after inherit:
+            //
+            //     inherit T(3)
+            //     inherit T(null)
+            //     inherit T("")
+            //     …
+            | SynExpr.Paren(expr = AtomicExprAfterType; range = range), SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
+                ValueSome range
+
+            // Parens are otherwise required in inherit T(x), etc. (see atomicExprAfterType in pars.fsy).
+            | SynExpr.Paren _, SyntaxNode.SynMemberDefn (SynMemberDefn.ImplicitInherit _) :: _ ->
+                ValueNone
+
             // We can't remove parens when they're required for fluent calls:
             //
             //     x.M(y).N z
@@ -1283,6 +1312,14 @@ module UnnecessaryParentheses =
                 | SynExpr.Downcast _, SynExpr.Typed _
                 | SynExpr.AddressOf _, SynExpr.Typed _
                 | SynExpr.JoinIn _, SynExpr.Typed _ -> ValueNone
+
+                // new T(expr)
+                | SynExpr.New _, AtomicExprAfterType -> ValueSome range
+                | SynExpr.New _, _ -> ValueNone
+
+                // { inherit T(expr); … }
+                | SynExpr.Record (baseInfo = Some (_, SynExpr.Paren (expr = Is inner), _, _, _)), AtomicExprAfterType -> ValueSome range
+                | SynExpr.Record (baseInfo = Some (_, SynExpr.Paren (expr = Is inner), _, _, _)), _ -> ValueNone
 
                 | _, SynExpr.Paren _
                 | _, SynExpr.Quote _

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -129,6 +129,10 @@ let _ =
             "new exn (null)", "new exn null"
             "new ResizeArray<int>(3)", "new ResizeArray<int> 3"
             "let x = 3 in new ResizeArray<int>(x)", "let x = 3 in new ResizeArray<int>(x)" // Unless the rules for ctor args in `new` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
+            "ResizeArray<int>([3])", "ResizeArray<int> [3]"
+            "new ResizeArray<int>([3])", "new ResizeArray<int>([3])"
+            "ResizeArray<int>([|3|])", "ResizeArray<int> [|3|]"
+            "new ResizeArray<int>([|3|])", "new ResizeArray<int> [|3|]"
 
             // ObjExpr
             "{ new System.IDisposable with member _.Dispose () = (ignore 3) }",

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -128,7 +128,7 @@ let _ =
             "new exn(null)", "new exn null"
             "new exn (null)", "new exn null"
             "new ResizeArray<int>(3)", "new ResizeArray<int> 3"
-            "let x = 3 in new ResizeArray<int>(x)", "let x = 3 in new ResizeArray<int>(x)" // Unless the rules for ctor args in `new` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
+            "let x = 3 in new ResizeArray<int>(x)", "let x = 3 in new ResizeArray<int>(x)"
             "ResizeArray<int>([3])", "ResizeArray<int> [3]"
             "new ResizeArray<int>([3])", "new ResizeArray<int>([3])"
             "ResizeArray<int>([|3|])", "ResizeArray<int> [|3|]"
@@ -1107,7 +1107,6 @@ let _ = (2 + 2) { return 5 }
                     inherit exn $"{message}"
                 """
 
-                // Unless the rules for ctor args in `inherit` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
                 "
                 type E (message : string) =
                     inherit exn (message)
@@ -1130,7 +1129,6 @@ let _ = (2 + 2) { return 5 }
                     new (str1, str2) = { inherit exn $"{str1}"; Message2 = str2 }
                 """
 
-                // Unless the rules for ctor args in `inherit` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
                 "
                 type E =
                     inherit exn

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -127,6 +127,8 @@ let _ =
             // New
             "new exn(null)", "new exn null"
             "new exn (null)", "new exn null"
+            "new ResizeArray<int>(3)", "new ResizeArray<int> 3"
+            "let x = 3 in new ResizeArray<int>(x)", "let x = 3 in new ResizeArray<int>(x)" // Unless the rules for ctor args in `new` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
 
             // ObjExpr
             "{ new System.IDisposable with member _.Dispose () = (ignore 3) }",
@@ -1091,6 +1093,52 @@ let builder = Builder ()
 let (+) _ _ = builder
 let _ = (2 + 2) { return 5 }
 "
+
+                """
+                type E (message : string) =
+                    inherit exn ($"{message}")
+                """,
+                """
+                type E (message : string) =
+                    inherit exn $"{message}"
+                """
+
+                // Unless the rules for ctor args in `inherit` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
+                "
+                type E (message : string) =
+                    inherit exn (message)
+                ",
+                "
+                type E (message : string) =
+                    inherit exn (message)
+                "
+
+                """
+                type E =
+                    inherit exn
+                    val Message2 : string
+                    new (str1, str2) = { inherit exn ($"{str1}"); Message2 = str2 }
+                """,
+                """
+                type E =
+                    inherit exn
+                    val Message2 : string
+                    new (str1, str2) = { inherit exn $"{str1}"; Message2 = str2 }
+                """
+
+                // Unless the rules for ctor args in `inherit` exprs are ever relaxed (e.g., atomicExprAfterType → argExpr in pars.fsy).
+                "
+                type E =
+                    inherit exn
+                    val Message2 : string
+                    new (str1, str2) = { inherit exn (str1); Message2 = str2 }
+                ",
+                "
+                type E =
+                    inherit exn
+                    val Message2 : string
+                    new (str1, str2) = { inherit exn (str1); Message2 = str2 }
+                "
             }
 
         [<Theory; MemberData(nameof moreComplexApps)>]


### PR DESCRIPTION
Followup to #16079.

- Disallow removing parentheses from around certain constructor argument expressions when the constructor is being invoked after the `new` or `inherit` keywords.

Constructor applications are handled differently in the parser after the `new` and `inherit` keywords than they are elsewhere: only a subset of expressions are allowed as an argument (as specified in `atomicExprAfterType` in pars.fsy). This means that any expression outside of that blessed subset must be parenthesized, even if the exact same ctor application would not require parentheses without `new` or `inherit`.

E.g.,

```fsharp
let x = 3
let _ = ResizeArray<int>(x)     // Fine.
let _ = ResizeArray<int> x      // Fine.
let _ = ResizeArray<int> 3      // Fine.
let _ = new ResizeArray<int>(x) // Fine.
let _ = new ResizeArray<int> x  // Not fine.
let _ = new ResizeArray<int> 3  // Fine.

let _ = ResizeArray<int>([|3|])     // Fine.
let _ = ResizeArray<int> [|3|]      // Fine.
let _ = ResizeArray<int>([3])       // Fine.
let _ = ResizeArray<int> [3]        // Fine.
let _ = new ResizeArray<int>([|3|]) // Fine.
let _ = new ResizeArray<int> [|3|]  // Fine.
let _ = new ResizeArray<int>([3])   // Fine.
let _ = new ResizeArray<int> [3]    // Not fine.

(* Likewise in object expressions (where `new` is required), etc. *)
```

```fsharp
type E (s : string) = inherit exn(s)     // Fine.
type E (s : string) = inherit exn $"{s}" // Fine.
type E (s : string) = inherit exn s      // Not fine.
```

This is due to the following in pars.fsy:

https://github.com/dotnet/fsharp/blob/24ef67194b4fa3366e2e87fc77a76c068ce78889/src/Compiler/pars.fsy#L4841

https://github.com/dotnet/fsharp/blob/24ef67194b4fa3366e2e87fc77a76c068ce78889/src/Compiler/pars.fsy#L5336

https://github.com/dotnet/fsharp/blob/24ef67194b4fa3366e2e87fc77a76c068ce78889/src/Compiler/pars.fsy#L5042-L5076

These are required to support the use of postfix generic notation in those contexts (as noted in https://github.com/dotnet/fsharp/pull/16239#issuecomment-1801860477) and possibly other things. Even though the use of postfix notation in such contexts seems likely to be quite rare on the whole, removing support for it would be a breaking change.

<details>

<summary>Edit: click to see the question that was answered in the comments</summary>

#### Question for those in the know

(I can open a new issue for this if it makes sense.)

I've run into this inconsistency repeatedly over the years and it has always bothered me. Is the `atomicExprAfterType` restriction here actually still needed? Would that suddenly cause more problems like those addressed by #15923? Or could we just replace it with `argExpr` in the parser for `new` and `inherit` and get rid of the inconsistency? Making that change locally seems to work and doesn't seem to cause any immediate problems in this codebase...

...Ideally `new ctor expr` and `ctor expr` would be completely interchangeable (except, probably, in object expressions), but there is one additional inconsistency that would require more changes to the compiler to resolve. Explicit type arguments are required when the application is preceded by `new` but can be inferred when `new` is not present: `ResizeArray 3` is allowed, but `new ResizeArray (3)` is not (regardless of parentheses around the arg).

</details>