### PR TITLE
Parser: recover on unfinished record decls, fix field ranges

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -423,8 +423,9 @@ module TcRecdUnionAndEnumDeclarations =
         let vis = CombineReprAccess parent vis
         Construct.NewRecdField isStatic konst id nameGenerated tyR isMutable vol attrsForProperty attrsForField xmldoc vis false
 
-    let TcFieldDecl (cenv: cenv) env parent isIncrClass tpenv (isStatic, synAttrs, id, nameGenerated, ty, isMutable, xmldoc, vis, m) =
+    let TcFieldDecl (cenv: cenv) env parent isIncrClass tpenv (isStatic, synAttrs, id: Ident, nameGenerated, ty, isMutable, xmldoc, vis) =
         let g = cenv.g
+        let m = id.idRange
         let attrs, _ = TcAttributesWithPossibleTargets false cenv env AttributeTargets.FieldDecl synAttrs
         let attrsForProperty, attrsForField = attrs |> List.partition (fun (attrTargets, _) -> (attrTargets &&& AttributeTargets.Property) <> enum 0) 
         let attrsForProperty = (List.map snd attrsForProperty) 
@@ -458,7 +459,7 @@ module TcRecdUnionAndEnumDeclarations =
 
         let checkXmlDocs = cenv.diagnosticOptions.CheckXmlDocs
         let xmlDoc = xmldoc.ToXmlDoc(checkXmlDocs, Some [])
-        TcFieldDecl cenv env parent false tpenv (isStatic, attribs, id, idOpt.IsNone, ty, isMutable, xmlDoc, vis, m)
+        TcFieldDecl cenv env parent false tpenv (isStatic, attribs, id, idOpt.IsNone, ty, isMutable, xmlDoc, vis)
 
     let TcNamedFieldDecl cenv env parent isIncrClass tpenv (SynField(Attributes attribs, isStatic, id, ty, isMutable, xmldoc, vis, m, _)) =
         match id with 
@@ -468,7 +469,7 @@ module TcRecdUnionAndEnumDeclarations =
         | Some id ->
             let checkXmlDocs = cenv.diagnosticOptions.CheckXmlDocs
             let xmlDoc = xmldoc.ToXmlDoc(checkXmlDocs, Some [])
-            Some(TcFieldDecl cenv env parent isIncrClass tpenv (isStatic, attribs, id, false, ty, isMutable, xmlDoc, vis, m)) 
+            Some(TcFieldDecl cenv env parent isIncrClass tpenv (isStatic, attribs, id, false, ty, isMutable, xmlDoc, vis)) 
 
     let TcNamedFieldDecls cenv env parent isIncrClass tpenv fields =
         fields |> List.choose (TcNamedFieldDecl cenv env parent isIncrClass tpenv) 

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1737,3 +1737,4 @@ featureReuseSameFieldsInStructUnions,"Share underlying fields in a [<Struct>] di
 3860,chkStaticMembersOnObjectExpressions,"Object expressions cannot implement interfaces with static abstract members or declare static members."
 3861,chkTailCallAttrOnNonRec,"The TailCall attribute should only be applied to recursive functions."
 3862,parsStaticMemberImcompleteSyntax,"Incomplete declaration of a static construct. Use 'static let','static do','static member' or 'static val' for declaration."
+3863,parsExpectingField,"Expecting record field"

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1183,7 +1183,20 @@ let mkSynField
     let xmlDoc = grabXmlDocAtRangeStart (parseState, attributes, mWhole)
     let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
 
-    SynField(attributes, Option.isSome mStatic, idOpt, t, Option.isSome isMutable, xmlDoc, vis, mWhole, { LeadingKeyword = leadingKeyword })
+    SynField(
+        attributes,
+        Option.isSome mStatic,
+        idOpt,
+        t,
+        Option.isSome isMutable,
+        xmlDoc,
+        vis,
+        mWhole,
+        {
+            LeadingKeyword = leadingKeyword
+            MutableKeyword = isMutable
+        }
+    )
 
 let mkValField
     parseState

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1140,7 +1140,17 @@ let mkAutoPropDefn mVal access ident typ mEquals (expr: SynExpr) accessors xmlDo
         trivia
     )
 
-let mkSynField parseState (idOpt: Ident option) (t: SynType option) (isMutable: range option) (vis: SynAccess option) (attributes: SynAttributes) (mStatic: range option) (rangeStart: range) (leadingKeyword: SynLeadingKeyword option) =
+let mkSynField
+    parseState
+    (idOpt: Ident option)
+    (t: SynType option)
+    (isMutable: range option)
+    (vis: SynAccess option)
+    (attributes: SynAttributes)
+    (mStatic: range option)
+    (rangeStart: range)
+    (leadingKeyword: SynLeadingKeyword option)
+    =
     let t, mStart =
         match t with
         | Some value -> value, rangeStart
@@ -1150,22 +1160,22 @@ let mkSynField parseState (idOpt: Ident option) (t: SynType option) (isMutable: 
                 | Some id -> id.idRange, rangeStart
                 | _ ->
 
-                match vis with
-                | Some vis -> vis.Range, rangeStart
-                | _ ->
-                    
-                match isMutable with
-                | Some m -> m, rangeStart
-                | _ -> 
+                    match vis with
+                    | Some vis -> vis.Range, rangeStart
+                    | _ ->
 
-                match leadingKeyword with
-                | Some keyword -> keyword.Range, rangeStart
-                | None ->
+                        match isMutable with
+                        | Some m -> m, rangeStart
+                        | _ ->
 
-                attributes
-                |> Seq.tryLast
-                |> Option.map (fun l -> l.Range, rangeStart)
-                |> Option.defaultWith (fun _ -> rangeStart.StartRange, rangeStart.StartRange)
+                            match leadingKeyword with
+                            | Some keyword -> keyword.Range, rangeStart
+                            | None ->
+
+                                attributes
+                                |> Seq.tryLast
+                                |> Option.map (fun l -> l.Range, rangeStart)
+                                |> Option.defaultWith (fun _ -> rangeStart.StartRange, rangeStart.StartRange)
 
             SynType.FromParseError(mType.EndRange), mStart
 
@@ -1175,11 +1185,23 @@ let mkSynField parseState (idOpt: Ident option) (t: SynType option) (isMutable: 
 
     SynField(attributes, Option.isSome mStatic, idOpt, t, Option.isSome isMutable, xmlDoc, vis, mWhole, { LeadingKeyword = leadingKeyword })
 
-let mkValField parseState mVal (isMutable: range option) access (idOpt: Ident option) (typ: SynType option) (rangeStart: range) attribs mStaticOpt =
+let mkValField
+    parseState
+    mVal
+    (isMutable: range option)
+    access
+    (idOpt: Ident option)
+    (typ: SynType option)
+    (rangeStart: range)
+    attribs
+    mStaticOpt
+    =
     let leadingKeyword =
         match mStaticOpt with
         | None -> SynLeadingKeyword.Val mVal
         | Some mStatic -> SynLeadingKeyword.StaticVal(mStatic, mVal)
 
-    let field = mkSynField parseState idOpt typ isMutable access attribs mStaticOpt rangeStart (Some leadingKeyword)
+    let field =
+        mkSynField parseState idOpt typ isMutable access attribs mStaticOpt rangeStart (Some leadingKeyword)
+
     SynMemberDefn.ValField(field, field.Range)

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1141,32 +1141,33 @@ let mkAutoPropDefn mVal access ident typ mEquals (expr: SynExpr) accessors xmlDo
     )
 
 let mkSynField
-        parseState
-        (idOpt: Ident option)
-        (t: SynType option)
-        (isMutable: range option)
-        (vis: SynAccess option)
-        (attributes: SynAttributes)
-        (mStatic: range option)
-        (rangeStart: range)
-        (leadingKeyword: SynLeadingKeyword option) =
+    parseState
+    (idOpt: Ident option)
+    (t: SynType option)
+    (isMutable: range option)
+    (vis: SynAccess option)
+    (attributes: SynAttributes)
+    (mStatic: range option)
+    (rangeStart: range)
+    (leadingKeyword: SynLeadingKeyword option)
+    =
 
     let t, mStart =
         match t with
         | Some value -> value, rangeStart
         | None ->
 
-        let mType, mStart =
-            idOpt
-            |> Option.map _.idRange
-            |> Option.orElseWith (fun _ -> vis |> Option.map (fun v -> v.Range))
-            |> Option.orElse isMutable
-            |> Option.orElseWith (fun _ -> leadingKeyword |> Option.map (fun k -> k.Range))
-            |> Option.orElseWith (fun _ -> attributes |> List.tryLast |> Option.map (fun l -> l.Range))
-            |> Option.map (fun m -> m, rangeStart)
-            |> Option.defaultWith (fun _ -> rangeStart.StartRange, rangeStart.StartRange)
+            let mType, mStart =
+                idOpt
+                |> Option.map _.idRange
+                |> Option.orElseWith (fun _ -> vis |> Option.map (fun v -> v.Range))
+                |> Option.orElse isMutable
+                |> Option.orElseWith (fun _ -> leadingKeyword |> Option.map (fun k -> k.Range))
+                |> Option.orElseWith (fun _ -> attributes |> List.tryLast |> Option.map (fun l -> l.Range))
+                |> Option.map (fun m -> m, rangeStart)
+                |> Option.defaultWith (fun _ -> rangeStart.StartRange, rangeStart.StartRange)
 
-        SynType.FromParseError(mType.EndRange), mStart
+            SynType.FromParseError(mType.EndRange), mStart
 
     let mWhole = unionRanges mStart t.Range
     let xmlDoc = grabXmlDocAtRangeStart (parseState, attributes, mWhole)

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -280,14 +280,13 @@ val mkAutoPropDefn:
                 SynMemberDefn
 
 val mkValField:
+    parseState: IParseState ->
     mVal: range ->
-    mRhs: range ->
-    mut: bool ->
+    isMutable: range option ->
     access: SynAccess option ->
-    ident: Ident ->
-    typ: SynType ->
-    xmlDoc: PreXmlDoc ->
-    range ->
+    idOpt: Ident option ->
+    typ: SynType option ->
+    rangeStart: range ->
     SynAttributes ->
     range option ->
         SynMemberDefn
@@ -295,11 +294,11 @@ val mkValField:
 val mkSynField:
     parseState: IParseState ->
     idOpt: Ident option ->
-    t: SynType ->
-    isMutable: bool ->
+    t: SynType option ->
+    isMutable: range option ->
     vis: SynAccess option ->
     attributes: SynAttributeList list ->
-    isStatic: bool ->
-    mWhole: range ->
+    mStatic: range option ->
+    rangeStart: range ->
     leadingKeyword: SynLeadingKeyword option ->
         SynField

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -1288,6 +1288,10 @@ type SynField =
         range: range *
         trivia: SynFieldTrivia
 
+    member this.Range =
+        match this with
+        | SynField(range = range) -> range
+
 [<NoEquality; NoComparison>]
 type SynComponentInfo =
     | SynComponentInfo of

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -1453,6 +1453,7 @@ type SynField =
         range: range *
         trivia: SynFieldTrivia
 
+    /// Gets the syntax range of this construct
     member Range: range
 
 /// Represents the syntax tree associated with the name of a type definition or module

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -1453,6 +1453,8 @@ type SynField =
         range: range *
         trivia: SynFieldTrivia
 
+    member Range: range
+
 /// Represents the syntax tree associated with the name of a type definition or module
 /// in signature or implementation.
 ///

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -383,9 +383,14 @@ type SynMemberDefnAbstractSlotTrivia =
 type SynFieldTrivia =
     {
         LeadingKeyword: SynLeadingKeyword option
+        MutableKeyword: range option
     }
 
-    static member Zero: SynFieldTrivia = { LeadingKeyword = None }
+    static member Zero: SynFieldTrivia =
+        {
+            LeadingKeyword = None
+            MutableKeyword = None
+        }
 
 [<NoEquality; NoComparison>]
 type SynTypeOrTrivia = { OrKeyword: range }

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -486,6 +486,8 @@ type SynFieldTrivia =
     {
         /// Used leading keyword of SynField
         LeadingKeyword: SynLeadingKeyword option
+        /// The syntax range of the `mutable` keyword
+        MutableKeyword: range option
     }
 
     static member Zero: SynFieldTrivia

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -728,7 +728,7 @@ moduleSpfn:
 valSpfn:
   | opt_attributes opt_access VAL opt_attributes opt_inline opt_mutable opt_access nameop opt_explicitValTyparDecls COLON topTypeWithTypeConstraints optLiteralValueSpfn
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier(), rhs parseState 2))
-        let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), (mEquals, konst: SynExpr option) = ($1), ($4), (Option.isSome $5), ($6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
+        let attr1, attr2, isInline, isMutable, vis2, id, doc, explicitValTyparDecls, (ty, arity), (mEquals, konst: SynExpr option) = ($1), ($4), (Option.isSome $5), (Option.isSome $6), ($7), ($8), grabXmlDoc(parseState, $1, 1), ($9), ($11), ($12)
         if not (isNil attr2) then errorR(Deprecated(FSComp.SR.parsAttributesMustComeBeforeVal(), rhs parseState 4))
         let m =
             rhs2 parseState 1 11
@@ -985,21 +985,23 @@ classMemberSpfn:
        SynMemberSig.Inherit(ty, unionRanges (rhs parseState 1) mInherit) }
 
   | opt_attributes opt_access VAL fieldDecl
-     { let mWhole = rhs2 parseState 1 4
-       if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+     { if Option.isSome $2 then
+           errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+       let mStart = rhs parseState 1
        let mVal = rhs parseState 3
-       let (SynField(xmlDoc = xmlDoc)) as field = $4 $1 false mWhole (Some(SynLeadingKeyword.Val mVal))
-       let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
-       SynMemberSig.ValField(field, mWhole) }
+       let leadingKeyword = Some(SynLeadingKeyword.Val mVal)
+       let (SynField(xmlDoc = xmlDoc; range = range)) as field = $4 $1 None mStart leadingKeyword
+       SynMemberSig.ValField(field, range) }
 
   | opt_attributes opt_access STATIC VAL fieldDecl
-     { let mWhole = rhs2 parseState 1 5
-       if Option.isSome $2 then errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+     { if Option.isSome $2 then
+           errorR (Error (FSComp.SR.parsVisibilityDeclarationsShouldComePriorToIdentifier (), rhs parseState 2))
+       let mStart = rhs parseState 1
        let mStatic = rhs parseState 3
        let mVal = rhs parseState 4
-       let (SynField(xmlDoc = xmlDoc)) as field = $5 $1 true mWhole (Some(SynLeadingKeyword.StaticVal(mStatic, mVal)))
-       let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
-       SynMemberSig.ValField(field, mWhole) }
+       let leadingKeyword = Some(SynLeadingKeyword.StaticVal(mStatic, mVal))
+       let (SynField(xmlDoc = xmlDoc; range = range)) as field = $5 $1 (Some mStatic) mStart leadingKeyword
+       SynMemberSig.ValField(field, range) }
 
   | opt_attributes opt_access STATIC typeKeyword tyconSpfn
      { let leadingKeyword = SynTypeDefnLeadingKeyword.StaticType(rhs parseState 3, rhs parseState 4)
@@ -2135,38 +2137,26 @@ classDefnMember:
 valDefnDecl:
   | VAL opt_mutable opt_access ident COLON typ
      { let mVal = rhs parseState 1
-       let mRhs = rhs2 parseState 4 6
        fun rangeStart attribs mStaticOpt ->
-           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
-           [ mkValField mVal mRhs $2 $3 $4 $6 xmlDoc rangeStart attribs mStaticOpt ] }
+           [ mkValField parseState mVal $2 $3 (Some $4) (Some $6) rangeStart attribs mStaticOpt ] }
 
   | VAL opt_mutable opt_access ident COLON recover
      { let mVal = rhs parseState 1
-       let mRhs = rhs2 parseState 4 6
        let mColon = rhs parseState 5
        let ty = SynType.FromParseError(mColon.EndRange)
        fun rangeStart attribs mStaticOpt ->
-           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
-           [ mkValField mVal mRhs $2 $3 $4 ty xmlDoc rangeStart attribs mStaticOpt ] }
+           [ mkValField parseState mVal $2 $3 (Some $4) (Some ty) rangeStart attribs mStaticOpt ] }
 
   | VAL opt_mutable opt_access ident recover
      { let mVal = rhs parseState 1
-       let mRhs = rhs2 parseState 4 6
-       let mColon = rhs parseState 5
-       let ty = SynType.FromParseError(mColon.EndRange)
+       let ty = SynType.FromParseError($4.idRange.EndRange)
        fun rangeStart attribs mStaticOpt ->
-           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
-           [ mkValField mVal mRhs $2 $3 $4 ty xmlDoc rangeStart attribs mStaticOpt ] }
+           [ mkValField parseState mVal $2 $3 (Some $4) (Some ty) rangeStart attribs mStaticOpt ] }
 
   | VAL opt_mutable opt_access recover
      { let mVal = rhs parseState 1
-       let mRhs = rhs2 parseState 4 6
-       let id = mkSynId mVal.EndRange ""
-       let mColon = rhs parseState 5
-       let ty = SynType.FromParseError(mColon.EndRange)
        fun rangeStart attribs mStaticOpt ->
-           let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
-           [ mkValField mVal mRhs $2 $3 id ty xmlDoc rangeStart attribs mStaticOpt ] }
+           [ mkValField parseState mVal $2 $3 None None rangeStart attribs mStaticOpt ] }
 
 
 /* An auto-property definition in an object type definition */
@@ -2174,7 +2164,7 @@ autoPropsDefnDecl:
   | VAL opt_mutable opt_access ident opt_typ EQUALS typedSequentialExprBlock classMemberSpfnGetSet
      { let mVal = rhs parseState 1
        let mEquals = rhs parseState 6
-       if $2 then
+       if Option.isSome $2 then
            errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
        fun attribs flags rangeStart ->
            let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
@@ -2187,7 +2177,7 @@ autoPropsDefnDecl:
            | Some t -> t.Range
            | _ -> $4.idRange
        let expr = arbExpr ("autoProp1", mEnd.EndRange)
-       if $2 then
+       if Option.isSome $2 then
            errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
        fun attribs flags rangeStart ->
            let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
@@ -2200,7 +2190,7 @@ autoPropsDefnDecl:
            | Some t -> t.Range
            | _ -> $4.idRange
        let expr = arbExpr ("autoProp2", mEnd.EndRange)
-       if $2 then
+       if Option.isSome $2 then
            errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
        fun attribs flags rangeStart ->
            let xmlDoc = grabXmlDocAtRangeStart (parseState, attribs, rangeStart)
@@ -2210,7 +2200,7 @@ autoPropsDefnDecl:
      { let mVal = rhs parseState 1
        let id = mkSynId mVal.EndRange ""
        let expr = arbExpr ("autoProp3", mVal.EndRange)
-       if $2 then
+       if Option.isSome $2 then
            errorR (Error(FSComp.SR.parsMutableOnAutoPropertyShouldBeGetSet (), rhs parseState 2))
        fun attribs flags rangeStart ->
            let xmlDoc = grabXmlDocAtRangeStart(parseState, attribs, rangeStart)
@@ -2463,6 +2453,10 @@ braceFieldDeclList:
 
   | LBRACE error rbrace
      { [] }
+
+  | LBRACE rbrace
+     { errorR (Error(FSComp.SR.parsExpectingField(), rhs parseState 2))
+       [] }
 
 anonRecdType:
     | STRUCT braceBarFieldDeclListCore
@@ -2836,8 +2830,8 @@ recdFieldDeclList:
 /* A field declaration in a record type */
 recdFieldDecl:
   | opt_attributes fieldDecl
-     { let mWhole = rhs2 parseState 1 2
-       let fld = $2 $1 false mWhole None
+     { let rangeStart = rhs parseState 1
+       let fld = $2 $1 None rangeStart None
        let (SynField (a, b, c, d, e, xmlDoc, vis, mWhole, trivia)) = fld
        if Option.isSome vis then errorR (Error (FSComp.SR.parsRecordFieldsCannotHaveVisibilityDeclarations (), rhs parseState 2))
        let mWhole = unionRangeWithXmlDoc xmlDoc mWhole
@@ -2846,14 +2840,19 @@ recdFieldDecl:
 /* Part of a field or val declaration in a record type or object type */
 fieldDecl:
   | opt_mutable opt_access ident COLON typ
-     { mkSynField parseState (Some $3) $5 $1 $2 }
+     { mkSynField parseState (Some $3) (Some $5) $1 $2 }
+
   | opt_mutable opt_access ident COLON recover
      { let mColon = rhs parseState 4
        let t = SynType.FromParseError(mColon.EndRange)
-       mkSynField parseState (Some $3) t $1 $2 }
+       mkSynField parseState (Some $3) (Some t) $1 $2 }
+
   | opt_mutable opt_access ident recover
      { let t = SynType.FromParseError($3.idRange.EndRange)
-       mkSynField parseState (Some $3) t $1 $2 }
+       mkSynField parseState (Some $3) (Some t) $1 $2 }
+
+  | opt_mutable opt_access recover
+     { mkSynField parseState None None $1 $2 }
 
 /* An exception definition */
 exconDefn:
@@ -3195,7 +3194,7 @@ localBinding:
             let spBind = if IsDebugPointBinding bindingPat expr then DebugPointAtBinding.Yes mWhole else DebugPointAtBinding.NoneAtLet
             let mWholeBindLhs = (mBindLhs, attrs) ||> unionRangeWithListBy (fun (a: SynAttributeList) -> a.Range)
             let trivia: SynBindingTrivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = Some mEquals }
-            mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mWholeBindLhs, spBind, optReturnType, expr, mRhs, opts, attrs, None, trivia))
+            mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, Option.isSome $2, mWholeBindLhs, spBind, optReturnType, expr, mRhs, opts, attrs, None, trivia))
         localBindingRange, localBindingBuilder }
 
   | opt_inline opt_mutable bindingPattern opt_topReturnTypeWithTypeConstraints EQUALS error
@@ -3210,7 +3209,7 @@ localBinding:
             let rhsExpr = arbExpr ("localBinding1", zeroWidthAtEnd)
             let spBind = if IsDebugPointBinding bindingPat rhsExpr then DebugPointAtBinding.Yes mWhole else DebugPointAtBinding.NoneAtLet
             let trivia: SynBindingTrivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = Some mEquals }
-            mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
+            mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, Option.isSome $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
         mWhole, localBindingBuilder }
 
   | opt_inline opt_mutable bindingPattern opt_topReturnTypeWithTypeConstraints recover
@@ -3224,7 +3223,7 @@ localBinding:
             let spBind = DebugPointAtBinding.Yes(unionRanges leadingKeyword.Range mRhs)
             let trivia = { LeadingKeyword = leadingKeyword; InlineKeyword = $1; EqualsRange = None }
             let rhsExpr = arbExpr ("localBinding2", mRhs)
-            mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
+            mkSynBinding (xmlDoc, bindingPat) (vis, Option.isSome $1, Option.isSome $2, mBindLhs, spBind, optReturnType, rhsExpr, mRhs, [], attrs, None, trivia))
         mWhole, localBindingBuilder }
 
 /* A single expression with an optional type annotation, and an optional static optimization block */
@@ -6717,8 +6716,8 @@ opt_inline:
   | /* EMPTY */ { None }
 
 opt_mutable:
-  | MUTABLE { true }
-  | /* EMPTY */ { false }
+  | MUTABLE { Some(rhs parseState 1) }
+  | /* EMPTY */ { None }
 
 /* A 'do' token in either #light or non-#light */
 doToken:

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Byl očekáván výraz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Očekává se vzorek.</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Ausdruck wird erwartet</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Muster wird erwartet</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Se espera una expresión</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Se espera un patrón</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -907,6 +907,11 @@
         <target state="translated"> Expression attendue</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Modèle attendu</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Prevista espressione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Criterio previsto</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -907,6 +907,11 @@
         <target state="translated">式を指定してください</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">必要なパターン</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -907,6 +907,11 @@
         <target state="translated">식이 필요함</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">예상되는 패턴</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Oczekiwanie na wyrażenie</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Oczekiwano wzorca</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Esperando uma expressão</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Padrão esperado</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -907,6 +907,11 @@
         <target state="translated">Ожидается выражение</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Ожидается шаблон</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -907,6 +907,11 @@
         <target state="translated">İfade bekleniyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Desen bekleniyor</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -907,6 +907,11 @@
         <target state="translated">应为表达式</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">预期模式</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -907,6 +907,11 @@
         <target state="translated">必須是運算式</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">必須是模式</target>

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/FieldMembers/FieldMembers.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/FieldMembers/FieldMembers.fs
@@ -34,8 +34,8 @@ module FieldMembers =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 880, Line 11, Col 20, Line 11, Col 33, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
-            (Error 881, Line 11, Col 20, Line 11, Col 33, "Static 'val' fields in types must be mutable, private and marked with the '[<DefaultValue>]' attribute. They are initialized to the 'null' or 'zero' value for their type. Consider also using a 'static let mutable' binding in a class type.")
+            (Error 880, Line 11, Col 20, Line 11, Col 27, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
+            (Error 881, Line 11, Col 20, Line 11, Col 27, "Static 'val' fields in types must be mutable, private and marked with the '[<DefaultValue>]' attribute. They are initialized to the 'null' or 'zero' value for their type. Consider also using a 'static let mutable' binding in a class type.")
         ]
 
     // SOURCE=E_StaticField02a.fs	# E_StaticField02a.fs
@@ -45,8 +45,8 @@ module FieldMembers =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 881, Line 7, Col 32, Line 7, Col 49, "Static 'val' fields in types must be mutable, private and marked with the '[<DefaultValue>]' attribute. They are initialized to the 'null' or 'zero' value for their type. Consider also using a 'static let mutable' binding in a class type.")
-            (Error 881, Line 16, Col 32, Line 16, Col 49, "Static 'val' fields in types must be mutable, private and marked with the '[<DefaultValue>]' attribute. They are initialized to the 'null' or 'zero' value for their type. Consider also using a 'static let mutable' binding in a class type.")
+            (Error 881, Line 7, Col 32, Line 7, Col 40, "Static 'val' fields in types must be mutable, private and marked with the '[<DefaultValue>]' attribute. They are initialized to the 'null' or 'zero' value for their type. Consider also using a 'static let mutable' binding in a class type.")
+            (Error 881, Line 16, Col 32, Line 16, Col 40, "Static 'val' fields in types must be mutable, private and marked with the '[<DefaultValue>]' attribute. They are initialized to the 'null' or 'zero' value for their type. Consider also using a 'static let mutable' binding in a class type.")
         ]
 
     // SOURCE=StaticField01.fs		# StaticField01.fs

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/RecordTypes/AnonymousRecords.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/RecordTypes/AnonymousRecords.fs
@@ -159,7 +159,9 @@ type ErrorResponse =
         |> withDiagnostics [
             Error 10, Line 5, Col 42, Line 5, Col 43, "Unexpected integer literal in field declaration. Expected ':' or other token."
             Error 10, Line 7, Col 12, Line 7, Col 14, "Unexpected symbol '|}' in field declaration. Expected identifier or other token."
+            Error 3244, Line 7, Col 9, Line 7, Col 14, "Invalid anonymous record type"
             Error 10, Line 10, Col 17, Line 10, Col 21, "Incomplete structured construct at or before this point in field declaration. Expected identifier or other token."
+            Error 3244, Line 10, Col 14, Line 11, Col 36, "Invalid anonymous record type"
         ]
         
     [<Fact>]

--- a/tests/FSharp.Compiler.ComponentTests/Language/StaticClassTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/StaticClassTests.fs
@@ -650,8 +650,8 @@ type B() =
          |> compile
          |> shouldFail
          |> withDiagnostics [
-             (Error 880, Line 4, Col 9, Line 4, Col 16, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
-             (Error 880, Line 5, Col 17, Line 5, Col 24, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
+             (Error 880, Line 4, Col 9, Line 4, Col 10, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
+             (Error 880, Line 5, Col 17, Line 5, Col 18, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
          ]
 
     [<Fact>]
@@ -682,8 +682,8 @@ type B() =
          |> compile
          |> shouldFail
          |> withDiagnostics [
-             (Error 880, Line 4, Col 9, Line 4, Col 16, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
-             (Error 880, Line 5, Col 17, Line 5, Col 24, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
+             (Error 880, Line 4, Col 9, Line 4, Col 10, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
+             (Error 880, Line 5, Col 17, Line 5, Col 18, "Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.")
              (Warning 3558, Line 4, Col 9, Line 4, Col 10, "If a type uses both [<Sealed>] and [<AbstractClass>] attributes, it means it is static. Explicit field declarations are not allowed.")
              (Warning 3558, Line 5, Col 17, Line 5, Col 18, "If a type uses both [<Sealed>] and [<AbstractClass>] attributes, it means it is static. Explicit field declarations are not allowed.")
          ]

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -7370,6 +7370,8 @@ FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType fieldType
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType get_fieldType()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.SyntaxTrivia.SynFieldTrivia get_trivia()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.SyntaxTrivia.SynFieldTrivia trivia
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -9757,8 +9757,10 @@ FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: FSharp.Compiler.SyntaxTrivia.SynFie
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: FSharp.Compiler.SyntaxTrivia.SynFieldTrivia get_Zero()
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword] LeadingKeyword
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword] get_LeadingKeyword()
+FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] MutableKeyword
+FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_MutableKeyword()
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword])
+FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Abstract: FSharp.Compiler.Text.Range abstractRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Abstract: FSharp.Compiler.Text.Range get_abstractRange()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+AbstractMember: FSharp.Compiler.Text.Range abstractRange

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -7370,6 +7370,8 @@ FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType fieldType
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Syntax.SynType get_fieldType()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.SyntaxTrivia.SynFieldTrivia get_trivia()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.SyntaxTrivia.SynFieldTrivia trivia
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range Range
+FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range get_Range()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynField: FSharp.Compiler.Xml.PreXmlDoc get_xmlDoc()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -9757,8 +9757,10 @@ FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: FSharp.Compiler.SyntaxTrivia.SynFie
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: FSharp.Compiler.SyntaxTrivia.SynFieldTrivia get_Zero()
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword] LeadingKeyword
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword] get_LeadingKeyword()
+FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] MutableKeyword
+FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_MutableKeyword()
 FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword])
+FSharp.Compiler.SyntaxTrivia.SynFieldTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Abstract: FSharp.Compiler.Text.Range abstractRange
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+Abstract: FSharp.Compiler.Text.Range get_abstractRange()
 FSharp.Compiler.SyntaxTrivia.SynLeadingKeyword+AbstractMember: FSharp.Compiler.Text.Range abstractRange

--- a/tests/fsharp/typecheck/sigs/neg16.bsl
+++ b/tests/fsharp/typecheck/sigs/neg16.bsl
@@ -83,7 +83,7 @@ neg16.fs(102,3,103,9): typecheck error FS0823: The 'VolatileField' attribute may
 
 neg16.fs(102,3,103,9): typecheck error FS0879: Volatile fields must be marked 'mutable' and cannot be thread-static
 
-neg16.fs(119,17,119,24): typecheck error FS0823: The 'VolatileField' attribute may only be used on 'let' bindings in classes
+neg16.fs(119,17,119,18): typecheck error FS0823: The 'VolatileField' attribute may only be used on 'let' bindings in classes
 
 neg16.fs(106,5,107,19): typecheck error FS0879: Volatile fields must be marked 'mutable' and cannot be thread-static
 

--- a/tests/fsharp/typecheck/sigs/neg28.bsl
+++ b/tests/fsharp/typecheck/sigs/neg28.bsl
@@ -1,7 +1,7 @@
 
 neg28.fsx(5,10,5,11): typecheck error FS1180: The struct, record or union type 'X' has the 'StructuralEquality' attribute but the component type '(int -> int)' does not satisfy the 'equality' constraint
 
-neg28.fsx(12,13,12,20): typecheck error FS0880: Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.
+neg28.fsx(12,13,12,14): typecheck error FS0880: Uninitialized 'val' fields must be mutable and marked with the '[<DefaultValue>]' attribute. Consider using a 'let' binding instead of a 'val' field.
 
 neg28.fsx(19,13,19,14): typecheck error FS1181: Each argument of the primary constructor for a struct must be given a type, for example 'type S(x1:int, x2: int) = ...'. These arguments determine the fields of the struct.
 

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/StructTypes/E_Regressions02b.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/StructTypes/E_Regressions02b.fs
@@ -1,7 +1,7 @@
 // #Regression #Conformance #ObjectOrientedTypes #Structs 
 // Regression for 4643:
 // infinite loop in typechecker - caused by recursive struct check via self typed static field
-//<Expects status="error" span="(9,23-9,30)" id="FS0881">Static 'val' fields in types must be mutable, private and marked with the '\[<DefaultValue>\]' attribute\. They are initialized to the 'null' or 'zero' value for their type\. Consider also using a 'static let mutable' binding in a class type\.$</Expects>
+//<Expects status="error" span="(9,23-9,24)" id="FS0881">Static 'val' fields in types must be mutable, private and marked with the '\[<DefaultValue>\]' attribute\. They are initialized to the 'null' or 'zero' value for their type\. Consider also using a 'static let mutable' binding in a class type\.$</Expects>
 [<Struct>]
 type RIP(x:int) =
 

--- a/tests/fsharpqa/Source/InteractiveSession/Misc/E_emptyRecord.fsx
+++ b/tests/fsharpqa/Source/InteractiveSession/Misc/E_emptyRecord.fsx
@@ -1,5 +1,5 @@
 // #Regression #NoMT #FSI 
 // Regression test for FSHARP1.0:5629
-//<Expects status="error" span="(4,12)" id="FS0010">Unexpected symbol '}' in field declaration\. Expected identifier or other token\.$</Expects>
+//<Expects status="error" span="(4,12)" id="FS3863">Expecting record field</Expects>
 type R = { };;
 exit 1;;

--- a/tests/service/XmlDocTests.fs
+++ b/tests/service/XmlDocTests.fs
@@ -1334,7 +1334,7 @@ type Point =
     match parseResults.ParseTree with
     | Members([SynMemberDefn.ValField(fieldInfo = SynField(range = fieldRange); range = range)]) ->
         assertRange (4, 8) (8, 20) range
-        assertRange (8, 12) (8, 20) fieldRange
+        assertRange (4, 8) (8, 20) fieldRange
     | x ->
         failwith $"Unexpected ParsedInput %A{x}"
 

--- a/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Exception/Recover Function Type 01.fs.bsl
@@ -19,7 +19,8 @@ ImplFile
                                 (3,17--3,27), { ArrowRange = (3,21--3,23) }),
                              false,
                              PreXmlDoc ((3,17), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, (3,17--3,27), { LeadingKeyword = None })],
+                             None, (3,17--3,27), { LeadingKeyword = None
+                                                   MutableKeyword = None })],
                        PreXmlDocEmpty, None, (3,10--3,27), { BarRange = None }),
                     None, PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
                     None, (3,0--3,27)), None, [], (3,0--3,27)), (3,0--3,27));
@@ -34,7 +35,8 @@ ImplFile
                             ([], false, None,
                              LongIdent (SynLongIdent ([int], [], [None])), false,
                              PreXmlDoc ((4,19), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, (4,19--4,22), { LeadingKeyword = None })],
+                             None, (4,19--4,22), { LeadingKeyword = None
+                                                   MutableKeyword = None })],
                        PreXmlDocEmpty, None, (4,10--4,22), { BarRange = None }),
                     None, PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
                     None, (4,0--4,22)), None, [], (4,0--4,22)), (4,0--4,22))],

--- a/tests/service/data/SyntaxTree/LeadingKeyword/StaticValKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/StaticValKeyword.fsi.bsl
@@ -23,8 +23,9 @@ SigFile
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,4--5,29),
                             { LeadingKeyword =
-                               Some (StaticVal ((5,4--5,10), (5,11--5,14))) }),
-                         (5,4--5,29))], (5,4--5,29)), [], (4,5--5,29),
+                               Some (StaticVal ((5,4--5,10), (5,11--5,14)))
+                              MutableKeyword = None }), (5,4--5,29))],
+                     (5,4--5,29)), [], (4,5--5,29),
                   { LeadingKeyword = Type (4,0--4,4)
                     EqualsRange = Some (4,7--4,8)
                     WithKeyword = None })], (4,0--5,29))], PreXmlDocEmpty, [],

--- a/tests/service/data/SyntaxTree/LeadingKeyword/ValKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/LeadingKeyword/ValKeyword.fsi.bsl
@@ -18,8 +18,9 @@ SigFile
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,4--5,15),
-                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
-                         (5,4--5,15))], (5,4--5,15)), [], (4,5--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7))
+                              MutableKeyword = None }), (5,4--5,15))],
+                     (5,4--5,15)), [], (4,5--5,15),
                   { LeadingKeyword = Type (4,0--4,4)
                     EqualsRange = Some (4,7--4,8)
                     WithKeyword = None })], (4,0--5,15))], PreXmlDocEmpty, [],

--- a/tests/service/data/SyntaxTree/Member/Field 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 01.fs.bsl
@@ -16,7 +16,7 @@ ImplFile
                            ([], false, Some F1,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,8--4,15),
+                            None, (4,4--4,15),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
                          (4,4--4,15))], (4,4--4,15)), [], None, (3,5--4,15),
                   { LeadingKeyword = Type (3,0--3,4)

--- a/tests/service/data/SyntaxTree/Member/Field 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 01.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,15),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,15))], (4,4--4,15)), [], None, (3,5--4,15),
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,15))],
+                     (4,4--4,15)), [], None, (3,5--4,15),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,15))],

--- a/tests/service/data/SyntaxTree/Member/Field 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 02.fs.bsl
@@ -17,16 +17,17 @@ ImplFile
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,11),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,11));
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,11));
                       ValField
                         (SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,4--5,15),
-                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
-                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7))
+                              MutableKeyword = None }), (5,4--5,15))],
+                     (4,4--5,15)), [], None, (3,5--5,15),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--5,15));

--- a/tests/service/data/SyntaxTree/Member/Field 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 02.fs.bsl
@@ -16,7 +16,7 @@ ImplFile
                            ([], false, Some F1, FromParseError (4,11--4,11),
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,8--5,4),
+                            None, (4,4--4,11),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
                          (4,4--4,11));
                       ValField
@@ -24,7 +24,7 @@ ImplFile
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15),
+                            None, (5,4--5,15),
                             { LeadingKeyword = Some (Val (5,4--5,7)) }),
                          (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
                   { LeadingKeyword = Type (3,0--3,4)

--- a/tests/service/data/SyntaxTree/Member/Field 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 03.fs.bsl
@@ -17,16 +17,17 @@ ImplFile
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,10),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,10));
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,10));
                       ValField
                         (SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,4--5,15),
-                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
-                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7))
+                              MutableKeyword = None }), (5,4--5,15))],
+                     (4,4--5,15)), [], None, (3,5--5,15),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--5,15));

--- a/tests/service/data/SyntaxTree/Member/Field 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 03.fs.bsl
@@ -13,17 +13,18 @@ ImplFile
                     (Unspecified,
                      [ValField
                         (SynField
-                           ([], false, Some F1, FromParseError (5,4--5,4), false,
+                           ([], false, Some F1, FromParseError (4,10--4,10),
+                            false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,8--134217728,0),
+                            None, (4,4--4,10),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--5,4));
+                         (4,4--4,10));
                       ValField
                         (SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15),
+                            None, (5,4--5,15),
                             { LeadingKeyword = Some (Val (5,4--5,7)) }),
                          (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
                   { LeadingKeyword = Type (3,0--3,4)

--- a/tests/service/data/SyntaxTree/Member/Field 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 04.fs.bsl
@@ -13,22 +13,22 @@ ImplFile
                     (Unspecified,
                      [ValField
                         (SynField
-                           ([], false, Some , FromParseError (1,13--1,13), false,
+                           ([], false, None, FromParseError (4,7--4,7), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,8--134217728,0),
+                            None, (4,4--4,7),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (1,13--4,7));
+                         (4,4--4,7));
                       ValField
                         (SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15),
+                            None, (5,4--5,15),
                             { LeadingKeyword = Some (Val (5,4--5,7)) }),
-                         (5,4--5,15))], (1,13--5,15)), [], None, (1,13--5,15),
+                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
-                    WithKeyword = None })], (1,13--5,15));
+                    WithKeyword = None })], (3,0--5,15));
            Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Member/Field 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 04.fs.bsl
@@ -16,16 +16,17 @@ ImplFile
                            ([], false, None, FromParseError (4,7--4,7), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,7),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,7));
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,7));
                       ValField
                         (SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,4--5,15),
-                            { LeadingKeyword = Some (Val (5,4--5,7)) }),
-                         (5,4--5,15))], (4,4--5,15)), [], None, (3,5--5,15),
+                            { LeadingKeyword = Some (Val (5,4--5,7))
+                              MutableKeyword = None }), (5,4--5,15))],
+                     (4,4--5,15)), [], None, (3,5--5,15),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--5,15));

--- a/tests/service/data/SyntaxTree/Member/Field 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 05.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,10),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,10))], (4,4--4,10)), [], None, (3,5--4,10),
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,10))],
+                     (4,4--4,10)), [], None, (3,5--4,10),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,10));

--- a/tests/service/data/SyntaxTree/Member/Field 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 05.fs.bsl
@@ -16,7 +16,7 @@ ImplFile
                            ([], false, Some F, FromParseError (4,10--4,10),
                             false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,8--6,1),
+                            None, (4,4--4,10),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
                          (4,4--4,10))], (4,4--4,10)), [], None, (3,5--4,10),
                   { LeadingKeyword = Type (3,0--3,4)

--- a/tests/service/data/SyntaxTree/Member/Field 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 06.fs.bsl
@@ -13,14 +13,14 @@ ImplFile
                     (Unspecified,
                      [ValField
                         (SynField
-                           ([], false, Some F, FromParseError (6,1--6,1), false,
+                           ([], false, Some F, FromParseError (4,9--4,9), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,8--134217728,0),
+                            None, (4,4--4,9),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--6,1))], (4,4--6,1)), [], None, (3,5--6,1),
+                         (4,4--4,9))], (4,4--4,9)), [], None, (3,5--4,9),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
-                    WithKeyword = None })], (3,0--6,1));
+                    WithKeyword = None })], (3,0--4,9));
            Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Member/Field 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 06.fs.bsl
@@ -16,11 +16,11 @@ ImplFile
                            ([], false, Some F, FromParseError (4,9--4,9), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,9),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,9))], (4,4--4,9)), [], None, (3,5--4,9),
-                  { LeadingKeyword = Type (3,0--3,4)
-                    EqualsRange = Some (3,7--3,8)
-                    WithKeyword = None })], (3,0--4,9));
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,9))], (4,4--4,9)),
+                  [], None, (3,5--4,9), { LeadingKeyword = Type (3,0--3,4)
+                                          EqualsRange = Some (3,7--3,8)
+                                          WithKeyword = None })], (3,0--4,9));
            Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Member/Field 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 07.fs.bsl
@@ -16,11 +16,11 @@ ImplFile
                            ([], false, None, FromParseError (4,7--4,7), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,7),
-                            { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (4,4--4,7))], (4,4--4,7)), [], None, (3,5--4,7),
-                  { LeadingKeyword = Type (3,0--3,4)
-                    EqualsRange = Some (3,7--3,8)
-                    WithKeyword = None })], (3,0--4,7));
+                            { LeadingKeyword = Some (Val (4,4--4,7))
+                              MutableKeyword = None }), (4,4--4,7))], (4,4--4,7)),
+                  [], None, (3,5--4,7), { LeadingKeyword = Type (3,0--3,4)
+                                          EqualsRange = Some (3,7--3,8)
+                                          WithKeyword = None })], (3,0--4,7));
            Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Member/Field 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 07.fs.bsl
@@ -13,14 +13,14 @@ ImplFile
                     (Unspecified,
                      [ValField
                         (SynField
-                           ([], false, Some , FromParseError (1,13--1,13), false,
+                           ([], false, None, FromParseError (4,7--4,7), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,0--134217728,0),
+                            None, (4,4--4,7),
                             { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                         (1,13--4,7))], (1,13--4,7)), [], None, (1,13--4,7),
+                         (4,4--4,7))], (4,4--4,7)), [], None, (3,5--4,7),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
-                    WithKeyword = None })], (1,13--4,7));
+                    WithKeyword = None })], (3,0--4,7));
            Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Member/Field 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 08.fs.bsl
@@ -13,11 +13,11 @@ ImplFile
                     (Struct,
                      [ValField
                         (SynField
-                           ([], false, Some , FromParseError (1,13--1,13), false,
+                           ([], false, None, FromParseError (5,11--5,11), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,4--134217728,0),
+                            None, (5,8--5,11),
                             { LeadingKeyword = Some (Val (5,8--5,11)) }),
-                         (1,13--5,11))], (4,4--6,7)), [], None, (3,5--6,7),
+                         (5,8--5,11))], (4,4--6,7)), [], None, (3,5--6,7),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--6,7));

--- a/tests/service/data/SyntaxTree/Member/Field 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 08.fs.bsl
@@ -16,8 +16,9 @@ ImplFile
                            ([], false, None, FromParseError (5,11--5,11), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,8--5,11),
-                            { LeadingKeyword = Some (Val (5,8--5,11)) }),
-                         (5,8--5,11))], (4,4--6,7)), [], None, (3,5--6,7),
+                            { LeadingKeyword = Some (Val (5,8--5,11))
+                              MutableKeyword = None }), (5,8--5,11))],
+                     (4,4--6,7)), [], None, (3,5--6,7),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--6,7));

--- a/tests/service/data/SyntaxTree/Member/Field 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 09.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,14),
                             { LeadingKeyword =
-                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (4,4--4,14))], (4,4--4,14)), [], None, (3,5--4,14),
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14)))
+                              MutableKeyword = None }), (4,4--4,14))],
+                     (4,4--4,14)), [], None, (3,5--4,14),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,14));

--- a/tests/service/data/SyntaxTree/Member/Field 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 09.fs.bsl
@@ -13,15 +13,15 @@ ImplFile
                     (Unspecified,
                      [ValField
                         (SynField
-                           ([], true, Some , FromParseError (1,13--1,13), false,
+                           ([], true, None, FromParseError (4,14--4,14), false,
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,0--134217728,0),
+                            None, (4,4--4,14),
                             { LeadingKeyword =
                                Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (1,13--4,10))], (1,13--4,10)), [], None, (1,13--4,10),
+                         (4,4--4,14))], (4,4--4,14)), [], None, (3,5--4,14),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
-                    WithKeyword = None })], (1,13--4,10));
+                    WithKeyword = None })], (3,0--4,14));
            Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Member/Field 10.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 10.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    static val mutable
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 10.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 10.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], true, None, FromParseError (4,22--4,22), true,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--4,22),
+                            { LeadingKeyword =
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
+                         (4,4--4,22))], (4,4--4,22)), [], None, (3,5--4,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,22));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 10.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,22),
                             { LeadingKeyword =
-                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (4,4--4,22))], (4,4--4,22)), [], None, (3,5--4,22),
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14)))
+                              MutableKeyword = Some (4,15--4,22) }), (4,4--4,22))],
+                     (4,4--4,22)), [], None, (3,5--4,22),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,22));

--- a/tests/service/data/SyntaxTree/Member/Field 11.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 11.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    static val mutable private
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 11.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 11.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 11.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], true, None, FromParseError (4,30--4,30), true,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            Some (Private (4,23--4,30)), (4,4--4,30),
+                            { LeadingKeyword =
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
+                         (4,4--4,30))], (4,4--4,30)), [], None, (3,5--4,30),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,30));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 11.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 11.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             Some (Private (4,23--4,30)), (4,4--4,30),
                             { LeadingKeyword =
-                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (4,4--4,30))], (4,4--4,30)), [], None, (3,5--4,30),
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14)))
+                              MutableKeyword = Some (4,15--4,22) }), (4,4--4,30))],
+                     (4,4--4,30)), [], None, (3,5--4,30),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,30));

--- a/tests/service/data/SyntaxTree/Member/Field 12.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 12.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    static val mutable private F
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 12.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             Some (Private (4,23--4,30)), (4,4--4,32),
                             { LeadingKeyword =
-                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (4,4--4,32))], (4,4--4,32)), [], None, (3,5--4,32),
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14)))
+                              MutableKeyword = Some (4,15--4,22) }), (4,4--4,32))],
+                     (4,4--4,32)), [], None, (3,5--4,32),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,32));

--- a/tests/service/data/SyntaxTree/Member/Field 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 12.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 12.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], true, Some F, FromParseError (4,32--4,32), true,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            Some (Private (4,23--4,30)), (4,4--4,32),
+                            { LeadingKeyword =
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
+                         (4,4--4,32))], (4,4--4,32)), [], None, (3,5--4,32),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,32));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition. Expected ':' or other token.

--- a/tests/service/data/SyntaxTree/Member/Field 13.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 13.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    static val mutable private F:
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 13.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 13.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 13.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], true, Some F, FromParseError (4,33--4,33), true,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            Some (Private (4,23--4,30)), (4,4--4,33),
+                            { LeadingKeyword =
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
+                         (4,4--4,33))], (4,4--4,33)), [], None, (3,5--4,33),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,33));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in type definition

--- a/tests/service/data/SyntaxTree/Member/Field 13.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 13.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             Some (Private (4,23--4,30)), (4,4--4,33),
                             { LeadingKeyword =
-                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (4,4--4,33))], (4,4--4,33)), [], None, (3,5--4,33),
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14)))
+                              MutableKeyword = Some (4,15--4,22) }), (4,4--4,33))],
+                     (4,4--4,33)), [], None, (3,5--4,33),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,33));

--- a/tests/service/data/SyntaxTree/Member/Field 14.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 14.fs
@@ -1,0 +1,6 @@
+module Module
+
+type T =
+    static val mutable private F: int
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 14.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 14.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 14.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([], true, Some F,
+                            LongIdent (SynLongIdent ([int], [], [None])), true,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            Some (Private (4,23--4,30)), (4,4--4,37),
+                            { LeadingKeyword =
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
+                         (4,4--4,37))], (4,4--4,37)), [], None, (3,5--4,37),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,37));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Member/Field 14.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 14.fs.bsl
@@ -18,8 +18,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             Some (Private (4,23--4,30)), (4,4--4,37),
                             { LeadingKeyword =
-                               Some (StaticVal ((4,4--4,10), (4,11--4,14))) }),
-                         (4,4--4,37))], (4,4--4,37)), [], None, (3,5--4,37),
+                               Some (StaticVal ((4,4--4,10), (4,11--4,14)))
+                              MutableKeyword = Some (4,15--4,22) }), (4,4--4,37))],
+                     (4,4--4,37)), [], None, (3,5--4,37),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,37));

--- a/tests/service/data/SyntaxTree/Member/Field 15.fs
+++ b/tests/service/data/SyntaxTree/Member/Field 15.fs
@@ -1,0 +1,7 @@
+module Module
+
+type T =
+    [<A>]
+    static val F: int
+
+()

--- a/tests/service/data/SyntaxTree/Member/Field 15.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 15.fs.bsl
@@ -24,8 +24,9 @@ ImplFile
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--5,21),
                             { LeadingKeyword =
-                               Some (StaticVal ((5,4--5,10), (5,11--5,14))) }),
-                         (4,4--5,21))], (4,4--5,21)), [], None, (3,5--5,21),
+                               Some (StaticVal ((5,4--5,10), (5,11--5,14)))
+                              MutableKeyword = None }), (4,4--5,21))],
+                     (4,4--5,21)), [], None, (3,5--5,21),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--5,21));

--- a/tests/service/data/SyntaxTree/Member/Field 15.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Field 15.fs.bsl
@@ -1,0 +1,36 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Member/Field 15.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [T],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  ObjectModel
+                    (Unspecified,
+                     [ValField
+                        (SynField
+                           ([{ Attributes =
+                                [{ TypeName = SynLongIdent ([A], [], [None])
+                                   ArgExpr = Const (Unit, (4,6--4,7))
+                                   Target = None
+                                   AppliesToGetterAndSetter = false
+                                   Range = (4,6--4,7) }]
+                               Range = (4,4--4,9) }], true, Some F,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,4--5,21),
+                            { LeadingKeyword =
+                               Some (StaticVal ((5,4--5,10), (5,11--5,14))) }),
+                         (4,4--5,21))], (4,4--5,21)), [], None, (3,5--5,21),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,21));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/GlobalNamespaceShouldStartAtNamespaceKeyword.fsi.bsl
@@ -21,13 +21,15 @@ SigFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((6,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (6,20--6,26), { LeadingKeyword = None });
+                                  None, (6,20--6,26), { LeadingKeyword = None
+                                                        MutableKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((6,29), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (6,29--6,32), { LeadingKeyword = None })],
+                                  None, (6,29--6,32), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((6,11), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (6,13--6,32), { BarRange = Some (6,11--6,12) })],
                         (6,11--6,32)), (6,11--6,32)), [], (6,5--6,32),

--- a/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/ModuleOrNamespaceSig/RangeMemberReturnsRangeOfSynModuleOrNamespaceSig.fsi.bsl
@@ -22,13 +22,15 @@ SigFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((4,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,20--4,26), { LeadingKeyword = None });
+                                  None, (4,20--4,26), { LeadingKeyword = None
+                                                        MutableKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,29), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,29--4,32), { LeadingKeyword = None })],
+                                  None, (4,29--4,32), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,13--4,32), { BarRange = Some (4,11--4,12) })],
                         (4,11--4,32)), (4,11--4,32)), [], (4,5--4,32),

--- a/tests/service/data/SyntaxTree/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi.bsl
+++ b/tests/service/data/SyntaxTree/NestedModule/RangeOfNestedModuleInSignatureFileShouldEndAtTheLastSynModuleSigDecl.fsi.bsl
@@ -297,7 +297,8 @@ SigFile
                                          (31,22--31,25)), false,
                                       PreXmlDoc ((31,22), FSharp.Compiler.Xml.XmlDocCollector),
                                       None, (31,22--31,25),
-                                      { LeadingKeyword = None })],
+                                      { LeadingKeyword = None
+                                        MutableKeyword = None })],
                                 PreXmlDoc ((31,6), FSharp.Compiler.Xml.XmlDocCollector),
                                 None, (30,6--31,25),
                                 { BarRange = Some (31,6--31,7) });
@@ -311,7 +312,8 @@ SigFile
                                          (33,22--33,25)), false,
                                       PreXmlDoc ((33,22), FSharp.Compiler.Xml.XmlDocCollector),
                                       None, (33,22--33,25),
-                                      { LeadingKeyword = None })],
+                                      { LeadingKeyword = None
+                                        MutableKeyword = None })],
                                 PreXmlDoc ((33,6), FSharp.Compiler.Xml.XmlDocCollector),
                                 None, (32,6--33,25),
                                 { BarRange = Some (33,6--33,7) });
@@ -325,7 +327,8 @@ SigFile
                                          (35,22--35,25)), false,
                                       PreXmlDoc ((35,22), FSharp.Compiler.Xml.XmlDocCollector),
                                       None, (35,22--35,25),
-                                      { LeadingKeyword = None })],
+                                      { LeadingKeyword = None
+                                        MutableKeyword = None })],
                                 PreXmlDoc ((35,6), FSharp.Compiler.Xml.XmlDocCollector),
                                 None, (34,6--35,25),
                                 { BarRange = Some (35,6--35,7) });
@@ -339,7 +342,8 @@ SigFile
                                          (37,22--37,25)), false,
                                       PreXmlDoc ((37,22), FSharp.Compiler.Xml.XmlDocCollector),
                                       None, (37,22--37,25),
-                                      { LeadingKeyword = None })],
+                                      { LeadingKeyword = None
+                                        MutableKeyword = None })],
                                 PreXmlDoc ((37,6), FSharp.Compiler.Xml.XmlDocCollector),
                                 None, (36,6--37,25),
                                 { BarRange = Some (37,6--37,7) });
@@ -353,7 +357,8 @@ SigFile
                                          (39,22--39,25)), false,
                                       PreXmlDoc ((39,22), FSharp.Compiler.Xml.XmlDocCollector),
                                       None, (39,22--39,25),
-                                      { LeadingKeyword = None })],
+                                      { LeadingKeyword = None
+                                        MutableKeyword = None })],
                                 PreXmlDoc ((39,6), FSharp.Compiler.Xml.XmlDocCollector),
                                 None, (38,6--39,25),
                                 { BarRange = Some (39,6--39,7) });
@@ -367,7 +372,8 @@ SigFile
                                          (41,22--41,25)), false,
                                       PreXmlDoc ((41,22), FSharp.Compiler.Xml.XmlDocCollector),
                                       None, (41,22--41,25),
-                                      { LeadingKeyword = None })],
+                                      { LeadingKeyword = None
+                                        MutableKeyword = None })],
                                 PreXmlDoc ((41,6), FSharp.Compiler.Xml.XmlDocCollector),
                                 None, (40,6--41,25),
                                 { BarRange = Some (41,6--41,7) })],

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributeShouldBeIncludedInSynExceptionDefnReprAndSynExceptionSig.fsi.bsl
@@ -26,13 +26,15 @@ SigFile
                             ([], false, None,
                              LongIdent (SynLongIdent ([obj], [], [None])), false,
                              PreXmlDoc ((6,25), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, (6,25--6,28), { LeadingKeyword = None });
+                             None, (6,25--6,28), { LeadingKeyword = None
+                                                   MutableKeyword = None });
                           SynField
                             ([], false, Some range,
                              LongIdent (SynLongIdent ([range], [], [None])),
                              false,
                              PreXmlDoc ((6,31), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, (6,31--6,43), { LeadingKeyword = None })],
+                             None, (6,31--6,43), { LeadingKeyword = None
+                                                   MutableKeyword = None })],
                        PreXmlDocEmpty, None, (6,10--6,43), { BarRange = None }),
                     None, PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
                     None, (5,0--6,43)), None, [], (5,0--6,43)), (5,0--6,43))],

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fsi.bsl
@@ -41,7 +41,8 @@ SigFile
                            ([], false, Some LongNameBarBarBarBarBarBarBar,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((10,12), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (10,12--10,46), { LeadingKeyword = None })],
+                            None, (10,12--10,46), { LeadingKeyword = None
+                                                    MutableKeyword = None })],
                         (8,4--11,9)), (8,4--11,9)),
                   [Member
                      (SynValSig

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfMembersShouldBeIncludedInSynExceptionSigAndSynModuleSigDeclException.fsi.bsl
@@ -15,13 +15,15 @@ SigFile
                             ([], false, None,
                              LongIdent (SynLongIdent ([obj], [], [None])), false,
                              PreXmlDoc ((4,25), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, (4,25--4,28), { LeadingKeyword = None });
+                             None, (4,25--4,28), { LeadingKeyword = None
+                                                   MutableKeyword = None });
                           SynField
                             ([], false, Some range,
                              LongIdent (SynLongIdent ([range], [], [None])),
                              false,
                              PreXmlDoc ((4,31), FSharp.Compiler.Xml.XmlDocCollector),
-                             None, (4,31--4,43), { LeadingKeyword = None })],
+                             None, (4,31--4,43), { LeadingKeyword = None
+                                                   MutableKeyword = None })],
                        PreXmlDocEmpty, None, (4,10--4,43), { BarRange = None }),
                     None, PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
                     None, (4,0--4,43)), Some (4,44--4,48),

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigRecordShouldEndAtLastMember.fsi.bsl
@@ -18,7 +18,8 @@ SigFile
                            ([], false, Some Level,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,6--4,16), { LeadingKeyword = None })],
+                            None, (4,6--4,16), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--4,18)), (4,4--4,18)),
                   [Member
                      (SynValSig

--- a/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/RangeOfSynTypeDefnSigSimpleShouldEndAtLastVal.fsi.bsl
@@ -17,8 +17,8 @@ SigFile
                          LongIdent (SynLongIdent ([int], [], [None])), false,
                          PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                          None, (4,4--4,23),
-                         { LeadingKeyword = Some (Val (4,4--4,7)) }),
-                      (4,4--4,23));
+                         { LeadingKeyword = Some (Val (4,4--4,7))
+                           MutableKeyword = None }), (4,4--4,23));
                    ValField
                      (SynField
                         ([], false, Some SomeThingElse,
@@ -28,8 +28,8 @@ SigFile
                             (5,24--5,37), { ArrowRange = (5,28--5,30) }), false,
                          PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                          None, (5,4--5,37),
-                         { LeadingKeyword = Some (Val (5,4--5,7)) }),
-                      (5,4--5,37))], (3,5--5,37),
+                         { LeadingKeyword = Some (Val (5,4--5,7))
+                           MutableKeyword = None }), (5,4--5,37))], (3,5--5,37),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = None
                     WithKeyword = Some (3,20--3,24) })], (3,0--5,37))],

--- a/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi.bsl
+++ b/tests/service/data/SyntaxTree/SignatureType/SynTypeDefnSigWithUnionContainsTheRangeOfTheEqualsSign.fsi.bsl
@@ -22,7 +22,8 @@ SigFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((5,12), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (5,12--5,15), { LeadingKeyword = None })],
+                                  None, (5,12--5,15), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((5,0), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,2--5,15), { BarRange = Some (5,0--5,1) });
                          SynUnionCase
@@ -33,13 +34,15 @@ SigFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((6,15), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (6,15--6,18), { LeadingKeyword = None });
+                                  None, (6,15--6,18), { LeadingKeyword = None
+                                                        MutableKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((6,21), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (6,21--6,24), { LeadingKeyword = None })],
+                                  None, (6,21--6,24), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((6,0), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (6,2--6,24), { BarRange = Some (6,0--6,1) })],
                         (5,0--6,24)), (5,0--6,24)), [], (4,5--6,24),

--- a/tests/service/data/SyntaxTree/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/RangeOfAttributesShouldBeIncludedInRecursiveTypes.fs.bsl
@@ -51,7 +51,8 @@ ImplFile
                                      [(4,34--4,35)], Some (4,38--4,39), false,
                                      (4,15--4,39)), false,
                                   PreXmlDoc ((4,15), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,15--4,39), { LeadingKeyword = None })],
+                                  None, (4,15--4,39), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,6--4,39), { BarRange = Some (4,4--4,5) })],
                         (4,4--4,39)), (4,4--4,39)), [], None, (2,0--4,39),
@@ -91,7 +92,8 @@ ImplFile
                            ([], false, Some Hash,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((8,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (8,8--8,18), { LeadingKeyword = None });
+                            None, (8,8--8,18), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, Some Foo,
                             App
@@ -102,7 +104,8 @@ ImplFile
                                [(9,20--9,21)], Some (9,24--9,25), false,
                                (9,14--9,25)), false,
                             PreXmlDoc ((9,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (9,8--9,25), { LeadingKeyword = None })],
+                            None, (9,8--9,25), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (7,4--10,5)), (7,4--10,5)), [], None, (6,4--10,5),
                   { LeadingKeyword = And (6,0--6,3)
                     EqualsRange = Some (6,56--6,57)

--- a/tests/service/data/SyntaxTree/Type/Record - Access 01.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 01.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    {
+        internal
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Access 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 01.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Access 01.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, None, FromParseError (5,16--5,16), false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,16), { LeadingKeyword = None })],
+                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,5));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected symbol '}' in field declaration. Expected identifier or other token.
+(5,8)-(6,5) parse error Accessibility modifiers are not permitted on record fields. Use 'type R = internal ...' or 'type R = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/Type/Record - Access 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 01.fs.bsl
@@ -16,7 +16,8 @@ ImplFile
                         [SynField
                            ([], false, None, FromParseError (5,16--5,16), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,16), { LeadingKeyword = None })],
+                            None, (5,8--5,16), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record - Access 02.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 02.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    {
+        mutable internal
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Access 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 02.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Access 02.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, None, FromParseError (5,24--5,24), true,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,24), { LeadingKeyword = None })],
+                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,5));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected symbol '}' in field declaration. Expected identifier or other token.
+(5,8)-(6,5) parse error Accessibility modifiers are not permitted on record fields. Use 'type R = internal ...' or 'type R = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/Type/Record - Access 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 02.fs.bsl
@@ -16,8 +16,10 @@ ImplFile
                         [SynField
                            ([], false, None, FromParseError (5,24--5,24), true,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,24), { LeadingKeyword = None })],
-                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                            None, (5,8--5,24),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (5,8--5,15) })], (4,4--6,5)),
+                     (4,4--6,5)), [], None, (3,5--6,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--6,5));

--- a/tests/service/data/SyntaxTree/Type/Record - Access 03.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 03.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    {
+        mutable internal F: int
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Access 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 03.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Access 03.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F,
+                            LongIdent (SynLongIdent ([int], [], [None])), true,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,31), { LeadingKeyword = None })],
+                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,5));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,8)-(5,31) parse error Accessibility modifiers are not permitted on record fields. Use 'type R = internal ...' or 'type R = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/Type/Record - Access 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 03.fs.bsl
@@ -17,8 +17,10 @@ ImplFile
                            ([], false, Some F,
                             LongIdent (SynLongIdent ([int], [], [None])), true,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,31), { LeadingKeyword = None })],
-                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                            None, (5,8--5,31),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (5,8--5,15) })], (4,4--6,5)),
+                     (4,4--6,5)), [], None, (3,5--6,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--6,5));

--- a/tests/service/data/SyntaxTree/Type/Record - Access 04.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 04.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    {
+        internal F: int
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Access 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 04.fs.bsl
@@ -17,7 +17,8 @@ ImplFile
                            ([], false, Some F,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,23), { LeadingKeyword = None })],
+                            None, (5,8--5,23), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record - Access 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Access 04.fs.bsl
@@ -1,0 +1,31 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Access 04.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,23), { LeadingKeyword = None })],
+                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,5));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,8)-(5,23) parse error Accessibility modifiers are not permitted on record fields. Use 'type R = internal ...' or 'type R = private ...' to give an accessibility to the whole representation.

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 01.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 01.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    {
+        mutable
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 01.fs.bsl
@@ -1,0 +1,30 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Mutable 01.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, None, FromParseError (5,15--5,15), true,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15), { LeadingKeyword = None })],
+                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,5));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected symbol '}' in field declaration. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 01.fs.bsl
@@ -16,8 +16,10 @@ ImplFile
                         [SynField
                            ([], false, None, FromParseError (5,15--5,15), true,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15), { LeadingKeyword = None })],
-                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                            None, (5,8--5,15),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (5,8--5,15) })], (4,4--6,5)),
+                     (4,4--6,5)), [], None, (3,5--6,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--6,5));

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 02.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 02.fs
@@ -1,0 +1,9 @@
+module Module
+
+type R =
+    {
+        F1: int
+        mutable
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 02.fs.bsl
@@ -17,12 +17,15 @@ ImplFile
                            ([], false, Some F1,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15), { LeadingKeyword = None });
+                            None, (5,8--5,15), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, None, FromParseError (6,15--6,15), true,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--6,15), { LeadingKeyword = None })],
-                        (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
+                            None, (6,8--6,15),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (6,8--6,15) })], (4,4--7,5)),
+                     (4,4--7,5)), [], None, (3,5--7,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--7,5));

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 02.fs.bsl
@@ -1,0 +1,35 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Mutable 02.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15), { LeadingKeyword = None });
+                         SynField
+                           ([], false, None, FromParseError (6,15--6,15), true,
+                            PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,8--6,15), { LeadingKeyword = None })],
+                        (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--7,5));
+           Expr (Const (Unit, (9,0--9,2)), (9,0--9,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--9,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(7,4)-(7,5) parse error Unexpected symbol '}' in field declaration. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 03.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 03.fs
@@ -1,0 +1,9 @@
+module Module
+
+type R =
+    {
+        mutable
+        F2: int
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 03.fs.bsl
@@ -16,12 +16,15 @@ ImplFile
                         [SynField
                            ([], false, None, FromParseError (5,15--5,15), true,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15), { LeadingKeyword = None });
+                            None, (5,8--5,15),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (5,8--5,15) });
                          SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--6,15), { LeadingKeyword = None })],
+                            None, (6,8--6,15), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 03.fs.bsl
@@ -1,0 +1,35 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Mutable 03.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, None, FromParseError (5,15--5,15), true,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,8--6,15), { LeadingKeyword = None })],
+                        (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--7,5));
+           Expr (Const (Unit, (9,0--9,2)), (9,0--9,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--9,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,16)-(6,8) parse error Incomplete structured construct at or before this point in field declaration. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 04.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 04.fs
@@ -1,0 +1,10 @@
+module Module
+
+type R =
+    {
+        F1: int
+        mutable
+        F3: int
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 04.fs.bsl
@@ -1,0 +1,40 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Mutable 04.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15), { LeadingKeyword = None });
+                         SynField
+                           ([], false, None, FromParseError (6,15--6,15), true,
+                            PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,8--6,15), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F3,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((7,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (7,8--7,15), { LeadingKeyword = None })],
+                        (4,4--8,5)), (4,4--8,5)), [], None, (3,5--8,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--8,5));
+           Expr (Const (Unit, (10,0--10,2)), (10,0--10,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--10,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,16)-(7,8) parse error Incomplete structured construct at or before this point in field declaration. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 04.fs.bsl
@@ -17,16 +17,20 @@ ImplFile
                            ([], false, Some F1,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15), { LeadingKeyword = None });
+                            None, (5,8--5,15), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, None, FromParseError (6,15--6,15), true,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--6,15), { LeadingKeyword = None });
+                            None, (6,8--6,15),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (6,8--6,15) });
                          SynField
                            ([], false, Some F3,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((7,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (7,8--7,15), { LeadingKeyword = None })],
+                            None, (7,8--7,15), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--8,5)), (4,4--8,5)), [], None, (3,5--8,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 05.fs
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 05.fs
@@ -1,0 +1,10 @@
+module Module
+
+type R =
+    {
+        F1: int
+        mutable F2: int
+        F3: int
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 05.fs.bsl
@@ -17,17 +17,21 @@ ImplFile
                            ([], false, Some F1,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,15), { LeadingKeyword = None });
+                            None, (5,8--5,15), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, Some F2,
                             LongIdent (SynLongIdent ([int], [], [None])), true,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--6,23), { LeadingKeyword = None });
+                            None, (6,8--6,23),
+                            { LeadingKeyword = None
+                              MutableKeyword = Some (6,8--6,15) });
                          SynField
                            ([], false, Some F3,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((7,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (7,8--7,15), { LeadingKeyword = None })],
+                            None, (7,8--7,15), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--8,5)), (4,4--8,5)), [], None, (3,5--8,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record - Mutable 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record - Mutable 05.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record - Mutable 05.fs", false, QualifiedNameOfFile Module, [],
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,8--5,15), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F2,
+                            LongIdent (SynLongIdent ([int], [], [None])), true,
+                            PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,8--6,23), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F3,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((7,8), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (7,8--7,15), { LeadingKeyword = None })],
+                        (4,4--8,5)), (4,4--8,5)), [], None, (3,5--8,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--8,5));
+           Expr (Const (Unit, (10,0--10,2)), (10,0--10,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--10,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Record 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 01.fs.bsl
@@ -20,7 +20,7 @@ ImplFile
                          SynField
                            ([], false, Some T, FromParseError (6,9--6,9), false,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--7,5), { LeadingKeyword = None })],
+                            None, (6,8--6,9), { LeadingKeyword = None })],
                         (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,8--3,9)

--- a/tests/service/data/SyntaxTree/Type/Record 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 01.fs.bsl
@@ -16,11 +16,13 @@ ImplFile
                            ([], false, Some Invest,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,19), { LeadingKeyword = None });
+                            None, (5,8--5,19), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, Some T, FromParseError (6,9--6,9), false,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--6,9), { LeadingKeyword = None })],
+                            None, (6,8--6,9), { LeadingKeyword = None
+                                                MutableKeyword = None })],
                         (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,8--3,9)

--- a/tests/service/data/SyntaxTree/Type/Record 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 02.fs.bsl
@@ -21,7 +21,7 @@ ImplFile
                            ([], false, Some T, FromParseError (6,11--6,11),
                             false,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--7,5), { LeadingKeyword = None })],
+                            None, (6,8--6,11), { LeadingKeyword = None })],
                         (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,8--3,9)

--- a/tests/service/data/SyntaxTree/Type/Record 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 02.fs.bsl
@@ -16,12 +16,14 @@ ImplFile
                            ([], false, Some Invest,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,8--5,19), { LeadingKeyword = None });
+                            None, (5,8--5,19), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, Some T, FromParseError (6,11--6,11),
                             false,
                             PreXmlDoc ((6,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,8--6,11), { LeadingKeyword = None })],
+                            None, (6,8--6,11), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--7,5)), (4,4--7,5)), [], None, (3,5--7,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,8--3,9)

--- a/tests/service/data/SyntaxTree/Type/Record 03.fs
+++ b/tests/service/data/SyntaxTree/Type/Record 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+type R =
+    { }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 03.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple (Record (None, [], (4,4--4,7)), (4,4--4,7)), [], None,
+                  (3,5--4,7), { LeadingKeyword = Type (3,0--3,4)
+                                EqualsRange = Some (3,7--3,8)
+                                WithKeyword = None })], (3,0--4,7));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,6)-(4,7) parse error Expecting record field

--- a/tests/service/data/SyntaxTree/Type/Record 04.fs
+++ b/tests/service/data/SyntaxTree/Type/Record 04.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    {
+      ;
+    }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 04.fs.bsl
@@ -15,7 +15,8 @@ ImplFile
                         [SynField
                            ([], false, None, FromParseError (5,6--5,6), false,
                             PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,6--5,6), { LeadingKeyword = None })],
+                            None, (5,6--5,6), { LeadingKeyword = None
+                                                MutableKeyword = None })],
                         (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 04.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, None, FromParseError (5,6--5,6), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,6), { LeadingKeyword = None })],
+                        (4,4--6,5)), (4,4--6,5)), [], None, (3,5--6,5),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,5));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,6)-(5,7) parse error Unexpected symbol ';' in field declaration. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Type/Record 05.fs
+++ b/tests/service/data/SyntaxTree/Type/Record 05.fs
@@ -1,0 +1,8 @@
+module Module
+
+type R =
+    { F1: int;
+      ;
+      F3: int }
+
+()

--- a/tests/service/data/SyntaxTree/Type/Record 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 05.fs.bsl
@@ -16,16 +16,19 @@ ImplFile
                            ([], false, Some F1,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (4,6--4,13), { LeadingKeyword = None });
+                            None, (4,6--4,13), { LeadingKeyword = None
+                                                 MutableKeyword = None });
                          SynField
                            ([], false, None, FromParseError (5,6--5,6), false,
                             PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,6--5,6), { LeadingKeyword = None });
+                            None, (5,6--5,6), { LeadingKeyword = None
+                                                MutableKeyword = None });
                          SynField
                            ([], false, Some F3,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((6,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (6,6--6,13), { LeadingKeyword = None })],
+                            None, (6,6--6,13), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (4,4--6,15)), (4,4--6,15)), [], None, (3,5--6,15),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)

--- a/tests/service/data/SyntaxTree/Type/Record 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Record 05.fs.bsl
@@ -1,0 +1,39 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Record 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [R],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Record
+                       (None,
+                        [SynField
+                           ([], false, Some F1,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((4,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,13), { LeadingKeyword = None });
+                         SynField
+                           ([], false, None, FromParseError (5,6--5,6), false,
+                            PreXmlDoc ((5,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,6), { LeadingKeyword = None });
+                         SynField
+                           ([], false, Some F3,
+                            LongIdent (SynLongIdent ([int], [], [None])), false,
+                            PreXmlDoc ((6,6), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (6,6--6,13), { LeadingKeyword = None })],
+                        (4,4--6,15)), (4,4--6,15)), [], None, (3,5--6,15),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--6,15));
+           Expr (Const (Unit, (8,0--8,2)), (8,0--8,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--8,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,6)-(5,7) parse error Unexpected symbol ';' in field declaration. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Type/Struct 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Struct 02.fs.bsl
@@ -17,8 +17,9 @@ ImplFile
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,8--5,22),
-                            { LeadingKeyword = Some (Val (5,8--5,11)) }),
-                         (5,8--5,22))], (4,4--6,7)), [], None, (3,5--6,7),
+                            { LeadingKeyword = Some (Val (5,8--5,11))
+                              MutableKeyword = None }), (5,8--5,22))],
+                     (4,4--6,7)), [], None, (3,5--6,7),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--6,7))],

--- a/tests/service/data/SyntaxTree/Type/Struct 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Struct 02.fs.bsl
@@ -16,7 +16,7 @@ ImplFile
                            ([], false, Some Field,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((5,8), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (5,12--5,22),
+                            None, (5,8--5,22),
                             { LeadingKeyword = Some (Val (5,8--5,11)) }),
                          (5,8--5,22))], (4,4--6,7)), [], None, (3,5--6,7),
                   { LeadingKeyword = Type (3,0--3,4)

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithRecordContainsTheRangeOfTheWithKeyword.fs.bsl
@@ -20,7 +20,8 @@ ImplFile
                            ([], false, Some Bar,
                             LongIdent (SynLongIdent ([int], [], [None])), false,
                             PreXmlDoc ((3,6), FSharp.Compiler.Xml.XmlDocCollector),
-                            None, (3,6--3,15), { LeadingKeyword = None })],
+                            None, (3,6--3,15), { LeadingKeyword = None
+                                                 MutableKeyword = None })],
                         (3,4--3,17)), (3,4--3,17)),
                   [Member
                      (SynBinding

--- a/tests/service/data/SyntaxTree/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/SynTypeDefnWithUnionContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -23,7 +23,8 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (3,16--3,19), { LeadingKeyword = None })],
+                                  None, (3,16--3,19), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,6--3,19), { BarRange = Some (3,4--3,5) });
                          SynUnionCase
@@ -34,13 +35,15 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,19), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,19--4,22), { LeadingKeyword = None });
+                                  None, (4,19--4,22), { LeadingKeyword = None
+                                                        MutableKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,25), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,25--4,28), { LeadingKeyword = None })],
+                                  None, (4,25--4,28), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,6--4,28), { BarRange = Some (4,4--4,5) })],
                         (3,4--4,28)), (3,4--4,28)), [], None, (2,5--4,28),

--- a/tests/service/data/SyntaxTree/UnionCase/Missing keyword of.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing keyword of.fs.bsl
@@ -37,7 +37,8 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((7,12), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (7,12--7,18), { LeadingKeyword = None })],
+                                  None, (7,12--7,18), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((7,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (7,6--7,18), { BarRange = Some (7,4--7,5) });
                          SynUnionCase
@@ -48,7 +49,8 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((8,15), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (8,15--8,18), { LeadingKeyword = None })],
+                                  None, (8,15--8,18), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((8,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (8,6--8,18), { BarRange = Some (8,4--8,5) });
                          SynUnionCase
@@ -58,7 +60,8 @@ ImplFile
                                  ([], false, None,
                                   StaticConstant (Int32 4, (9,12--9,13)), false,
                                   PreXmlDoc ((9,12), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (9,12--9,13), { LeadingKeyword = None })],
+                                  None, (9,12--9,13), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((9,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (9,6--9,13), { BarRange = Some (9,4--9,5) })],
                         (6,4--9,13)), (6,4--9,13)), [], None, (5,5--9,13),

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 03.fs.bsl
@@ -21,7 +21,8 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,7), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,7--4,10), { LeadingKeyword = None })],
+                                  None, (4,7--4,10), { LeadingKeyword = None
+                                                       MutableKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,4--4,10), { BarRange = None })],
                         (4,4--4,10)), (4,4--4,10)), [], None, (3,5--4,10),

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 04.fs.bsl
@@ -25,7 +25,8 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((5,9), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (5,9--5,12), { LeadingKeyword = None })],
+                                  None, (5,9--5,12), { LeadingKeyword = None
+                                                       MutableKeyword = None })],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,6--5,12), { BarRange = Some (5,4--5,5) });
                          SynUnionCase

--- a/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Missing name 05.fs.bsl
@@ -25,7 +25,8 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((5,18), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (5,18--5,21), { LeadingKeyword = None })],
+                                  None, (5,18--5,21), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (5,6--5,21), { BarRange = Some (5,4--5,5) });
                          SynUnionCase

--- a/tests/service/data/SyntaxTree/UnionCase/MultipleSynUnionCasesHaveBarRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/MultipleSynUnionCasesHaveBarRange.fs.bsl
@@ -21,7 +21,8 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((3,13), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (3,13--3,19), { LeadingKeyword = None })],
+                                  None, (3,13--3,19), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((3,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,6--3,19), { BarRange = Some (3,4--3,5) });
                          SynUnionCase
@@ -32,7 +33,8 @@ ImplFile
                                   LongIdent (SynLongIdent ([int], [], [None])),
                                   false,
                                   PreXmlDoc ((4,14), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (4,14--4,17), { LeadingKeyword = None })],
+                                  None, (4,14--4,17), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (4,6--4,17), { BarRange = Some (4,4--4,5) })],
                         (3,4--4,17)), (3,4--4,17)), [], None, (2,5--4,17),

--- a/tests/service/data/SyntaxTree/UnionCase/PrivateKeywordHasRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/PrivateKeywordHasRange.fs.bsl
@@ -21,7 +21,8 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((9,14), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (9,14--9,20), { LeadingKeyword = None })],
+                                  None, (9,14--9,20), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((9,4), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (9,6--9,20), { BarRange = Some (9,4--9,5) })],
                         (7,4--9,20)), (7,4--9,20)), [], None, (2,5--9,20),

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 01.fs.bsl
@@ -26,7 +26,8 @@ ImplFile
                                      (3,20--3,30), { ArrowRange = (3,24--3,26) }),
                                   false,
                                   PreXmlDoc ((3,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (3,20--3,30), { LeadingKeyword = None })],
+                                  None, (3,20--3,30), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((3,11), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,13--3,30), { BarRange = Some (3,11--3,12) })],
                         (3,11--3,30)), (3,11--3,30)), [], None, (3,5--3,30),

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 02.fs.bsl
@@ -26,7 +26,8 @@ ImplFile
                                      (3,19--3,29), { ArrowRange = (3,23--3,25) }),
                                   false,
                                   PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (3,16--3,29), { LeadingKeyword = None })],
+                                  None, (3,16--3,29), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((3,9), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,11--3,29), { BarRange = Some (3,9--3,10) })],
                         (3,9--3,29)), (3,9--3,29)), [], None, (3,5--3,29),

--- a/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/Recover Function Type 03.fs.bsl
@@ -31,7 +31,8 @@ ImplFile
                                      (3,16--3,33), { ArrowRange = (3,20--3,22) }),
                                   false,
                                   PreXmlDoc ((3,16), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (3,16--3,33), { LeadingKeyword = None })],
+                                  None, (3,16--3,33), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((3,9), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,11--3,33), { BarRange = Some (3,9--3,10) })],
                         (3,9--3,33)), (3,9--3,33)), [], None, (3,5--3,33),

--- a/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseHasBarRange.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseHasBarRange.fs.bsl
@@ -21,7 +21,8 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((2,20), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (2,20--2,26), { LeadingKeyword = None })],
+                                  None, (2,20--2,26), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (2,13--2,26), { BarRange = Some (2,11--2,12) })],
                         (2,11--2,26)), (2,11--2,26)), [], None, (2,5--2,26),

--- a/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseWithoutBar.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/SingleSynUnionCaseWithoutBar.fs.bsl
@@ -21,7 +21,8 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((2,18), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (2,18--2,24), { LeadingKeyword = None })],
+                                  None, (2,18--2,24), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
                             PreXmlDoc ((2,11), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (2,11--2,24), { BarRange = None })],
                         (2,11--2,24)), (2,11--2,24)), [], None, (2,5--2,24),

--- a/tests/service/data/SyntaxTree/UnionCase/UnionCaseFieldsCanHaveComments.fs.bsl
+++ b/tests/service/data/SyntaxTree/UnionCase/UnionCaseFieldsCanHaveComments.fs.bsl
@@ -21,13 +21,15 @@ ImplFile
                                   LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
                                   PreXmlDoc ((6,2), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (5,2--6,15), { LeadingKeyword = None });
+                                  None, (5,2--6,15), { LeadingKeyword = None
+                                                       MutableKeyword = None });
                                SynField
                                  ([], false, None,
                                   LongIdent (SynLongIdent ([bool], [], [None])),
                                   false,
                                   PreXmlDoc ((8,2), FSharp.Compiler.Xml.XmlDocCollector),
-                                  None, (7,2--8,6), { LeadingKeyword = None })],
+                                  None, (7,2--8,6), { LeadingKeyword = None
+                                                      MutableKeyword = None })],
                             PreXmlDoc ((4,0), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,0--8,6), { BarRange = Some (4,0--4,1) })],
                         (3,0--8,6)), (3,0--8,6)), [], None, (2,5--8,6),


### PR DESCRIPTION
Adds recovery for some missing cases in record type definitions and `val` field definitions. Also fixes some wrong ranges from previously recovered things.

```fsharp
type R =
    { }
```

```fsharp
type R =
    { ; }
```

```fsharp
type R =
    { mutable }
```

```fsharp
type R =
    { mutable internal }
```

```fsharp
type R =
    val mutable
```

```fsharp
type R =
    val mutable internal
```