### PR TITLE
Fixes #16359 - correctly handle imports with 0 length public key tokens

### DIFF
--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -1946,7 +1946,12 @@ and seekReadAssemblyManifest (ctxt: ILMetadataReader) pectxt idx =
         Name = name
         AuxModuleHashAlgorithm = hash
         SecurityDeclsStored = ctxt.securityDeclsReader_Assembly
-        PublicKey = pubkey
+        PublicKey =
+            // The runtime and C# treat a 0 length publicKey as an unsigned assembly, so if a public record exists with a length of 0
+            // treat it as unsigned
+            match pubkey with
+            | Some pkBytes when pkBytes.Length > 0 -> pubkey
+            | _ -> None
         Version = Some(ILVersionInfo(v1, v2, v3, v4))
         Locale = readStringHeapOption ctxt localeIdx
         CustomAttrsStored = ctxt.customAttrsReader_Assembly


### PR DESCRIPTION
## Description

When the F# compiler imported an assembly, if the assembly had a publickey token record that was empty, I.e a 0 length Public key record, it treated the assembly as having a public key.  When we subsequently wrote an assembly reference to this assembly, we would add a public key made up of a garbage value.  This particular form is not usually produced by MS compilers and so it has escaped detection, however, some obfuscation programs when obfuscating signed assemblies will make the assembly unsigned by zeroing out the public key record length rather than the public key address.  This change to the compiler ensures that when we import types we treat references to 0 length public keys as if there was no public key.


Fixes #16359 

## Checklist
- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succint description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Examples of release notes entries:
    > - Respect line limit in quick info popup - https://github.com/dotnet/fsharp/pull/16208
    > - More inlines for Result module - https://github.com/dotnet/fsharp/pull/16106
    > - Miscellaneous fixes to parens analysis - https://github.com/dotnet/fsharp/pull/16262
    >

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**