### PR TITLE
Lower interpolation into a call to concat

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -29,3 +29,4 @@
 * Reduce allocations in compiler checking via `ValueOption` usage ([PR #16323](https://github.com/dotnet/fsharp/pull/16323), [PR #16567](https://github.com/dotnet/fsharp/pull/16567))
 * Reverted [#16348](https://github.com/dotnet/fsharp/pull/16348) `ThreadStatic` `CancellationToken` changes to improve test stability and prevent potential unwanted cancellations. ([PR #16536](https://github.com/dotnet/fsharp/pull/16536))
 * Refactored parenthesization API. ([PR #16461])(https://github.com/dotnet/fsharp/pull/16461))
+* Optimize some interpolated strings by lowering to string concatenation. ([PR #16556](https://github.com/dotnet/fsharp/pull/16556))

--- a/docs/release-notes/.Language/preview.md
+++ b/docs/release-notes/.Language/preview.md
@@ -8,3 +8,7 @@
 ### Fixed
 
 * Allow extension methods without type attribute work for types from imported assemblies. ([PR #16368](https://github.com/dotnet/fsharp/pull/16368))
+
+### Changed
+
+* Lower interpolated strings to string concatenation. ([PR #16556](https://github.com/dotnet/fsharp/pull/16556))

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -140,9 +140,11 @@ exception StandardOperatorRedefinitionWarning of string * range
 
 exception InvalidInternalsVisibleToAssemblyName of badName: string * fileName: string option
 
-/// A set of helpers for determining if/what specifiers a string has.
-/// Used to decide if interpolated string can be lowered to a concat call.
-/// We don't have to care about single- vs multi-$ strings here, because lexer took care of that already.
+//----------------------------------------------------------------------------------------------
+// Helpers for determining if/what specifiers a string has.
+// Used to decide if interpolated string can be lowered to a concat call.
+// We don't care about single- vs multi-$ strings here, because lexer took care of that already.
+//----------------------------------------------------------------------------------------------
 module private ParseString =
     open System.Text.RegularExpressions
 
@@ -7391,7 +7393,13 @@ and TcInterpolatedStringExpr cenv (overallTy: OverallTy) env m tpenv (parts: Syn
                         | _ -> true
                     | SynInterpolatedStringPart.String(s, _) -> not <| ParseString.HasFormatSpecifier s)
 
-            if isString && (nonEmptyParts.Length < 5) && (argTys |> List.forall (isStringTy g)) && (noSpecifiers nonEmptyParts) then
+            if
+                (g.langVersion.SupportsFeature LanguageFeature.LowerInterpolatedStringToConcat)
+                && isString
+                && (nonEmptyParts.Length < 5)
+                && (argTys |> List.forall (isStringTy g))
+                && (noSpecifiers nonEmptyParts)
+            then
 
                 let args =
                     // We already have the type-checked fill expressions from before

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -151,6 +151,7 @@ let (|HasFormatSpecifier|_|) (s: string) =
     if
         Regex.IsMatch(
             s,
+            // Regex pattern for something like: %[flags][width][.precision][type]
             """
             (^|[^%])                # Start with beginning of string or any char other than '%'
             (%%)*%                  # followed by an odd number of '%' chars
@@ -165,6 +166,7 @@ let (|HasFormatSpecifier|_|) (s: string) =
     else
         ValueNone
 
+// Removes trailing "%s" unless it was escaped by another '%' (checks for odd sequence of '%' before final "%s")
 let (|WithTrailingStringSpecifierRemoved|) (s: string) =
     if s.EndsWith "%s" then
         let i = s.AsSpan(0, s.Length - 2).LastIndexOfAnyExcept '%'

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -7336,6 +7336,33 @@ and TcInterpolatedStringExpr cenv (overallTy: OverallTy) env m tpenv (parts: Syn
             // Type check the expressions filling the holes
             let fillExprs, tpenv = TcExprsNoFlexes cenv env m tpenv argTys synFillExprs
 
+            // If all fill expressions are strings and there is less then 5 parts of the interpolated string total
+            // then we can use System.String.Concat instead of a sprintf call
+            if isString && (parts.Length < 5) && (argTys |> List.forall (isStringTy g)) then
+                let rec f xs ys acc =
+                    match xs with
+                    | SynInterpolatedStringPart.String(s, m)::xs ->
+                        let sb = System.Text.StringBuilder(s).Replace("%%", "%")
+                        f xs ys ((mkString g m (sb.ToString()))::acc)
+                    | SynInterpolatedStringPart.FillExpr(_, _)::xs ->
+                        match ys with
+                        | y::ys -> f xs ys (y::acc)
+                        | _ -> error(Error((0, "FOOBAR"), m)) // TODO XXX wrong error
+                    | _ -> acc
+
+                let args = f parts fillExprs [] |> List.rev
+                assert (args.Length = parts.Length)
+                if args.Length = 4 then
+                    (mkStaticCall_String_Concat4 g m args[0] args[1] args[2] args[3], tpenv)
+                elif args.Length = 3 then
+                    (mkStaticCall_String_Concat3 g m args[0] args[1] args[2], tpenv)
+                elif args.Length = 2 then
+                    (mkStaticCall_String_Concat2 g m args[0] args[1], tpenv)
+                else
+                    // Throw some error
+                    error(Error((0, "FOOBAR2"), m)) // TODO XXX wrong error
+            else // TODO XXX messed up indentation below
+
             let fillExprsBoxed = (argTys, fillExprs) ||> List.map2 (mkCallBox g m)
 
             let argsExpr = mkArray (g.obj_ty, fillExprsBoxed, m)

--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -317,13 +317,10 @@ let parseFormatStringInternal
             |> Seq.takeWhile (fun c -> c = '%')
             |> Seq.length
         if delimLen <= 1 && fmt[i..(i+1)] = "%%" then
-            match context with
-            | Some _ ->
-                specifierLocations.Add(
-                    (Range.mkFileIndexRange m.FileIndex
-                        (Position.mkPos fragLine fragCol)
-                        (Position.mkPos fragLine (fragCol+2))), 0)
-            | None -> ()
+            specifierLocations.Add(
+                (Range.mkFileIndexRange m.FileIndex
+                    (Position.mkPos fragLine fragCol)
+                    (Position.mkPos fragLine (fragCol+2))), 0)
             appendToDotnetFormatString "%"
             parseLoop acc (i+2, fragLine, fragCol+2) fragments
         elif delimLen > 1 && nPercentSigns < delimLen then
@@ -384,15 +381,12 @@ let parseFormatStringInternal
                     failwith (FSComp.SR.forFormatInvalidForInterpolated3())
 
             let collectSpecifierLocation fragLine fragCol numStdArgs =
-                match context with
-                | Some _ ->
-                    let numArgsForSpecifier =
-                        numStdArgs + (if widthArg then 1 else 0) + (if precisionArg then 1 else 0)
-                    specifierLocations.Add(
-                        (Range.mkFileIndexRange m.FileIndex
-                            (Position.mkPos fragLine startFragCol)
-                            (Position.mkPos fragLine (fragCol + 1))), numArgsForSpecifier)
-                | None -> ()
+                let numArgsForSpecifier =
+                    numStdArgs + (if widthArg then 1 else 0) + (if precisionArg then 1 else 0)
+                specifierLocations.Add(
+                    (Range.mkFileIndexRange m.FileIndex
+                        (Position.mkPos fragLine startFragCol)
+                        (Position.mkPos fragLine (fragCol + 1))), numArgsForSpecifier)
 
             let ch = fmt[i]
             match ch with

--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -317,10 +317,13 @@ let parseFormatStringInternal
             |> Seq.takeWhile (fun c -> c = '%')
             |> Seq.length
         if delimLen <= 1 && fmt[i..(i+1)] = "%%" then
-            specifierLocations.Add(
-                (Range.mkFileIndexRange m.FileIndex
-                    (Position.mkPos fragLine fragCol)
-                    (Position.mkPos fragLine (fragCol+2))), 0)
+            match context with
+            | Some _ ->
+                specifierLocations.Add(
+                    (Range.mkFileIndexRange m.FileIndex
+                        (Position.mkPos fragLine fragCol)
+                        (Position.mkPos fragLine (fragCol+2))), 0)
+            | None -> ()
             appendToDotnetFormatString "%"
             parseLoop acc (i+2, fragLine, fragCol+2) fragments
         elif delimLen > 1 && nPercentSigns < delimLen then

--- a/src/Compiler/Checking/CheckFormatStrings.fs
+++ b/src/Compiler/Checking/CheckFormatStrings.fs
@@ -384,12 +384,15 @@ let parseFormatStringInternal
                     failwith (FSComp.SR.forFormatInvalidForInterpolated3())
 
             let collectSpecifierLocation fragLine fragCol numStdArgs =
-                let numArgsForSpecifier =
-                    numStdArgs + (if widthArg then 1 else 0) + (if precisionArg then 1 else 0)
-                specifierLocations.Add(
-                    (Range.mkFileIndexRange m.FileIndex
-                        (Position.mkPos fragLine startFragCol)
-                        (Position.mkPos fragLine (fragCol + 1))), numArgsForSpecifier)
+                match context with
+                | Some _ ->
+                    let numArgsForSpecifier =
+                        numStdArgs + (if widthArg then 1 else 0) + (if precisionArg then 1 else 0)
+                    specifierLocations.Add(
+                        (Range.mkFileIndexRange m.FileIndex
+                            (Position.mkPos fragLine startFragCol)
+                            (Position.mkPos fragLine (fragCol + 1))), numArgsForSpecifier)
+                | None -> ()
 
             let ch = fmt[i]
             match ch with

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1594,6 +1594,7 @@ featureWarningIndexedPropertiesGetSetSameType,"Indexed properties getter and set
 featureChkTailCallAttrOnNonRec,"Raises warnings if the 'TailCall' attribute is used on non-recursive functions."
 featureUnionIsPropertiesVisible,"Union case test properties"
 featureBooleanReturningAndReturnTypeDirectedPartialActivePattern,"Boolean-returning and return-type-directed partial active patterns"
+featureLowerInterpolatedStringToConcat,"Optimizes interpolated strings in certains cases, by lowering to concatenation"
 3354,tcNotAFunctionButIndexerNamedIndexingNotYetEnabled,"This value supports indexing, e.g. '%s.[index]'. The syntax '%s[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation."
 3354,tcNotAFunctionButIndexerIndexingNotYetEnabled,"This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation."
 3355,tcNotAnIndexerNamedIndexingNotYetEnabled,"The value '%s' is not a function and does not support index notation."

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1594,7 +1594,7 @@ featureWarningIndexedPropertiesGetSetSameType,"Indexed properties getter and set
 featureChkTailCallAttrOnNonRec,"Raises warnings if the 'TailCall' attribute is used on non-recursive functions."
 featureUnionIsPropertiesVisible,"Union case test properties"
 featureBooleanReturningAndReturnTypeDirectedPartialActivePattern,"Boolean-returning and return-type-directed partial active patterns"
-featureLowerInterpolatedStringToConcat,"Optimizes interpolated strings in certains cases, by lowering to concatenation"
+featureLowerInterpolatedStringToConcat,"Optimizes interpolated strings in certain cases, by lowering to concatenation"
 3354,tcNotAFunctionButIndexerNamedIndexingNotYetEnabled,"This value supports indexing, e.g. '%s.[index]'. The syntax '%s[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation."
 3354,tcNotAFunctionButIndexerIndexingNotYetEnabled,"This expression supports indexing, e.g. 'expr.[index]'. The syntax 'expr[index]' requires /langversion:preview. See https://aka.ms/fsharp-index-notation."
 3355,tcNotAnIndexerNamedIndexingNotYetEnabled,"The value '%s' is not a function and does not support index notation."

--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -85,6 +85,7 @@ type LanguageFeature =
     | WarningIndexedPropertiesGetSetSameType
     | WarningWhenTailCallAttrOnNonRec
     | BooleanReturningAndReturnTypeDirectedPartialActivePattern
+    | LowerInterpolatedStringToConcat
 
 /// LanguageVersion management
 type LanguageVersion(versionText) =
@@ -197,6 +198,7 @@ type LanguageVersion(versionText) =
                 LanguageFeature.WarningWhenTailCallAttrOnNonRec, previewVersion
                 LanguageFeature.UnionIsPropertiesVisible, previewVersion
                 LanguageFeature.BooleanReturningAndReturnTypeDirectedPartialActivePattern, previewVersion
+                LanguageFeature.LowerInterpolatedStringToConcat, previewVersion
             ]
 
     static let defaultLanguageVersion = LanguageVersion("default")
@@ -340,6 +342,7 @@ type LanguageVersion(versionText) =
         | LanguageFeature.WarningWhenTailCallAttrOnNonRec -> FSComp.SR.featureChkTailCallAttrOnNonRec ()
         | LanguageFeature.BooleanReturningAndReturnTypeDirectedPartialActivePattern ->
             FSComp.SR.featureBooleanReturningAndReturnTypeDirectedPartialActivePattern ()
+        | LanguageFeature.LowerInterpolatedStringToConcat -> FSComp.SR.featureLowerInterpolatedStringToConcat ()
 
     /// Get a version string associated with the given feature.
     static member GetFeatureVersionString feature =

--- a/src/Compiler/Facilities/LanguageFeatures.fsi
+++ b/src/Compiler/Facilities/LanguageFeatures.fsi
@@ -76,6 +76,7 @@ type LanguageFeature =
     | WarningIndexedPropertiesGetSetSameType
     | WarningWhenTailCallAttrOnNonRec
     | BooleanReturningAndReturnTypeDirectedPartialActivePattern
+    | LowerInterpolatedStringToConcat
 
 /// LanguageVersion management
 type LanguageVersion =

--- a/src/Compiler/Utilities/ReadOnlySpan.fs
+++ b/src/Compiler/Utilities/ReadOnlySpan.fs
@@ -59,4 +59,19 @@ type ReadOnlySpanExtensions =
                 i <- i - 1
 
         if found then i else -1
+
+    [<Extension>]
+    static member LastIndexOfAnyExcept(span: ReadOnlySpan<char>, value: char) =
+        let mutable i = span.Length - 1
+        let mutable found = false
+
+        while not found && i >= 0 do
+            let c = span[i]
+
+            if c <> value then
+                found <- true
+            else
+                i <- i - 1
+
+        if found then i else -1
 #endif

--- a/src/Compiler/Utilities/ReadOnlySpan.fs
+++ b/src/Compiler/Utilities/ReadOnlySpan.fs
@@ -68,10 +68,7 @@ type ReadOnlySpanExtensions =
         while not found && i >= 0 do
             let c = span[i]
 
-            if c <> value then
-                found <- true
-            else
-                i <- i - 1
+            if c <> value then found <- true else i <- i - 1
 
         if found then i else -1
 #endif

--- a/src/Compiler/Utilities/ReadOnlySpan.fsi
+++ b/src/Compiler/Utilities/ReadOnlySpan.fsi
@@ -17,4 +17,7 @@ type internal ReadOnlySpanExtensions =
 
     [<Extension>]
     static member LastIndexOfAnyInRange: span: ReadOnlySpan<char> * lowInclusive: char * highInclusive: char -> int
+
+    [<Extension>]
+    static member LastIndexOfAnyExcept: span: ReadOnlySpan<char> * value: char -> int
 #endif

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -6776,8 +6776,8 @@ interpolatedStringParts:
   | INTERP_STRING_END
      { [ SynInterpolatedStringPart.String(fst $1, rhs parseState 1) ] }
 
-    | INTERP_STRING_PART interpolatedStringFill interpolatedStringParts
-        { SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
+  | INTERP_STRING_PART interpolatedStringFill interpolatedStringParts
+     { SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
 
   | INTERP_STRING_PART interpolatedStringParts
      { let rbrace = parseState.InputEndPosition 1

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -372,6 +372,11 @@
         <target state="translated">rozhraní s vícenásobným obecným vytvářením instancí</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Povolit duplikát malými písmeny při atributu RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -372,6 +372,11 @@
         <target state="translated">Schnittstellen mit mehrfacher generischer Instanziierung</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">DU in Kleinbuchstaben zulassen, wenn requireQualifiedAccess-Attribut</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -372,6 +372,11 @@
         <target state="translated">interfaces con creación de instancias genéricas múltiples</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Permitir DU en minúsculas con el atributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -372,6 +372,11 @@
         <target state="translated">interfaces avec plusieurs instanciations génériques</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Autoriser les DU en minuscules pour l'attribut RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -372,6 +372,11 @@
         <target state="translated">interfacce con più creazioni di istanze generiche</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Consentire l’unione discriminata minuscola quando l'attributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -372,6 +372,11 @@
         <target state="translated">複数のジェネリックのインスタンス化を含むインターフェイス</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">RequireQualifiedAccess 属性の場合に小文字 DU を許可する</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -372,6 +372,11 @@
         <target state="translated">여러 제네릭 인스턴스화가 포함된 인터페이스</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">RequireQualifiedAccess 특성이 있는 경우 소문자 DU 허용</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -372,6 +372,11 @@
         <target state="translated">interfejsy z wieloma ogólnymi wystąpieniami</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Zezwalaj na małą literę DU, gdy występuje RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -372,6 +372,11 @@
         <target state="translated">interfaces com várias instanciações genéricas</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Permitir DU em minúsculas quando o atributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -372,6 +372,11 @@
         <target state="translated">интерфейсы с множественным универсальным созданием экземпляра</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">Разрешить du в нижнем регистре, если атрибут RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -372,6 +372,11 @@
         <target state="translated">birden çok genel örnek oluşturma içeren arabirimler</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">RequireQualifiedAccess özniteliğinde küçük harf DU'ya izin ver</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -372,6 +372,11 @@
         <target state="translated">具有多个泛型实例化的接口</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">当 RequireQualifiedAccess 属性时允许小写 DU</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -373,8 +373,8 @@
         <note />
       </trans-unit>
       <trans-unit id="featureLowerInterpolatedStringToConcat">
-        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
-        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <source>Optimizes interpolated strings in certain cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certain cases, by lowering to concatenation</target>
         <note />
       </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -372,6 +372,11 @@
         <target state="translated">具有多個泛型具現化的介面</target>
         <note />
       </trans-unit>
+      <trans-unit id="featureLowerInterpolatedStringToConcat">
+        <source>Optimizes interpolated strings in certains cases, by lowering to concatenation</source>
+        <target state="new">Optimizes interpolated strings in certains cases, by lowering to concatenation</target>
+        <note />
+      </trans-unit>
       <trans-unit id="featureLowercaseDUWhenRequireQualifiedAccess">
         <source>Allow lowercase DU when RequireQualifiedAccess attribute</source>
         <target state="translated">RequireQualifiedAccess 屬性時允許小寫 DU</target>

--- a/tests/AheadOfTime/Trimming/check.ps1
+++ b/tests/AheadOfTime/Trimming/check.ps1
@@ -42,4 +42,4 @@ function CheckTrim($root, $tfm, $outputfile, $expected_len) {
 CheckTrim -root "SelfContained_Trimming_Test" -tfm "net8.0" -outputfile "FSharp.Core.dll" -expected_len 287232
 
 # Check net7.0 trimmed assemblies
-CheckTrim -root "StaticLinkedFSharpCore_Trimming_Test" -tfm "net8.0" -outputfile "StaticLinkedFSharpCore_Trimming_Test.dll" -expected_len 8821248
+CheckTrim -root "StaticLinkedFSharpCore_Trimming_Test" -tfm "net8.0" -outputfile "StaticLinkedFSharpCore_Trimming_Test.dll" -expected_len 8820736

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -5,8 +5,8 @@ namespace EmittedIL
 open Xunit
 open FSharp.Test.Compiler
 
-#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
 module ``StringFormatAndInterpolation`` =
+#if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
     [<Fact>]
     let ``Interpolated string with no holes is reduced to a string or simple format when used in printf``() =
         FSharp """
@@ -34,3 +34,21 @@ IL_0017:  ret"""]
 
 #endif
 
+    [<Fact>]
+    let ``Interpolated string with 3 parts consisting only of strings is lowered to concat`` () =
+        let str = "$\"\"\"ab{\"c\"}d\"\"\""
+        FSharp $"""
+module StringFormatAndInterpolation
+
+let str () = {str}
+        """
+        |> compile
+        |> shouldSucceed
+        |> verifyIL ["""
+IL_0000:  ldstr      "ab"
+IL_0005:  ldstr      "c"
+IL_000a:  ldstr      "d"
+IL_000f:  call       string [runtime]System.String::Concat(string,
+                                                                  string,
+                                                                  string)
+IL_0014:  ret"""]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -42,6 +42,7 @@ module StringFormatAndInterpolation
 
 let str () = {str}
         """
+        |> withLangVersionPreview
         |> compile
         |> shouldSucceed
         |> verifyIL ["""

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StringFormatAndInterpolation.fs
@@ -35,12 +35,30 @@ IL_0017:  ret"""]
 #endif
 
     [<Fact>]
-    let ``Interpolated string with 3 parts consisting only of strings is lowered to concat`` () =
-        let str = "$\"\"\"ab{\"c\"}d\"\"\""
+    let ``Interpolated string with 2 parts consisting only of strings is lowered to concat`` () =
         FSharp $"""
 module StringFormatAndInterpolation
 
-let str () = {str}
+let f (s: string) = $"ab{{s}}"
+        """
+        |> withLangVersionPreview
+        |> compile
+        |> shouldSucceed
+        |> verifyIL ["""
+IL_0000:  ldstr      "ab"
+IL_0005:  ldarg.0
+IL_0006:  call       string [runtime]System.String::Concat(string,
+                                                                  string)
+IL_000b:  ret"""]
+
+    [<Fact>]
+    let ``Interpolated string with 3 parts consisting only of strings is lowered to concat`` () =
+        //let str = "$\"\"\"ab{\"c\"}d\"\"\""
+        FSharp $"""
+module StringFormatAndInterpolation
+
+let c = "c"
+let str = $"ab{{c}}d"
         """
         |> withLangVersionPreview
         |> compile
@@ -51,5 +69,26 @@ IL_0005:  ldstr      "c"
 IL_000a:  ldstr      "d"
 IL_000f:  call       string [runtime]System.String::Concat(string,
                                                                   string,
+                                                                  string)"""]
+
+    [<Fact>]
+    let ``Interpolated string with 4 parts consisting only of strings is lowered to concat`` () =
+        let str = "$\"\"\"a{\"b\"}{\"c\"}d\"\"\""
+        FSharp $"""
+module StringFormatAndInterpolation
+
+let str () = {str}
+        """
+        |> withLangVersionPreview
+        |> compile
+        |> shouldSucceed
+        |> verifyIL ["""
+IL_0000:  ldstr      "a"
+IL_0005:  ldstr      "b"
+IL_000a:  ldstr      "c"
+IL_000f:  ldstr      "d"
+IL_0014:  call       string [runtime]System.String::Concat(string,
+                                                                  string,
+                                                                  string,
                                                                   string)
-IL_0014:  ret"""]
+IL_0019:  ret"""]

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -132,10 +132,10 @@ type Foo () =
 
     [<Theory>]
     // Test different number of interpolated string parts
-    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde")>]
-    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde")>]
-    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde")>]
-    let ``Interpolated expressions are strings`` (strToPrint: string, expectedOut: string) =
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"")>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"")>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"")>]
+    let ``Interpolated expressions are strings`` (strToPrint: string) =
         Fsx $"""
 let x = {strToPrint}
 printfn "%%s" x
@@ -143,13 +143,28 @@ printfn "%%s" x
         |> withLangVersionPreview
         |> compileExeAndRun
         |> shouldSucceed
-        |> withStdOutContains expectedOut
+        |> withStdOutContains "abcde"
+
+    let ``Multiline interpolated expression is a string`` () =
+        let strToPrint = String.Join(Environment.NewLine, "$\"\"\"a", "b", "c", "{\"d\"}", "e\"\"\"")
+        Fsx $"""
+let x = {strToPrint}
+printfn "%%s" x
+        """
+        |> withLangVersionPreview
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains """a
+b
+c
+d
+e"""
 
     [<Theory>]
-    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde", 1)>]
-    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde", 2)>]
-    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde", 2)>]
-    let ``In FormattableString, interpolated expressions are strings`` (formattableStr: string, expectedOut: string, argCount: int) =
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", 1)>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", 2)>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", 2)>]
+    let ``In FormattableString, interpolated expressions are strings`` (formattableStr: string, argCount: int) =
         Fsx $"""
 let x = {formattableStr} : System.FormattableString
 assert(x.ArgumentCount = {argCount})
@@ -158,4 +173,4 @@ printfn "%%s" (System.Globalization.CultureInfo "en-US" |> x.ToString)
         |> withLangVersionPreview
         |> compileExeAndRun
         |> shouldSucceed
-        |> withStdOutContains expectedOut
+        |> withStdOutContains "abcde"

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -129,3 +129,31 @@ type Foo () =
         """
         |> compile
         |> shouldSucceed
+
+    [<Theory>]
+    // Test different number of interpolated string parts
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde")>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde")>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde")>]
+    let ``Interpolated expressions are strings`` (strToPrint: string, expectedOut: string) =
+        Fsx $"""
+let x = {strToPrint}
+printfn "%%s" x
+        """
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains expectedOut
+
+    [<Theory>]
+    [<InlineData("$\"\"\"abc{\"d\"}e\"\"\"", "abcde", 1)>]
+    [<InlineData("$\"\"\"abc{\"d\"}{\"e\"}\"\"\"", "abcde", 2)>]
+    [<InlineData("$\"\"\"a{\"b\"}c{\"d\"}e\"\"\"", "abcde", 2)>]
+    let ``In FormattableString, interpolated expressions are strings`` (formattableStr: string, expectedOut: string, argCount: int) =
+        Fsx $"""
+let x = {formattableStr} : System.FormattableString
+assert(x.ArgumentCount = {argCount})
+printfn "%%s" (System.Globalization.CultureInfo "en-US" |> x.ToString)
+        """
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains expectedOut

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -140,6 +140,7 @@ type Foo () =
 let x = {strToPrint}
 printfn "%%s" x
         """
+        |> withLangVersionPreview
         |> compileExeAndRun
         |> shouldSucceed
         |> withStdOutContains expectedOut
@@ -154,6 +155,7 @@ let x = {formattableStr} : System.FormattableString
 assert(x.ArgumentCount = {argCount})
 printfn "%%s" (System.Globalization.CultureInfo "en-US" |> x.ToString)
         """
+        |> withLangVersionPreview
         |> compileExeAndRun
         |> shouldSucceed
         |> withStdOutContains expectedOut


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Optimization that lowers string interpolation into a call to concat iff there are at most 4 string parts and all fill expressions are strings.

Fixes #16247

## Benchmarks

Run a benchmark like in [this gist](https://gist.github.com/abonie/af32962df723a4a53a4e96ed84eb1f88) with and without the feature flag set.

Results without the flag (**no optimization**):
```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3155/22H2/2022Update/SunValley2)
11th Gen Intel Core i7-11850H 2.50GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.300-preview.24101.10
  [Host]     : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI DEBUG
  DefaultJob : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI


```
| Method         | Mean      | Error    | StdDev   | Gen0   | Allocated |
|--------------- |----------:|---------:|---------:|-------:|----------:|
| SingleVariable |  70.49 ns | 1.214 ns | 1.136 ns | 0.0107 |     136 B |
| JustLiterals   | 145.61 ns | 1.443 ns | 1.350 ns | 0.0215 |     272 B |
| Variables      | 144.05 ns | 0.959 ns | 0.897 ns | 0.0215 |     272 B |
| Function       | 116.73 ns | 1.557 ns | 1.381 ns | 0.0191 |     240 B |
| LongString     | 363.35 ns | 2.838 ns | 2.654 ns | 0.4330 |    5432 B |

Results with the flag set (**with optimization**):
```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3155/22H2/2022Update/SunValley2)
11th Gen Intel Core i7-11850H 2.50GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.300-preview.24101.10
  [Host]     : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI DEBUG
  DefaultJob : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI


```
| Method         | Mean        | Error     | StdDev    | Median      | Gen0   | Allocated |
|--------------- |------------:|----------:|----------:|------------:|-------:|----------:|
| SingleVariable |   0.0004 ns | 0.0013 ns | 0.0011 ns |   0.0000 ns |      - |         - |
| JustLiterals   |  12.0562 ns | 0.0719 ns | 0.0673 ns |  12.0500 ns | 0.0032 |      40 B |
| Variables      |  11.9894 ns | 0.0810 ns | 0.0718 ns |  12.0101 ns | 0.0032 |      40 B |
| Function       |  12.2912 ns | 0.1201 ns | 0.1124 ns |  12.3161 ns | 0.0032 |      40 B |
| LongString     | 206.0906 ns | 2.4311 ns | 2.0301 ns | 206.5404 ns | 0.4158 |    5216 B |
## Checklist

- [x] Test cases added
- [x] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated