### PR TITLE
Small optimization for DateTime comparison

### DIFF
--- a/docs/release-notes/.FSharp.Core/8.0.300.md
+++ b/docs/release-notes/.FSharp.Core/8.0.300.md
@@ -1,3 +1,7 @@
 ### Fixed
 
 * Preserve original stack traces in resumable state machines generated code if available. ([PR #16568](https://github.com/dotnet/fsharp/pull/16568))
+
+### Changed
+
+* Optimize DateTime comparisons on older platforms ([PR 16587](https://github.com/dotnet/fsharp/pull/16587))

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -1725,7 +1725,7 @@ namespace Microsoft.FSharp.Core
                   when 'T : char    = (# "ceq" x y : bool #)
                   when 'T : string  = System.String.Equals((# "" x : string #),(# "" y : string #))
                   when 'T : decimal = System.Decimal.op_Equality((# "" x:decimal #), (# "" y:decimal #))
-                  when 'T : DateTime = DateTime.Equals((# "" x : DateTime #), (# "" y : DateTime #))
+                  when 'T : DateTime = DateTime.op_Equality((# "" x : DateTime #), (# "" y : DateTime #))
                                
             /// Implements generic equality between two values, with PER semantics for NaN (so equality on two NaN values returns false)
             //
@@ -1749,7 +1749,7 @@ namespace Microsoft.FSharp.Core
                   when 'T : unativeint  = (# "ceq" x y : bool #)
                   when 'T : string  = System.String.Equals((# "" x : string #),(# "" y : string #))
                   when 'T : decimal = System.Decimal.op_Equality((# "" x:decimal #), (# "" y:decimal #))
-                  when 'T : DateTime = DateTime.Equals((# "" x : DateTime #), (# "" y : DateTime #))
+                  when 'T : DateTime = DateTime.op_Equality((# "" x : DateTime #), (# "" y : DateTime #))
 
 
             /// A compiler intrinsic generated during optimization of calls to GenericEqualityIntrinsic on tuple values.
@@ -1778,7 +1778,7 @@ namespace Microsoft.FSharp.Core
                   when 'T : unativeint  = (# "ceq" x y : bool #)
                   when 'T : string  = System.String.Equals((# "" x : string #),(# "" y : string #))                  
                   when 'T : decimal = System.Decimal.op_Equality((# "" x:decimal #), (# "" y:decimal #))
-                  when 'T : DateTime = DateTime.Equals((# "" x : DateTime #), (# "" y : DateTime #))
+                  when 'T : DateTime = DateTime.op_Equality((# "" x : DateTime #), (# "" y : DateTime #))
 
             /// Fill in the implementation of CountLimitedHasherPER
             type CountLimitedHasherPER with

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.net472.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.net472.debug.bsl
@@ -218,8 +218,8 @@
       IL_002a:  stloc.s    V_6
       IL_002c:  ldloc.s    V_4
       IL_002e:  ldloc.s    V_5
-      IL_0030:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_0030:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_0035:  ret
 
       IL_0036:  ldc.i4.0

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.net472.release.bsl
@@ -191,8 +191,8 @@
       IL_001a:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
       IL_001f:  ldloc.2
       IL_0020:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
-      IL_0025:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_0025:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_002a:  ret
 
       IL_002b:  ldc.i4.0
@@ -247,8 +247,8 @@
       IL_0004:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
       IL_0009:  ldloc.0
       IL_000a:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
-      IL_000f:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_000f:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_0014:  ret
     } 
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.netcore.debug.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.netcore.debug.bsl
@@ -218,8 +218,8 @@
       IL_002a:  stloc.s    V_6
       IL_002c:  ldloc.s    V_4
       IL_002e:  ldloc.s    V_5
-      IL_0030:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_0030:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_0035:  ret
 
       IL_0036:  ldc.i4.0
@@ -274,8 +274,8 @@
       IL_0004:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
       IL_0009:  ldloc.0
       IL_000a:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
-      IL_000f:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_000f:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_0014:  ret
     } 
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.netcore.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/StaticInit/StaticInit_Struct01.fs.il.netcore.release.bsl
@@ -191,8 +191,8 @@
       IL_001a:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
       IL_001f:  ldloc.2
       IL_0020:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
-      IL_0025:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_0025:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_002a:  ret
 
       IL_002b:  ldc.i4.0
@@ -247,8 +247,8 @@
       IL_0004:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
       IL_0009:  ldloc.0
       IL_000a:  ldfld      valuetype [runtime]System.DateTime assembly/C::s
-      IL_000f:  call       bool [netstandard]System.DateTime::Equals(valuetype [netstandard]System.DateTime,
-                                                                     valuetype [netstandard]System.DateTime)
+      IL_000f:  call       bool [netstandard]System.DateTime::op_Equality(valuetype [netstandard]System.DateTime,
+                                                                          valuetype [netstandard]System.DateTime)
       IL_0014:  ret
     } 
 


### PR DESCRIPTION
This is basically a followup to [this one](https://github.com/dotnet/fsharp/issues/8447). The DateTime comparisons were added [later](https://github.com/dotnet/fsharp/pull/9224/files) in the old fashion.

`DateTime.op_Equality` is [faster](https://sharplab.io/#v2:EYLgHgbALANANiAZgZxgFxAQ2QWwD4D2ADgKYB2ABAMoCeyaJOAsAFDHnUAWmATkQDKZgAOgBKAVzJoAljhKsFLVmhqkKAYQAUASgoBeVhSMUA2gB4AUtLQBxciR7SAxppWkCiMwBFMDACqyJAB82kEAuobG9L7OFHI4wA7UcAQA7mYA5H5BOvoUkcbGOL5OnBRuJB6Z2RSp1mUFhRR45TS1nBwqwgCiAI7imHDIrqqVnj7+gSEUALRBFACMjYUtAPqz8wBMy8aN5la29o4uFVUTJAFyIeGN0TJOcYyJPBQAYtho1Tm6evksTUUSmVTp4svM6mgGv8Ac1yu0OH5RsJiKs+gM4NYaK4YK13ONfBcpro5osdkY1hsKNtoQCyX8YfSYawgA) than `DateTime.Equals` on older platforms.
![image](https://github.com/dotnet/fsharp/assets/5451366/ed578883-ff17-47fe-bd7f-eae0921be769)
