### PR TITLE
Facelifting compiled code benchmarks

### DIFF
--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Async.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Async.fs
@@ -8,7 +8,7 @@ open BenchmarkDotNet.Attributes
 [<MarkdownExporterAttribute.GitHub>]
 type AsyncWhileMemoryBench() =
 
-  [<Params((* 0, 1, 100, *) 1000, 10000)>]
+  [<Params(1000, 10000)>]
   member val Length = 0 with get, set
 
   [<Benchmark>]

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Benchmarks.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Benchmarks.fs
@@ -1,8 +1,3 @@
-(*
-msbuild tests\fsharp\perf\tasks\FS\TaskPerf.fsproj /p:Configuration=Release
-dotnet artifacts\bin\TaskPerf\Release\netcoreapp2.1\TaskPerf.dll
-*)
-
 namespace TaskPerf
 
 open BenchmarkDotNet.Running
@@ -10,9 +5,7 @@ open BenchmarkDotNet.Running
 module Main = 
 
     [<EntryPoint>]
-    let main argv = 
+    let main _ = 
         printfn "Running benchmarks..."
-        //let results = BenchmarkRunner.Run<Benchmarks>()
-        //let results = BenchmarkRunner.Run<Async.AsyncWhileMemoryBench>()
-        let results = BenchmarkRunner.Run<Collections.CollectionsBenchmark>()
+        let _ = BenchmarkRunner.Run<Collections.CollectionsBenchmark>()
         0  

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/CS/MicroPerfCSharp.cs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/CS/MicroPerfCSharp.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 public class MicroPerfCSharp
 {
     //
-    // FSharp will not inline the code so we shouldn't eiter.
+    // FSharp will not inline the code so we shouldn't either.
     //
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static int Cond(int x)

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Collections.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Collections.fs
@@ -1,10 +1,6 @@
 module Collections
 
 open BenchmarkDotNet.Attributes
-open BenchmarkDotNet.Running
-open BenchmarkDotNet.Configs
-open BenchmarkDotNet.Diagnosers
-open System.Runtime.CompilerServices
 
 [<SimpleJob(launchCount = 2, warmupCount = 1, targetCount = 2)>]
 [<GcServer(true)>]
@@ -15,7 +11,7 @@ type CollectionsBenchmark() =
     let mutable list = []
     let mutable array = [||]
             
-    [<Params( (* 0, 1, 100, *) 1000, 10000)>]
+    [<Params(1000, 10000)>]
     member this.Length
         with get () = length
         and set (value) = 

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/MicroPerf.fsproj
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/MicroPerf.fsproj
@@ -2,13 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <!-- Workaround to get rid of:
-        error NU1505: Duplicate 'PackageDownload' items found.
-        Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior.
-        The duplicate 'PackageDownload' items are:
-          Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2].
-    -->
-    <NoWarn>$(NoWarn);NU1505</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <!-- Turn off "This function is for use by compiled F# code and should not be used directly" -->
     <OtherFlags>$(OtherFlags) --nowarn:1204</OtherFlags>
@@ -16,13 +9,6 @@
     <OtherFlags>$(OtherFlags) --nowarn:57</OtherFlags>
     <OtherFlags>$(OtherFlags) --langversion:preview</OtherFlags>
     <OtherFlags>$(OtherFlags) --define:PREVIEW</OtherFlags>
-    <!-- By default this project will compile with the proto compiler -->
-    <!-- Uncommenting this will build with a previous installed compiler  -->
-    <!--
-    <FscToolPath>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp</FscToolPath>
-    <FscToolExe>fsc.exe</FscToolExe>
-    <DotnetFscCompilerPath></DotnetFscCompilerPath>
-    -->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Async.fs" />
@@ -30,6 +16,7 @@
     <Compile Include="Collections.fs" />
     <Compile Include="Benchmarks.fs" />
     <ProjectReference Include="..\..\..\..\src\FSharp.Core\FSharp.Core.fsproj" />
+    <ProjectReference Include="CS\MicroPerfCSharp.csproj" />
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
   </ItemGroup>

--- a/tests/benchmarks/CompiledCodeBenchmarks/TaskPerf/TaskPerf/TaskPerf.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/TaskPerf/TaskPerf/TaskPerf.fs
@@ -1,19 +1,11 @@
-(*
-msbuild tests\benchmarks\CompiledCodeBenchmarks\TaskPerf\TaskPerf\TaskPerf.fsproj /p:Configuration=Release
-dotnet artifacts\bin\TaskPerf\Release\net7.0\TaskPerf.dll
-*)
-
 namespace TaskPerf
 
-//open FSharp.Control.Tasks
 open System
-open System.Diagnostics
 open System.Threading.Tasks
 open System.IO
 open BenchmarkDotNet.Attributes
 open BenchmarkDotNet.Running
 open TaskBuilderTasks //.ContextSensitive // TaskBuilder.fs extension members
-//open FSharp.Control.ContextSensitiveTasks // the default
 open FSharp.Control // AsyncSeq
 open Tests.SyncBuilder
 open BenchmarkDotNet.Configs

--- a/tests/benchmarks/CompiledCodeBenchmarks/TaskPerf/TaskPerf/TaskPerf.fsproj
+++ b/tests/benchmarks/CompiledCodeBenchmarks/TaskPerf/TaskPerf/TaskPerf.fsproj
@@ -3,13 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-	<!-- Workaround to get rid of:
-        error NU1505: Duplicate 'PackageDownload' items found.
-        Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior.
-        The duplicate 'PackageDownload' items are:
-          Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2], Microsoft.NETCore.App.Host.win-x64 [6.0.2].
-    -->
-    <NoWarn>NU1505</NoWarn>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <!-- Turn off "This function is for use by compiled F# code and should not be used directly" -->
 	<OtherFlags>$(OtherFlags) --nowarn:1204</OtherFlags>
@@ -23,9 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <!--
-    <Compile Include="empty.fs"  />
-	-->
 	<Compile Include="sync.fs" />
 	<Compile Include="list.fs" />
 	<Compile Include="array.fs" />
@@ -37,14 +27,9 @@
 	<Compile Include="taskSeq.fs" />
 	<Compile Include="TaskBuilder.fs" />
 	<Compile Include="TaskPerf.fs" />
-	  <!--
-    <Compile Include="seq2.fs" />
--->	
 	<ProjectReference Include="..\TaskPerfCSharp\TaskPerfCSharp.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\FSharp.Core\FSharp.Core.fsproj" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-     <!-- this must be manually enabled because CI fails because some post-build checks don't like the DLL-->
-	  <!-- <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.0.3" />  -->
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="System.Interactive.Async" Version="4.1.1" />
   </ItemGroup>
 

--- a/tests/benchmarks/CompiledCodeBenchmarks/TaskPerf/TaskPerfCSharp/TaskPerfCSharp.csproj
+++ b/tests/benchmarks/CompiledCodeBenchmarks/TaskPerf/TaskPerfCSharp/TaskPerfCSharp.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="System.Interactive.Async" Version="4.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This does some cleanup in the tests/benchmarks/CompiledCodeBenchmarks folder:
- fixes the compile error in `MicroPerf.fsproj` - the project lost the dependency in [this PR](https://github.com/dotnet/fsharp/pull/13771)
- removes the NU1505 workarounds - those were added [here](https://github.com/dotnet/fsharp/pull/13423) but looks like in the meantime the original problem was fixed, the `VisualFSharp.sln` compiles just fine without the hack now
- migrates one of the projects from .NET7 to .NET8 - was forgotten to be done in [this PR](https://github.com/dotnet/fsharp/pull/15245/)
- consolidates BDN dep in some places
- removes a bunch of commented code