### PR TITLE
VS: Fix dark mode detection

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -11,7 +11,6 @@ open Microsoft.VisualStudio.Editor
 open Microsoft.VisualStudio.PlatformUI
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio.Shell.Interop
-open Microsoft.Internal.VisualStudio.Shell.Interop
 open Microsoft.VisualStudio.Language.StandardClassification
 open Microsoft.VisualStudio.Text.Classification
 open Microsoft.VisualStudio.Utilities
@@ -91,23 +90,7 @@ module internal ClassificationDefinitions =
             [<Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider
         ) =
 
-        let (|LightTheme|DarkTheme|UnknownTheme|) id =
-            if
-                id = KnownColorThemes.Light
-                || id = KnownColorThemes.Blue
-                || id = Guids.blueHighContrastThemeId
-            then
-                LightTheme
-            elif id = KnownColorThemes.Dark then
-                DarkTheme
-            else
-                UnknownTheme
-
-        let getCurrentThemeId () =
-            let themeService =
-                serviceProvider.GetService(typeof<SVsColorThemeService>) :?> IVsColorThemeService
-
-            themeService.CurrentTheme.ThemeId
+        let mutable isDarkBackground = false
 
         let customColorData =
             [
@@ -143,7 +126,16 @@ module internal ClassificationDefinitions =
                 |}
             ]
 
+        let setIsDarkBackground () =
+            isDarkBackground <-
+                VSColorTheme
+                    .GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey)
+                    .GetBrightness() < 0.5f
+
         let setColors _ =
+
+            setIsDarkBackground()
+
             let fontAndColorStorage =
                 serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
 
@@ -172,10 +164,9 @@ module internal ClassificationDefinitions =
                         let oldProps = formatMap.GetTextProperties(ict)
 
                         let newProps =
-                            match getCurrentThemeId () with
-                            | LightTheme -> oldProps.SetForeground item.LightThemeColor
-                            | DarkTheme -> oldProps.SetForeground item.DarkThemeColor
-                            | UnknownTheme -> oldProps
+                            if isDarkBackground
+                            then oldProps.SetForeground item.DarkThemeColor
+                            else oldProps.SetForeground item.LightThemeColor
 
                         formatMap.SetTextProperties(ict, newProps)
 
@@ -187,15 +178,13 @@ module internal ClassificationDefinitions =
 
         do VSColorTheme.add_ThemeChanged handler
 
+        do setIsDarkBackground ()
+
         member _.GetColor(ctype) =
             match customColorData |> List.tryFindV (fun item -> item.ClassificationName = ctype) with
             | ValueSome item ->
                 let light, dark = item.LightThemeColor, item.DarkThemeColor
-
-                match getCurrentThemeId () with
-                | LightTheme -> Nullable light
-                | DarkTheme -> Nullable dark
-                | UnknownTheme -> Nullable()
+                if isDarkBackground then Nullable dark else Nullable light
             | ValueNone -> Nullable()
 
         interface ISetThemeColors with

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationDefinitions.fs
@@ -134,7 +134,7 @@ module internal ClassificationDefinitions =
 
         let setColors _ =
 
-            setIsDarkBackground()
+            setIsDarkBackground ()
 
             let fontAndColorStorage =
                 serviceProvider.GetService(typeof<SVsFontAndColorStorage>) :?> IVsFontAndColorStorage
@@ -164,9 +164,10 @@ module internal ClassificationDefinitions =
                         let oldProps = formatMap.GetTextProperties(ict)
 
                         let newProps =
-                            if isDarkBackground
-                            then oldProps.SetForeground item.DarkThemeColor
-                            else oldProps.SetForeground item.LightThemeColor
+                            if isDarkBackground then
+                                oldProps.SetForeground item.DarkThemeColor
+                            else
+                                oldProps.SetForeground item.LightThemeColor
 
                         formatMap.SetTextProperties(ict, newProps)
 


### PR DESCRIPTION
 A quick and dirty stopgap solution for #16300.

This PR attempts to detect if VS is in dark mode by "looking" at window background color.
Tested only manually, but at first glance seems to work fine with all the new "UI refresh" themes.
Also reacts correctly to switching dark mode in Windows when "Use system setting" is selected in options.

All credit to Bing chat 😁.