### PR TITLE
Run TransparentCompiler unit tests with local response files.

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -802,88 +802,6 @@ module Stuff =
 
         ()
 
-let mkWorkflowBuilderForResponseFile
-    (useTransparentCompiler:bool)
-    (responseFile: FileInfo)
-    : SyntheticProject * ProjectWorkflowBuilder
-    =
-    if not responseFile.Exists then
-        failwith $"%s{responseFile.FullName} does not exist"
-    
-    let compilerArgs = File.ReadAllLines responseFile.FullName
-
-    let fsharpFileExtensions = set [| ".fs" ; ".fsi" ; ".fsx" |]
-
-    let isFSharpFile (file : string) =
-        Set.exists (fun (ext : string) -> file.EndsWith (ext, StringComparison.Ordinal)) fsharpFileExtensions
-          
-    let fsharpFiles =
-        compilerArgs
-        |> Array.choose (fun (line : string) ->
-            if not (isFSharpFile line) then
-                None
-            else
-
-            let fullPath = Path.Combine (responseFile.DirectoryName, line)
-            if not (File.Exists fullPath) then
-                None
-            else
-                Some fullPath
-        )
-        |> Array.toList
-
-    let signatureFiles, implementationFiles =
-        fsharpFiles |> List.partition (fun path -> path.EndsWith ".fsi")
-
-    let signatureFiles = set signatureFiles
-
-    let sourceFiles =
-        implementationFiles
-        |> List.map (fun implPath ->
-            {
-                  Id = implPath
-                  PublicVersion = 1
-                  InternalVersion = 1
-                  DependsOn = []
-                  FunctionName = "f"
-                  SignatureFile =
-                      let sigPath = $"%s{implPath}i" in
-                      if signatureFiles.Contains sigPath then Custom(File.ReadAllText sigPath) else No
-                  HasErrors = false
-                  Source = File.ReadAllText implPath
-                  ExtraSource = ""
-                  EntryPoint = false
-            }
-        )
-    
-    let otherOptions =
-        compilerArgs
-        |> Array.filter (fun line -> not (isFSharpFile line))
-        |> Array.toList
-  
-    let syntheticProject: SyntheticProject =
-        {
-            Name = Path.GetFileNameWithoutExtension responseFile.Name
-            ProjectDir = responseFile.DirectoryName
-            SourceFiles = sourceFiles
-            DependsOn = List.empty
-            RecursiveNamespace = false
-            OtherOptions = otherOptions
-            AutoAddModules = false
-            NugetReferences = List.empty
-            FrameworkReferences = List.empty
-            SkipInitialCheck = false
-        }
-
-    let builder =
-        ProjectWorkflowBuilder(
-            syntheticProject,
-            isExistingProject = true,
-            useTransparentCompiler = useTransparentCompiler
-        )
-
-    syntheticProject, builder
-
 /// Update these paths to a local response file with compiler arguments of existing F# projects.
 /// References projects are expected to have been built.
 let localResponseFiles =
@@ -900,12 +818,19 @@ let localResponseFiles =
 // Uncomment this attribute if you want run this test against local response files.
 // [<Theory>]
 [<MemberData(nameof(localResponseFiles))>]
-let ``TypeCheck last file in project with transparent compiler`` useTransparent responseFile =
+let ``TypeCheck last file in project with transparent compiler`` useTransparentCompiler responseFile =
     let responseFile = FileInfo responseFile
-    let project, workflow = mkWorkflowBuilderForResponseFile useTransparent responseFile
+    let syntheticProject = mkSyntheticProjectForResponseFile responseFile
+
+    let workflow =     
+        ProjectWorkflowBuilder(
+            syntheticProject,
+            isExistingProject = true,
+            useTransparentCompiler = useTransparentCompiler
+        )
 
     let lastFile =
-        project.SourceFiles
+        syntheticProject.SourceFiles
         |> List.last
         |> fun sf -> sf.Id
 

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -831,8 +831,12 @@ let ``TypeCheck last file in project with transparent compiler`` useTransparentC
 
     let lastFile =
         syntheticProject.SourceFiles
-        |> List.last
-        |> fun sf -> sf.Id
+        |> List.tryLast
+        |> Option.map (fun sf -> sf.Id)
+
+    match lastFile with
+    | None -> failwithf "Last file of project could not be found"
+    | Some lastFile ->
 
     workflow {
         clearCache 

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -193,14 +193,12 @@ type SyntheticSourceFile =
         Source: string
         ExtraSource: string
         EntryPoint: bool
-        /// The absolute path of an existing F# file.
-        PhysicalFileName: string option
+        /// Indicates whether this is an existing F# file on disk.
+        IsPhysicalFile: bool
     }
 
     member this.FileName =
-        match this.PhysicalFileName with
-        | Some f -> f
-        | None -> $"File%s{this.Id}.fs"
+        if this.IsPhysicalFile then $"%s{this.Id}.fs" else $"File%s{this.Id}.fs"
 
     member this.SignatureFileName = $"{this.FileName}i"
     member this.TypeName = $"T{this.Id}V_{this.PublicVersion}"
@@ -223,7 +221,7 @@ let sourceFile fileId deps =
       Source = ""
       ExtraSource = ""
       EntryPoint = false
-      PhysicalFileName = None }
+      IsPhysicalFile = false }
 
 
 let OptionsCache = ConcurrentDictionary()
@@ -530,7 +528,7 @@ let mkSyntheticProjectForResponseFile (responseFile: FileInfo) : SyntheticProjec
                   Source = File.ReadAllText implPath
                   ExtraSource = ""
                   EntryPoint = false
-                  PhysicalFileName = Some implPath 
+                  IsPhysicalFile = true 
             }
         )
     

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -536,18 +536,12 @@ let mkSyntheticProjectForResponseFile (responseFile: FileInfo) : SyntheticProjec
         compilerArgs
         |> Array.filter (fun line -> not (isFSharpFile line))
         |> Array.toList
- 
-    {
-        Name = Path.GetFileNameWithoutExtension responseFile.Name
+
+    { SyntheticProject.Create(Path.GetFileNameWithoutExtension responseFile.Name) with
         ProjectDir = responseFile.DirectoryName
         SourceFiles = sourceFiles
-        DependsOn = List.empty
-        RecursiveNamespace = false
         OtherOptions = otherOptions
         AutoAddModules = false
-        NugetReferences = List.empty
-        FrameworkReferences = List.empty
-        SkipInitialCheck = false
     }
 
 [<AutoOpen>]


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

To experiment with the new Transparent Compiler on local projects, I've implemented infrastructure capable of handling a response file from a local project. This approach mirrors the tests in [CompilationFromCmdlineArgsTests](https://github.com/dotnet/fsharp/blob/main/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/CompilationFromCmdlineArgsTests.fs), offering valuable insights for local testing.

<details><summary>How to generate a response file?</summary>
<h3>Poor man's response file</h3>
<p>
Just run your regular <code>dotnet build -v:n</code> with Verbosity set to normal, wait until you see <code>CoreCompile</code> and grab the compiler arguments.
</p>
<h3>Via script</h3>
<p>
The <a href="https://github.com/dotnet/fsharp/blob/main/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/scrape.fsx">scrape.fsx script</a> does a build of a project and extracts it from the bin log file.
</p>
<h3>Via Telplin</h3>
<p>
My <a href="https://github.com/nojaf/telplin">Telplin tool</a> has a bit of a hidden feature that it can save the response file without generating any signatures at all.<br /> <code>dotnet tool install -g telplin</code> and then <code>telplin --only-record MyProject.fsproj</code>
</p>
</details> 



## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**