### PR TITLE
Nullness-related aggressive trimming of FSharp.Core

### DIFF
--- a/src/FSharp.Core/ILLink.LinkAttributes.xml
+++ b/src/FSharp.Core/ILLink.LinkAttributes.xml
@@ -169,5 +169,11 @@
     <type fullname="Microsoft.FSharp.Core.CompilerServices.TypeProviderXmlDocAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="System.Runtime.CompilerServices.NullableAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.NullableContextAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
   </assembly>
 </linker>

--- a/src/FSharp.Core/ILLink.Substitutions.xml
+++ b/src/FSharp.Core/ILLink.Substitutions.xml
@@ -4,5 +4,10 @@
     <resource name="FSharpOptimizationInfo.FSharp.Core" action="remove" />
     <resource name="FSharpSignatureCompressedData.FSharp.Core" action="remove" />
     <resource name="FSharpSignatureInfo.FSharp.Core" action="remove" />
+
+    <resource name="FSharpOptimizationCompressedDataB.FSharp.Core" action="remove" />
+    <resource name="FSharpOptimizationDataB.FSharp.Core" action="remove" />
+    <resource name="FSharpSignatureCompressedDataB.FSharp.Core" action="remove" />
+    <resource name="FSharpSignatureDataB.FSharp.Core" action="remove" />
   </assembly>
 </linker>

--- a/tests/AheadOfTime/Trimming/check.ps1
+++ b/tests/AheadOfTime/Trimming/check.ps1
@@ -1,7 +1,6 @@
 function CheckTrim($root, $tfm, $outputfile, $expected_len) {
     Write-Host "Publish and Execute: ${tfm} - ${root}"
     Write-Host "Expecting ${expected_len}"
-    Write-Host "CompressAllMetadata value: ${compressAllMetadata}"
 
     $cwd = Get-Location
     Set-Location (Join-Path $PSScriptRoot "${root}")
@@ -39,11 +38,9 @@ function CheckTrim($root, $tfm, $outputfile, $expected_len) {
 
 # NOTE: Trimming now errors out on desktop TFMs, as shown below:
 # error NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.
-$compressAllMetadata = $env:_kind -eq "-compressAllMetadata"
-$expectedForSelfContained = if ($compressAllMetadata) {288256} else {288256}
 
 # Check net7.0 trimmed assemblies
-CheckTrim -root "SelfContained_Trimming_Test" -tfm "net8.0" -outputfile "FSharp.Core.dll" -expected_len $expectedForSelfContained
+CheckTrim -root "SelfContained_Trimming_Test" -tfm "net8.0" -outputfile "FSharp.Core.dll" -expected_len 288256
 
 # Check net7.0 trimmed assemblies
 CheckTrim -root "StaticLinkedFSharpCore_Trimming_Test" -tfm "net8.0" -outputfile "StaticLinkedFSharpCore_Trimming_Test.dll" -expected_len 8821760 

--- a/tests/AheadOfTime/Trimming/check.ps1
+++ b/tests/AheadOfTime/Trimming/check.ps1
@@ -40,7 +40,7 @@ function CheckTrim($root, $tfm, $outputfile, $expected_len) {
 # NOTE: Trimming now errors out on desktop TFMs, as shown below:
 # error NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.
 $compressAllMetadata = $env:_kind -eq "-compressAllMetadata"
-$expectedForSelfContained = if ($compressAllMetadata) {300032} else {288256}
+$expectedForSelfContained = if ($compressAllMetadata) {288256} else {288256}
 
 # Check net7.0 trimmed assemblies
 CheckTrim -root "SelfContained_Trimming_Test" -tfm "net8.0" -outputfile "FSharp.Core.dll" -expected_len $expectedForSelfContained


### PR DESCRIPTION
(this is not merging into main, but into the nullness feature branch)

Adds config to trim out nullness related part of FSharp.Core.
They are a compiler(s)-only feature, without affecting runtime.