### PR TITLE
Point source link to dotnet/fsharp

### DIFF
--- a/docs/fcs/untypedtree.fsx
+++ b/docs/fcs/untypedtree.fsx
@@ -85,8 +85,9 @@ Walking over the AST
 
 The abstract syntax tree is defined as a number of discriminated unions that represent
 different syntactical elements (such as expressions, patterns, declarations etc.). The best
-way to understand the AST is to look at the definitions in [`SyntaxTree.fsi` in the source 
-code](https://github.com/fsharp/fsharp/blob/main/src/Compiler/SyntaxTree.fsi).
+way to understand the AST is to look at the definitions in 
+[`SyntaxTree.fsi`](https://github.com/dotnet/fsharp/blob/main/src/Compiler/SyntaxTree/SyntaxTree.fsi) 
+in the source  code.
 
 The relevant parts are in the following namespace:
 *)


### PR DESCRIPTION
I noticed today that the link [here](https://fsharp.github.io/fsharp-compiler-docs/fcs/untypedtree.html#Walking-over-the-AST) in the docs points to the `fsharp/fsharp` repo rather than `dotnet/fsharp`.

The link ends in a 404 and the repository is archived. This change points that link to the equivalent file in this repo.