### PR TITLE
Speed up unused opens handling for empty results

### DIFF
--- a/src/Compiler/Service/ServiceAnalysis.fs
+++ b/src/Compiler/Service/ServiceAnalysis.fs
@@ -297,12 +297,19 @@ module UnusedOpens =
     /// Async to allow cancellation.
     let getUnusedOpens (checkFileResults: FSharpCheckFileResults, getSourceLineStr: int -> string) : Async<range list> =
         async {
-            let! ct = Async.CancellationToken
-            let symbolUses = checkFileResults.GetAllUsesOfAllSymbolsInFile(ct)
-            let symbolUses = filterSymbolUses getSourceLineStr symbolUses
-            let symbolUses = splitSymbolUses symbolUses
-            let openStatements = getOpenStatements checkFileResults.OpenDeclarations
-            return! filterOpenStatements symbolUses openStatements
+            if checkFileResults.OpenDeclarations.Length = 0 then
+                return []
+            else
+                let! ct = Async.CancellationToken
+                let symbolUses = checkFileResults.GetAllUsesOfAllSymbolsInFile(ct)
+                let symbolUses = filterSymbolUses getSourceLineStr symbolUses
+                let symbolUses = splitSymbolUses symbolUses
+                let openStatements = getOpenStatements checkFileResults.OpenDeclarations
+
+                if openStatements.Length = 0 then
+                    return []
+                else
+                    return! filterOpenStatements symbolUses openStatements
         }
 
 module SimplifyNames =


### PR DESCRIPTION
Before:

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.2861)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2 DEBUG
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
```

|      Method |     Mean |    Error |   StdDev |   Median |    Gen0 | Allocated |
|------------ |---------:|---------:|---------:|---------:|--------:|----------:|
| UnusedOpens | 924.6 us | 41.93 us | 119.0 us | 889.5 us | 11.7188 | 747.91 KB |

After:

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.2861)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2 DEBUG
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
```

|      Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|------------ |---------:|---------:|---------:|-------:|----------:|
| UnusedOpens | 80.31 us | 1.602 us | 2.348 us | 0.6104 |  43.21 KB |