### PR TITLE
Incremental builder: fix exception when source files list is empty

### DIFF
--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -725,7 +725,7 @@ module IncrementalBuilderHelpers =
       }
 
     /// Finish up the typechecking to produce outputs for the rest of the compilation process
-    let FinalizeTypeCheckTask (tcConfig: TcConfig) tcGlobals partialCheck assemblyName outfile (initialErrors: SingleFileDiagnostics) (boundModels: GraphNode<BoundModel> seq) =
+    let FinalizeTypeCheckTask (tcConfig: TcConfig) tcGlobals partialCheck assemblyName outfile (boundModels: GraphNode<BoundModel> seq) =
       node {
         let diagnosticsLogger = CompilationDiagnosticLogger("FinalizeTypeCheckTask", tcConfig.diagnosticsOptions)
         use _ = new CompilationGlobalsScope(diagnosticsLogger, BuildPhase.TypeCheck)
@@ -820,7 +820,6 @@ module IncrementalBuilderHelpers =
         let diagnostics = [
             diagnosticsLogger.GetDiagnostics()
             yield! partialDiagnostics |> Seq.rev
-            initialErrors
         ]
 
         let! finalBoundModelWithErrors = finalBoundModel.Finish(diagnostics, Some topAttrs)
@@ -927,7 +926,6 @@ type IncrementalBuilderState =
     {
         slots: Slot list
         stampedReferencedAssemblies: ImmutableArray<DateTime>
-        initialBoundModel: GraphNode<BoundModel>
         finalizedBoundModel: GraphNode<(ILAssemblyRef * ProjectAssemblyDataResult * CheckedImplFile list option * BoundModel) * DateTime>
     }
     member this.stampedFileNames = this.slots |> List.map (fun s -> s.Stamp)
@@ -949,7 +947,6 @@ module IncrementalBuilderStateHelpers =
     let createFinalizeBoundModelGraphNode (initialState: IncrementalBuilderInitialState) (boundModels: GraphNode<BoundModel> seq) =
         GraphNode(node {
             use _ = Activity.start "GetCheckResultsAndImplementationsForProject" [|Activity.Tags.project, initialState.outfile|]
-            let! initialErrors = initialState.initialBoundModel.Diagnostics.GetOrComputeValue()
             let! result = 
                 FinalizeTypeCheckTask 
                     initialState.tcConfig 
@@ -957,7 +954,6 @@ module IncrementalBuilderStateHelpers =
                     initialState.enablePartialTypeChecking
                     initialState.assemblyName 
                     initialState.outfile 
-                    initialErrors
                     boundModels
             return result, DateTime.UtcNow
         })
@@ -1060,11 +1056,10 @@ type IncrementalBuilderState with
         let boundModels = 
             syntaxTrees
             |> Seq.scan createBoundModelGraphNode initialBoundModel
-            |> Seq.skip 1
 
         let slots =
             [
-                for model, syntaxTree, hasSignature in Seq.zip3 boundModels syntaxTrees hasSignature do
+                for model, syntaxTree, hasSignature in Seq.zip3 (boundModels |> Seq.skip 1) syntaxTrees hasSignature do
                     {
                         HasSignature = hasSignature
                         Stamp = DateTime.MinValue
@@ -1079,7 +1074,6 @@ type IncrementalBuilderState with
             {
                 slots = slots
                 stampedReferencedAssemblies = ImmutableArray.init referencedAssemblies.Length (fun _ -> DateTime.MinValue)
-                initialBoundModel = initialBoundModel
                 finalizedBoundModel = createFinalizeBoundModelGraphNode initialState boundModels
             }
         let state = computeStampedReferencedAssemblies initialState state false cache

--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5763,3 +5763,18 @@ let ``References from #r nuget are included in script project options`` () =
         |> Seq.distinct
     printfn "%s" (assemblyNames |> String.concat "\n")
     assemblyNames |> should contain "Dapper.dll"
+
+module internal EmptyProject =
+    let base2 = tryCreateTemporaryFileName ()
+    let dllName = Path.ChangeExtension(base2, ".dll")
+    let projFileName = Path.ChangeExtension(base2, ".fsproj")
+
+    let fileNames = []
+    let args = mkProjectCommandLineArgs (dllName, fileNames)
+    let options =  checker.GetProjectOptionsFromCommandLineArgs (projFileName, args)
+
+[<Test>]
+let ``Empty source list produces error FS0207`` () =
+    let results = checker.ParseAndCheckProject(EmptyProject.options) |> Async.RunImmediate
+    results.Diagnostics.Length |> shouldEqual 1
+    results.Diagnostics[0].ErrorNumber |> shouldEqual 207


### PR DESCRIPTION
Attempt to fix #16312

It seems the desired behavior when given no sources should be `FS0207: "No inputs specified"`

Let's see if anything breaks.

