### PR TITLE
Remove DotNet-Blob-Feed variables from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,13 +110,10 @@ stages:
             demands: ImageOverride -equals windows.vs2022preview.amd64
           timeoutInMinutes: 300
           variables:
-          - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
           - group: DotNet-DevDiv-Insertion-Workflow-Variables
           - name: _SignType
             value: Real
-          - name: _DotNetPublishToBlobFeed
-            value: true
           steps:
           - checkout: self
             clean: true
@@ -131,9 +128,6 @@ stages:
                     /p:MicroBuild_SigningEnabled=true
                     /p:OverridePackageSource=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                     /p:TeamName=$(_TeamName)
-                    /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                    /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                    /p:DotNetPublishToBlobFeed=true
                     /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                     /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                     /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)


### PR DESCRIPTION
They are no longer used and are being removed from arcade: https://github.com/dotnet/arcade/issues/13963

They were deprecated in Arcade 5: https://github.com/dotnet/arcade/blob/66c9c5397d599af40f2a94989241944f5a73442a/Documentation/CorePackages/Publishing.md#publishingusingpipelines--deprecated-properties
