### PR TITLE
[ignore] checking which test breaks when DeclarationListInfo.Create throws.

### DIFF
--- a/src/Compiler/Service/ServiceDeclarationLists.fs
+++ b/src/Compiler/Service/ServiceDeclarationLists.fs
@@ -1146,6 +1146,7 @@ type DeclarationListInfo(declarations: DeclarationListItem[], isForType: bool, i
                 | None -> x.Item.DisplayName)
 
             |> List.map (fun (_, items) -> 
+                failwith "checking which tests get broken"
                 let item = items.Head
                 let textInDeclList = 
                     match item.Unresolved with


### PR DESCRIPTION
I'm interested in the list of tests that run through `DeclarationListInfo.Create` bit.

You can ignore this PR.