### PR TITLE
revert #16327 (addition of XliffTasks reference) to fix #16424

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,7 +13,4 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)" />
     <PackageReference Include="NunitXml.TestLogger" Version="$(NunitXmlTestLoggerVersion)" />
   </ItemGroup>
- <ItemGroup>
-    <PackageReference Condition="'$(BUILDING_USING_DOTNET)' == 'true'" Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" />  
- </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -192,7 +192,6 @@
     <XUnitRunnerVersion>2.4.2</XUnitRunnerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
-    <MicrosoftDotNetXliffTasksVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksVersion>
     <!-- MIBC profile packages -->
     <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.23614.4</optimizationwindows_ntx64MIBCRuntimeVersion>
     <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.23614.4</optimizationwindows_ntx86MIBCRuntimeVersion>


### PR DESCRIPTION
## Description

Fixes #16424 by reverting #16327.
It seems the reference to XliffTasks is now handled automagically for `dotnet build src/Compiler /t:UpdateXlf`, so we can remove the explicit reference and thus avoid stopping dotnet test when FSComp.txt is changed.
