### PR TITLE
Ad-hoc fix for #16524

### DIFF
--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -436,7 +436,12 @@ let AdjustCalledArgType (infoReader: InfoReader) ad isConstraint enforceNullable
             else 
                 destByrefTy g calledArgTy
 #else
-            calledArgTy, TypeDirectedConversionUsed.No, None
+            // If caller argument is a refcell type called is inref, convert to refcell.
+            // Ad-hoc fix for https://github.com/dotnet/fsharp/issues/16524
+            if isRefCellTy g callerArgTy then
+                mkRefCellTy g (destByrefTy g calledArgTy), TypeDirectedConversionUsed.No, None
+            else
+                calledArgTy, TypeDirectedConversionUsed.No, None
 #endif
 
         // If the called method argument is a (non inref) byref type, then the caller may provide a byref or ref.


### PR DESCRIPTION
That is a very ad-hoc fix for #16524.


I am not entirely sure we want to allow that, since it will explicitly allow cases with inrefs which were forbidden earlier. I would love to hear from @TIHan and @dsyme.

Alternatives would be:
a. Carry mutability info of the ref cell and only allow that for immutable ref cells.
b. Carry info about that it's not an inref, but ref readonly, and only allow it in this case.
c. Don't do anything, and say that it's by design (`ref readonly` is treated as `inref` and `RefCell` cannot be passed there). This would be a breaking change comparing to 8.0.100 (which had incorrect parsing for `ref readonly`), but the behaviour itself is initiated by BCL change (`ref` parameter -> `ref readonly` parameter on methods in Volatile).

cc @radekm