### PR TITLE
Bugfix - underscore dot lambda followed with a method call and explicit type arguments

### DIFF
--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -97,6 +97,9 @@ let rec pushUnaryArg expr arg =
     | SynExpr.DotGet(synExpr, rangeOfDot, synLongIdent, range) -> SynExpr.DotGet(pushUnaryArg synExpr arg, rangeOfDot, synLongIdent, range)
     | SynExpr.DotIndexedGet(objectExpr, indexArgs, dotRange, range) ->
         SynExpr.DotIndexedGet(pushUnaryArg objectExpr arg, indexArgs, dotRange, range)
+    | SynExpr.TypeApp(innerExpr,mLess,tyargs,mCommas,mGreater,mTypars,m) ->
+        let innerExpr = pushUnaryArg innerExpr arg
+        SynExpr.TypeApp(innerExpr,mLess,tyargs,mCommas,mGreater,mTypars,m)
     | _ ->
         errorR (Error(FSComp.SR.tcDotLambdaAtNotSupportedExpression (), expr.Range))
         expr

--- a/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
@@ -61,7 +61,6 @@ let neverEndingLambda = _.(while true do ())"""
 [<InlineData("_.\"🙃\"")>]
 [<InlineData("_.[||]")>]
 [<InlineData("_.{||}")>]
-[<InlineData("_.typeof<int>")>]
 [<InlineData("_.null")>]
 [<InlineData("_.__SOURCE_DIRECTORY__")>]
 [<InlineData("_.(<@ 1 @>)")>]
@@ -199,7 +198,31 @@ let a6 = [1] |> List.map _.ToString()
     |> withLangVersion80
     |> typecheck
     |> shouldSucceed
-        
+
+[<Fact>]
+let ``Regression 16318 Error on explicit generic type argument dot dot lambda`` () =
+
+    
+    FSharp """
+module Regression
+type A() =
+    member x.M<'T>() = 1
+
+let _ = [A()] |> Seq.map _.M<int>()
+let _ = [A()] |> Seq.map _.M()
+    """
+    |> withLangVersion80
+    |> typecheck
+    |> shouldSucceed
+
+[<Fact>]
+let ``Regression 16318 typeof dotlambda should fail`` () = 
+    FSharp """ let x = _.typeof<int>"""
+    |> withLangVersion80
+    |> typecheck
+    |> shouldFail
+    |> withDiagnostics [Error 72, Line 1, Col 10, Line 1, Col 18, "Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved."]
+
 [<Fact>]
 let ``Nested anonymous unary function shorthands fails because of ambigous discard`` () =
     FSharp """


### PR DESCRIPTION
Fixes #16318 .

The following code was working fine if type argument was infered, and not working when it was explicit:
This did change the behavior for `typeof`, because typeof is not a keyword, but a library defined function.
A type can in theory define its own generic method with the name `typeof` just fine => typechecking that correctness is therefore left for subsequent typechecking phases.

```fsharp
module Regression
type A() =
    member x.M<'T>() = 1

let _ = [A()] |> Seq.map _.M<int>()    // <--- error was here
let _ = [A()] |> Seq.map _.M()

```