### PR TITLE
Small refactor of TailCallChecks.fs for simplicity

### DIFF
--- a/src/Compiler/Checking/TailCallChecks.fs
+++ b/src/Compiler/Checking/TailCallChecks.fs
@@ -68,8 +68,6 @@ type cenv =
 
         amap: Import.ImportMap
 
-        reportErrors: bool
-
         /// Values in module that have been marked [<TailCall>]
         mustTailCall: Zset<Val>
     }
@@ -140,12 +138,8 @@ let rec mkArgsForAppliedExpr isBaseCall argsl x =
     | Expr.Op(TOp.Coerce, _, [ f ], _) -> mkArgsForAppliedExpr isBaseCall argsl f
     | _ -> []
 
-/// Check an expression, where the expression is in a position where byrefs can be generated
-let rec CheckExprNoByrefs cenv (tailCall: TailCall) expr =
-    CheckExpr cenv expr PermitByRefExpr.No tailCall
-
 /// Check an expression, warn if it's attributed with TailCall but our analysis concludes it's not a valid tail call
-and CheckForNonTailRecCall (cenv: cenv) expr (tailCall: TailCall) =
+let CheckForNonTailRecCall (cenv: cenv) expr (tailCall: TailCall) =
     let g = cenv.g
     let expr = stripExpr expr
     let expr = stripDebugPoints expr
@@ -153,67 +147,69 @@ and CheckForNonTailRecCall (cenv: cenv) expr (tailCall: TailCall) =
     match expr with
     | Expr.App(f, _fty, _tyargs, argsl, m) ->
 
-        if cenv.reportErrors then
-            if cenv.g.langVersion.SupportsFeature LanguageFeature.WarningWhenTailRecAttributeButNonTailRecUsage then
-                match f with
-                | ValUseAtApp(vref, valUseFlags) when cenv.mustTailCall.Contains vref.Deref ->
+        match f with
+        | ValUseAtApp(vref, valUseFlags) when cenv.mustTailCall.Contains vref.Deref ->
 
-                    let canTailCall =
-                        match tailCall with
-                        | TailCall.No -> // an upper level has already decided that this is not in a tailcall position
-                            false
-                        | TailCall.Yes returnType ->
-                            if vref.IsMemberOrModuleBinding && vref.ValReprInfo.IsSome then
-                                let topValInfo = vref.ValReprInfo.Value
+            let canTailCall =
+                match tailCall with
+                | TailCall.No -> // an upper level has already decided that this is not in a tailcall position
+                    false
+                | TailCall.Yes returnType ->
+                    if vref.IsMemberOrModuleBinding && vref.ValReprInfo.IsSome then
+                        let topValInfo = vref.ValReprInfo.Value
 
-                                let nowArgs, laterArgs =
-                                    let _, curriedArgInfos, _, _ =
-                                        GetValReprTypeInFSharpForm cenv.g topValInfo vref.Type m
+                        let nowArgs, laterArgs =
+                            let _, curriedArgInfos, _, _ =
+                                GetValReprTypeInFSharpForm cenv.g topValInfo vref.Type m
 
-                                    if argsl.Length >= curriedArgInfos.Length then
-                                        (List.splitAfter curriedArgInfos.Length argsl)
-                                    else
-                                        ([], argsl)
-
-                                let numEnclosingTypars = CountEnclosingTyparsOfActualParentOfVal vref.Deref
-
-                                let _, _, _, returnTy, _ =
-                                    GetValReprTypeInCompiledForm g topValInfo numEnclosingTypars vref.Type m
-
-                                let _, _, isNewObj, isSuperInit, isSelfInit, _, _, _ =
-                                    GetMemberCallInfo cenv.g (vref, valUseFlags)
-
-                                let isCCall =
-                                    match valUseFlags with
-                                    | PossibleConstrainedCall _ -> true
-                                    | _ -> false
-
-                                let hasByrefArg = nowArgs |> List.exists (tyOfExpr cenv.g >> isByrefTy cenv.g)
-
-                                let mustGenerateUnitAfterCall =
-                                    (Option.isNone returnTy && returnType <> TailCallReturnType.MustReturnVoid)
-
-                                let noTailCallBlockers =
-                                    not isNewObj
-                                    && not isSuperInit
-                                    && not isSelfInit
-                                    && not mustGenerateUnitAfterCall
-                                    && isNil laterArgs
-                                    && not (IsValRefIsDllImport cenv.g vref)
-                                    && not isCCall
-                                    && not hasByrefArg
-
-                                noTailCallBlockers // blockers that will prevent the IL level from emmiting a tail instruction
+                            if argsl.Length >= curriedArgInfos.Length then
+                                (List.splitAfter curriedArgInfos.Length argsl)
                             else
-                                true
+                                ([], argsl)
 
-                    // warn if we call inside of recursive scope in non-tail-call manner/with tail blockers. See
-                    // ``Warn successfully in match clause``
-                    // ``Warn for byref parameters``
-                    if not canTailCall then
-                        warning (Error(FSComp.SR.chkNotTailRecursive vref.DisplayName, m))
-                | _ -> ()
+                        let numEnclosingTypars = CountEnclosingTyparsOfActualParentOfVal vref.Deref
+
+                        let _, _, _, returnTy, _ =
+                            GetValReprTypeInCompiledForm g topValInfo numEnclosingTypars vref.Type m
+
+                        let _, _, isNewObj, isSuperInit, isSelfInit, _, _, _ =
+                            GetMemberCallInfo cenv.g (vref, valUseFlags)
+
+                        let isCCall =
+                            match valUseFlags with
+                            | PossibleConstrainedCall _ -> true
+                            | _ -> false
+
+                        let hasByrefArg = nowArgs |> List.exists (tyOfExpr cenv.g >> isByrefTy cenv.g)
+
+                        let mustGenerateUnitAfterCall =
+                            (Option.isNone returnTy && returnType <> TailCallReturnType.MustReturnVoid)
+
+                        let noTailCallBlockers =
+                            not isNewObj
+                            && not isSuperInit
+                            && not isSelfInit
+                            && not mustGenerateUnitAfterCall
+                            && isNil laterArgs
+                            && not (IsValRefIsDllImport cenv.g vref)
+                            && not isCCall
+                            && not hasByrefArg
+
+                        noTailCallBlockers // blockers that will prevent the IL level from emmiting a tail instruction
+                    else
+                        true
+
+            // warn if we call inside of recursive scope in non-tail-call manner/with tail blockers. See
+            // ``Warn successfully in match clause``
+            // ``Warn for byref parameters``
+            if not canTailCall then
+                warning (Error(FSComp.SR.chkNotTailRecursive vref.DisplayName, m))
+        | _ -> ()
     | _ -> ()
+
+/// Check an expression, where the expression is in a position where byrefs can be generated
+let rec CheckExprNoByrefs cenv (tailCall: TailCall) expr =
+    CheckExpr cenv expr PermitByRefExpr.No tailCall
 
 /// Check call arguments, including the return argument.
 and CheckCall cenv args ctxts (tailCall: TailCall) =
@@ -730,10 +726,7 @@ and CheckBindings cenv binds =
 let CheckModuleBinding cenv (isRec: bool) (TBind _ as bind) =
 
     // warn for non-rec functions which have the attribute
-    if
-        cenv.reportErrors
-        && cenv.g.langVersion.SupportsFeature LanguageFeature.WarningWhenTailCallAttrOnNonRec
-    then
+    if cenv.g.langVersion.SupportsFeature LanguageFeature.WarningWhenTailCallAttrOnNonRec then
         let isNotAFunction =
             match bind.Var.ValReprInfo with
             | Some info -> info.HasNoArgs
@@ -842,14 +835,17 @@ and CheckModuleSpec cenv isRec mbind =
 
     | ModuleOrNamespaceBinding.Module(_mspec, rhs) -> CheckDefnInModule cenv rhs
 
-let CheckImplFile (g, amap, reportErrors, implFileContents) =
-    let cenv =
-        {
-            g = g
-            reportErrors = reportErrors
-            stackGuard = StackGuard(PostInferenceChecksStackGuardDepth, "CheckImplFile")
-            amap = amap
-            mustTailCall = Zset.empty valOrder
-        }
+let CheckImplFile (g: TcGlobals, amap, reportErrors, implFileContents) =
+    if
+        reportErrors
+        && g.langVersion.SupportsFeature LanguageFeature.WarningWhenTailRecAttributeButNonTailRecUsage
+    then
+        let cenv =
+            {
+                g = g
+                stackGuard = StackGuard(PostInferenceChecksStackGuardDepth, "CheckImplFile")
+                amap = amap
+                mustTailCall = Zset.empty valOrder
+            }
 
-    CheckDefnInModule cenv implFileContents
+        CheckDefnInModule cenv implFileContents


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

As the whole purpose of this module is to report warnings, we can check for the `reportErrors` flag and the language feature at the entry point and be done with it.
Also, move `CheckForNonTailRecCall` out of the mutual recursive function group as it doesn't call anything from that group.

( No release notes needed, I think)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**