### PR TITLE
Parens: Keep parentheses around non-struct tuples in `&` patterns

### DIFF
--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -1627,7 +1627,10 @@ module UnnecessaryParentheses =
                 | SynPat.Tuple _, SynPat.As _
 
                 // x, (y, z)
+                // x & (y, z)
+                // (x, y) & z
                 | SynPat.Tuple _, SynPat.Tuple(isStruct = false)
+                | SynPat.Ands _, SynPat.Tuple(isStruct = false)
 
                 // A, (B | C)
                 // A & (B | C)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -1680,7 +1680,7 @@ module Patterns =
                                 Ands(pats |> List.updateAt i (Paren inner)), Ands(pats |> List.updateAt i inner)
                             else
                                 Ands(pats |> List.updateAt i (Paren inner)), Ands(pats |> List.updateAt i (Paren inner))
-                    | Ands pats, (Or _ | As _) ->
+                    | Ands pats, (Or _ | As _ | Tuple _) ->
                         for i, _ in Seq.indexed pats do
                             Ands(pats |> List.updateAt i (Paren inner)), Ands(pats |> List.updateAt i (Paren inner))
                     | Ands pats, _ ->


### PR DESCRIPTION
Another followup to #16079.

## Description

Keep parentheses around non-struct tuple patterns nested inside of `&` patterns, e.g.:

```fsharp
match x, y with
| (A, B) & (C, D) -> …
```

## Checklist

- [x] Test cases added.
- [ ]  Release notes entry updated.

As an aside: the AST-equivalence-asserting code that I originally wanted to include in #16079 does catch this, but it's still too messy and slow to include as part of the tests proper.