### PR TITLE
Parens: only disallow removal from first expr in sequential expr when second on same line

### DIFF
--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -1319,7 +1319,10 @@ module UnnecessaryParentheses =
                     ->
                     ValueNone
 
-                | SynExpr.Sequential(expr1 = SynExpr.Paren(expr = Is inner)), Dangling.Problematic _ -> ValueNone
+                | SynExpr.Sequential (expr1 = SynExpr.Paren(expr = Is inner); expr2 = expr2), Dangling.Problematic _ when
+                    problematic inner.Range expr2.Range
+                    ->
+                    ValueNone
 
                 | SynExpr.Paren _, SynExpr.Typed _
                 | SynExpr.Quote _, SynExpr.Typed _


### PR DESCRIPTION
Addresses an unforeseen interaction between #16262 and #16248.

4c36a98 from #16262 caused the test case in https://github.com/dotnet/fsharp/pull/16248#issuecomment-1812849686 to hit this:

https://github.com/dotnet/fsharp/blob/9e357ca5f82f5e800b259cbda7d91507b41d2e9a/src/Compiler/Service/ServiceAnalysis.fs#L1322

That should really only be if `expr1` and `expr2` are on the same line.