### PR TITLE
Checker: recover on unresolved type in 'inherit' member

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -1334,10 +1334,10 @@ module MutRecBindingChecking =
                             
                         // Phase2B: typecheck the argument to an 'inherits' call and build the new object expr for the inherit-call 
                         | Phase2AInherit (synBaseTy, arg, baseValOpt, m) ->
-                            let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Use WarnOnIWSAM.Yes envInstance tpenv synBaseTy
-                            let baseTy = baseTy |> convertToTypeWithMetadataIfPossible g
                             let inheritsExpr, tpenv =
-                                try 
+                                try
+                                   let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurence.Use WarnOnIWSAM.Yes envInstance tpenv synBaseTy
+                                   let baseTy = baseTy |> convertToTypeWithMetadataIfPossible g
                                    TcNewExpr cenv envInstance tpenv baseTy (Some synBaseTy.Range) true arg m
                                 with RecoverableException e ->
                                     errorRecovery e m

--- a/tests/service/Symbols.fs
+++ b/tests/service/Symbols.fs
@@ -1123,3 +1123,14 @@ let z = builder
                     if symbolUse.Symbol.DisplayName = "builder" then
                         (symbolUse.Range.StartLine, symbolUse.Range.StartColumn), symbolUse.IsFromComputationExpression
             ]
+
+module Member =
+    [<Test>]
+    let ``Inherit 01`` () =
+        let _, checkResults = getParseAndCheckResults """
+type T() =
+    inherit Foo()
+
+    let i = 1
+"""
+        assertHasSymbolUsages ["i"] checkResults


### PR DESCRIPTION
Fixes skipped analysis for types with unresolved types in `inherit` member:

<img width="188" alt="Screenshot 2023-12-13 at 16 50 04" src="https://github.com/dotnet/fsharp/assets/3923587/ddc3285f-b62e-4360-adea-7f3711725233">
