### PR TITLE
Move to non-deprecated NuGetAuthenticate@1 task

### DIFF
--- a/eng/restore-internal-tools.yml
+++ b/eng/restore-internal-tools.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     inputs:
       nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
       forceReinstallCredentialProvider: true


### PR DESCRIPTION
See https://github.com/dotnet/arcade/pull/14314. The build will start failing at the end of the month unless the task is bumped.

There are also some eng/common usages that will be fixed by https://github.com/dotnet/fsharp/pull/16460, it'd be good to get that one merged as well.

/cc @vzarytovskii 