### PR TITLE
Diagnostics/extended data: support NoConstructorsAvailableForType

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -6,6 +6,7 @@
 
 * Parser recovers on complex primary constructor patterns, better tree representation for primary constructor patterns. ([PR #16425](https://github.com/dotnet/fsharp/pull/16425))
 * Name resolution: keep type vars in subsequent checks ([PR #16456](https://github.com/dotnet/fsharp/pull/16456))
+* Diagnostics: extended data for NoConstructorsAvailableForType ([PR #16543](https://github.com/dotnet/fsharp/pull/16543))
 
 ### Changed
 

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -2550,6 +2550,8 @@ let ResolveLongIdentAsModuleOrNamespaceThen sink atMostOne amap m fullyQualified
 // Bind name used in "new Foo.Bar(...)" constructs
 //-------------------------------------------------------------------------
 
+exception NoConstructorsAvailableForType of TType * DisplayEnv * range
+
 let private ResolveObjectConstructorPrim (ncenv: NameResolver) edenv resInfo m ad ty =
     let g = ncenv.g
     let amap = ncenv.amap
@@ -2570,7 +2572,7 @@ let private ResolveObjectConstructorPrim (ncenv: NameResolver) edenv resInfo m a
                     [DefaultStructCtor(g, ty)]
                 else []
             if (isNil defaultStructCtorInfo && isNil ctorInfos) || (not (isAppTy g ty) && not (isAnyTupleTy g ty)) then
-                raze (Error(FSComp.SR.nrNoConstructorsAvailableForType(NicePrint.minimalStringOfType edenv ty), m))
+                raze (NoConstructorsAvailableForType(ty, edenv, m))
             else
                 let ctorInfos = ctorInfos |> List.filter (IsMethInfoAccessible amap m ad)
                 let metadataTy = convertToTypeWithMetadataIfPossible g ty

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -673,6 +673,8 @@ exception internal IndeterminateType of range
 /// Used to report a warning condition for the use of upper-case identifiers in patterns
 exception internal UpperCaseIdentifierInPattern of range
 
+exception internal NoConstructorsAvailableForType of TType * DisplayEnv * range
+
 /// Generate a new reference to a record field with a fresh type instantiation
 val FreshenRecdFieldRef: NameResolver -> range -> RecdFieldRef -> RecdFieldInfo
 

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -216,7 +216,6 @@ type Exception with
         // DO NOT CHANGE THESE NUMBERS
         | ErrorFromAddingTypeEquation _ -> 1
         | FunctionExpected _ -> 2
-        | NotAFunctionButIndexer _ -> 3217
         | NotAFunction _ -> 3
         | FieldNotMutable _ -> 5
         | Recursion _ -> 6
@@ -320,7 +319,6 @@ type Exception with
         | BadEventTransformation _ -> 91
         | HashLoadedScriptConsideredSource _ -> 92
         | UnresolvedConversionOperator _ -> 93
-        | ArgumentsInSigAndImplMismatch _ -> 3218
         // avoid 94-100 for safety
         | ObsoleteError _ -> 101
 #if !NO_TYPEPROVIDERS
@@ -328,6 +326,8 @@ type Exception with
         | TypeProviders.ProvidedTypeResolution _ -> 103
 #endif
         | PatternMatchCompilation.EnumMatchIncomplete _ -> 104
+        | NotAFunctionButIndexer _ -> 3217
+        | ArgumentsInSigAndImplMismatch _ -> 3218
 
         // Strip TargetInvocationException wrappers
         | :? TargetInvocationException as e -> e.InnerException.DiagnosticNumber

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -326,6 +326,7 @@ type Exception with
         | TypeProviders.ProvidedTypeResolution _ -> 103
 #endif
         | PatternMatchCompilation.EnumMatchIncomplete _ -> 104
+        | NoConstructorsAvailableForType _ -> 1133
         | NotAFunctionButIndexer _ -> 3217
         | ArgumentsInSigAndImplMismatch _ -> 3218
 
@@ -605,6 +606,7 @@ module OldStyleMessages =
     let MSBuildReferenceResolutionErrorE () = Message("MSBuildReferenceResolutionError", "%s%s")
     let TargetInvocationExceptionWrapperE () = Message("TargetInvocationExceptionWrapper", "%s")
     let ArgumentsInSigAndImplMismatchE () = Message("ArgumentsInSigAndImplMismatch", "%s%s")
+    let NoConstructorsAvailableForTypeE () = Message("NoConstructorsAvailableForType", "%s")
 
 #if DEBUG
 let mutable showParserStackOnParseError = false
@@ -1856,6 +1858,9 @@ type Exception with
 
         | ArgumentsInSigAndImplMismatch(sigArg, implArg) ->
             os.AppendString(ArgumentsInSigAndImplMismatchE().Format sigArg.idText implArg.idText)
+
+        | NoConstructorsAvailableForType(ty, denv, _) ->
+            os.AppendString(NoConstructorsAvailableForTypeE().Format(NicePrint.stringOfTy denv ty))
 
         // Strip TargetInvocationException wrappers
         | :? TargetInvocationException as exn -> exn.InnerException.Output(os, suggestNames)

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1010,7 +1010,6 @@ lexfltSeparatorTokensOfPatternMatchMisaligned,"The '|' tokens separating rules o
 1129,nrRecordDoesNotContainSuchLabel,"The record type '%s' does not contain a label '%s'."
 1130,nrInvalidFieldLabel,"Invalid field label"
 1132,nrInvalidExpression,"Invalid expression '%s'"
-1133,nrNoConstructorsAvailableForType,"No constructors are available for the type '%s'"
 1134,nrUnionTypeNeedsQualifiedAccess,"The union type for union case '%s' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('%s') in the name you are using."
 1135,nrRecordTypeNeedsQualifiedAccess,"The record type for the record field '%s' was defined with the RequireQualifiedAccessAttribute. Include the name of the record type ('%s') in the name you are using."
 1136,ilwriteErrorCreatingPdb,"Unexpected error creating debug information file '%s'"

--- a/src/Compiler/FSStrings.resx
+++ b/src/Compiler/FSStrings.resx
@@ -1113,6 +1113,9 @@
   <data name="ArgumentsInSigAndImplMismatch" xml:space="preserve">
     <value>The argument names in the signature '{0}' and implementation '{1}' do not match. The argument name from the signature file will be used. This may cause problems when debugging or profiling.</value>
   </data>
+  <data name="NoConstructorsAvailableForType" xml:space="preserve">
+    <value>No constructors are available for the type '{0}'</value>
+  </data>
   <data name="Parser.TOKEN.WHILE.BANG" xml:space="preserve">
     <value>keyword 'while!'</value>
   </data>

--- a/src/Compiler/Symbols/FSharpDiagnostic.fs
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fs
@@ -110,6 +110,13 @@ module ExtendedData =
         member x.SignatureRange = sigArg.idRange
         member x.ImplementationRange = implArg.idRange
 
+    [<Experimental("This FCS API is experimental and subject to change.")>]
+    type TypeUsageErrorExtendedData(ty: TType, symbolEnv: SymbolEnv) =
+
+        interface IFSharpDiagnosticExtendedData
+
+        member x.Type = FSharpType(symbolEnv, ty)
+
 open ExtendedData
 
 type FSharpDiagnostic(m: range, severity: FSharpDiagnosticSeverity, message: string, subcategory: string, errorNum: int, numberPrefix: string, extendedData: IFSharpDiagnosticExtendedData option) =

--- a/src/Compiler/Symbols/FSharpDiagnostic.fs
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fs
@@ -68,8 +68,8 @@ module ExtendedData =
     type IFSharpDiagnosticExtendedData = interface end
 
     [<Experimental("This FCS API is experimental and subject to change.")>]
-    type TypeMismatchDiagnosticExtendedData
-        internal (symbolEnv: SymbolEnv, dispEnv: DisplayEnv, expectedType: TType, actualType: TType, context: DiagnosticContextInfo) =
+    type TypeMismatchDiagnosticExtendedData(symbolEnv: SymbolEnv, dispEnv: DisplayEnv, expectedType: TType, actualType: TType, context: DiagnosticContextInfo) =
+
         interface IFSharpDiagnosticExtendedData
 
         member x.ExpectedType = FSharpType(symbolEnv, expectedType)
@@ -78,30 +78,33 @@ module ExtendedData =
         member x.DisplayContext = FSharpDisplayContext(fun _ -> dispEnv)
 
     [<Experimental("This FCS API is experimental and subject to change.")>]
-    type ExpressionIsAFunctionExtendedData
-        internal (symbolEnv: SymbolEnv, actualType: TType) =
+    type ExpressionIsAFunctionExtendedData(symbolEnv: SymbolEnv, actualType: TType) =
+
         interface IFSharpDiagnosticExtendedData
 
         member x.ActualType = FSharpType(symbolEnv, actualType)
 
     [<Experimental("This FCS API is experimental and subject to change.")>]
-    type FieldNotContainedDiagnosticExtendedData
-        internal (symbolEnv: SymbolEnv, implTycon: Tycon, sigTycon: Tycon, signatureField: RecdField, implementationField: RecdField) =
+    type FieldNotContainedDiagnosticExtendedData(symbolEnv: SymbolEnv, implTycon: Tycon, sigTycon: Tycon, signatureField: RecdField, implementationField: RecdField) =
+
         interface IFSharpDiagnosticExtendedData
+
         member x.SignatureField = FSharpField(symbolEnv, RecdFieldRef.RecdFieldRef(mkLocalTyconRef sigTycon, signatureField.Id.idText))
         member x.ImplementationField = FSharpField(symbolEnv, RecdFieldRef.RecdFieldRef(mkLocalTyconRef implTycon, implementationField.Id.idText))
 
     [<Experimental("This FCS API is experimental and subject to change.")>]
-    type ValueNotContainedDiagnosticExtendedData
-        internal (symbolEnv: SymbolEnv, signatureValue: Val, implValue: Val) =
+    type ValueNotContainedDiagnosticExtendedData(symbolEnv: SymbolEnv, signatureValue: Val, implValue: Val) =
+
         interface IFSharpDiagnosticExtendedData
+
         member x.SignatureValue = FSharpMemberOrFunctionOrValue(symbolEnv, mkLocalValRef signatureValue)
         member x.ImplementationValue = FSharpMemberOrFunctionOrValue(symbolEnv, mkLocalValRef implValue)
 
     [<Experimental("This FCS API is experimental and subject to change.")>]
-    type ArgumentsInSigAndImplMismatchExtendedData
-        internal(sigArg: Ident, implArg: Ident) =
+    type ArgumentsInSigAndImplMismatchExtendedData(sigArg: Ident, implArg: Ident) =
+
         interface IFSharpDiagnosticExtendedData
+
         member x.SignatureName = sigArg.idText
         member x.ImplementationName = implArg.idText
         member x.SignatureRange = sigArg.idRange

--- a/src/Compiler/Symbols/FSharpDiagnostic.fsi
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fsi
@@ -106,6 +106,12 @@ module public ExtendedData =
         /// Argument identifier range within implementation file
         member ImplementationRange: range
 
+    [<Class; Experimental("This FCS API is experimental and subject to change.")>]
+    type TypeUsageErrorExtendedData =
+        interface IFSharpDiagnosticExtendedData
+
+        member Type: FSharpType
+
 open ExtendedData
 
 /// Represents a diagnostic produced by the F# compiler

--- a/src/Compiler/Symbols/FSharpDiagnostic.fsi
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fsi
@@ -46,14 +46,15 @@ module public ExtendedData =
 
     /// Contextually-relevant data to each particular diagnostic
     [<Interface; Experimental("This FCS API is experimental and subject to change.")>]
-    type public IFSharpDiagnosticExtendedData =
+    type IFSharpDiagnosticExtendedData =
         interface
         end
 
     /// Additional data for type-mismatch-like (usually with ErrorNumber = 1) diagnostics
     [<Class; Experimental("This FCS API is experimental and subject to change.")>]
-    type public TypeMismatchDiagnosticExtendedData =
+    type TypeMismatchDiagnosticExtendedData =
         interface IFSharpDiagnosticExtendedData
+
         /// Represents F# type expected in the current context
         member ExpectedType: FSharpType
         /// Represents F# type type actual in the current context
@@ -65,15 +66,17 @@ module public ExtendedData =
 
     /// Additional data for 'This expression is a function value, i.e. is missing arguments' diagnostic
     [<Class; Experimental("This FCS API is experimental and subject to change.")>]
-    type public ExpressionIsAFunctionExtendedData =
+    type ExpressionIsAFunctionExtendedData =
         interface IFSharpDiagnosticExtendedData
+
         /// Represents F# type of the expression
         member ActualType: FSharpType
 
     /// Additional data for diagnostics about a field whose declarations differ in signature and implementation
     [<Class; Experimental("This FCS API is experimental and subject to change.")>]
-    type public FieldNotContainedDiagnosticExtendedData =
+    type FieldNotContainedDiagnosticExtendedData =
         interface IFSharpDiagnosticExtendedData
+
         /// Represents F# field in signature file
         member SignatureField: FSharpField
         /// Represents F# field in implementation file
@@ -81,8 +84,9 @@ module public ExtendedData =
 
     /// Additional data for diagnostics about a value whose declarations differ in signature and implementation
     [<Class; Experimental("This FCS API is experimental and subject to change.")>]
-    type public ValueNotContainedDiagnosticExtendedData =
+    type ValueNotContainedDiagnosticExtendedData =
         interface IFSharpDiagnosticExtendedData
+
         /// Represents F# value in signature file
         member SignatureValue: FSharpMemberOrFunctionOrValue
         /// Represents F# value in implementation file
@@ -92,6 +96,7 @@ module public ExtendedData =
     [<Class; Experimental("This FCS API is experimental and subject to change.")>]
     type ArgumentsInSigAndImplMismatchExtendedData =
         interface IFSharpDiagnosticExtendedData
+
         /// Argument name in signature file
         member SignatureName: string
         /// Argument name in implementation file

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Neplatný výraz {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Pro typ {0} nejsou k dispozici žádné konstruktory.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Typ sjednocení pro případ sjednocení {0} se definoval pomocí atributu RequireQualifiedAccessAttribute. Do jména, které používáte, přidejte název typu sjednocení ({1}).</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Ungültiger Ausdruck "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Für den Typ "{0}" sind keine Konstruktoren verfügbar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Der Union-Typ für Union-Fall "{0}" wurde mit RequireQualifiedAccessAttribute definiert. Fügen Sie den Union-Typnamen ("{1}") in den verwendeten Namen ein.</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Expresión '{0}' no válida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">No hay constructores disponibles para el tipo '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">El tipo de unión del caso de unión "{0}" se definió con el atributo RequireQualifiedAccessAttribute. Incluya el nombre del tipo de unión ("{1}") en el nombre que esté usando.</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Expression non valide '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Aucun constructeur n'est disponible pour le type '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Le type union du cas d'union '{0}' a été défini avec RequireQualifiedAccessAttribute. Incluez le nom du type union ('{1}') dans le nom que vous utilisez.</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Espressione '{0}' non valida</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Nessun costruttore disponibile per il tipo '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Il tipo di unione per il case di unione '{0}' è stato definito con RequireQualifiedAccessAttribute. Includere il nome del tipo di unione ('{1}') nel nome da usare.</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">式 '{0}' は無効です</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">型 '{0}' に使用できるコンストラクターがありません</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">共用体ケース '{0}' の共用体型が RequireQualifiedAccessAttribute によって定義されました。使用中の名前に共用体型 ('{1}') の名前を含めてください。</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">'{0}' 식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">'{0}' 형식에 대해 사용할 수 있는 생성자가 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">공용 구조체 케이스 '{0}'에 대한 공용 구조체 형식은 RequireQualifiedAccessAttribute로 정의됩니다. 사용 중인 이름에 공용 구조체 형식('{1}') 이름을 포함하세요.</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Nieprawidłowe wyrażenie „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Brak konstruktorów dostępnych dla typu „{0}”</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Typ unii dla przypadku unii „{0}” został zdefiniowany z użyciem wartości RequireQualifiedAccessAttribute. Uwzględnij nazwę typu unii („{1}”) w używanej nazwie.</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Expressão '{0}' inválida</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Nenhum construtor está disponível para o tipo '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">O tipo de união para o caso de união '{0}' foi definido com o RequireQualifiedAccessAttribute. Inclua o nome do tipo de união ('{1}') no nome que você está usando.</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Недопустимое выражение "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Недоступны конструкторы для типа "{0}"</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Тип объединения для ветви объединения "{0}" определен с RequireQualifiedAccessAttribute. Включите имя типа объединения ("{1}") в используемое имя.</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">Geçersiz ifade: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">'{0}' türü için kullanılabilir bir oluşturucu yok</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">{0}' birleşim durumunun birleşim türü RequireQualifiedAccessAttribute ile tanımlanmış. Kullandığınız ada birleşim türünün adını ('{1}') dahil edin.</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">表达式“{0}”无效</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">没有对类型“{0}”可用的构造函数</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">使用 RequireQualifiedAccessAttribute 定义联合用例“{0}”的联合类型。包括所使用的名称中联合类型 ('{1}') 的名称。</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -6287,11 +6287,6 @@
         <target state="translated">無效的運算式 '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">沒有可供類型 '{0}' 使用的建構函式</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">聯集 '{0}' 的等位型別由 RequireQualifiedAccessAttribute 定義。請在您使用的名稱中，加入等位型別 '{1}' 的名稱。</target>

--- a/src/Compiler/xlf/FSStrings.cs.xlf
+++ b/src/Compiler/xlf/FSStrings.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Nejméně jedna informační zpráva v načteném souboru\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Případy sjednocení s malými písmeny jsou povolené jenom při použití atributu RequireQualifiedAccess.</target>

--- a/src/Compiler/xlf/FSStrings.de.xlf
+++ b/src/Compiler/xlf/FSStrings.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Mindestens eine Informationsmeldung in der geladenen Datei.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Diskriminierte Union-Fälle in Kleinbuchstaben sind nur zulässig, wenn das RequireQualifiedAccess-Attribut verwendet wird.</target>

--- a/src/Compiler/xlf/FSStrings.es.xlf
+++ b/src/Compiler/xlf/FSStrings.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Uno o más mensajes informativos en el archivo cargado.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Los casos de unión discriminada en minúsculas solo se permiten cuando se usa el atributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.fr.xlf
+++ b/src/Compiler/xlf/FSStrings.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Un ou plusieurs messages d’information dans le fichier chargé.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Les cas d’union discriminée en minuscules sont uniquement autorisés lors de l’utilisation de l’attribut RequireQualifiedAccess.</target>

--- a/src/Compiler/xlf/FSStrings.it.xlf
+++ b/src/Compiler/xlf/FSStrings.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Uno o più messaggi informativi nel file caricato.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">I casi di unione discriminati minuscoli sono consentiti solo quando si usa l'attributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.ja.xlf
+++ b/src/Compiler/xlf/FSStrings.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">読み込まれたファイル内の 1 つ以上の情報メッセージ。\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">小文字で区別される和集合のケースは、RequireQualifiedAccess 属性を使用する場合にのみ許可されます</target>

--- a/src/Compiler/xlf/FSStrings.ko.xlf
+++ b/src/Compiler/xlf/FSStrings.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">로드된 파일에 하나 이상의 정보 메시지가 있습니다.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">소문자로 구분된 공용 구조체 케이스는 RequireQualifiedAccess 특성을 사용하는 경우에만 허용됩니다.</target>

--- a/src/Compiler/xlf/FSStrings.pl.xlf
+++ b/src/Compiler/xlf/FSStrings.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Jeden lub więcej komunikatów informacyjnych w załadowanym pliku.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Przypadki unii z dyskryminatorem z małymi literami są dozwolone tylko w przypadku używania atrybutu RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.pt-BR.xlf
+++ b/src/Compiler/xlf/FSStrings.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Uma ou mais mensagens informativas no arquivo carregado.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Os casos de união discriminados em letras minúsculas só são permitidos ao usar o atributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.ru.xlf
+++ b/src/Compiler/xlf/FSStrings.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Одно или несколько информационных сообщений в загруженном файле.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Размеченные в нижнем регистре случаи объединения разрешены только при использовании атрибута RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.tr.xlf
+++ b/src/Compiler/xlf/FSStrings.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Yüklenen dosyada bir veya daha fazla bilgi mesajı.\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Küçük harf ayrımlı birleşim durumlarına yalnızca RequireQualifiedAccess özniteliği kullanılırken izin verilir</target>

--- a/src/Compiler/xlf/FSStrings.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSStrings.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">加载文件 .\n 中有一条或多条信息性消息</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">仅当使用 RequireQualifiedAccess 属性时才允许区分小写的联合事例</target>

--- a/src/Compiler/xlf/FSStrings.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSStrings.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">已載入檔案中的一或多個資訊訊息。\n</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">只有在使用 RequireQualifiedAccess 屬性時，才允許小寫區分聯結案例</target>


### PR DESCRIPTION
I'm trying to add diagnostic extended data for another diagnostic:

<img width="428" alt="Screenshot 2020-06-02 at 19 38 20" src="https://github.com/dotnet/fsharp/assets/3923587/d3f906b6-9585-4d01-aa11-ca3340edce02">
