### PR TITLE
Name resolution: don't search extension members in type abbreviations

### DIFF
--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -578,8 +578,8 @@ let private GetCSharpStyleIndexedExtensionMembersForTyconRef (amap: Import.Impor
     let pri = NextExtensionMethodPriority()
     
     if g.langVersion.SupportsFeature(LanguageFeature.CSharpExtensionAttributeNotRequired) then
-        let csharpStyleExtensionMembers = 
-            if IsTyconRefUsedForCSharpStyleExtensionMembers g m tcrefOfStaticClass || tcrefOfStaticClass.IsLocalRef then
+        let csharpStyleExtensionMembers =
+            if IsTyconRefUsedForCSharpStyleExtensionMembers g m tcrefOfStaticClass || (tcrefOfStaticClass.IsLocalRef && not tcrefOfStaticClass.IsTypeAbbrev) then
                 protectAssemblyExploration [] (fun () ->
                     let ty = generalizedTyconRef g tcrefOfStaticClass
                     GetImmediateIntrinsicMethInfosOfType (None, AccessorDomain.AccessibleFromSomeFSharpCode) g amap m ty

--- a/tests/FSharp.Compiler.ComponentTests/Language/ExtensionMethodTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ExtensionMethodTests.fs
@@ -609,3 +609,42 @@ type Bar =
             |> withReferences [ fsharp ]
         
         csharp |> compile |> shouldSucceed
+
+    [<Fact>]
+    let ``Abbreviated CSharp type with extensions`` () =
+        let csharp =
+            CSharp """
+namespace CSharpLib {
+
+    public interface I
+    {
+        public int P { get; }
+    }
+
+    public static class Ext
+    {
+        public static void M(this I i)
+        {
+        }
+    }
+}
+    """
+            |> withName "CSLib"
+        
+        let fsharp =
+            FSharp """
+module Module
+
+open CSharpLib
+
+module M =
+    type Ext2 = CSharpLib.Ext
+ 
+    let f (i: I) =
+        i.M()
+"""
+           |> withLangVersion80
+           |> withName "FSLib"
+           |> withReferences [ csharp ]
+        
+        fsharp |> compile |> shouldSucceed


### PR DESCRIPTION
Fixes #16389.

The internal errors are gone and the code completion works as expected now:

<img width="621" alt="Screenshot 2023-12-05 at 18 50 49" src="https://github.com/dotnet/fsharp/assets/3923587/a53de375-18ff-4cec-b3af-b8094507fb6a">