### PR TITLE
Parens: Fix some some parenthesization corner-cases in record expressions

### DIFF
--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -919,6 +919,39 @@ in x
 
                 // AnonRecd
                 "id ({||})", "id {||}"
+                "{| A = (fun () -> ()) |}", "{| A = fun () -> () |}"
+                "{| A = (fun () -> ()); B = 3 |}", "{| A = (fun () -> ()); B = 3 |}"
+                "{| A = (let x = 3 in x); B = 3 |}", "{| A = (let x = 3 in x); B = 3 |}"
+                "{| (try {||} with _ -> reraise ()) with A = 4 |}", "{| (try {||} with _ -> reraise ()) with A = 4 |}"
+
+                "
+                {| A = (fun () -> ())
+                   B = 3 |}
+                ",
+                "
+                {| A = fun () -> ()
+                   B = 3 |}
+                "
+
+                "
+                {| A = (let x = 3 in x)
+                   B = 3 |}
+                ",
+                "
+                {| A = let x = 3 in x
+                   B = 3 |}
+                "
+
+                "
+                {| (try {||} with _ -> reraise ())
+                    with
+                    A = 4 |}
+                ",
+                "
+                {| (try {||} with _ -> reraise ())
+                    with
+                    A = 4 |}
+                "
 
                 // ArrayOrList
                 "id ([])", "id []"
@@ -928,6 +961,49 @@ in x
 
                 // Record
                 "id ({ A = x })", "id { A = x }"
+                "{ A = (fun () -> ()) }", "{ A = fun () -> () }"
+                "{ A = (fun () -> ()); B = 3 }", "{ A = (fun () -> ()); B = 3 }"
+                "{ A = (let x = 3 in x); B = 3 }", "{ A = (let x = 3 in x); B = 3 }"
+                "{ A.B.C.D.X = (match () with () -> ()); A.B.C.D.Y = 3 }", "{ A.B.C.D.X = (match () with () -> ()); A.B.C.D.Y = 3 }"
+                "{ (try { A = 3 } with _ -> reraise ()) with A = 4 }", "{ (try { A = 3 } with _ -> reraise ()) with A = 4 }"
+
+                "
+                { A = (fun () -> ())
+                  B = 3 }
+                ",
+                "
+                { A = fun () -> ()
+                  B = 3 }
+                "
+
+                "
+                { A = (let x = 3 in x)
+                  B = 3 }
+                ",
+                "
+                { A = let x = 3 in x
+                  B = 3 }
+                "
+
+                "
+                { A.B.C.D.X = (match () with () -> ())
+                  A.B.C.D.Y = 3 }
+                ",
+                "
+                { A.B.C.D.X = match () with () -> ()
+                  A.B.C.D.Y = 3 }
+                "
+
+                "
+                { (try { A = 3 } with _ -> reraise ())
+                  with
+                    A = 4 }
+                ",
+                "
+                { (try { A = 3 } with _ -> reraise ())
+                  with
+                    A = 4 }
+                "
 
                 // New
                 "id (new obj())", "id (new obj())"


### PR DESCRIPTION
Another followup to #16079.

## Description

* Keep parens around problematic expressions (sequential, `try`-`with`/`finally`, matches, lambdas, etc.) in record copy expressions.

   ```fsharp
   { (try { A = 3 } with _ -> reraise ()) with A = 4 }
   ```

* Keep parens around dangling problematic expressions in record field assignments when there are subsequent record fields on the same line.


   ```fsharp
   { A = (fun x -> printfn $"{x}"); B = 3 }
   ```

## Checklist

- [x] Test cases added
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succint description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Examples of release notes entries:
    > - Respect line limit in quick info popup - https://github.com/dotnet/fsharp/pull/16208
    > - More inlines for Result module - https://github.com/dotnet/fsharp/pull/16106
    > - Miscellaneous fixes to parens analysis - https://github.com/dotnet/fsharp/pull/16262
    >

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**