### PR TITLE
Set LKG for plain builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,8 @@
   <Import Project="$(RepoRoot)/Directory.Build.props.user" Condition = "Exists('$(RepoRoot)/Directory.Build.props.user')" />
 
   <PropertyGroup Condition="'$(BUILDING_USING_DOTNET)' == 'true'">
+    <BUILDING_WITH_LKG>true</BUILDING_WITH_LKG>
+    <BUILD_FROM_SOURCE>true</BUILD_FROM_SOURCE>
     <DisableAutoSetFscCompilerPath>false</DisableAutoSetFscCompilerPath>
     <FSHARPCORE_USE_PACKAGE Condition="'$(FSHARPCORE_USE_PACKAGE)' == ''">true</FSHARPCORE_USE_PACKAGE>
     <DISABLE_ARCADE Condition="'$(DISABLE_ARCADE)' == ''">true</DISABLE_ARCADE>


### PR DESCRIPTION
Set the LKG define for plain builds, this will allow us not fail when working with FCS solution (i.e. use LKG dotnet).