### PR TITLE
Attempt to make links from single identifier module names.

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -1,6 +1,7 @@
 ### Fixed
 
 * Code generated files with > 64K methods and generated symbols crash when loaded. Use infered sequence points for debugging. ([Issue #16399](https://github.com/dotnet/fsharp/issues/16399), [#PR 16514](https://github.com/dotnet/fsharp/pull/16514))
+* `nameof Module` expressions and patterns are processed to link files in `--test:GraphBasedChecking`. ([PR #16550](https://github.com/dotnet/fsharp/pull/16550))
 
 ### Added
 

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -302,9 +302,27 @@ let visitSynTypeConstraint (tc: SynTypeConstraint) : FileContentEntry list =
     | SynTypeConstraint.WhereTyparIsEnum(typeArgs = typeArgs) -> List.collect visitSynType typeArgs
     | SynTypeConstraint.WhereTyparIsDelegate(typeArgs = typeArgs) -> List.collect visitSynType typeArgs
 
+/// Special case of `nameof Module` type of expression
+let (|NameofExpr|_|) (e: SynExpr) =
+    let rec stripParen (e: SynExpr) =
+        match e with
+        | SynExpr.Paren(expr = expr) -> stripParen expr
+        | _ -> e
+
+    match e with
+    | SynExpr.App(flag = ExprAtomicFlag.NonAtomic; isInfix = false; funcExpr = SynExpr.Ident nameofIdent; argExpr = moduleNameExpr) ->
+        if nameofIdent.idText <> "nameof" then
+            None
+        else
+            match stripParen moduleNameExpr with
+            | SynExpr.Ident moduleNameIdent -> Some moduleNameIdent
+            | _ -> None
+    | _ -> None
+
 let visitSynExpr (e: SynExpr) : FileContentEntry list =
     let rec visit (e: SynExpr) (continuation: FileContentEntry list -> FileContentEntry list) : FileContentEntry list =
         match e with
+        | NameofExpr moduleNameIdent -> continuation [ visitIdentAsPotentialModuleName moduleNameIdent ]
         | SynExpr.Const _ -> continuation []
         | SynExpr.Paren(expr = expr) -> visit expr continuation
         | SynExpr.Quote(operator = operator; quotedExpr = quotedExpr) ->
@@ -389,7 +407,7 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
         | SynExpr.IfThenElse(ifExpr = ifExpr; thenExpr = thenExpr; elseExpr = elseExpr) ->
             let continuations = List.map visit (ifExpr :: thenExpr :: Option.toList elseExpr)
             Continuation.concatenate continuations continuation
-        | SynExpr.Typar _ -> continuation []
+        | SynExpr.Typar _
         | SynExpr.Ident _ -> continuation []
         | SynExpr.LongIdent(longDotId = longDotId) -> continuation (visitSynLongIdent longDotId)
         | SynExpr.LongIdentSet(longDotId, expr, _) -> visit expr (fun nodes -> visitSynLongIdent longDotId @ nodes |> continuation)
@@ -517,9 +535,32 @@ let visitSynExpr (e: SynExpr) : FileContentEntry list =
 
     visit e id
 
+/// Special case of `| nameof Module ->` type of pattern
+let (|NameofPat|_|) (pat: SynPat) =
+    let rec stripPats p =
+        match p with
+        | SynPat.Paren(pat = pat) -> stripPats pat
+        | _ -> p
+
+    match pat with
+    | SynPat.LongIdent(longDotId = SynLongIdent(id = [ nameofIdent ]); typarDecls = None; argPats = SynArgPats.Pats [ moduleNamePat ]) ->
+        if nameofIdent.idText <> "nameof" then
+            None
+        else
+            match stripPats moduleNamePat with
+            | SynPat.LongIdent(
+                longDotId = SynLongIdent.SynLongIdent(id = [ moduleNameIdent ]; dotRanges = []; trivia = [ None ])
+                extraId = None
+                typarDecls = None
+                argPats = SynArgPats.Pats []
+                accessibility = None) -> Some moduleNameIdent
+            | _ -> None
+    | _ -> None
+
 let visitPat (p: SynPat) : FileContentEntry list =
     let rec visit (p: SynPat) (continuation: FileContentEntry list -> FileContentEntry list) : FileContentEntry list =
         match p with
+        | NameofPat moduleNameIdent -> continuation [ visitIdentAsPotentialModuleName moduleNameIdent ]
         | SynPat.Paren(pat = pat) -> visit pat continuation
         | SynPat.Typed(pat = pat; targetType = t) -> visit pat (fun nodes -> nodes @ visitSynType t)
         | SynPat.Const _ -> continuation []

--- a/src/Compiler/Driver/GraphChecking/Types.fs
+++ b/src/Compiler/Driver/GraphChecking/Types.fs
@@ -73,6 +73,9 @@ type internal FileContentEntry =
     /// Being explicit about nested modules allows for easier reasoning what namespaces (paths) are open.
     /// We can scope an `OpenStatement` to the everything that is happening inside the nested module.
     | NestedModule of name: string * nestedContent: FileContentEntry list
+    /// A single identifier that could be the name of a module.
+    /// Example use-case: `let x = nameof Foo` where `Foo` is a module.
+    | ModuleName of name: Identifier
 
 type internal FileContent =
     {

--- a/src/Compiler/Driver/GraphChecking/Types.fsi
+++ b/src/Compiler/Driver/GraphChecking/Types.fsi
@@ -67,6 +67,9 @@ type internal FileContentEntry =
     /// Being explicit about nested modules allows for easier reasoning what namespaces (paths) are open.
     /// For example we can limit the scope of an `OpenStatement` to symbols defined inside the nested module.
     | NestedModule of name: string * nestedContent: FileContentEntry list
+    /// A single identifier that could be the name of a module.
+    /// Example use-case: `let x = nameof Foo` where `Foo` is a module.
+    | ModuleName of name: Identifier
 
 /// File identifiers and its content extract for dependency resolution
 type internal FileContent =

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -800,4 +800,34 @@ printfn "Hello"
 """
                     Set.empty
             ]
+        scenario
+            "parentheses around module name in nameof pattern"
+            [
+                sourceFile "A.fs" "module Foo" Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+module Bar
+
+do
+    match "" with
+    | nameof ((Foo)) -> ()
+    | _ -> ()
+"""
+                    (set [| 0 |])
+            ]
+            
+        scenario
+            "parentheses around module name in nameof expression"
+            [
+                sourceFile "A.fs" "module Foo" Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+module Bar
+
+let _ = nameof ((Foo))
+"""
+                    (set [| 0 |])
+            ]
     ]

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -801,6 +801,86 @@ printfn "Hello"
                     Set.empty
             ]
         scenario
+            "Nameof module with namespace"
+            [
+                sourceFile
+                    "A.fs"
+                    """
+namespace X.Y.Z
+
+module Foo =
+    let x = 2
+"""
+                    Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+namespace X.Y.Z
+
+module Point =
+    let y = nameof Foo
+"""
+                    (set [| 0 |])
+            ]
+        scenario
+            "Nameof module without namespace"
+            [
+                sourceFile
+                    "A.fs"
+                    """
+module Foo
+
+let x = 2
+"""
+                    Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+module Point
+
+let y = nameof Foo
+"""
+                    (set [| 0 |])
+            ]
+        scenario
+            "Single module name should always be checked, regardless of own namespace"
+            [
+                sourceFile "X.fs" "namespace X.Y" Set.empty
+                sourceFile
+                    "A.fs"
+                    """
+module Foo
+
+let x = 2
+"""
+                    Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+namespace X.Y
+
+type T() =
+    let _ = nameof Foo
+"""
+                    (set [| 1 |])
+            ]
+        scenario
+            "nameof pattern"
+            [
+                sourceFile "A.fs" "module Foo" Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+module Bar
+
+do
+    match "" with
+    | nameof Foo -> ()
+    | _ -> ()
+"""
+                    (set [| 0 |])
+            ]
+        scenario
             "parentheses around module name in nameof pattern"
             [
                 sourceFile "A.fs" "module Foo" Set.empty


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I notice in some production code a missing link when using graph-based type-checking.

The problem is the following

![image](https://github.com/dotnet/fsharp/assets/2621499/bc972814-3402-49cf-b579-c7c4a4bd16a0)

In our line of thinking we always assumed that a single identifier needs to be preceded by an open statement before becoming available. That is why we don't check of single word identifiers in expressions and patterns if they can be matched. 

In this screenshot, to consume `module Foo` in file `B`, you would either `open Foo`  or prefix the usage of `x` (as `Foo.x`). So we either process the open statement or an identifier with two (or more) words.

Today, I found out that `nameof ModuleName` is a special case.
It can theoretically be linked to a node in the Trie. 
Which is something we didn't foresee.

I can't think of any other examples besides `nameof` where this kind of behaviour is allowed, but to be safe I solved it without explicitly looking for the `nameof` presence.

@safesparrow could you please review this PR and let me know if this makes sense?

@vzarytovskii I know the window for `8.0.200` is probably closed, yet I'm asking you to consider merging this in the `200` branch. Otherwise, this fix will most likely only be available in May.

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**