### PR TITLE
Bugfix - underscore dot lambda conversion to Func<> in LINQ

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -9438,7 +9438,8 @@ and GetNewInferenceTypeForMethodArg (cenv: cenv) env tpenv x =
         GetNewInferenceTypeForMethodArg cenv env tpenv a
     | SynExpr.AddressOf (true, a, _, m) ->
         mkByrefTyWithInference g (GetNewInferenceTypeForMethodArg cenv env tpenv a) (NewByRefKindInferenceType g m)
-    | SynExpr.Lambda (body = a) ->
+    | SynExpr.Lambda (body = a) 
+    | SynExpr.DotLambda (expr = a) ->
         mkFunTy g (NewInferenceType g) (GetNewInferenceTypeForMethodArg cenv env tpenv a)
     | SynExpr.Quote (_, raw, a, _, _) ->
         if raw then mkRawQuotedExprTy g

--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -841,7 +841,7 @@ let InferLambdaArgsForLambdaPropagation origRhsExpr =
         match e with 
         | SynExpr.Lambda (body = rest) -> 1 + loop rest
         | SynExpr.MatchLambda _ -> 1
-        | SynExpr.DotLambda _ -> 1
+        | SynExpr.DotLambda (expr = body) -> 1 + loop body
         | _ -> 0
     loop origRhsExpr
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
@@ -225,3 +225,12 @@ let c : string = let _ = "test" in "asd" |> _.ToString()
     |> typecheck
     |> shouldFail
     |> withSingleDiagnostic (Warning 3570, Line 3, Col 43, Line 3, Col 44, "The meaning of _ is ambiguous here. It cannot be used for a discarded variable and a function shorthand in the same scope.")
+    
+[<Fact>]
+let ``DotLambda selector converted to Func when used in LINQ`` () =
+    FSharp """open System.Linq
+let _ = [""; ""; ""].Select(fun x -> x.Length)
+let _ = [""; ""; ""].Select(_.Length)"""
+    |> withLangVersion80
+    |> typecheck
+    |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
@@ -231,7 +231,13 @@ let ``DotLambda selector converted to Func when used in LINQ`` () =
     FSharp """open System.Linq
 let _ = [""; ""; ""].Select(fun x -> x.Length)
 let _ = [""; ""; ""].Select(_.Length)
-let _ = [""; ""; ""].Select _.Length"""
+let _ = [""; ""; ""].Select _.Length
+
+let asQ = [""; ""; ""].AsQueryable()
+let _ = asQ.Select(fun x -> x.Length)
+let _ = asQ.Select(_.Length)
+let _ = asQ.Select _.Length
+"""
     |> withLangVersion80
     |> typecheck
     |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/DotLambdaTests.fs
@@ -230,7 +230,8 @@ let c : string = let _ = "test" in "asd" |> _.ToString()
 let ``DotLambda selector converted to Func when used in LINQ`` () =
     FSharp """open System.Linq
 let _ = [""; ""; ""].Select(fun x -> x.Length)
-let _ = [""; ""; ""].Select(_.Length)"""
+let _ = [""; ""; ""].Select(_.Length)
+let _ = [""; ""; ""].Select _.Length"""
     |> withLangVersion80
     |> typecheck
     |> shouldSucceed


### PR DESCRIPTION
Fixes #16305 

This changes how dot lambda is being recognized for type inference, making sure it is treated like a function type.
With that, it will be detected in method call scenarios for a possible conversion between function type to `Func<,>`.

The following three now work (before, only the first did):
```fsharp
open System.Linq
let _ = [""; ""; ""].Select(fun x -> x.Length)
let _ = [""; ""; ""].Select(_.Length)
let _ = [""; ""; ""].Select _.Length
```