### PR TITLE
Bugfix : Struct DU with DefaultAugment(false) and a non-nullary field

### DIFF
--- a/src/Compiler/CodeGen/EraseUnions.fs
+++ b/src/Compiler/CodeGen/EraseUnions.fs
@@ -751,6 +751,53 @@ let convAlternativeDef
     // within FSharp.Core.dll on fresh unpublished cons cells.
     let isTotallyImmutable = (cud.HasHelpers <> SpecialFSharpListHelpers)
 
+    let makeNonNullaryMakerMethod () =
+        let locals, ilInstrs =
+            if repr.RepresentAlternativeAsStructValue info then
+                let local = mkILLocal baseTy None
+                let ldloca = I_ldloca(0us)
+
+                let ilInstrs =
+                    [
+                        ldloca
+                        ILInstr.I_initobj baseTy
+                        if (repr.DiscriminationTechnique info) = IntegerTag && num <> 0 then
+                            ldloca
+                            mkLdcInt32 num
+                            mkSetTagToField g.ilg cuspec baseTy
+                        for i in 0 .. fields.Length - 1 do
+                            ldloca
+                            mkLdarg (uint16 i)
+                            mkNormalStfld (mkILFieldSpecInTy (baseTy, fields[i].LowerName, fields[i].Type))
+                        mkLdloc 0us
+                    ]
+
+                [ local ], ilInstrs
+            else
+                let ilInstrs =
+                    [
+                        for i in 0 .. fields.Length - 1 do
+                            mkLdarg (uint16 i)
+                        yield! convNewDataInstrInternal g.ilg cuspec num
+                    ]
+
+                [], ilInstrs
+
+        let mdef =
+            mkILNonGenericStaticMethod (
+                mkMakerName cuspec altName,
+                cud.HelpersAccessibility,
+                fields
+                |> Array.map (fun fd -> mkILParamNamed (fd.LowerName, fd.Type))
+                |> Array.toList,
+                mkILReturn baseTy,
+                mkMethodBody (true, locals, fields.Length + locals.Length, nonBranchingInstrsToCode ilInstrs, attr, imports)
+            )
+            |> addMethodGeneratedAttrs
+            |> addAltAttribs
+
+        mdef
+
     let altUniqObjMeths =
 
         // This method is only generated if helpers are not available. It fetches the unique object for the alternative
@@ -885,54 +932,13 @@ let convAlternativeDef
                     [ nullaryMeth ], [ nullaryProp ]
 
                 else
-                    let locals, ilInstrs =
-                        if repr.RepresentAlternativeAsStructValue info then
-                            let local = mkILLocal baseTy None
-                            let ldloca = I_ldloca(0us)
-
-                            let ilInstrs =
-                                [
-                                    ldloca
-                                    ILInstr.I_initobj baseTy
-                                    if (repr.DiscriminationTechnique info) = IntegerTag && num <> 0 then
-                                        ldloca
-                                        mkLdcInt32 num
-                                        mkSetTagToField g.ilg cuspec baseTy
-                                    for i in 0 .. fields.Length - 1 do
-                                        ldloca
-                                        mkLdarg (uint16 i)
-                                        mkNormalStfld (mkILFieldSpecInTy (baseTy, fields[i].LowerName, fields[i].Type))
-                                    mkLdloc 0us
-                                ]
-
-                            [ local ], ilInstrs
-                        else
-                            let ilInstrs =
-                                [
-                                    for i in 0 .. fields.Length - 1 do
-                                        mkLdarg (uint16 i)
-                                    yield! convNewDataInstrInternal g.ilg cuspec num
-                                ]
-
-                            [], ilInstrs
-
-                    let mdef =
-                        mkILNonGenericStaticMethod (
-                            mkMakerName cuspec altName,
-                            cud.HelpersAccessibility,
-                            fields
-                            |> Array.map (fun fd -> mkILParamNamed (fd.LowerName, fd.Type))
-                            |> Array.toList,
-                            mkILReturn baseTy,
-                            mkMethodBody (true, locals, fields.Length + locals.Length, nonBranchingInstrsToCode ilInstrs, attr, imports)
-                        )
-                        |> addMethodGeneratedAttrs
-                        |> addAltAttribs
-
-                    [ mdef ], []
+                    [ makeNonNullaryMakerMethod () ], []
 
             (baseMakerMeths @ baseTesterMeths), (baseMakerProps @ baseTesterProps)
 
+        | NoHelpers when not (alt.IsNullary) && cuspecRepr.RepresentAlternativeAsStructValue(cuspec) ->
+            // For non-nullary struct DUs, maker method is used to create their values.
+            [ makeNonNullaryMakerMethod () ], []
         | NoHelpers -> [], []
 
     let typeDefs, altDebugTypeDefs, altNullaryFields =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
@@ -708,15 +708,17 @@ type GenericStructDu<'T> = EmptyFirst | SingleVal of f:'T | DoubleVal of f2:'T *
 [<DefaultAugmentation(false)>]
 type Foo =
     | Baz of int
+    | Bat
+    | Batman
 
 
-let foo = Baz 42
+let foo = [Baz 42; Bat; Batman]
 printf "%A" foo"""
         |> asExe
         |> compile
         |> shouldSucceed
         |> run
-        |> verifyOutput "Baz 42"
+        |> verifyOutput "[Baz 42; Bat; Batman]"
 
     [<Fact>]
     let ``Struct DU ValueOption keeps working`` ()  =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
@@ -711,7 +711,7 @@ type Foo =
 
 
 let foo = Baz 42
-printfn "%A" foo"""
+printf "%A" foo"""
         |> asExe
         |> compile
         |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
@@ -702,6 +702,23 @@ type GenericStructDu<'T> = EmptyFirst | SingleVal of f:'T | DoubleVal of f2:'T *
         |> shouldSucceed
 
     [<Fact>]
+    let ``Regression 16282 DefaultAugment false on a struct union with fields`` ()  =
+        Fsx """
+[<Struct>]
+[<DefaultAugmentation(false)>]
+type Foo =
+    | Baz of int
+
+
+let foo = Baz 42
+printfn "%A" foo"""
+        |> asExe
+        |> compile
+        |> shouldSucceed
+        |> run
+        |> verifyOutput "Baz 42"
+
+    [<Fact>]
     let ``Struct DU ValueOption keeps working`` ()  =
         Fsx """
 module VOTests


### PR DESCRIPTION
The fixed codepath for struct DU cases with fields include a call to a static method $"New{caseName}".
However, with DefaultAugment(false), this method is not existing.

If such a case is spotted (struct DU, at least 1 non nullary case), the NewXYZ method will be emitted in spite of DefaultAugment(false).

HEADS UP: This is an opinionated decision in order to make the code work.
Basically it prefers working correctly instead of 100% following DefaultAugment's instruction.

Other augmented methods (e.g. tester IsXYZ methods) will NOT be emitted.

Fixes https://github.com/dotnet/fsharp/issues/16282 