### PR TITLE
Use `AsyncLocal` to keep diagnostics instead of `ThreadStatic`

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -22,3 +22,4 @@
 * Reduce allocations in compiler checking via `ValueOption` usage ([PR #16323](https://github.com/dotnet/fsharp/pull/16323), [PR #16567](https://github.com/dotnet/fsharp/pull/16567))
 * Reverted [#16348](https://github.com/dotnet/fsharp/pull/16348) `ThreadStatic` `CancellationToken` changes to improve test stability and prevent potential unwanted cancellations. ([PR #16536](https://github.com/dotnet/fsharp/pull/16536))
 * Refactored parenthesization API. ([PR #16461])(https://github.com/dotnet/fsharp/pull/16461))
+* Replaced `ThreadStatic` diagnostics globals with `AsyncLocal` for better stability of Transparent Compiler. ([PR #16602](https://github.com/dotnet/fsharp/pull/16602))

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2238,6 +2238,7 @@ and [<Sealed>] TcImports
                 | ParallelReferenceResolution.On -> NodeCode.Parallel
                 | ParallelReferenceResolution.Off -> NodeCode.Sequential
 
+            let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
             let! results =
                 nms
                 |> List.map (fun nm ->
@@ -2245,6 +2246,7 @@ and [<Sealed>] TcImports
                         try
                             return! tcImports.TryRegisterAndPrepareToImportReferencedDll(ctok, nm)
                         with e ->
+                            use _ = UseDiagnosticsLogger diagnosticsLogger
                             errorR (Error(FSComp.SR.buildProblemReadingAssembly (nm.resolvedPath, e.Message), nm.originalReference.Range))
                             return None
                     })

--- a/src/Compiler/Facilities/BuildGraph.fs
+++ b/src/Compiler/Facilities/BuildGraph.fs
@@ -7,7 +7,7 @@ open System.Threading
 open System.Threading.Tasks
 open System.Diagnostics
 open System.Globalization
-open FSharp.Compiler.DiagnosticsLogger
+//open FSharp.Compiler.DiagnosticsLogger
 open Internal.Utilities.Library
 
 [<NoEquality; NoComparison>]
@@ -15,14 +15,15 @@ type NodeCode<'T> = Node of Async<'T>
 
 let wrapThreadStaticInfo computation =
     async {
-        let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
-        let phase = DiagnosticsThreadStatics.BuildPhase
+        //let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
+        //let phase = DiagnosticsThreadStatics.BuildPhase
 
         try
             return! computation
         finally
-            DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
-            DiagnosticsThreadStatics.BuildPhase <- phase
+            //DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
+            //DiagnosticsThreadStatics.BuildPhase <- phase
+            ()
     }
 
 type Async<'T> with
@@ -92,19 +93,19 @@ type NodeCodeBuilder() =
     [<DebuggerHidden; DebuggerStepThrough>]
     member _.Combine(Node(p1): NodeCode<unit>, Node(p2): NodeCode<'T>) : NodeCode<'T> = Node(async.Combine(p1, p2))
 
-    [<DebuggerHidden; DebuggerStepThrough>]
-    member _.Using(value: CompilationGlobalsScope, binder: CompilationGlobalsScope -> NodeCode<'U>) =
-        Node(
-            async {
-                DiagnosticsThreadStatics.DiagnosticsLogger <- value.DiagnosticsLogger
-                DiagnosticsThreadStatics.BuildPhase <- value.BuildPhase
+    //[<DebuggerHidden; DebuggerStepThrough>]
+    //member _.Using(value: CompilationGlobalsScope, binder: CompilationGlobalsScope -> NodeCode<'U>) =
+    //    Node(
+    //        async {
+    //            DiagnosticsThreadStatics.DiagnosticsLogger <- value.DiagnosticsLogger
+    //            DiagnosticsThreadStatics.BuildPhase <- value.BuildPhase
 
-                try
-                    return! binder value |> Async.AwaitNodeCode
-                finally
-                    (value :> IDisposable).Dispose()
-            }
-        )
+    //            try
+    //                return! binder value |> Async.AwaitNodeCode
+    //            finally
+    //                (value :> IDisposable).Dispose()
+    //        }
+    //    )
 
     [<DebuggerHidden; DebuggerStepThrough>]
     member _.Using(value: IDisposable, binder: IDisposable -> NodeCode<'U>) =
@@ -123,22 +124,23 @@ type NodeCode private () =
     static let cancellationToken = Node(wrapThreadStaticInfo Async.CancellationToken)
 
     static member RunImmediate(computation: NodeCode<'T>, ct: CancellationToken) =
-        let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
-        let phase = DiagnosticsThreadStatics.BuildPhase
+        //let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
+        //let phase = DiagnosticsThreadStatics.BuildPhase
 
         try
             try
                 let work =
                     async {
-                        DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
-                        DiagnosticsThreadStatics.BuildPhase <- phase
+                        //DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
+                        //DiagnosticsThreadStatics.BuildPhase <- phase
                         return! computation |> Async.AwaitNodeCode
                     }
 
                 Async.StartImmediateAsTask(work, cancellationToken = ct).Result
             finally
-                DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
-                DiagnosticsThreadStatics.BuildPhase <- phase
+                //DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
+                //DiagnosticsThreadStatics.BuildPhase <- phase
+                ()
         with :? AggregateException as ex when ex.InnerExceptions.Count = 1 ->
             raise (ex.InnerExceptions[0])
 
@@ -146,21 +148,22 @@ type NodeCode private () =
         NodeCode.RunImmediate(computation, CancellationToken.None)
 
     static member StartAsTask_ForTesting(computation: NodeCode<'T>, ?ct: CancellationToken) =
-        let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
-        let phase = DiagnosticsThreadStatics.BuildPhase
+        //let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
+        //let phase = DiagnosticsThreadStatics.BuildPhase
 
         try
             let work =
                 async {
-                    DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
-                    DiagnosticsThreadStatics.BuildPhase <- phase
+                    //DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
+                    //DiagnosticsThreadStatics.BuildPhase <- phase
                     return! computation |> Async.AwaitNodeCode
                 }
 
             Async.StartAsTask(work, cancellationToken = defaultArg ct CancellationToken.None)
         finally
-            DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
-            DiagnosticsThreadStatics.BuildPhase <- phase
+            //DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
+            //DiagnosticsThreadStatics.BuildPhase <- phase
+            ()
 
     static member CancellationToken = cancellationToken
 
@@ -193,14 +196,14 @@ type NodeCode private () =
         }
 
     static member Parallel(computations: NodeCode<'T> seq) =
-        let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
-        let phase = DiagnosticsThreadStatics.BuildPhase
+        //let diagnosticsLogger = DiagnosticsThreadStatics.DiagnosticsLogger
+        //let phase = DiagnosticsThreadStatics.BuildPhase
 
         computations
         |> Seq.map (fun (Node x) ->
             async {
-                DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
-                DiagnosticsThreadStatics.BuildPhase <- phase
+                //DiagnosticsThreadStatics.DiagnosticsLogger <- diagnosticsLogger
+                //DiagnosticsThreadStatics.BuildPhase <- phase
                 return! x
             })
         |> Async.Parallel

--- a/src/Compiler/Facilities/BuildGraph.fsi
+++ b/src/Compiler/Facilities/BuildGraph.fsi
@@ -44,8 +44,8 @@ type NodeCodeBuilder =
 
     member Combine: x1: NodeCode<unit> * x2: NodeCode<'T> -> NodeCode<'T>
 
-    /// A limited form 'use' for establishing the compilation globals.
-    member Using: CompilationGlobalsScope * (CompilationGlobalsScope -> NodeCode<'T>) -> NodeCode<'T>
+    ///// A limited form 'use' for establishing the compilation globals.
+    //member Using: CompilationGlobalsScope * (CompilationGlobalsScope -> NodeCode<'T>) -> NodeCode<'T>
 
     /// A generic 'use' that disposes of the IDisposable at the end of the computation.
     member Using: IDisposable * (IDisposable -> NodeCode<'T>) -> NodeCode<'T>

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -232,8 +232,6 @@ type DiagnosticsThreadStatics =
 
     static member BuildPhase: BuildPhase with get, set
 
-    static member BuildPhaseUnchecked: BuildPhase
-
     static member DiagnosticsLogger: DiagnosticsLogger with get, set
 
 [<AutoOpen>]

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -626,7 +626,7 @@ let fuzzingTest seed (project: SyntheticProject) = task {
             ()
         with
             | e ->
-                let _log = log.Values |> Seq.collect id |> Seq.sortBy p13 |> Seq.toArray
+                // let _log = log.Values |> Seq.collect id |> Seq.sortBy p13 |> Seq.toArray
                 failwith $"Seed: {seed}\nException: %A{e}"
     }
     let log = log.Values |> Seq.collect id |> Seq.sortBy p13 |> Seq.toArray


### PR DESCRIPTION
Introduction of Transparent Compiler revealed some instability w.r.t. `DiagnosticsThreadStatics`:
https://github.com/dotnet/fsharp/pull/16576#issuecomment-1910321553
#16576
#16589

Turns out we used `[<ThreadStatic>]` to keep a compilation-global `DiagnosticsLogger`, and a custom `NodeCode` CE to flow it across threads during execution.
`AsyncLocal` is a BCL class that provides exactly that functionality: flowing state along the async execution path.

This replaces the `ThreadStatic` diagnostics state for `AsyncLocal`.
`NodeCode<'T>` is no longer needed. For now we make it into an alias for `Async<'T>`, and the `node` CE is an alias for `async` builder. To be decided if we want to remove it in this or a separate PR.

