### PR TITLE
Bugfix: [Linux,macOS] PlatformNotSupportedException on FSI on overflowing content at end of terminal

### DIFF
--- a/src/fsi/console.fs
+++ b/src/fsi/console.fs
@@ -5,6 +5,7 @@ namespace FSharp.Compiler.Interactive
 open System
 open System.Text
 open System.Collections.Generic
+open System.Runtime.InteropServices
 open FSharp.Compiler.DiagnosticsLogger
 
 type internal Style =
@@ -242,6 +243,8 @@ type internal Anchor =
 type internal ReadLineConsole() =
     let history = new History()
 
+    static let supportsBufferHeightChange = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+
     let mutable complete: (string option * string -> seq<string>) =
         fun (_s1, _s2) -> Seq.empty
 
@@ -347,7 +350,11 @@ type internal ReadLineConsole() =
 
             if Console.CursorLeft + charSize > Utils.bufferWidth () then
                 if Console.CursorTop + 1 = Console.BufferHeight then
-                    Console.BufferHeight <- Console.BufferHeight + 1
+                    if supportsBufferHeightChange then
+                        Console.BufferHeight <- Console.BufferHeight + 1
+                    else
+                        Console.WriteLine()
+                        anchor <- { anchor with top = (anchor).top - 1 }
 
                 Cursor.Move(0)
 


### PR DESCRIPTION
This fixes https://github.com/dotnet/fsharp/issues/14946

Verification attempt #1:
Debugging WSL in VS.
This works except for not starting a terminal. Output is shown in VS output pane, but input cannot be entered, or I have not figured out  way how.

Verification attempt #2:

This did repro using regular `dotnet fsi` within WSL (Ubuntu) from the SDK from me.
I then use the same on a self-built `dotnet fsi.dll` from my local drive.
After the fix, it did not reproduce on WSL (Ubuntu) anymore.

Proof:

https://github.com/dotnet/fsharp/assets/46543583/e618e8ba-21f3-4d6d-8348-4131884cba94

