### PR TITLE
Bugfix for DotLambda - (a, (b, c))  was incorrectly detected as a discard (a compiler generated one was there)

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -5585,9 +5585,13 @@ and TcExprUndelayed (cenv: cenv) (overallTy: OverallTy) env tpenv (synExpr: SynE
         CallExprHasTypeSink cenv.tcSink (m, env.NameEnv, overallTy.Commit, env.AccessRights)
         TcConstExpr cenv overallTy env m tpenv synConst
     | SynExpr.DotLambda (synExpr, m, trivia) ->
-        if env.NameEnv.eUnqualifiedItems |> Map.containsKey "_arg1"
-        then
+        match env.NameEnv.eUnqualifiedItems |> Map.tryFind "_arg1" with        
+        // Compiler-generated _arg items can have more forms, the real underscore will be 1-character wide
+        | Some (Item.Value(valRef)) when valRef.Range.StartColumn+1 = valRef.Range.EndColumn ->
             warning(Error(FSComp.SR.tcAmbiguousDiscardDotLambda(), trivia.UnderscoreRange))
+        | Some _ -> ()
+        | None -> ()
+            
         let unaryArg = mkSynId trivia.UnderscoreRange (cenv.synArgNameGenerator.New())
         let svar = mkSynCompGenSimplePatVar unaryArg
         let pushedExpr = pushUnaryArg synExpr unaryArg

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -389,6 +389,7 @@ type PhasedDiagnostic with
         | 3559 -> false // typrelNeverRefinedAwayFromTop - off by default
         | 3579 -> false // alwaysUseTypedStringInterpolation - off by default
         | 3582 -> false // infoIfFunctionShadowsUnionCase - off by default
+        | 3570 -> false // tcAmbiguousDiscardDotLambda - off by default
         | _ ->
             match x.Exception with
             | DiagnosticEnabledWithLanguageFeature(_, _, _, enabled) -> enabled

--- a/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
@@ -203,6 +203,7 @@ let f (a, (b, c)) =
         let _ = 458
         (fun _ -> 5 |> _.ToString()))"""
     |> withLangVersion80
+    |> withWarnOn 3570
     |> typecheck
     |> shouldFail
     |> withSingleDiagnostic (Warning 3570, Line 7, Col 24, Line 7, Col 25, "The meaning of _ is ambiguous here. It cannot be used for a discarded variable and a function shorthand in the same scope.")
@@ -231,6 +232,7 @@ module One
 let a : string = {| Inner =  (fun x -> x.ToString()) |} |> _.Inner([5] |> _.[0])
     """
     |> withLangVersion80
+    |> withWarnOn 3570
     |> typecheck
     |> shouldFail
     |> withDiagnostics [ 
@@ -246,6 +248,7 @@ let b : int -> int -> string = function |5 -> (fun _ -> "Five") |_ -> _.ToString
 let c : string = let _ = "test" in "asd" |> _.ToString()
     """
     |> withLangVersion80
+    |> withWarnOn 3570
     |> typecheck
     |> shouldFail
     |> withSingleDiagnostic (Warning 3570, Line 3, Col 43, Line 3, Col 44, "The meaning of _ is ambiguous here. It cannot be used for a discarded variable and a function shorthand in the same scope.")

--- a/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
@@ -205,7 +205,7 @@ let f (a, (b, c)) =
     |> withLangVersion80
     |> typecheck
     |> shouldFail
-    |> withSingleDiagnostic (Warning 3570, Line 5, Col 20, Line 5, Col 21, "The meaning of _ is ambiguous here. It cannot be used for a discarded variable and a function shorthand in the same scope.")
+    |> withSingleDiagnostic (Warning 3570, Line 7, Col 24, Line 7, Col 25, "The meaning of _ is ambiguous here. It cannot be used for a discarded variable and a function shorthand in the same scope.")
 
 [<Fact>]
 let ``Simple anonymous unary function shorthands compile`` () =


### PR DESCRIPTION
Fixes #16276 .


This change makes sure that only real "_" discards produce a warning.
Hidden compiler-generated discards that cover a different construct (e.g. a discard for a tuple which is not reference as a whole) are not going to produce a warning for ambiguity.

**At the same time, this also changes the warning to be an optional one.**