### PR TITLE
Allow parameter-less CustomOperation

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.200.md
@@ -6,6 +6,7 @@
 * Limit a type to 65K methods, introduce a compile-time error if any class has over approx 64K methods in generated IL. ([Issue #16398](https://github.com/dotnet/fsharp/issues/16398), [#PR 16427](https://github.com/dotnet/fsharp/pull/16427))
 
 ### Added
+
 * Raise a new error when interfaces with auto properties are implemented on constructor-less types. ([PR #16352](https://github.com/dotnet/fsharp/pull/16352))
 * Allow usage of `[<TailCall>]` with older `FSharp.Core` package versions. ([PR #16373](https://github.com/dotnet/fsharp/pull/16373))
 * Parser recovers on unfinished `as` patterns. ([PR #16404](https://github.com/dotnet/fsharp/pull/16404))
@@ -13,3 +14,4 @@
 * Parser recovers on unfinished enum case declarations. ([PR #16401](https://github.com/dotnet/fsharp/pull/16401))
 * Parser recovers on unfinished record declarations. ([PR #16357](https://github.com/dotnet/fsharp/pull/16357))
 * `MutableKeyword` to [SynFieldTrivia](../reference/fsharp-compiler-syntaxtrivia-synfieldtrivia.html) ([PR #16357](https://github.com/dotnet/fsharp/pull/16357))
+* Added support for a new parameterless constructor for `CustomOperationAttribute`, which, when applied, will use method name as keyword for custom operation in computation expression builder. ([PR #16475](https://github.com/dotnet/fsharp/pull/16475), part of implementation for [fslang-suggestions/1250](https://github.com/fsharp/fslang-suggestions/issues/1250))

--- a/docs/release-notes/.FSharp.Core/8.0.200.md
+++ b/docs/release-notes/.FSharp.Core/8.0.200.md
@@ -1,3 +1,4 @@
 ### Added
 
 * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
+* Added a new parameterless constructor for `CustomOperationAttribute` ([PR #16475](https://github.com/dotnet/fsharp/pull/16475), part of implementation for [fslang-suggestions/1250](https://github.com/fsharp/fslang-suggestions/issues/1250))

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.23611.3">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.23627.2">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>229464299759d6667e8b907d9c321d31a8dcc123</Sha>
+      <Sha>2a008ae4f42c0db384db5a4864752b2ff52d720b</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.7.0-preview-23217-02">

--- a/src/Compiler/Checking/AttributeChecking.fs
+++ b/src/Compiler/Checking/AttributeChecking.fs
@@ -207,7 +207,7 @@ let TryBindMethInfoAttribute g (m: range) (AttribInfo(atref, _) as attribSpec) m
         (fun provAttribs -> 
             match provAttribs.PUntaint((fun a -> a.GetAttributeConstructorArgs(provAttribs.TypeProvider.PUntaintNoFailure(id), atref.FullName)), m) with
             | Some args -> f3 args
-            | None -> None)  
+            | None -> None)
 #else
         (fun _provAttribs -> None)
 #endif

--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -274,11 +274,14 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
                     TryBindMethInfoAttribute cenv.g mBuilderVal cenv.g.attrib_CustomOperationAttribute methInfo
                         IgnoreAttribute // We do not respect this attribute for IL methods
                         (fun attr ->
+                            // NOTE: right now, we support of custom operations with spaces in them ([<CustomOperation("foo bar")>])
+                            // In the parameterless CustomOperationAttribute - we use the method name, and also allow it to be ````-quoted (member _.``foo bar`` _ = ...)
                             match attr with
-                            | Attrib(_, _, [ AttribStringArg msg ], _, _, _, _) when msg = "" ->
+                            // Empty string and parameterless constructor - we use the method name
+                            | Attrib(_, _, [ AttribStringArg "" ], _, _, _, _) // Empty string as parameter
+                            | Attrib(_, _, [ ], _, _, _, _) -> // No parameters, same as empty string for compat reasons.
                                 Some methInfo.LogicalName
-                            | Attrib(_, _, [ ], _, _, _, _) ->
-                                Some methInfo.LogicalName
+                            // Use the specified name
                             | Attrib(_, _, [ AttribStringArg msg ], _, _, _, _) ->
                                 Some msg
                             | _ -> None)

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -287,6 +287,7 @@ namespace Microsoft.FSharp.Core
         let mutable maintainsVarSpace = false
         let mutable maintainsVarSpaceWithBind = false
         let mutable joinOnWord = ""
+        new() = CustomOperationAttribute("")
         member _.Name = name
         member _.AllowIntoPattern with get() = allowInto and set v = allowInto <- v
         member _.IsLikeZip with get() = isBinary and set v = isBinary <- v

--- a/src/FSharp.Core/prim-types.fsi
+++ b/src/FSharp.Core/prim-types.fsi
@@ -420,6 +420,10 @@ namespace Microsoft.FSharp.Core
         /// <returns>CustomOperationAttribute</returns>
         new: name:string -> CustomOperationAttribute
 
+        /// <summary>Create an instance of attribute with empty name</summary>
+        /// <returns>CustomOperationAttribute</returns>
+        new: unit -> CustomOperationAttribute
+
         /// <summary>Get the name of the custom operation when used in a query or other computation expression</summary>
         member Name: string
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/CustomOperations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/CustomOperations.fs
@@ -14,6 +14,8 @@ module CustomOperations =
                 member this.Foo _ = "Foo"
                 [<CustomOperation>]
                 member this.foo _ = "foo"
+                [<CustomOperation("")>]
+                member this.bar _ = "bar"
                 member this.Yield _ = ()
                 member this.Zero _ = ()
 
@@ -24,6 +26,7 @@ module CustomOperations =
 
                 let x = cb { Foo }
                 let y = cb { foo }
+                let z = cb { bar }
                 printfn $"{x}"
                 printfn $"{y}"
 
@@ -31,6 +34,8 @@ module CustomOperations =
                     failwith "not Foo"
                 if y <> "foo" then
                     failwith "not foo"
+                if z <> "bar" then
+                    failwith "not bar"
                 0
         """
         |> asExe

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/CustomOperations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/CustomOperations.fs
@@ -1,0 +1,41 @@
+namespace Conformance.Expressions.ComputationExpressions
+
+open Xunit
+open FSharp.Test.Compiler
+
+module CustomOperations =
+
+// it becomes increasingly difficult to use packaged fslib in tests.
+#if !FSHARPCORE_USE_PACKAGE
+    [<Fact>]
+#endif
+    let ``[<CustomOperation>] without explicit name is allowed, uses method name as operation name`` () =
+        FSharp """
+            module CustomOperationTest
+            type CBuilder() =
+                [<CustomOperation>]
+                member this.Foo _ = "Foo"
+                [<CustomOperation>]
+                member this.foo _ = "foo"
+                member this.Yield _ = ()
+                member this.Zero _ = ()
+
+
+            [<EntryPoint>]
+            let main _ =
+                let cb = CBuilder()
+
+                let x = cb { Foo }
+                let y = cb { foo }
+                printfn $"{x}"
+                printfn $"{y}"
+
+                if x <> "Foo" then
+                    failwith "not Foo"
+                if y <> "foo" then
+                    failwith "not foo"
+                0
+        """
+        |> asExe
+        |> compileAndRun
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/CustomOperations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/CustomOperations.fs
@@ -5,10 +5,7 @@ open FSharp.Test.Compiler
 
 module CustomOperations =
 
-// it becomes increasingly difficult to use packaged fslib in tests.
-#if !FSHARPCORE_USE_PACKAGE
     [<Fact>]
-#endif
     let ``[<CustomOperation>] without explicit name is allowed, uses method name as operation name`` () =
         FSharp """
             module CustomOperationTest

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -31,53 +31,77 @@
       <Link>FsUnit.fs</Link>
     </Compile>
     <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\Basic\Basic.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\OnOverridesAndIFaceImpl\OnOverridesAndIFaceImpl.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\OnTypeMembers\OnTypeMembers.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\PermittedLocations\PermittedLocations.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\CustomAttributes\AttributeInheritance\AttributeInheritance.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\CustomAttributes\AttributeUsage\AttributeUsage.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\OnOverridesAndIFaceImpl\OnOverridesAndIFaceImpl.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\OnTypeMembers\OnTypeMembers.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\AccessibilityAnnotations\PermittedLocations\PermittedLocations.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\CustomAttributes\AttributeInheritance\AttributeInheritance.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\CustomAttributes\AttributeUsage\AttributeUsage.fs" />
     <Compile Include="Conformance\BasicGrammarElements\CustomAttributes\Basic\Basic.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\CustomAttributes\ImportedAttributes\ImportedAttributes.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\CustomAttributes\ArgumentsOfAllTypes\ArgumentsOfAllTypes.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\CustomAttributes\ImportedAttributes\ImportedAttributes.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\CustomAttributes\ArgumentsOfAllTypes\ArgumentsOfAllTypes.fs" />
     <Compile Include="Conformance\BasicGrammarElements\DelegateTypes\DelegateDefinition.fs" />
     <Compile Include="Conformance\BasicGrammarElements\EntryPoint\EntryPoint.fs" />
     <Compile Include="Conformance\BasicGrammarElements\Events\Basic\Basic.fs" />
     <Compile Include="Conformance\BasicGrammarElements\ExceptionDefinitions\ExceptionDefinitions.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\ExplicitObjectConstructors\ExplicitObjectConstructors.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\ExplicitObjectConstructors\ExplicitObjectConstructors.fs" />
     <Compile Include="Conformance\BasicGrammarElements\FieldMembers\FieldMembers.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\ImplicitObjectConstructors\ImplicitObjectConstructors.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\ImplicitObjectConstructors\ImplicitObjectConstructors.fs" />
     <Compile Include="Conformance\BasicGrammarElements\ImportDeclarations\ImportDeclarations.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\InterfaceSpecificationsAndImplementations\InterfaceSpecificationsAndImplementations.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\InterfaceSpecificationsAndImplementations\InterfaceSpecificationsAndImplementations.fs" />
     <Compile Include="Conformance\BasicGrammarElements\LetBindings\Basic\Basic.fs" />
     <Compile Include="Conformance\BasicGrammarElements\LetBindings\TypeFunctions\TypeFunctions.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\LetBindings\ActivePatternBindings\ActivePatternBindings.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\LetBindings\ExplicitTypeParameters\ExplicitTypeParameters.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\LetBindings\ActivePatternBindings\ActivePatternBindings.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\LetBindings\ExplicitTypeParameters\ExplicitTypeParameters.fs" />
     <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\MemberDefinitions.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\ImplementingDispatchSlots\ImplementingDispatchSlots.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\MethodsAndProperties\MethodsAndProperties.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\NamedArguments\NamedArguments.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\OptionalArguments\OptionalArguments.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\OptionalDefaultParamArgs\OptionalDefaultParamArgs.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\MemberDefinitions\OverloadingMembers\OverloadingMembers.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\MemberDefinitions\ImplementingDispatchSlots\ImplementingDispatchSlots.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\MemberDefinitions\MethodsAndProperties\MethodsAndProperties.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\MemberDefinitions\NamedArguments\NamedArguments.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\MemberDefinitions\OptionalArguments\OptionalArguments.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\MemberDefinitions\OptionalDefaultParamArgs\OptionalDefaultParamArgs.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\MemberDefinitions\OverloadingMembers\OverloadingMembers.fs" />
     <Compile Include="Conformance\BasicGrammarElements\MethodResolution.fs" />
     <Compile Include="Conformance\BasicGrammarElements\ModuleAbbreviations\ModuleAbbreviations.fs" />
     <Compile Include="Conformance\BasicGrammarElements\ModuleDefinitions\ModuleDefinitions.fs" />
     <Compile Include="Conformance\BasicGrammarElements\NamespaceDeclGroups\NamespaceDeclGroups.fs" />
     <Compile Include="Conformance\BasicGrammarElements\NullRepresentations\NullRepresentations.fs" />
     <Compile Include="Conformance\BasicGrammarElements\OperatorNames\OperatorNames.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\PrecedenceAndOperators\PrecedenceAndOperators.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\PrecedenceAndOperators\PrecedenceAndOperators.fs" />
     <Compile Include="Conformance\BasicGrammarElements\StaticLet\StaticLetInUnionsAndRecords.fs" />
     <Compile Include="Conformance\BasicGrammarElements\TypeAbbreviations\TypeAbbreviations.fs" />
-    <Compile Include="Conformance\BasicGrammarElements\TypeAbbreviations\WarnForAutoOpenAttributeAlias.fs" />
+    <Compile
+      Include="Conformance\BasicGrammarElements\TypeAbbreviations\WarnForAutoOpenAttributeAlias.fs" />
     <Compile Include="Conformance\BasicGrammarElements\ValueRestriction\ValueRestriction.fs" />
     <Compile Include="Conformance\BasicGrammarElements\UseBindings\UseBindings.fs" />
-	<Compile Include="Conformance\Constraints\Unmanaged.fs" />
-    <Compile Include="Conformance\GeneratedEqualityHashingComparison\Attributes\Diags\Attributes_Diags.fs" />
-    <Compile Include="Conformance\GeneratedEqualityHashingComparison\Attributes\Legacy\Attributes_Legacy.fs" />
+    <Compile Include="Conformance\Constraints\Unmanaged.fs" />
+    <Compile
+      Include="Conformance\GeneratedEqualityHashingComparison\Attributes\Diags\Attributes_Diags.fs" />
+    <Compile
+      Include="Conformance\GeneratedEqualityHashingComparison\Attributes\Legacy\Attributes_Legacy.fs" />
     <Compile Include="Conformance\GeneratedEqualityHashingComparison\Basic\Basic.fs" />
     <Compile Include="Conformance\GeneratedEqualityHashingComparison\IComparison\IComparison.fs" />
-    <Compile Include="Conformance\Expressions\ApplicationExpressions\BasicApplication\BasicApplication.fs" />
+    <Compile
+      Include="Conformance\Expressions\ApplicationExpressions\BasicApplication\BasicApplication.fs" />
     <Compile Include="Conformance\Expressions\BindingExpressions\BindingExpressions.fs" />
+    <Compile Include="Conformance\Expressions\ComputationExpressions\CustomOperations.fs" />
     <Compile Include="Conformance\Expressions\ObjectExpressions\ObjectExpressions.fs" />
     <Compile Include="Conformance\Expressions\ControlFlowExpressions\PatternMatching\PatternMatching.fs" />
     <Compile Include="Conformance\Expressions\ControlFlowExpressions\SequenceIteration\SequenceIteration.fs" />

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard20.debug.bsl
@@ -950,6 +950,7 @@ Microsoft.FSharp.Core.CustomOperationAttribute: System.String JoinConditionWord
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String Name
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_JoinConditionWord()
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_Name()
+Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor()
 Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor(System.String)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_AllowIntoPattern(Boolean)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_IsLikeGroupJoin(Boolean)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard20.release.bsl
@@ -952,6 +952,7 @@ Microsoft.FSharp.Core.CustomOperationAttribute: System.String JoinConditionWord
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String Name
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_JoinConditionWord()
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_Name()
+Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor()
 Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor(System.String)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_AllowIntoPattern(Boolean)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_IsLikeGroupJoin(Boolean)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard21.debug.bsl
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard21.debug.bsl
@@ -672,12 +672,14 @@ Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Microsoft.FSharp.Contro
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Microsoft.FSharp.Control.FSharpAsync`1[T] Scan[T](Microsoft.FSharp.Core.FSharpFunc`2[TMsg,Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Control.FSharpAsync`1[T]]], Microsoft.FSharp.Core.FSharpOption`1[System.Int32])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Microsoft.FSharp.Control.FSharpHandler`1[System.Exception] Error
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg] Start(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg],Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.Unit]], Microsoft.FSharp.Core.FSharpOption`1[System.Threading.CancellationToken])
+Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg] StartImmediate(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg],Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.Unit]], Microsoft.FSharp.Core.FSharpOption`1[System.Threading.CancellationToken])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Microsoft.FSharp.Core.FSharpOption`1[TReply] TryPostAndReply[TReply](Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Control.FSharpAsyncReplyChannel`1[TReply],TMsg], Microsoft.FSharp.Core.FSharpOption`1[System.Int32])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: TReply PostAndReply[TReply](Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Control.FSharpAsyncReplyChannel`1[TReply],TMsg], Microsoft.FSharp.Core.FSharpOption`1[System.Int32])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void .ctor(Microsoft.FSharp.Core.FSharpFunc`2[Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg],Microsoft.FSharp.Control.FSharpAsync`1[Microsoft.FSharp.Core.Unit]], Microsoft.FSharp.Core.FSharpOption`1[System.Threading.CancellationToken])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void Dispose()
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void Post(TMsg)
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void Start()
+Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void StartImmediate()
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void add_Error(Microsoft.FSharp.Control.FSharpHandler`1[System.Exception])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void remove_Error(Microsoft.FSharp.Control.FSharpHandler`1[System.Exception])
 Microsoft.FSharp.Control.FSharpMailboxProcessor`1[TMsg]: Void set_DefaultTimeout(Int32)
@@ -951,6 +953,7 @@ Microsoft.FSharp.Core.CustomOperationAttribute: System.String JoinConditionWord
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String Name
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_JoinConditionWord()
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_Name()
+Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor()
 Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor(System.String)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_AllowIntoPattern(Boolean)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_IsLikeGroupJoin(Boolean)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard21.release.bsl
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.SurfaceArea.netstandard21.release.bsl
@@ -953,6 +953,7 @@ Microsoft.FSharp.Core.CustomOperationAttribute: System.String JoinConditionWord
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String Name
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_JoinConditionWord()
 Microsoft.FSharp.Core.CustomOperationAttribute: System.String get_Name()
+Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor()
 Microsoft.FSharp.Core.CustomOperationAttribute: Void .ctor(System.String)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_AllowIntoPattern(Boolean)
 Microsoft.FSharp.Core.CustomOperationAttribute: Void set_IsLikeGroupJoin(Boolean)

--- a/tests/projects/Sample_Local_Compiler_and_FSLib/LocalCompilerAndFslib.fsproj
+++ b/tests/projects/Sample_Local_Compiler_and_FSLib/LocalCompilerAndFslib.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
+    <DotnetFscCompilerPath>$(MSBuildThisFileDirectory)../../../artifacts/bin/fsc/Debug/net8.0/fsc.dll</DotnetFscCompilerPath>
+    <Fsc_DotNET_DotnetFscCompilerPath>$(MSBuildThisFileDirectory)../../../artifacts/bin/fsc/Debug/net8.0/fsc.dll</Fsc_DotNET_DotnetFscCompilerPath>
+    <FSharpPreferNetFrameworkTools>False</FSharpPreferNetFrameworkTools>
+    <FSharpPrefer64BitTools>True</FSharpPrefer64BitTools>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="$(MSBuildThisFileDirectory)../../../artifacts/bin/FSharp.Core/Debug/netstandard2.0/FSharp.Core.dll" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/projects/Sample_Local_Compiler_and_FSLib/Program.fs
+++ b/tests/projects/Sample_Local_Compiler_and_FSLib/Program.fs
@@ -1,0 +1,25 @@
+module Program
+
+type CBuilder() =
+    [<CustomOperation>]
+    member this.Foo _ = "Foo"
+    [<CustomOperation>]
+    member this.foo _ = "foo"
+    member this.Yield _ = ()
+    member this.Zero _ = ()
+
+
+[<EntryPoint>]
+let main _ =
+    let cb = CBuilder()
+
+    let x = cb { Foo }
+    let y = cb { foo }
+    printfn $"{x}"
+    printfn $"{y}"
+
+    if x <> "Foo" then
+        failwith "not Foo"
+    if y <> "foo" then
+        failwith "not foo"
+    0


### PR DESCRIPTION
## Description

Implements https://github.com/fsharp/fslang-suggestions/issues/1250

I can't think of the need of putting it under language version, since if new fslib is used with old compiler, said compiler will be unable to produce warning that new attribute constructor won't have any effect


## Checklist

- [x] Test cases added
    - [x] Add lower and upper case methods
    - [x] ~~Add ``Quoted method names`` test, disallow if needed~~ this is allowed now, so we'll allow it in the new attribute.
    - [x] ~~Add operators methods~~ irrelevant, since operators are static methods.
- [x] ~~Add RFC (does this need an RFC?)~~ this doesn't need an RFC, since it's a very minor change.
- [x] ~~Disallow empty string as name (allowed now, but unusable, should it be an equivalent of unit constructor?)~~ empty name is the equivalent of parameterless attribute.
- [x] Release notes entry updated