### PR TITLE
Using Ordinal is both faster and more correct as our intent is to do …

### DIFF
--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -2,7 +2,6 @@
 
 module internal FSharp.Compiler.CheckFormatStrings
 
-open System
 open System.Text
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -59,7 +58,7 @@ let escapeDotnetFormatString str =
 
 [<return: Struct>]
 let (|PrefixedBy|_|) (prefix: string) (str: string) =
-    if str.StartsWith(prefix, StringComparison.Ordinal) then
+    if str.StartsWithOrdinal(prefix) then
         ValueSome prefix.Length
     else
         ValueNone
@@ -371,7 +370,7 @@ let parseFormatStringInternal
             // type checker.  They should always have '(...)' after for format string.
             let requireAndSkipInterpolationHoleFormat i =
                 if i < len && fmt[i] = '(' then
-                    let i2 = fmt.IndexOf(")", i+1, StringComparison.Ordinal)
+                    let i2 = fmt.IndexOfOrdinal(")", i+1)
                     if i2 = -1 then
                         failwith (FSComp.SR.forFormatInvalidForInterpolated3())
                     else

--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -2,6 +2,7 @@
 
 module internal FSharp.Compiler.CheckFormatStrings
 
+open System
 open System.Text
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -58,7 +59,7 @@ let escapeDotnetFormatString str =
 
 [<return: Struct>]
 let (|PrefixedBy|_|) (prefix: string) (str: string) =
-    if str.StartsWith prefix then
+    if str.StartsWith(prefix, StringComparison.Ordinal) then
         ValueSome prefix.Length
     else
         ValueNone
@@ -370,7 +371,7 @@ let parseFormatStringInternal
             // type checker.  They should always have '(...)' after for format string.
             let requireAndSkipInterpolationHoleFormat i =
                 if i < len && fmt[i] = '(' then
-                    let i2 = fmt.IndexOf(")", i+1)
+                    let i2 = fmt.IndexOf(")", i+1, StringComparison.Ordinal)
                     if i2 = -1 then
                         failwith (FSComp.SR.forFormatInvalidForInterpolated3())
                     else

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -42,6 +42,7 @@
 
 module internal FSharp.Compiler.ConstraintSolver
 
+open System
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -1713,7 +1714,7 @@ and SolveMemberConstraint (csenv: ConstraintSolverEnv) ignoreUnresolvedOverload 
                   None
 
           let anonRecdPropSearch = 
-              let isGetProp = nm.StartsWith "get_" 
+              let isGetProp = nm.StartsWith("get_", StringComparison.Ordinal)
               if not isRigid && isGetProp && memFlags.IsInstance  then
                   let propName = nm[4..]
                   let props = 

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -42,7 +42,6 @@
 
 module internal FSharp.Compiler.ConstraintSolver
 
-open System
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -1714,7 +1713,7 @@ and SolveMemberConstraint (csenv: ConstraintSolverEnv) ignoreUnresolvedOverload 
                   None
 
           let anonRecdPropSearch = 
-              let isGetProp = nm.StartsWith("get_", StringComparison.Ordinal)
+              let isGetProp = nm.StartsWithOrdinal("get_")
               if not isRigid && isGetProp && memFlags.IsInstance  then
                   let propName = nm[4..]
                   let props = 

--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -5,7 +5,6 @@ module internal FSharp.Compiler.MethodCalls
 
 open Internal.Utilities
 
-open System
 open Internal.Utilities.Library 
 open FSharp.Compiler 
 open FSharp.Compiler.AbstractIL.IL 
@@ -539,7 +538,7 @@ type CalledMeth<'T>
     // Detect the special case where an indexer setter using param aray takes 'value' argument after ParamArray arguments
     let isIndexerSetter =
         match pinfoOpt with
-        | Some pinfo when pinfo.HasSetter && minfo.LogicalName.StartsWith("set_", StringComparison.Ordinal)  && (List.concat fullCurriedCalledArgs).Length >= 2 -> true
+        | Some pinfo when pinfo.HasSetter && minfo.LogicalName.StartsWithOrdinal("set_") && (List.concat fullCurriedCalledArgs).Length >= 2 -> true
         | _ -> false
 
     let argSetInfos = 

--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -5,6 +5,7 @@ module internal FSharp.Compiler.MethodCalls
 
 open Internal.Utilities
 
+open System
 open Internal.Utilities.Library 
 open FSharp.Compiler 
 open FSharp.Compiler.AbstractIL.IL 
@@ -538,7 +539,7 @@ type CalledMeth<'T>
     // Detect the special case where an indexer setter using param aray takes 'value' argument after ParamArray arguments
     let isIndexerSetter =
         match pinfoOpt with
-        | Some pinfo when pinfo.HasSetter && minfo.LogicalName.StartsWith "set_"  && (List.concat fullCurriedCalledArgs).Length >= 2 -> true
+        | Some pinfo when pinfo.HasSetter && minfo.LogicalName.StartsWith("set_", StringComparison.Ordinal)  && (List.concat fullCurriedCalledArgs).Length >= 2 -> true
         | _ -> false
 
     let argSetInfos = 

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -55,7 +55,7 @@ module internal PrintUtilities =
 
     let comment str = wordL (tagText (sprintf "(* %s *)" str))
 
-    let isDiscard (name: string) = name.StartsWith("_", StringComparison.Ordinal)
+    let isDiscard (name: string) = name.StartsWithOrdinal("_")
 
     let ensureFloat (s: string) =
         if String.forall (fun c -> Char.IsDigit c || c = '-') s then

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -55,7 +55,7 @@ module internal PrintUtilities =
 
     let comment str = wordL (tagText (sprintf "(* %s *)" str))
 
-    let isDiscard (name: string) = name.StartsWith("_")
+    let isDiscard (name: string) = name.StartsWith("_", StringComparison.Ordinal)
 
     let ensureFloat (s: string) =
         if String.forall (fun c -> Char.IsDigit c || c = '-') s then

--- a/src/Compiler/Checking/SignatureHash.fs
+++ b/src/Compiler/Checking/SignatureHash.fs
@@ -1,5 +1,6 @@
 ﻿module internal Fsharp.Compiler.SignatureHash
 
+open System
 open Internal.Utilities.Library
 open Internal.Utilities.Rational
 open FSharp.Compiler.AbstractIL.IL
@@ -476,7 +477,7 @@ let calculateHashOfImpliedSignature g observer (expr: ModuleOrNamespaceContents)
 
     let rec hashModuleOrNameSpaceBinding (monb: ModuleOrNamespaceBinding) =
         match monb with
-        | ModuleOrNamespaceBinding.Binding b when b.Var.LogicalName.StartsWith("doval@") -> 0
+        | ModuleOrNamespaceBinding.Binding b when b.Var.LogicalName.StartsWith("doval@", StringComparison.Ordinal) -> 0
         | ModuleOrNamespaceBinding.Binding b -> HashTastMemberOrVals.hashValOrMemberNoInst (g, observer) (mkLocalValRef b.Var)
         | ModuleOrNamespaceBinding.Module(moduleInfo, contents) -> hashSingleModuleOrNameSpaceIncludingName (moduleInfo, contents)
 

--- a/src/Compiler/Checking/SignatureHash.fs
+++ b/src/Compiler/Checking/SignatureHash.fs
@@ -1,6 +1,5 @@
 ﻿module internal Fsharp.Compiler.SignatureHash
 
-open System
 open Internal.Utilities.Library
 open Internal.Utilities.Rational
 open FSharp.Compiler.AbstractIL.IL
@@ -477,7 +476,7 @@ let calculateHashOfImpliedSignature g observer (expr: ModuleOrNamespaceContents)
 
     let rec hashModuleOrNameSpaceBinding (monb: ModuleOrNamespaceBinding) =
         match monb with
-        | ModuleOrNamespaceBinding.Binding b when b.Var.LogicalName.StartsWith("doval@", StringComparison.Ordinal) -> 0
+        | ModuleOrNamespaceBinding.Binding b when b.Var.LogicalName.StartsWithOrdinal("doval@") -> 0
         | ModuleOrNamespaceBinding.Binding b -> HashTastMemberOrVals.hashValOrMemberNoInst (g, observer) (mkLocalValRef b.Var)
         | ModuleOrNamespaceBinding.Module(moduleInfo, contents) -> hashSingleModuleOrNameSpaceIncludingName (moduleInfo, contents)
 

--- a/src/Compiler/Checking/infos.fs
+++ b/src/Compiler/Checking/infos.fs
@@ -812,7 +812,7 @@ type MethInfo =
     member x.IsUnionCaseTester =
         let tcref = x.ApparentEnclosingTyconRef
         tcref.IsUnionTycon &&
-        x.LogicalName.StartsWith("get_Is", StringComparison.Ordinal) &&
+        x.LogicalName.StartsWithOrdinal("get_Is") &&
         match x.ArbitraryValRef with 
         | Some v -> v.IsImplied
         | None -> false

--- a/src/Compiler/Checking/infos.fs
+++ b/src/Compiler/Checking/infos.fs
@@ -812,7 +812,7 @@ type MethInfo =
     member x.IsUnionCaseTester =
         let tcref = x.ApparentEnclosingTyconRef
         tcref.IsUnionTycon &&
-        x.LogicalName.StartsWith("get_Is") &&
+        x.LogicalName.StartsWith("get_Is", StringComparison.Ordinal) &&
         match x.ArbitraryValRef with 
         | Some v -> v.IsImplied
         | None -> false

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -5,6 +5,7 @@ module internal FSharp.Compiler.IlxGen
 
 open FSharp.Compiler.IlxGenSupport
 
+open System
 open System.IO
 open System.Reflection
 open System.Collections.Generic
@@ -2694,7 +2695,7 @@ let CodeGenThen (cenv: cenv) mgbuf (entryPointInfo, methodName, eenv, alreadyUse
     match selfArgOpt with
     | Some selfArg when
         selfArg.LogicalName <> "this"
-        && not (selfArg.LogicalName.StartsWith("_"))
+        && not (selfArg.LogicalName.StartsWith("_", StringComparison.Ordinal))
         && not cenv.options.localOptimizationsEnabled
         ->
         let ilTy = selfArg.Type |> GenType cenv m eenv.tyenv

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -5,7 +5,6 @@ module internal FSharp.Compiler.IlxGen
 
 open FSharp.Compiler.IlxGenSupport
 
-open System
 open System.IO
 open System.Reflection
 open System.Collections.Generic
@@ -2695,7 +2694,7 @@ let CodeGenThen (cenv: cenv) mgbuf (entryPointInfo, methodName, eenv, alreadyUse
     match selfArgOpt with
     | Some selfArg when
         selfArg.LogicalName <> "this"
-        && not (selfArg.LogicalName.StartsWith("_", StringComparison.Ordinal))
+        && not (selfArg.LogicalName.StartsWithOrdinal("_"))
         && not cenv.options.localOptimizationsEnabled
         ->
         let ilTy = selfArg.Type |> GenType cenv m eenv.tyenv

--- a/src/Compiler/DependencyManager/DependencyProvider.fs
+++ b/src/Compiler/DependencyManager/DependencyProvider.fs
@@ -612,7 +612,10 @@ type DependencyProvider
                 let managers =
                     RegisteredDependencyManagers compilerTools (Option.ofString outputDir) reportError
 
-                match managers |> Seq.tryFind (fun kv -> path.StartsWith(kv.Value.Key + ":", StringComparison.Ordinal)) with
+                match
+                    managers
+                    |> Seq.tryFind (fun kv -> path.StartsWith(kv.Value.Key + ":", StringComparison.Ordinal))
+                with
                 | None ->
                     let err, msg =
                         this.CreatePackageManagerUnknownError(compilerTools, outputDir, path.Split(':').[0], reportError)

--- a/src/Compiler/DependencyManager/DependencyProvider.fs
+++ b/src/Compiler/DependencyManager/DependencyProvider.fs
@@ -612,7 +612,7 @@ type DependencyProvider
                 let managers =
                     RegisteredDependencyManagers compilerTools (Option.ofString outputDir) reportError
 
-                match managers |> Seq.tryFind (fun kv -> path.StartsWith(kv.Value.Key + ":")) with
+                match managers |> Seq.tryFind (fun kv -> path.StartsWith(kv.Value.Key + ":", StringComparison.Ordinal)) with
                 | None ->
                     let err, msg =
                         this.CreatePackageManagerUnknownError(compilerTools, outputDir, path.Split(':').[0], reportError)

--- a/src/Compiler/DependencyManager/DependencyProvider.fs
+++ b/src/Compiler/DependencyManager/DependencyProvider.fs
@@ -612,10 +612,7 @@ type DependencyProvider
                 let managers =
                     RegisteredDependencyManagers compilerTools (Option.ofString outputDir) reportError
 
-                match
-                    managers
-                    |> Seq.tryFind (fun kv -> path.StartsWith(kv.Value.Key + ":", StringComparison.Ordinal))
-                with
+                match managers |> Seq.tryFind (fun kv -> path.StartsWithOrdinal(kv.Value.Key + ":")) with
                 | None ->
                     let err, msg =
                         this.CreatePackageManagerUnknownError(compilerTools, outputDir, path.Split(':').[0], reportError)

--- a/src/Compiler/DependencyManager/NativeDllResolveHandler.fs
+++ b/src/Compiler/DependencyManager/NativeDllResolveHandler.fs
@@ -8,6 +8,7 @@ open System.IO
 open System.Reflection
 open System.Runtime.InteropServices
 open Internal.Utilities
+open Internal.Utilities.Library
 open Internal.Utilities.FSharpEnvironment
 open FSharp.Compiler.IO
 
@@ -88,7 +89,7 @@ type internal NativeDllResolveHandlerCoreClr(nativeProbingRoots: NativeResolutio
         let isRooted = Path.IsPathRooted name
 
         let useSuffix s =
-            not (name.Contains(s + ".") || name.EndsWith(s, StringComparison.Ordinal)) // linux devs often append version # to libraries I.e mydll.so.5.3.2
+            not (name.Contains(s + ".") || name.EndsWithOrdinal(s)) // linux devs often append version # to libraries I.e mydll.so.5.3.2
 
         let usePrefix =
             name.IndexOf(Path.DirectorySeparatorChar) = -1 // If name has directory information no add no prefix

--- a/src/Compiler/DependencyManager/NativeDllResolveHandler.fs
+++ b/src/Compiler/DependencyManager/NativeDllResolveHandler.fs
@@ -88,7 +88,7 @@ type internal NativeDllResolveHandlerCoreClr(nativeProbingRoots: NativeResolutio
         let isRooted = Path.IsPathRooted name
 
         let useSuffix s =
-            not (name.Contains(s + ".") || name.EndsWith(s)) // linux devs often append version # to libraries I.e mydll.so.5.3.2
+            not (name.Contains(s + ".") || name.EndsWith(s, StringComparison.Ordinal)) // linux devs often append version # to libraries I.e mydll.so.5.3.2
 
         let usePrefix =
             name.IndexOf(Path.DirectorySeparatorChar) = -1 // If name has directory information no add no prefix

--- a/src/Compiler/Driver/FxResolver.fs
+++ b/src/Compiler/Driver/FxResolver.fs
@@ -238,7 +238,7 @@ type internal FxResolver
                             dotnetConfig.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
                             + pattern.Length
 
-                        let endPos = dotnetConfig.IndexOf("\"", startPos)
+                        let endPos = dotnetConfig.IndexOf("\"", startPos, StringComparison.Ordinal)
                         let ver = dotnetConfig[startPos .. endPos - 1]
 
                         let path =
@@ -364,7 +364,7 @@ type internal FxResolver
                 let implDir, warnings = getImplementationAssemblyDir ()
                 let version = DirectoryInfo(implDir).Name
 
-                if version.StartsWith("x") then
+                if version.StartsWith("x", StringComparison.Ordinal) then
                     // Is running on the desktop
                     (None, None), warnings
                 else
@@ -403,7 +403,7 @@ type internal FxResolver
             | ".NET", "Core" when arr.Length >= 3 -> Some("netcoreapp" + (getTfmNumber arr[2]))
 
             | ".NET", "Framework" when arr.Length >= 3 ->
-                if arr[2].StartsWith("4.8") then
+                if arr[2].StartsWith("4.8", StringComparison.Ordinal) then
                     Some "net48"
                 else
                     Some "net472"
@@ -560,7 +560,7 @@ type internal FxResolver
                 dotnetConfig.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
                 + pattern.Length
 
-            let endPos = dotnetConfig.IndexOf("\"", startPos)
+            let endPos = dotnetConfig.IndexOf("\"", startPos, StringComparison.Ordinal)
             let tfm = dotnetConfig[startPos .. endPos - 1]
             tfm
         with _ ->

--- a/src/Compiler/Driver/FxResolver.fs
+++ b/src/Compiler/Driver/FxResolver.fs
@@ -238,7 +238,7 @@ type internal FxResolver
                             dotnetConfig.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
                             + pattern.Length
 
-                        let endPos = dotnetConfig.IndexOf("\"", startPos, StringComparison.Ordinal)
+                        let endPos = dotnetConfig.IndexOfOrdinal("\"", startPos)
                         let ver = dotnetConfig[startPos .. endPos - 1]
 
                         let path =
@@ -364,7 +364,7 @@ type internal FxResolver
                 let implDir, warnings = getImplementationAssemblyDir ()
                 let version = DirectoryInfo(implDir).Name
 
-                if version.StartsWith("x", StringComparison.Ordinal) then
+                if version.StartsWithOrdinal("x") then
                     // Is running on the desktop
                     (None, None), warnings
                 else
@@ -403,7 +403,7 @@ type internal FxResolver
             | ".NET", "Core" when arr.Length >= 3 -> Some("netcoreapp" + (getTfmNumber arr[2]))
 
             | ".NET", "Framework" when arr.Length >= 3 ->
-                if arr[2].StartsWith("4.8", StringComparison.Ordinal) then
+                if arr[2].StartsWithOrdinal("4.8") then
                     Some "net48"
                 else
                     Some "net472"
@@ -560,7 +560,7 @@ type internal FxResolver
                 dotnetConfig.IndexOf(pattern, StringComparison.OrdinalIgnoreCase)
                 + pattern.Length
 
-            let endPos = dotnetConfig.IndexOf("\"", startPos, StringComparison.Ordinal)
+            let endPos = dotnetConfig.IndexOfOrdinal("\"", startPos)
             let tfm = dotnetConfig[startPos .. endPos - 1]
             tfm
         with _ ->

--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -97,7 +97,7 @@ type StringText(str: string) =
             if lastIndex <= startIndex || lastIndex >= str.Length then
                 invalidArg "target" "Too big."
 
-            str.IndexOf(target, startIndex, target.Length) <> -1
+            str.IndexOf(target, startIndex, target.Length, StringComparison.Ordinal) <> -1
 
         member _.Length = str.Length
 

--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -6,6 +6,7 @@ namespace FSharp.Compiler.Text
 
 open System
 open System.IO
+open Internal.Utilities.Library
 
 type ISourceText =
 
@@ -97,7 +98,7 @@ type StringText(str: string) =
             if lastIndex <= startIndex || lastIndex >= str.Length then
                 invalidArg "target" "Too big."
 
-            str.IndexOf(target, startIndex, target.Length, StringComparison.Ordinal) <> -1
+            str.IndexOfOrdinal(target, startIndex, target.Length) <> -1
 
         member _.Length = str.Length
 

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1526,7 +1526,7 @@ let ConvReflectionTypeToILTypeRef (reflectionTy: Type) =
     let scoref = ILScopeRef.Assembly aref
 
     let fullName = reflectionTy.FullName
-    let index = fullName.IndexOf("[", StringComparison.Ordinal)
+    let index = fullName.IndexOfOrdinal("[")
 
     let fullName =
         if index = -1 then

--- a/src/Compiler/Interactive/fsi.fs
+++ b/src/Compiler/Interactive/fsi.fs
@@ -1526,7 +1526,7 @@ let ConvReflectionTypeToILTypeRef (reflectionTy: Type) =
     let scoref = ILScopeRef.Assembly aref
 
     let fullName = reflectionTy.FullName
-    let index = fullName.IndexOf("[")
+    let index = fullName.IndexOf("[", StringComparison.Ordinal)
 
     let fullName =
         if index = -1 then

--- a/src/Compiler/Optimize/LowerStateMachines.fs
+++ b/src/Compiler/Optimize/LowerStateMachines.fs
@@ -2,6 +2,7 @@
 
 module internal FSharp.Compiler.LowerStateMachines
 
+open System
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -114,7 +115,7 @@ let isExpandVar g (v: Val) =
 let isStateMachineBindingVar g (v: Val) = 
     isExpandVar g v  ||
     (let nm = v.LogicalName
-     (nm.StartsWith "builder@" || v.IsMemberThisVal) &&
+     (nm.StartsWith("builder@", StringComparison.Ordinal) || v.IsMemberThisVal) &&
      not v.IsCompiledAsTopLevel)
 
 type env = 
@@ -833,7 +834,7 @@ type LowerStateMachine(g: TcGlobals) =
                 |> Result.Ok
             elif bind.Var.IsCompiledAsTopLevel || 
                 not (resBody.resumableVars.FreeLocals.Contains(bind.Var)) || 
-                bind.Var.LogicalName.StartsWith stackVarPrefix then
+                bind.Var.LogicalName.StartsWith(stackVarPrefix, StringComparison.Ordinal) then
                 if sm_verbose then printfn "LetExpr (non-control-flow, rewrite rhs, RepresentBindingAsTopLevelOrLocal)" 
                 RepresentBindingAsTopLevelOrLocal bind resBody m
                 |> Result.Ok

--- a/src/Compiler/Optimize/LowerStateMachines.fs
+++ b/src/Compiler/Optimize/LowerStateMachines.fs
@@ -2,7 +2,6 @@
 
 module internal FSharp.Compiler.LowerStateMachines
 
-open System
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -115,7 +114,7 @@ let isExpandVar g (v: Val) =
 let isStateMachineBindingVar g (v: Val) = 
     isExpandVar g v  ||
     (let nm = v.LogicalName
-     (nm.StartsWith("builder@", StringComparison.Ordinal) || v.IsMemberThisVal) &&
+     (nm.StartsWithOrdinal("builder@") || v.IsMemberThisVal) &&
      not v.IsCompiledAsTopLevel)
 
 type env = 
@@ -834,7 +833,7 @@ type LowerStateMachine(g: TcGlobals) =
                 |> Result.Ok
             elif bind.Var.IsCompiledAsTopLevel || 
                 not (resBody.resumableVars.FreeLocals.Contains(bind.Var)) || 
-                bind.Var.LogicalName.StartsWith(stackVarPrefix, StringComparison.Ordinal) then
+                bind.Var.LogicalName.StartsWithOrdinal(stackVarPrefix) then
                 if sm_verbose then printfn "LetExpr (non-control-flow, rewrite rhs, RepresentBindingAsTopLevelOrLocal)" 
                 RepresentBindingAsTopLevelOrLocal bind resBody m
                 |> Result.Ok

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -5,6 +5,7 @@
 /// are never used.
 module internal FSharp.Compiler.Optimizer
 
+open System
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -1534,11 +1535,11 @@ let ValueOfExpr expr =
 
 let IsMutableStructuralBindingForTupleElement (vref: ValRef) =
     vref.IsCompilerGenerated &&
-    vref.LogicalName.EndsWith suffixForTupleElementAssignmentTarget
+    vref.LogicalName.EndsWith(suffixForTupleElementAssignmentTarget, StringComparison.Ordinal)
 
 let IsMutableForOutArg (vref: ValRef) =
     vref.IsCompilerGenerated &&
-    vref.LogicalName.StartsWith(outArgCompilerGeneratedName)
+    vref.LogicalName.StartsWith(outArgCompilerGeneratedName, StringComparison.Ordinal)
 
 let IsKnownOnlyMutableBeforeUse (vref: ValRef) =
     IsMutableStructuralBindingForTupleElement vref || 
@@ -1672,7 +1673,7 @@ let TryEliminateBinding cenv _env bind e2 _m =
        not vspec1.IsCompilerGenerated then 
        None 
     elif vspec1.IsFixed then None 
-    elif vspec1.LogicalName.StartsWith stackVarPrefix ||
+    elif vspec1.LogicalName.StartsWith(stackVarPrefix, StringComparison.Ordinal) ||
          vspec1.LogicalName.Contains suffixForVariablesThatMayNotBeEliminated then None
     else
 

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -5,7 +5,6 @@
 /// are never used.
 module internal FSharp.Compiler.Optimizer
 
-open System
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open Internal.Utilities.Library.Extras
@@ -1535,11 +1534,11 @@ let ValueOfExpr expr =
 
 let IsMutableStructuralBindingForTupleElement (vref: ValRef) =
     vref.IsCompilerGenerated &&
-    vref.LogicalName.EndsWith(suffixForTupleElementAssignmentTarget, StringComparison.Ordinal)
+    vref.LogicalName.EndsWithOrdinal suffixForTupleElementAssignmentTarget
 
 let IsMutableForOutArg (vref: ValRef) =
     vref.IsCompilerGenerated &&
-    vref.LogicalName.StartsWith(outArgCompilerGeneratedName, StringComparison.Ordinal)
+    vref.LogicalName.StartsWithOrdinal(outArgCompilerGeneratedName)
 
 let IsKnownOnlyMutableBeforeUse (vref: ValRef) =
     IsMutableStructuralBindingForTupleElement vref || 
@@ -1673,7 +1672,7 @@ let TryEliminateBinding cenv _env bind e2 _m =
        not vspec1.IsCompilerGenerated then 
        None 
     elif vspec1.IsFixed then None 
-    elif vspec1.LogicalName.StartsWith(stackVarPrefix, StringComparison.Ordinal) ||
+    elif vspec1.LogicalName.StartsWithOrdinal stackVarPrefix ||
          vspec1.LogicalName.Contains suffixForVariablesThatMayNotBeEliminated then None
     else
 

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -1909,7 +1909,7 @@ type internal TypeCheckInfo
                 | Some(_, lines) ->
                     let lines =
                         lines
-                        |> List.filter (fun line -> not (line.StartsWith("//")) && not (String.IsNullOrEmpty line))
+                        |> List.filter (fun line -> not (line.StartsWith("//", StringComparison.Ordinal)) && not (String.IsNullOrEmpty line))
 
                     ToolTipText.ToolTipText
                         [

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -1909,7 +1909,9 @@ type internal TypeCheckInfo
                 | Some(_, lines) ->
                     let lines =
                         lines
-                        |> List.filter (fun line -> not (line.StartsWith("//", StringComparison.Ordinal)) && not (String.IsNullOrEmpty line))
+                        |> List.filter (fun line ->
+                            not (line.StartsWith("//", StringComparison.Ordinal))
+                            && not (String.IsNullOrEmpty line))
 
                     ToolTipText.ToolTipText
                         [

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -1909,9 +1909,7 @@ type internal TypeCheckInfo
                 | Some(_, lines) ->
                     let lines =
                         lines
-                        |> List.filter (fun line ->
-                            not (line.StartsWith("//", StringComparison.Ordinal))
-                            && not (String.IsNullOrEmpty line))
+                        |> List.filter (fun line -> not (line.StartsWithOrdinal("//")) && not (String.IsNullOrEmpty line))
 
                     ToolTipText.ToolTipText
                         [

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -2,6 +2,7 @@
 
 namespace FSharp.Compiler.EditorServices
 
+open System
 open System.Diagnostics
 open System.Collections.Generic
 open System.Collections.Immutable
@@ -75,7 +76,7 @@ module TcResolutionsExtensions =
         && protectAssemblyExplorationNoReraise false false (fun () ->
             ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
 
-    let isDiscard (str: string) = str.StartsWith("_")
+    let isDiscard (str: string) = str.StartsWith("_", StringComparison.Ordinal)
 
     let isValRefDisposable g amap (vref: ValRef) =
         not (isDiscard vref.DisplayName)

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -76,7 +76,8 @@ module TcResolutionsExtensions =
         && protectAssemblyExplorationNoReraise false false (fun () ->
             ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
 
-    let isDiscard (str: string) = str.StartsWith("_", StringComparison.Ordinal)
+    let isDiscard (str: string) =
+        str.StartsWith("_", StringComparison.Ordinal)
 
     let isValRefDisposable g amap (vref: ValRef) =
         not (isDiscard vref.DisplayName)

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -2,7 +2,6 @@
 
 namespace FSharp.Compiler.EditorServices
 
-open System
 open System.Diagnostics
 open System.Collections.Generic
 open System.Collections.Immutable
@@ -76,8 +75,7 @@ module TcResolutionsExtensions =
         && protectAssemblyExplorationNoReraise false false (fun () ->
             ExistsHeadTypeInEntireHierarchy g amap range0 ty g.tcref_System_IDisposable)
 
-    let isDiscard (str: string) =
-        str.StartsWith("_", StringComparison.Ordinal)
+    let isDiscard (str: string) = str.StartsWithOrdinal("_")
 
     let isValRefDisposable g amap (vref: ValRef) =
         not (isDiscard vref.DisplayName)

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -2,7 +2,6 @@
 
 namespace FSharp.Compiler.EditorServices
 
-open System
 open System.Collections.Generic
 open System.Runtime.CompilerServices
 open Internal.Utilities.Library
@@ -436,7 +435,7 @@ module UnusedDeclarations =
                 su.IsFromDefinition
                 && su.Symbol.DeclarationLocation.IsSome
                 && (isScript || su.IsPrivateToFile)
-                && not (su.Symbol.DisplayName.StartsWith("_", StringComparison.Ordinal))
+                && not (su.Symbol.DisplayName.StartsWithOrdinal "_")
                 && isPotentiallyUnusedDeclaration su.Symbol
             then
                 Some(su, usages.Contains su.Symbol.DeclarationLocation.Value)

--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -2,6 +2,7 @@
 
 namespace FSharp.Compiler.EditorServices
 
+open System
 open System.Collections.Generic
 open System.Runtime.CompilerServices
 open Internal.Utilities.Library
@@ -435,7 +436,7 @@ module UnusedDeclarations =
                 su.IsFromDefinition
                 && su.Symbol.DeclarationLocation.IsSome
                 && (isScript || su.IsPrivateToFile)
-                && not (su.Symbol.DisplayName.StartsWith "_")
+                && not (su.Symbol.DisplayName.StartsWith("_", StringComparison.Ordinal))
                 && isPotentiallyUnusedDeclaration su.Symbol
             then
                 Some(su, usages.Contains su.Symbol.DeclarationLocation.Value)

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -2,7 +2,6 @@
 
 module FSharp.Compiler.SyntaxTreeOps
 
-open System
 open Internal.Utilities.Library
 open FSharp.Compiler.DiagnosticsLogger
 open FSharp.Compiler.Syntax
@@ -411,7 +410,7 @@ let opNameQMark = CompileOpName qmark
 let mkSynOperator (opm: range) (oper: string) =
     let trivia =
         if
-            oper.StartsWith("~", StringComparison.Ordinal)
+            oper.StartsWithOrdinal("~")
             && ((opm.EndColumn - opm.StartColumn) = (oper.Length - 1))
         then
             // PREFIX_OP token where the ~ was actually absent

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -410,7 +410,10 @@ let opNameQMark = CompileOpName qmark
 
 let mkSynOperator (opm: range) (oper: string) =
     let trivia =
-        if oper.StartsWith("~", StringComparison.Ordinal) && ((opm.EndColumn - opm.StartColumn) = (oper.Length - 1)) then
+        if
+            oper.StartsWith("~", StringComparison.Ordinal)
+            && ((opm.EndColumn - opm.StartColumn) = (oper.Length - 1))
+        then
             // PREFIX_OP token where the ~ was actually absent
             IdentTrivia.OriginalNotation(string (oper.[1..]))
         else

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -2,6 +2,7 @@
 
 module FSharp.Compiler.SyntaxTreeOps
 
+open System
 open Internal.Utilities.Library
 open FSharp.Compiler.DiagnosticsLogger
 open FSharp.Compiler.Syntax
@@ -409,7 +410,7 @@ let opNameQMark = CompileOpName qmark
 
 let mkSynOperator (opm: range) (oper: string) =
     let trivia =
-        if oper.StartsWith("~") && ((opm.EndColumn - opm.StartColumn) = (oper.Length - 1)) then
+        if oper.StartsWith("~", StringComparison.Ordinal) && ((opm.EndColumn - opm.StartColumn) = (oper.Length - 1)) then
             // PREFIX_OP token where the ~ was actually absent
             IdentTrivia.OriginalNotation(string (oper.[1..]))
         else

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -8,6 +8,7 @@
 /// comparison and hashing functions.
 module internal FSharp.Compiler.TcGlobals
 
+open System
 open System.Collections.Concurrent
 open System.Linq
 open System.Diagnostics
@@ -1882,7 +1883,7 @@ type TcGlobals(
       let memberName =
           let nm = t.MemberLogicalName
           let coreName =
-              if nm.StartsWith "op_" then nm[3..]
+              if nm.StartsWith("op_", StringComparison.Ordinal) then nm[3..]
               elif nm = "get_Zero" then "GenericZero"
               elif nm = "get_One" then "GenericOne"
               else nm

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -8,7 +8,6 @@
 /// comparison and hashing functions.
 module internal FSharp.Compiler.TcGlobals
 
-open System
 open System.Collections.Concurrent
 open System.Linq
 open System.Diagnostics
@@ -1883,7 +1882,7 @@ type TcGlobals(
       let memberName =
           let nm = t.MemberLogicalName
           let coreName =
-              if nm.StartsWith("op_", StringComparison.Ordinal) then nm[3..]
+              if nm.StartsWithOrdinal "op_" then nm[3..]
               elif nm = "get_Zero" then "GenericZero"
               elif nm = "get_One" then "GenericOne"
               else nm

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -3,7 +3,6 @@
 /// Defines derived expression manipulation and construction functions.
 module internal FSharp.Compiler.TypedTreeOps
 
-open System
 open System.CodeDom.Compiler
 open System.Collections.Generic
 open System.Collections.Immutable
@@ -10417,7 +10416,7 @@ let (|SequentialResumableCode|_|) (g: TcGlobals) expr =
         Some (e1, e2, m, (fun e1 e2 -> Expr.Sequential(e1, e2, NormalSeq, m)))
 
     // let __stack_step = e1 in e2
-    | Expr.Let(bind, e2, m, _) when bind.Var.CompiledName(g.CompilerGlobalState).StartsWith(stackVarPrefix, StringComparison.Ordinal) ->
+    | Expr.Let(bind, e2, m, _) when bind.Var.CompiledName(g.CompilerGlobalState).StartsWithOrdinal(stackVarPrefix) ->
         Some (bind.Expr, e2, m, (fun e1 e2 -> mkLet bind.DebugPoint m bind.Var e1 e2))
 
     | _ -> None

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -3,6 +3,7 @@
 /// Defines derived expression manipulation and construction functions.
 module internal FSharp.Compiler.TypedTreeOps
 
+open System
 open System.CodeDom.Compiler
 open System.Collections.Generic
 open System.Collections.Immutable
@@ -10416,7 +10417,7 @@ let (|SequentialResumableCode|_|) (g: TcGlobals) expr =
         Some (e1, e2, m, (fun e1 e2 -> Expr.Sequential(e1, e2, NormalSeq, m)))
 
     // let __stack_step = e1 in e2
-    | Expr.Let(bind, e2, m, _) when bind.Var.CompiledName(g.CompilerGlobalState).StartsWith(stackVarPrefix) ->
+    | Expr.Let(bind, e2, m, _) when bind.Var.CompiledName(g.CompilerGlobalState).StartsWith(stackVarPrefix, StringComparison.Ordinal) ->
         Some (bind.Expr, e2, m, (fun e1 e2 -> mkLet bind.DebugPoint m bind.Var e1 e2))
 
     | _ -> None

--- a/src/Compiler/Utilities/PathMap.fs
+++ b/src/Compiler/Utilities/PathMap.fs
@@ -22,7 +22,7 @@ module internal PathMap =
         let normalSrc = FileSystem.GetFullPathShim src
 
         let oldPrefix =
-            if normalSrc.EndsWith dirSepStr then
+            if normalSrc.EndsWith(dirSepStr, StringComparison.Ordinal) then
                 normalSrc
             else
                 normalSrc + dirSepStr
@@ -60,7 +60,7 @@ module internal PathMap =
         |> Option.defaultValue filePath
 
     let applyDir pathMap (dirName: string) : string =
-        if dirName.EndsWith dirSepStr then
+        if dirName.EndsWith(dirSepStr, StringComparison.Ordinal) then
             apply pathMap dirName
         else
             let mapped = apply pathMap (dirName + dirSepStr)

--- a/src/Compiler/Utilities/PathMap.fs
+++ b/src/Compiler/Utilities/PathMap.fs
@@ -6,6 +6,7 @@ namespace Internal.Utilities
 open System
 open System.IO
 
+open Internal.Utilities.Library
 open FSharp.Compiler.IO
 
 type PathMap = PathMap of Map<string, string>
@@ -22,7 +23,7 @@ module internal PathMap =
         let normalSrc = FileSystem.GetFullPathShim src
 
         let oldPrefix =
-            if normalSrc.EndsWith(dirSepStr, StringComparison.Ordinal) then
+            if normalSrc.EndsWithOrdinal dirSepStr then
                 normalSrc
             else
                 normalSrc + dirSepStr
@@ -41,7 +42,7 @@ module internal PathMap =
             // oldPrefix always ends with a path separator, so there's no need
             // to check if it was a partial match
             // e.g. for the map /goo=/bar and file name /goooo
-            if filePath.StartsWith(oldPrefix, StringComparison.Ordinal) then
+            if filePath.StartsWithOrdinal oldPrefix then
                 let replacement = replacementPrefix + filePath.Substring(oldPrefix.Length - 1)
 
                 // Normalize the path separators if used uniformly in the replacement
@@ -60,7 +61,7 @@ module internal PathMap =
         |> Option.defaultValue filePath
 
     let applyDir pathMap (dirName: string) : string =
-        if dirName.EndsWith(dirSepStr, StringComparison.Ordinal) then
+        if dirName.EndsWithOrdinal dirSepStr then
             apply pathMap dirName
         else
             let mapped = apply pathMap (dirName + dirSepStr)

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -124,6 +124,15 @@ module internal PervasiveAutoOpens =
         member inline x.EndsWithOrdinalIgnoreCase value =
             x.EndsWith(value, StringComparison.OrdinalIgnoreCase)
 
+        member inline x.IndexOfOrdinal value =
+            x.IndexOf(value, StringComparison.Ordinal)
+
+        member inline x.IndexOfOrdinal(value, startIndex) =
+            x.IndexOf(value, startIndex, StringComparison.Ordinal)
+
+        member inline x.IndexOfOrdinal(value, startIndex, count) =
+            x.IndexOf(value, startIndex, count, StringComparison.Ordinal)
+
     /// Get an initialization hole
     let getHole (r: _ ref) =
         match r.Value with

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -79,6 +79,12 @@ module internal PervasiveAutoOpens =
 
         member inline EndsWithOrdinalIgnoreCase: value: string -> bool
 
+        member inline IndexOfOrdinal: value: string -> int
+
+        member inline IndexOfOrdinal: value: string * startIndex: int -> int
+
+        member inline IndexOfOrdinal: value: string * startIndex: int * count: int -> int
+
     type Async with
 
         /// Runs the computation synchronously, always starting on the current thread.

--- a/src/Compiler/Utilities/sformat.fs
+++ b/src/Compiler/Utilities/sformat.fs
@@ -285,7 +285,7 @@ module Layout =
 #if COMPILER
     let rec endsWithL (text: string) layout =
         match layout with
-        | Leaf(_, s, _) -> s.Text.EndsWith(text)
+        | Leaf(_, s, _) -> s.Text.EndsWith(text, StringComparison.Ordinal)
         | Node(_, r, _) -> endsWithL text r
         | Attr(_, _, l) -> endsWithL text l
         | ObjLeaf _ -> false
@@ -512,7 +512,7 @@ module ReflectUtils =
                         FSharpValue.GetTupleFields obj |> Array.mapi (fun i v -> (v, tyArgs[i]))
 
                     let tupleType =
-                        if reprty.Name.StartsWith "ValueTuple" then
+                        if reprty.Name.StartsWith("ValueTuple", StringComparison.Ordinal) then
                             TupleType.Value
                         else
                             TupleType.Reference


### PR DESCRIPTION
## Description

Using Ordinal is both faster and more correct as our intent is to do symbolic compares.
See [best-practices-strings](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings) for the full story. Thanks to @Smaug123 for raising the awareness of these things.

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**