### PR TITLE
Fixing and simplifying background compiler benchmarks

### DIFF
--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -783,7 +783,6 @@ type ProjectWorkflowBuilder
         initialProject: SyntheticProject,
         ?initialContext,
         ?checker: FSharpChecker,
-        ?useGetSource,
         ?useChangeNotifications,
         ?useSyntaxTreeCache,
         ?useTransparentCompiler,
@@ -792,7 +791,6 @@ type ProjectWorkflowBuilder
     ) =
 
     let useTransparentCompiler = defaultArg useTransparentCompiler false
-    let useGetSource = not useTransparentCompiler && defaultArg useGetSource false
     let useChangeNotifications = not useTransparentCompiler && defaultArg useChangeNotifications false
     let autoStart = defaultArg autoStart true
 
@@ -810,7 +808,7 @@ type ProjectWorkflowBuilder
                 enableBackgroundItemKeyStoreAndSemanticClassification = true,
                 enablePartialTypeChecking = true,
                 captureIdentifiersWhenParsing = true,
-                documentSource = (if useGetSource then DocumentSource.Custom getSource else DocumentSource.FileSystem),
+                documentSource = (if useChangeNotifications then DocumentSource.Custom getSource else DocumentSource.FileSystem),
                 useSyntaxTreeCache = defaultArg useSyntaxTreeCache false))
 
     let mapProjectAsync f workflow =
@@ -837,7 +835,6 @@ type ProjectWorkflowBuilder
         ProjectWorkflowBuilder(
             ctx.Project,
             ctx,
-            useGetSource = useGetSource,
             useChangeNotifications = useChangeNotifications,
             useTransparentCompiler = useTransparentCompiler,
             ?runTimeout = runTimeout)

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -783,6 +783,7 @@ type ProjectWorkflowBuilder
         initialProject: SyntheticProject,
         ?initialContext,
         ?checker: FSharpChecker,
+        ?useGetSource,
         ?useChangeNotifications,
         ?useSyntaxTreeCache,
         ?useTransparentCompiler,
@@ -791,6 +792,7 @@ type ProjectWorkflowBuilder
     ) =
 
     let useTransparentCompiler = defaultArg useTransparentCompiler false
+    let useGetSource = not useTransparentCompiler && defaultArg useGetSource false
     let useChangeNotifications = not useTransparentCompiler && defaultArg useChangeNotifications false
     let autoStart = defaultArg autoStart true
 
@@ -808,7 +810,7 @@ type ProjectWorkflowBuilder
                 enableBackgroundItemKeyStoreAndSemanticClassification = true,
                 enablePartialTypeChecking = true,
                 captureIdentifiersWhenParsing = true,
-                documentSource = (if useChangeNotifications then DocumentSource.Custom getSource else DocumentSource.FileSystem),
+                documentSource = (if useGetSource then DocumentSource.Custom getSource else DocumentSource.FileSystem),
                 useSyntaxTreeCache = defaultArg useSyntaxTreeCache false))
 
     let mapProjectAsync f workflow =
@@ -835,6 +837,7 @@ type ProjectWorkflowBuilder
         ProjectWorkflowBuilder(
             ctx.Project,
             ctx,
+            useGetSource = useGetSource,
             useChangeNotifications = useChangeNotifications,
             useTransparentCompiler = useTransparentCompiler,
             ?runTimeout = runTimeout)

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/BackgroundCompilerBenchmarks.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/BackgroundCompilerBenchmarks.fs
@@ -152,9 +152,6 @@ type NoFileSystemCheckerBenchmark() =
     let mutable benchmark : ProjectWorkflowBuilder = Unchecked.defaultof<_>
 
     [<ParamsAllValues>]
-    member val UseGetSource = true with get,set
-
-    [<ParamsAllValues>]
     member val UseChangeNotifications = true with get,set
 
     [<ParamsAllValues>]
@@ -165,7 +162,6 @@ type NoFileSystemCheckerBenchmark() =
         benchmark <-
             ProjectWorkflowBuilder(
             project,
-            useGetSource = this.UseGetSource,
             useChangeNotifications = this.UseChangeNotifications).CreateBenchmarkBuilder()
 
     [<IterationSetup>]
@@ -178,7 +174,6 @@ type NoFileSystemCheckerBenchmark() =
     member this.ExampleWorkflow() =
 
         use _ = Activity.start "Benchmark" [
-            "UseGetSource", this.UseGetSource.ToString()
             "UseChangeNotifications", this.UseChangeNotifications.ToString()
         ]
 
@@ -186,7 +181,7 @@ type NoFileSystemCheckerBenchmark() =
         let middle = $"File%03d{size / 2}"
         let last = $"File%03d{size}"
 
-        if this.UseGetSource && this.UseChangeNotifications then
+        if this.UseChangeNotifications then
 
             benchmark {
                 updateFile first updatePublicSurface

--- a/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/BackgroundCompilerBenchmarks.fs
+++ b/tests/benchmarks/FCSBenchmarks/CompilerServiceBenchmarks/BackgroundCompilerBenchmarks.fs
@@ -152,7 +152,7 @@ type NoFileSystemCheckerBenchmark() =
     let mutable benchmark : ProjectWorkflowBuilder = Unchecked.defaultof<_>
 
     [<ParamsAllValues>]
-    member val UseChangeNotifications = true with get,set
+    member val UseInMemoryDocuments = true with get,set
 
     [<ParamsAllValues>]
     member val EmptyCache = true with get,set
@@ -162,7 +162,8 @@ type NoFileSystemCheckerBenchmark() =
         benchmark <-
             ProjectWorkflowBuilder(
             project,
-            useChangeNotifications = this.UseChangeNotifications).CreateBenchmarkBuilder()
+            useGetSource = this.UseInMemoryDocuments,
+            useChangeNotifications = this.UseInMemoryDocuments).CreateBenchmarkBuilder()
 
     [<IterationSetup>]
     member this.EditFirstFile_OnlyInternalChange() =
@@ -174,14 +175,14 @@ type NoFileSystemCheckerBenchmark() =
     member this.ExampleWorkflow() =
 
         use _ = Activity.start "Benchmark" [
-            "UseChangeNotifications", this.UseChangeNotifications.ToString()
+            "UseInMemoryDocuments", this.UseInMemoryDocuments.ToString()
         ]
 
         let first = "File001"
         let middle = $"File%03d{size / 2}"
         let last = $"File%03d{size}"
 
-        if this.UseChangeNotifications then
+        if this.UseInMemoryDocuments then
 
             benchmark {
                 updateFile first updatePublicSurface


### PR DESCRIPTION
2 of 8 benchmarks were broken here.

|          Method | UseGetSource | UseChangeNotifications | EmptyCache |    Mean |    Error |   StdDev |  Median |      Gen0 |      Gen1 |    Allocated |
|---------------- |------------- |----------------------- |----------- |--------:|---------:|---------:|--------:|----------:|----------:|-------------:|
| ExampleWorkflow |        False |                  False |      False | 6.248 s | 0.3708 s | 1.0150 s | 5.761 s | 5000.0000 | 1000.0000 | 6032595592 B |
| ExampleWorkflow |        False |                  False |       True | 6.919 s | 0.3501 s | 0.9760 s | 6.648 s | 5000.0000 | 1000.0000 | 6143764208 B |
| ExampleWorkflow |        False |                   True |      False | 7.086 s | 0.1505 s | 0.4318 s | 7.074 s | 5000.0000 | 1000.0000 | 6032798168 B |
| ExampleWorkflow |        False |                   True |       True | 6.951 s | 0.1351 s | 0.2401 s | 6.888 s | 5000.0000 | 1000.0000 | 6144653048 B |
| ExampleWorkflow |         True |                  False |      False |      NA |       NA |       NA |      NA |         - |         - |            - |
| ExampleWorkflow |         True |                  False |       True |      NA |       NA |       NA |      NA |         - |         - |            - |
| ExampleWorkflow |         True |                   True |      False | 7.376 s | 0.3092 s | 0.9019 s | 7.344 s | 5000.0000 | 1000.0000 | 6041351816 B |
| ExampleWorkflow |         True |                   True |       True | 6.129 s | 0.1767 s | 0.5097 s | 5.905 s | 5000.0000 | 1000.0000 | 6151601544 B |

After a brief consultation with @0101, decided to keep the benchmark for the exemplary purposes but to shrink it to the scenarios that work and make the most sense.

Current benchmark results on my machine.

---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.2861)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2 DEBUG
  Job-ZMGPSB : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

InvocationCount=1  UnrollFactor=1

|          Method | UseChangeNotifications | EmptyCache |    Mean |    Error |   StdDev |  Median |      Gen0 |      Gen1 | Allocated |
|---------------- |----------------------- |----------- |--------:|---------:|---------:|--------:|----------:|----------:|----------:|
| ExampleWorkflow |                  False |      False | 6.749 s | 0.3663 s | 1.0090 s | 6.266 s | 5000.0000 | 1000.0000 |   5.62 GB |
| ExampleWorkflow |                  False |       True | 6.729 s | 0.2630 s | 0.7502 s | 6.410 s | 5000.0000 | 1000.0000 |   5.72 GB |
| ExampleWorkflow |                   True |      False | 6.925 s | 0.3304 s | 0.9534 s | 6.583 s | 5000.0000 | 1000.0000 |   5.63 GB |
| ExampleWorkflow |                   True |       True | 6.656 s | 0.2270 s | 0.6366 s | 6.433 s | 5000.0000 | 1000.0000 |   5.73 GB |