### PR TITLE
Added default dotnet-tools + additional tasks to launch them

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,12 +1,36 @@
 {
-  "version": 1,
   "isRoot": true,
   "tools": {
+    "dotnet-counters": {
+      "commands": ["dotnet-counters"],
+      "version": "8.0.460601"
+    },
+    "dotnet-dump": {
+      "commands": ["dotnet-dump"],
+      "version": "8.0.460601"
+    },
+    "dotnet-gcdump": {
+      "commands": ["dotnet-gcdump"],
+      "version": "8.0.460601"
+    },
+    "dotnet-sos": {
+      "commands": ["dotnet-sos"],
+      "version": "8.0.460601"
+    },
+    "dotnet-symbol": {
+      "commands": ["dotnet-symbol"],
+      "version": "1.0.460401"
+    },
+    "dotnet-trace": {
+      "commands": ["dotnet-trace"],
+      "version": "8.0.460601"
+    },
     "fantomas": {
-      "version": "6.2.3",
       "commands": [
         "fantomas"
-      ]
+      ],
+      "version": "6.2.3"
     }
-  }
+  },
+  "version": 1
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,17 +17,17 @@
     ],
     "configurations": [
         {
-            "name": "Launch FSI (Debug, .NET 7.0)",
+            "name": "Launch FSI",
             "type": "coreclr",
             "request": "launch",
             // TODO: Shall we assume that it's already been built, or build it every time we debug?
-            "preLaunchTask": "Build (Debug)",
+            "preLaunchTask": "${defaultBuildTask}",
             // If you have changed target frameworks, make sure to update the program p
             "program": "${workspaceFolder}/artifacts/bin/fsi/Debug/net8.0/fsi.dll",
             "args": [
                 "${input:fsiArgsPrompt}"
             ],
-            "cwd": "${workspaceFolder}/src",
+            "cwd": "${workspaceFolder}",
             "console": "integratedTerminal", // This is the default to be able to run in Codespaces.
             "internalConsoleOptions": "neverOpen",
             "suppressJITOptimizations": true,
@@ -46,14 +46,16 @@
             },
         },
         {
-            "name": "Launch FSC (Debug, .NET 7.0)",
+            "name": "Launch FSC",
             "type": "coreclr",
             "request": "launch",
             // TODO: Shall we assume that it's already been built, or build it every time we debug?
-            "preLaunchTask": "Build (Debug)",
+            "preLaunchTask": "${defaultBuildTask}",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/artifacts/bin/fsc/Debug/net8.0/fsc.dll",
             "args": [
+                "--targetprofile:netstandard",
+                "--simpleresolution",
                 "${input:fscArgsPrompt}"
             ],
             "cwd": "${workspaceFolder}",
@@ -75,7 +77,7 @@
             },
         },
         {
-            "name": "Attach to a .NET process",
+            "name": "Attach to a .NET process with debugger",
             "type": "coreclr",
             "request": "attach",
             "processId": "${command:pickProcess}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,20 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
+    "inputs": [
+        {
+            "id": "fscArgsPrompt",
+            "description": "Enter arguments for fsc",
+            "default": "",
+            "type": "promptString",
+        },
+        {
+            "id": "fsiArgsPrompt",
+            "description": "Enter arguments for fsi",
+            "default": "",
+            "type": "promptString",
+        }
+    ],
     "windows": {
         "options": {
             "shell": {
@@ -72,17 +86,54 @@
             "group": "build"
         },
         {
-            "label": "Update xlf files",
-            "command": "./build.sh",
+            "label": "Run FSI with dotnet-trace",
+            "command": "dotnet",
             "type": "shell",
-            "windows": {
-                "command": "${workspaceFolder}/Build.cmd"
-            },
-            "options": {
-                "env": {
-                    "UpdateXlfOnBuild": "true"
-                }
-            },
+            "args": [
+                "dotnet-trace",
+                "collect",
+                "--format",
+                "Speedscope",
+                "--",
+                "dotnet",
+                "${workspaceFolder}/artifacts/bin/fsi/Debug/net8.0/fsi.dll",
+                "${input:fsiArgsPrompt}"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "Run FSC with dotnet-trace",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "dotnet-trace",
+                "collect",
+                "--format",
+                "Speedscope",
+                "--",
+                "dotnet",
+                "${workspaceFolder}/artifacts/bin/fsc/Debug/net8.0/fsc.dll",
+                "--targetprofile:netstandard",
+                "--simpleresolution",
+                "${input:fscArgsPrompt}"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "Update xlf files",
+            "command": "dotnet",
+            "type": "shell",
+            "args": ["build", "-t:UpdateXlf", "src/Compiler/FSharp.Compiler.Service.fsproj"],
+            "problemMatcher": "$msCompile",
+            "group": "build"
+        },
+        {
+            "label": "Run Fantomas",
+            "command": "dotnet",
+            "args": ["fantomas", "."],
+            "type": "shell",
             "problemMatcher": "$msCompile",
             "group": "build"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,6 +14,11 @@
             "description": "Enter arguments for fsi",
             "default": "",
             "type": "promptString",
+        },
+        {
+            "id": "PickProcess",
+            "description": "Enter process id",
+            "type": "promptString"
         }
     ],
     "windows": {
@@ -117,6 +122,49 @@
                 "--targetprofile:netstandard",
                 "--simpleresolution",
                 "${input:fscArgsPrompt}"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "Create a process dump with dotnet-dump",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "dotnet-dump",
+                "collect",
+                "--diag",
+                "--crashreport",
+                "--type",
+                "Full",
+                "--process-id",
+                "${input:PickProcess}",
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "Create a process GC dump with dotnet-gcdump",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "dotnet-gcdump",
+                "collect",
+                "--process-id",
+                "${input:PickProcess}",
+            ],
+            "problemMatcher": "$msCompile",
+            "group": "none"
+        },
+        {
+            "label": "Collect process counters with dotnet-counters",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "dotnet-counters",
+                "collect",
+                "--process-id",
+                "${input:PickProcess}",
             ],
             "problemMatcher": "$msCompile",
             "group": "none"


### PR DESCRIPTION
Added tools I use the most. Now I need to manually install them in dev container every time, this will allow installing them in one command.

Also, added a task to launch fsi/fsc under trace, so it can be opened with speedscope later.