### PR TITLE
Don't throw on invalid input in Graph construction

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -2,6 +2,7 @@
 
 * Code generated files with > 64K methods and generated symbols crash when loaded. Use infered sequence points for debugging. ([Issue #16399](https://github.com/dotnet/fsharp/issues/16399), [#PR 16514](https://github.com/dotnet/fsharp/pull/16514))
 * `nameof Module` expressions and patterns are processed to link files in `--test:GraphBasedChecking`. ([PR #16550](https://github.com/dotnet/fsharp/pull/16550))
+* Graph Based Checking doesn't throw on invalid parsed input so it can be used for IDE scenarios ([PR #16575](https://github.com/dotnet/fsharp/pull/16575))
 
 ### Added
 

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -56,7 +56,7 @@ let visitSynModuleDecl (decl: SynModuleDecl) : FileContentEntry list =
         | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ ident ]; attributes = attributes); decls = decls) ->
             yield! visitSynAttributes attributes
             yield FileContentEntry.NestedModule(ident.idText, List.collect visitSynModuleDecl decls)
-        | SynModuleDecl.NestedModule _ -> failwith "A nested module cannot have multiple identifiers"
+        | SynModuleDecl.NestedModule _ -> () // "A nested module cannot have multiple identifiers"
         | SynModuleDecl.Let(bindings = bindings) -> yield! List.collect visitBinding bindings
         | SynModuleDecl.Types(typeDefns = typeDefns) -> yield! List.collect visitSynTypeDefn typeDefns
         | SynModuleDecl.HashDirective _ -> ()
@@ -80,7 +80,7 @@ let visitSynModuleSigDecl (md: SynModuleSigDecl) =
         | SynModuleSigDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ ident ]; attributes = attributes); moduleDecls = decls) ->
             yield! visitSynAttributes attributes
             yield FileContentEntry.NestedModule(ident.idText, List.collect visitSynModuleSigDecl decls)
-        | SynModuleSigDecl.NestedModule _ -> failwith "A nested module cannot have multiple identifiers"
+        | SynModuleSigDecl.NestedModule _ -> () // "A nested module cannot have multiple identifiers"
         | SynModuleSigDecl.ModuleAbbrev(longId = longId) -> yield! visitLongIdentForModuleAbbrev longId
         | SynModuleSigDecl.Val(valSig, _) -> yield! visitSynValSig valSig
         | SynModuleSigDecl.Types(types = types) -> yield! List.collect visitSynTypeDefnSig types

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -56,7 +56,7 @@ let visitSynModuleDecl (decl: SynModuleDecl) : FileContentEntry list =
         | SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ ident ]; attributes = attributes); decls = decls) ->
             yield! visitSynAttributes attributes
             yield FileContentEntry.NestedModule(ident.idText, List.collect visitSynModuleDecl decls)
-        | SynModuleDecl.NestedModule _ -> () // "A nested module cannot have multiple identifiers"
+        | SynModuleDecl.NestedModule _ -> () // A nested module cannot have multiple identifiers. This will already be a parse error, but we could be working with recovered syntax tree
         | SynModuleDecl.Let(bindings = bindings) -> yield! List.collect visitBinding bindings
         | SynModuleDecl.Types(typeDefns = typeDefns) -> yield! List.collect visitSynTypeDefn typeDefns
         | SynModuleDecl.HashDirective _ -> ()
@@ -80,7 +80,7 @@ let visitSynModuleSigDecl (md: SynModuleSigDecl) =
         | SynModuleSigDecl.NestedModule(moduleInfo = SynComponentInfo(longId = [ ident ]; attributes = attributes); moduleDecls = decls) ->
             yield! visitSynAttributes attributes
             yield FileContentEntry.NestedModule(ident.idText, List.collect visitSynModuleSigDecl decls)
-        | SynModuleSigDecl.NestedModule _ -> () // "A nested module cannot have multiple identifiers"
+        | SynModuleSigDecl.NestedModule _ -> () // A nested module cannot have multiple identifiers. This will already be a parse error, but we could be working with recovered syntax tree
         | SynModuleSigDecl.ModuleAbbrev(longId = longId) -> yield! visitLongIdentForModuleAbbrev longId
         | SynModuleSigDecl.Val(valSig, _) -> yield! visitSynValSig valSig
         | SynModuleSigDecl.Types(types = types) -> yield! List.collect visitSynTypeDefnSig types

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/FileContentMappingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/FileContentMappingTests.fs
@@ -121,3 +121,18 @@ module B = C
     match content with
     | [ TopLevelNamespace "" [ PrefixedIdentifier "C" ] ] -> Assert.Pass()
     | content -> Assert.Fail($"Unexpected content: {content}")
+
+[<Test>]
+let ``Invalid nested module should just be ignored`` () =
+    let content =
+        getContent
+            false
+            """
+module A
+
+module B.C
+"""
+
+    match content with
+    | [ TopLevelNamespace "" [] ] -> Assert.Pass()
+    | content -> Assert.Fail($"Unexpected content: {content}")


### PR DESCRIPTION
When using graph checking in IDE this `failwith` can be reached and crash type checking. We can just ignore it and carry on. The error will be reported from parsing.