### PR TITLE
Fix Test-Source mapping for FSharp.Editor.Tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -91,7 +91,7 @@
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <!-- Versions for package groups -->
-    <RoslynVersion>4.6.0-2.23126.2</RoslynVersion>
+    <RoslynVersion>4.6.0-3.23329.3</RoslynVersion>
     <VisualStudioEditorPackagesVersion>17.7.25-preview</VisualStudioEditorPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.7.35338-preview.1</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.7.58-pre</VisualStudioProjectSystemPackagesVersion>


### PR DESCRIPTION
The mapping between tests and their source code was not working for  FSharp.Editor.Tests.
@KevinRansom bisected it down to a usage of a type from Microsoft.CodeAnalysis (Roslyn).

With the help of @nohwnd, this was debugged and the following issue has been shown:
- testhost.net472.exe, PortableSymbolReader: Failed to load symbols for binary: D:\fsharp\artifacts\bin\FSharp.Editor.Tests\Debug\net472\FSharp.Editor.Tests.dll
-  at System.Reflection.Assembly.GetTypes()
-  System.Collections.Immutable, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a: Failed to load assembly.


The testhost only tries to read types via reflection, but that has failed and therefore all source-test mapping was not available.
The issue in this codebase was caused by Roslyn packages depending on v6 of System.Collections.Immutable, whereas other parts of the compiler have a direct dependency to v7.

The solution is to update Roslyn packages.
This version is still in the 4.6 range, but uses Immutable v7 already. (we could do more rapid updates up to 4.8 or even 4.9)