### PR TITLE
Many match clauses

### DIFF
--- a/src/Compiler/Checking/PatternMatchCompilation.fs
+++ b/src/Compiler/Checking/PatternMatchCompilation.fs
@@ -1733,7 +1733,7 @@ let isProblematicClause (clause: MatchClause) =
         let ips = investigationPoints clause.Pattern
         ips.Length > 0 && Span.exists id (ips.AsSpan (0, ips.Length - 1))
 
-let rec CompilePattern  g denv amap tcVal infoReader mExpr mMatch warnOnUnused actionOnFailure (origInputVal, origInputValTypars, origInputExprOpt) (clausesL: MatchClause list) inputTy resultTy =
+let CompilePattern  g denv amap tcVal infoReader mExpr mMatch warnOnUnused actionOnFailure (origInputVal, origInputValTypars, origInputExprOpt) (clausesL: MatchClause list) inputTy resultTy =
     match clausesL with
     | _ when List.exists isProblematicClause clausesL ->
 

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -246,6 +246,7 @@
     <Compile Include="TypeChecks\TyparNameTests.fs" />
     <Compile Include="TypeChecks\CheckTypeTests.fs" />
     <Compile Include="TypeChecks\TypeExtensions\PropertyShadowingTests.fs" />
+    <Compile Include="TypeChecks\PatternMatchTests.fs" />
     <Compile Include="CompilerOptions\fsc\checked\checked.fs" />
     <Compile Include="CompilerOptions\fsc\cliversion.fs" />
     <Compile Include="CompilerOptions\fsc\codepage\codepage.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/PatternMatchTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/PatternMatchTests.fs
@@ -1,0 +1,38 @@
+﻿namespace TypeChecks
+
+open Xunit
+open NUnit.Framework
+open FSharp.Test
+open FSharp.Test.Compiler
+
+module PatternMatchTests =
+
+    [<Fact>]
+    let ``Over 9000 match clauses`` () =
+        let max = 9001
+
+        let aSource =
+            let me =
+                [ 0 .. max ]
+                |> List.map (fun i -> $"    | %i{i} -> %i{i} + 1")
+                |> String.concat "\n"
+                |> sprintf """let f (a: int) : int =
+    match a with
+%s
+    | i -> i + 1
+            """
+
+            $"module A\n\n%s{me}"
+
+        let bSource = """module B
+
+open A
+
+let g = f 0
+"""
+
+        FSharp aSource
+        |> withAdditionalSourceFile (FsSource bSource)
+        |> typecheckResults
+        |> fun results ->
+            Assert.IsEmpty results.Diagnostics


### PR DESCRIPTION
## Description

I'm investigating whether we can delay the creation of the decision tree in a match expression. 
While doing this, I learned that you can't create a match clause with 9000 clauses.
It leads to a stackoverflow exception, I'm going to do some digging if that can be avoided.

Fixes # (issue, if applicable)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succint description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Examples of release notes entries:
    > - Respect line limit in quick info popup - https://github.com/dotnet/fsharp/pull/16208
    > - More inlines for Result module - https://github.com/dotnet/fsharp/pull/16106
    > - Miscellaneous fixes to parens analysis - https://github.com/dotnet/fsharp/pull/16262
    >

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**