### PR TITLE
Move paren release note entries to appropriate versions

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.200.md
@@ -1,6 +1,5 @@
 ### Fixed
 
-* Miscellaneous fixes to parentheses analysis. ([PR #16262](https://github.com/dotnet/fsharp/pull/16262), [PR #16391](https://github.com/dotnet/fsharp/pull/16391), [PR #16370](https://github.com/dotnet/fsharp/pull/16370), [PR #16395](https://github.com/dotnet/fsharp/pull/16395), [PR #16372](https://github.com/dotnet/fsharp/pull/16372))
 * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
 * Range of [SynField](../reference/fsharp-compiler-syntax-synfield.html) ([PR #16357](https://github.com/dotnet/fsharp/pull/16357))
 * Limit a type to 65K methods, introduce a compile-time error if any class has over approx 64K methods in generated IL. ([Issue #16398](https://github.com/dotnet/fsharp/issues/16398), [#PR 16427](https://github.com/dotnet/fsharp/pull/16427))
@@ -15,6 +14,7 @@
 * Parser recovers on unfinished record declarations. ([PR #16357](https://github.com/dotnet/fsharp/pull/16357))
 * `MutableKeyword` to [SynFieldTrivia](../reference/fsharp-compiler-syntaxtrivia-synfieldtrivia.html) ([PR #16357](https://github.com/dotnet/fsharp/pull/16357))
 * Added support for a new parameterless constructor for `CustomOperationAttribute`, which, when applied, will use method name as keyword for custom operation in computation expression builder. ([PR #16475](https://github.com/dotnet/fsharp/pull/16475), part of implementation for [fslang-suggestions/1250](https://github.com/fsharp/fslang-suggestions/issues/1250))
+* Compiler service API for getting ranges of unnecessary parentheses. ([PR #16079](https://github.com/dotnet/fsharp/pull/16079) et seq.)
 
 ### Changed
 

--- a/docs/release-notes/.VisualStudio/17.9.md
+++ b/docs/release-notes/.VisualStudio/17.9.md
@@ -1,0 +1,3 @@
+### Added
+
+* Analyzer & code fix for removing unnecessary parentheses. ([PR #16079](https://github.com/dotnet/fsharp/pull/16079) et seq.)


### PR DESCRIPTION
## Description

- Move the release note entries for the parenthesization API, analyzer, and code fix to the appropriate versions.
  - FSharp.Compiler.Service 43.8.200.
  - Visual Studio 17.9.

The first few paren PRs were merged before the new release notes process was set up for this repo, but I believe that 8.200 and 17.9 are the FCS/SDK/VS versions that they will actually be shipped in.

I have simplified the release note entries to refer only to "#16079 et seq.," since the followup PRs link back to and are visible from the original, but I can list them individually instead if we want to try to make the release notes reflect exactly which PRs are shipped in each FCS/SDK/VS version.

## Checklist

- [x] Release notes entries updated.