### PR TITLE
[WIP] Lowering string interpolation to calls to concat

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -5,8 +5,8 @@ namespace EmittedIL
 open Xunit
 open FSharp.Test.Compiler
 
-#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
 module ``StringFormatAndInterpolation`` =
+#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
     [<Fact>]
     let ``Interpolated string with no holes is reduced to a string or simple format when used in printf``() =
         FSharp """
@@ -34,3 +34,21 @@ IL_0017:  ret"""]
 
 #endif
 
+    [<Fact>]
+    let ``Interpolated string with 3 parts consisting only of strings is lowered to concat`` () =
+        let str = "$\"\"\"ab{\"c\"}d\"\"\""
+        FSharp $"""
+module StringFormatAndInterpolation
+
+let str () = {str}
+        """
+        |> compile
+        |> shouldSucceed
+        |> verifyIL ["""
+IL_0000:  ldstr      "ab"
+IL_0005:  ldstr      "c"
+IL_000a:  ldstr      "d"
+IL_000f:  call       string [runtime]System.String::Concat(string,
+                                                                  string,
+                                                                  string)
+IL_0014:  ret"""]

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -145,12 +145,13 @@ printfn "%%s" x
         |> withStdOutContains expectedOut
 
     [<Theory>]
-    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde")>]
-    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde")>]
-    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde")>]
-    let ``In FormattableString, interpolated expressions are strings`` (formattableStr: string, expectedOut: string) =
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde", 1)>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde", 2)>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde", 2)>]
+    let ``In FormattableString, interpolated expressions are strings`` (formattableStr: string, expectedOut: string, argCount: int) =
         Fsx $"""
 let x = {formattableStr} : System.FormattableString
+assert(x.ArgumentCount = {argCount})
 printfn "%%s" (System.Globalization.CultureInfo "en-US" |> x.ToString)
         """
         |> compileExeAndRun

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -129,3 +129,30 @@ type Foo () =
         """
         |> compile
         |> shouldSucceed
+
+    [<Theory>]
+    // Test different number of interpolated string parts
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde")>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde")>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde")>]
+    let ``Interpolated expressions are strings`` (strToPrint: string, expectedOut: string) =
+        Fsx $"""
+let x = {strToPrint}
+printfn "%%s" x
+        """
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains expectedOut
+
+    [<Theory>]
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde")>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde")>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde")>]
+    let ``In FormattableString, interpolated expressions are strings`` (formattableStr: string, expectedOut: string) =
+        Fsx $"""
+let x = {formattableStr} : System.FormattableString
+printfn "%%s" (System.Globalization.CultureInfo "en-US" |> x.ToString)
+        """
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains expectedOut


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

A draft PR to test on CI.

The idea is to lower string interpolation to a call to concat if interpolated string has at most 4 parts and all the parts are strings.

### TODOs:
- More IL tests?
- Benchmark
- Filter out empty strings? E.g. `$"{0}{1}"` has technically 5 parts - an empty string, first interpolated expression, an empty string, second interpolated expression and another empty string
- Benchmark
- Make the code nicer

Fixes # (issue, if applicable)

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**