### PR TITLE
Faster equality in generic contexts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -794,7 +794,7 @@ stages:
             condition: always()
 
         # Test trimming on Windows
-        - job: Build_And_Test_Trimming_Windows
+        - job: Build_And_Test_AOT_Windows
           pool:
             name: $(DncEngPublicBuildPool)
             demands: ImageOverride -equals $(WindowsMachineQueueName)
@@ -825,9 +825,9 @@ stages:
             env:
               NativeToolsOnMachine: true
             displayName: Initial build and prepare packages.
-          - script: $(Build.SourcesDirectory)/tests/AheadOfTime/Trimming/check.cmd
+          - script: $(Build.SourcesDirectory)/tests/AheadOfTime/check.cmd
             displayName: Build, trim, publish and check the state of the trimmed app.
-            workingDirectory: $(Build.SourcesDirectory)/tests/AheadOfTime/Trimming
+            workingDirectory: $(Build.SourcesDirectory)/tests/AheadOfTime
           - task: PublishPipelineArtifact@1
             displayName: Publish Trim Tests Logs
             inputs:

--- a/docs/release-notes/.FSharp.Core/8.0.300.md
+++ b/docs/release-notes/.FSharp.Core/8.0.300.md
@@ -1,6 +1,8 @@
 ### Added
 
 * Minor tweaks to inline specifications to support Visibility PR ([PR #15484](https://github.com/dotnet/fsharp/pull/15484), [#PR 16427](https://github.com/dotnet/fsharp/pull/15484)
+* Optimize equality in generic contexts. ([PR #16615](https://github.com/dotnet/fsharp/pull/16615))
 
 ### Fixed
+
 * Preserve original stack traces in resumable state machines generated code if available. ([PR #16568](https://github.com/dotnet/fsharp/pull/16568))

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -680,7 +680,7 @@ try {
     }
 
     if ($testAOT) {
-        Push-Location "$RepoRoot\tests\AheadOfTime\Trimming"
+        Push-Location "$RepoRoot\tests\AheadOfTime"
         ./check.cmd
         Pop-Location
     }

--- a/tests/AheadOfTime/Equality/Equality.fsproj
+++ b/tests/AheadOfTime/Equality/Equality.fsproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
+    <PublishTrimmed>true</PublishTrimmed>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DotnetFscCompilerPath>$(MSBuildThisFileDirectory)../../../artifacts/bin/fsc/Release/net8.0/fsc.dll</DotnetFscCompilerPath>
+    <Fsc_DotNET_DotnetFscCompilerPath>$(MSBuildThisFileDirectory)../../../artifacts/bin/fsc/Release/net8.0/fsc.dll</Fsc_DotNET_DotnetFscCompilerPath>
+    <FSharpPreferNetFrameworkTools>False</FSharpPreferNetFrameworkTools>
+    <FSharpPrefer64BitTools>True</FSharpPrefer64BitTools>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)../../../eng/Versions.props" />
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCorePreviewPackageVersionValue)"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/AheadOfTime/Equality/Program.fs
+++ b/tests/AheadOfTime/Equality/Program.fs
@@ -1,0 +1,77 @@
+open System.Collections.Generic
+open NonStructuralComparison
+
+let failures = HashSet<string>()
+
+let reportFailure (s: string) = 
+    stderr.Write " NO: "
+    stderr.WriteLine s
+    failures.Add s |> ignore
+
+let test testName x y =
+    let result = HashIdentity.Structural.Equals(x, y)
+    if result = false
+    then
+        stderr.WriteLine($"\n***** {testName}: Expected: 'true' Result: '{result}' = FAIL\n");
+        reportFailure testName
+
+module BasicTypes =
+    test "test000" true true
+    test "test001" 1y 1y
+    test "test002" 1uy 1uy
+    test "test003" 1s 1s
+    test "test004" 1us 1us
+    test "test005" 1 1
+    test "test006" 1u 1u
+    test "test007" 1L 1L
+    test "test008" 1UL 1UL
+    test "test009" (nativeint 1) (nativeint 1)
+    test "test010" (unativeint 1) (unativeint 1)
+    test "test011" 'a' 'a'
+    test "test012" "a" "a"
+    test "test013" 1m 1m
+    test "test014" 1.0 1.0
+    test "test015" 1.0f 1.0f
+
+module Arrays =
+    test "test100" [|1|] [|1|]
+    test "test101" [|1L|] [|1L|]
+    test "test102" [|1uy|] [|1uy|]
+    test "test103" [|box 1|] [|box 1|]
+
+module Structs = 
+    test "test200" struct (1, 1) struct (1, 1)
+    test "test201" struct (1, 1, 1) struct (1, 1, 1)
+    test "test202" struct (1, 1, 1, 1) struct (1, 1, 1, 1)
+    test "test203" struct (1, 1, 1, 1, 1) struct (1, 1, 1, 1, 1)
+    test "test204" struct (1, 1, 1, 1, 1, 1) struct (1, 1, 1, 1, 1, 1)
+    test "test205" struct (1, 1, 1, 1, 1, 1, 1) struct (1, 1, 1, 1, 1, 1, 1)
+    test "test206" struct (1, 1, 1, 1, 1, 1, 1, 1) struct (1, 1, 1, 1, 1, 1, 1, 1)
+
+module OptionsAndCo = 
+    open System
+
+    test "test301" (Some 1) (Some 1)
+    test "test302" (ValueSome 1) (ValueSome 1)
+    test "test303" (Ok 1) (Ok 1)
+    test "test304" (Nullable 1) (Nullable 1)
+
+module Enums =
+    open System
+
+    type SomeEnum = 
+        | Case0 = 0
+        | Case1 = 1
+
+    test "test401" (enum<SomeEnum>(1)) (enum<SomeEnum>(1)) 
+    test "test402" (enum<DayOfWeek>(1)) (enum<DayOfWeek>(1)) 
+
+[<EntryPoint>]
+let main _ =
+    match failures with 
+    | set when set.Count = 0 -> 
+        stdout.WriteLine "All tests passed"
+        exit 0
+    | _ -> 
+        stdout.WriteLine "Some tests failed"
+        exit 1

--- a/tests/AheadOfTime/Equality/check.ps1
+++ b/tests/AheadOfTime/Equality/check.ps1
@@ -1,0 +1,32 @@
+Write-Host "Publish and Execute: net8.0 - Equality"
+
+$build_output = dotnet publish -restore -c release -f:net8.0 $(Join-Path $PSScriptRoot Equality.fsproj)
+
+# Checking that the build succeeded
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Error "Build failed with exit code ${LASTEXITCODE}"
+    Write-Error "${build_output}" -ErrorAction Stop
+}
+
+$process = Start-Process `
+    -FilePath $(Join-Path $PSScriptRoot bin\release\net8.0\win-x64\publish\Equality.exe) `
+    -Wait `
+    -NoNewWindow `
+    -PassThru `
+    -RedirectStandardOutput $(Join-Path $PSScriptRoot output.txt)
+
+$output = Get-Content $(Join-Path $PSScriptRoot output.txt)
+
+# Checking that it is actually running.
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Error "Test failed with exit code ${LASTEXITCODE}" -ErrorAction Stop
+}
+
+# Checking that the output is as expected.
+$expected = "All tests passed"
+if ($output -ne $expected)
+{
+    Write-Error "Test failed with unexpected output:`nExpected:`n`t${expected}`nActual`n`t${output}" -ErrorAction Stop
+}

--- a/tests/AheadOfTime/Trimming/check.cmd
+++ b/tests/AheadOfTime/Trimming/check.cmd
@@ -1,2 +1,0 @@
-@echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0check.ps1""""

--- a/tests/AheadOfTime/Trimming/check.ps1
+++ b/tests/AheadOfTime/Trimming/check.ps1
@@ -39,7 +39,7 @@ function CheckTrim($root, $tfm, $outputfile, $expected_len) {
 # error NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher.
 
 # Check net7.0 trimmed assemblies
-CheckTrim -root "SelfContained_Trimming_Test" -tfm "net8.0" -outputfile "FSharp.Core.dll" -expected_len 287232
+CheckTrim -root "SelfContained_Trimming_Test" -tfm "net8.0" -outputfile "FSharp.Core.dll" -expected_len 284160
 
 # Check net8.0 trimmed assemblies
-CheckTrim -root "StaticLinkedFSharpCore_Trimming_Test" -tfm "net8.0" -outputfile "StaticLinkedFSharpCore_Trimming_Test.dll" -expected_len 8820736
+CheckTrim -root "StaticLinkedFSharpCore_Trimming_Test" -tfm "net8.0" -outputfile "StaticLinkedFSharpCore_Trimming_Test.dll" -expected_len 8817152

--- a/tests/AheadOfTime/check.cmd
+++ b/tests/AheadOfTime/check.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Trimming\check.ps1""""
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Equality\check.ps1""""

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Benchmarks.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Benchmarks.fs
@@ -1,11 +1,11 @@
-namespace TaskPerf
+namespace MicroPerf
 
 open BenchmarkDotNet.Running
 
-module Main = 
+module Main =
 
     [<EntryPoint>]
-    let main _ = 
+    let main args = 
         printfn "Running benchmarks..."
-        let _ = BenchmarkRunner.Run<Collections.CollectionsBenchmark>()
-        0  
+        BenchmarkSwitcher.FromAssembly(typeof<Equality.FSharpCoreFunctions>.Assembly).Run(args) |> ignore
+        0

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Arrays.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Arrays.fs
@@ -1,0 +1,23 @@
+namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+type Arrays() =
+
+    let numbers = Array.init 1000 id
+
+    [<Benchmark>]
+    member _.Int32() =
+        numbers |> Array.countBy  (fun n -> [| n % 7 |])
+
+    [<Benchmark>]
+    member _.Int64() =
+        numbers |> Array.countBy  (fun n -> [| int64 (n % 7) |])
+
+    [<Benchmark>]
+    member _.Byte() =
+        numbers |> Array.countBy  (fun n -> [| byte (n % 7) |])
+
+    [<Benchmark>]
+    member _.Obj() =
+        numbers |> Array.countBy  (fun n -> [| box (n % 7) |])

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/BasicTypes.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/BasicTypes.fs
@@ -1,0 +1,63 @@
+﻿namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+[<MemoryDiagnoser>]
+type BasicTypes() =
+
+    let bools = Array.init 1000 (fun n -> n % 2 = 0)
+    let sbytes = Array.init 1000 sbyte
+    let bytes = Array.init 1000 byte
+    let int16s = Array.init 1000 int16
+    let uint16s = Array.init 1000 uint16
+    let int32s = Array.init 1000 id
+    let uint32s = Array.init 1000 uint32
+    let int64s = Array.init 1000 int64
+    let uint64s = Array.init 1000 uint64
+    let intptrs = Array.init 1000 nativeint
+    let uintptrs = Array.init 1000 unativeint
+    let chars = Array.init 1000 char
+    let strings = Array.init 1000 string
+    let decimals = Array.init 1000 decimal
+
+    [<Benchmark>]
+    member _.Bool() = bools |> Array.distinct
+
+    [<Benchmark>]
+    member _.SByte() = sbytes |> Array.distinct
+
+    [<Benchmark>]
+    member _.Byte() = bytes |> Array.distinct
+
+    [<Benchmark>]
+    member _.Int16() = int16s |> Array.distinct
+
+    [<Benchmark>]
+    member _.UInt16() = uint16s |> Array.distinct
+    
+    [<Benchmark>]
+    member _.Int32() = int32s |> Array.distinct
+
+    [<Benchmark>]
+    member _.UInt32() = uint32s |> Array.distinct
+
+    [<Benchmark>]
+    member _.Int64() = int64s |> Array.distinct
+
+    [<Benchmark>]
+    member _.UInt64() = uint64s |> Array.distinct
+
+    [<Benchmark>]
+    member _.IntPtr() = intptrs |> Array.distinct
+
+    [<Benchmark>]
+    member _.UIntPtr() = uintptrs |> Array.distinct
+
+    [<Benchmark>]
+    member _.Char() = chars |> Array.distinct
+
+    [<Benchmark>]
+    member _.String() = strings |> Array.distinct
+
+    [<Benchmark>]
+    member _.Decimal() = decimals |> Array.distinct

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/FSharpCoreFunctions.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/FSharpCoreFunctions.fs
@@ -1,0 +1,102 @@
+namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+[<Struct>]
+type SomeStruct =
+    val A : int
+    new a = { A = a }
+
+type FSharpCoreFunctions() =
+
+    let array = Array.init 1000 id
+    let list = List.init 1000 id
+    let seq = Seq.init 1000 id
+
+    [<Benchmark>]
+    member _.ArrayCountBy() =
+        array
+        |> Array.countBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ArrayGroupBy() =
+        array
+        |> Array.groupBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ArrayDistinct() =
+        array
+        |> Array.map (fun n -> SomeStruct(n % 7))
+        |> Array.distinct
+
+    [<Benchmark>]
+    member _.ArrayDistinctBy() =
+        array
+        |> Array.distinctBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ArrayExcept() =
+        array
+        |> Array.map SomeStruct
+        |> Array.except ([| SomeStruct 42 |])
+
+    [<Benchmark>]
+    member _.ListCountBy() =
+        list
+        |> List.countBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ListGroupBy() =
+        list
+        |> List.groupBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ListDistinct() =
+        list
+        |> List.map (fun n -> SomeStruct(n % 7))
+        |> List.distinct
+
+    [<Benchmark>]
+    member _.ListDistinctBy() =
+        list
+        |> List.distinctBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ListExcept() =
+        List.init 1000 id
+        |> List.map SomeStruct
+        |> List.except ([| SomeStruct 42 |])
+
+    [<Benchmark>]
+    member _.SeqCountBy() =
+        seq
+        |> Seq.countBy (fun n -> SomeStruct(n % 7))
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqGroupBy() =
+        seq
+        |> Seq.groupBy (fun n -> SomeStruct(n % 7))
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqDistinct() =
+        seq
+        |> Seq.map (fun n -> SomeStruct(n % 7))
+        |> Seq.distinct
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqDistinctBy() =
+        seq
+        |> Seq.distinctBy (fun n -> SomeStruct(n % 7))
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqExcept() =
+        seq
+        |> Seq.map SomeStruct
+        |> Seq.except ([| SomeStruct 42 |])
+        |> Seq.last
+
+

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Floats.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Floats.fs
@@ -1,0 +1,20 @@
+namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+[<MemoryDiagnoser>]
+type Floats() =
+
+    let numbers = Array.init 1000 (fun id -> id % 7)
+
+    [<Benchmark>]
+    member _.FloatER() = numbers |> Array.groupBy float
+
+    [<Benchmark>]
+    member _.Float32ER() = numbers |> Array.groupBy float32
+
+    [<Benchmark>]
+    member _.FloatPER() = numbers |> Array.Parallel.groupBy float
+
+    [<Benchmark>]
+    member _.Float32PER() = numbers |> Array.Parallel.groupBy float32

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Misc.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Misc.fs
@@ -1,0 +1,78 @@
+namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+open System
+
+[<Struct>]
+type BigStruct = 
+    val A : int64
+    val B : int64
+    new (a, b) = { A = a; B = b }
+
+[<Struct>]
+type Container<'a> =
+    val Item : 'a
+    new i = { Item = i }
+
+type RandomRecord = { 
+    Field1 : int
+    Field2 : string
+    Field3 : byte 
+}
+
+[<Struct>]
+type RandomRecordStruct = { 
+    Field1S : int
+    Field2S : string
+    Field3S : byte 
+}
+
+type RandomGeneric<'a> = RandomGeneric of 'a * 'a
+
+[<MemoryDiagnoser>]
+type Misc() =
+
+    let createBigStruct() = 
+        let n = Random().NextInt64()
+        Container (BigStruct (n, n))
+
+    [<Benchmark>]
+    member _.BigStruct() =
+        let set = Set.empty
+        for _ = 0 to 200000 do
+            set.Add (createBigStruct ()) |> ignore
+
+    [<Benchmark>]
+    member _.Record() =
+        let array = Array.init 1000 id
+        array |> Array.countBy (fun n -> { 
+            Field1 = n
+            Field2 = string n
+            Field3 = byte n 
+        })
+    
+    [<Benchmark>]
+    member _.RecordStruct() =
+        let array = Array.init 1000 id
+        array |> Array.countBy (fun n -> { 
+            Field1S = n
+            Field2S = string n
+            Field3S = byte n 
+        })
+
+    // BDN can't work with F# anon records yet
+    // https://github.com/dotnet/BenchmarkDotNet/issues/2530
+    // [<Benchmark>]
+    member _.AnonymousRecord() =
+        let array = Array.init 1000 id
+        array |> Array.countBy (fun n -> {| 
+            Field1A = n
+            Field2A = string n
+            Field3A = byte n 
+        |})
+
+    [<Benchmark>]
+    member _.GenericUnion() =
+        let array = Array.init 1000 id
+        array |> Array.countBy (fun n -> RandomGeneric(n, n))

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/OptionsAndCo.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/OptionsAndCo.fs
@@ -1,0 +1,45 @@
+namespace Equality
+
+open System
+open BenchmarkDotNet.Attributes
+
+[<MemoryDiagnoser>]
+type OptionsAndCo() =
+
+    let numbers = Array.init 1000 id
+
+    let createOption x = 
+        match x with
+        | x when x % 2 = 0 -> Some x
+        | _ -> None
+
+    let createValueOption x = 
+        match x with
+        | x when x % 2 = 0 -> ValueSome x
+        | _ -> ValueNone
+
+    let createResult x = 
+        match x with
+        | x when x % 2 = 0 -> Ok x
+        | x -> Error x
+
+    let createNullable x = 
+        match x with
+        | x when x % 2 = 0 -> Nullable x
+        | _ -> Nullable 42
+
+    [<Benchmark>]
+    member _.Option() = 
+        numbers |> Array.countBy createOption
+
+    [<Benchmark>]
+    member _.ValueOption() = 
+        numbers |> Array.countBy createValueOption
+
+    [<Benchmark>]
+    member _.Result() = 
+        numbers |> Array.countBy createResult
+
+    [<Benchmark>]
+    member _.Nullable() = 
+        numbers |> Array.countBy createNullable

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Structs.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Structs.fs
@@ -1,0 +1,39 @@
+namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+[<MemoryDiagnoser>]
+type Structs() =
+
+    let numbers = Array.init 1000 id
+
+    let createStruct3 (x: int) = struct (x, x, x)
+    let createStruct4 (x: int) = struct (x, x, x, x)
+    let createStruct5 (x: int) = struct (x, x, x, x, x)
+    let createStruct6 (x: int) = struct (x, x, x, x, x, x)
+    let createStruct7 (x: int) = struct (x, x, x, x, x, x, x)
+    let createStruct8 (x: int) = struct (x, x, x, x, x, x, x, x)
+
+    [<Benchmark(Baseline = true)>]
+    member _.Struct3() =
+        numbers |> Array.countBy (fun n -> createStruct3 n)
+
+    [<Benchmark>]
+    member _.Struct4() =
+        numbers |> Array.countBy (fun n -> createStruct4 n)
+
+    [<Benchmark>]
+    member _.Struct5() =
+        numbers |> Array.countBy (fun n -> createStruct5 n)
+
+    [<Benchmark>]
+    member _.Struct6() =
+        numbers |> Array.countBy (fun n -> createStruct6 n)
+
+    [<Benchmark>]
+    member _.Struct7() =
+        numbers |> Array.countBy (fun n -> createStruct7 n)
+
+    [<Benchmark>]
+    member _.Struct8() =
+        numbers |> Array.countBy (fun n -> createStruct8 n)

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Tuples.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/Tuples.fs
@@ -1,0 +1,67 @@
+namespace Equality
+
+open BenchmarkDotNet.Attributes
+
+type SmallNonGenericTuple = SmallNonGenericTuple of int * string
+
+type SmallGenericTuple<'a> = SmallGenericTuple of int * 'a
+
+type BigNonGenericTuple = BigNonGenericTuple of int * string * byte * int * string * byte
+
+type BigGenericTuple<'a> = BigGenericTuple of int * 'a * byte * int * 'a * byte
+
+[<Struct>]
+type SmallNonGenericTupleStruct = SmallNonGenericTupleStruct of int * string
+
+[<Struct>]
+type SmallGenericTupleStruct<'a> = SmallGenericTupleStruct of int * 'a
+
+[<Struct>]
+type BigNonGenericTupleStruct = BigNonGenericTupleStruct of int * string * byte * int * string * byte
+
+[<Struct>]
+type BigGenericTupleStruct<'a> = BigGenericTupleStruct of int * 'a * byte * int * 'a * byte
+
+type ReferenceTuples() =
+
+    let numbers = Array.init 1000 id
+
+    [<Benchmark>]
+    member _.SmallNonGenericTuple() =
+        numbers
+        |> Array.countBy (fun n -> SmallNonGenericTuple(n, string n))
+
+    [<Benchmark>]
+    member _.SmallGenericTuple() =
+        numbers
+        |> Array.countBy (fun n -> SmallGenericTuple(n, string n))
+
+    [<Benchmark>]
+    member _.BigNonGenericTuple() =
+        numbers
+        |> Array.countBy (fun n -> BigNonGenericTuple(n, string n, byte n, n, string n, byte n))
+
+    [<Benchmark>]
+    member _.BigGenericTuple() =
+        numbers
+        |> Array.countBy (fun n -> BigGenericTuple(n, string n, byte n, n, string n, byte n))
+
+    [<Benchmark>]
+    member _.SmallNonGenericTupleStruct() =
+        numbers
+        |> Array.countBy (fun n -> SmallNonGenericTupleStruct(n, string n))
+
+    [<Benchmark>]
+    member _.SmallGenericTupleStruct() =
+        numbers
+        |> Array.countBy (fun n -> SmallGenericTupleStruct(n, string n))
+
+    [<Benchmark>]
+    member _.BigNonGenericTupleStruct() =
+        numbers
+        |> Array.countBy (fun n -> BigNonGenericTupleStruct(n, string n, byte n, n, string n, byte n))
+
+    [<Benchmark>]
+    member _.BigGenericTupleStruct() =
+        numbers
+        |> Array.countBy (fun n -> BigGenericTupleStruct(n, string n, byte n, n, string n, byte n))

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/ValueTypes.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/Equality/ValueTypes.fs
@@ -1,0 +1,39 @@
+namespace Equality
+
+open System
+open BenchmarkDotNet.Attributes
+
+type SomeEnum = 
+    | Case0 = 0
+    | Case1 = 1
+    | Case2 = 2
+
+[<MemoryDiagnoser>]
+type ValueTypes() =
+
+    let numbers = Array.init 1000 id
+    let now = DateTimeOffset.Now
+
+    let createFSharpStruct (x: int) = 
+        struct (x % 7, x % 7)
+
+    let createFSharpEnum (x: int) =
+        enum<SomeEnum>(x % 3)
+
+    let createCSharpStruct (x: int) = 
+        now.AddMinutes x
+
+    let createCSharpEnum (x: int) =
+        enum<System.DayOfWeek>(x % 7)
+
+    [<Benchmark>]
+    member _.FSharpStruct() = numbers |> Array.countBy createFSharpStruct
+
+    [<Benchmark>]
+    member _.FSharpEnum() = numbers |> Array.countBy createFSharpEnum
+
+    [<Benchmark>]
+    member _.CSharpStruct() = numbers |> Array.countBy createCSharpStruct
+
+    [<Benchmark>]
+    member _.CSharpEnum() = numbers |> Array.countBy createCSharpEnum

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/MicroPerf.fsproj
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/MicroPerf.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(FSharpNetCoreProductTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -11,6 +11,15 @@
     <OtherFlags>$(OtherFlags) --define:PREVIEW</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Equality\BasicTypes.fs" />
+    <Compile Include="Equality\FSharpCoreFunctions.fs" />
+    <Compile Include="Equality\Arrays.fs" />
+    <Compile Include="Equality\Floats.fs" />
+    <Compile Include="Equality\Tuples.fs" />
+    <Compile Include="Equality\ValueTypes.fs" />
+    <Compile Include="Equality\Misc.fs" />
+    <Compile Include="Equality\Structs.fs" />
+    <Compile Include="Equality\OptionsAndCo.fs" />
     <Compile Include="Async.fs" />
     <Compile Include="Conditions.fs" />
     <Compile Include="Collections.fs" />


### PR DESCRIPTION
**What is this?**

This is the first part of [this effort](https://github.com/dotnet/fsharp/issues/16125) to resurrect the awesome work on compiler performance by @manofstick.

**How is this different?**

Many things have changed, among other things we now have a bigger team & community to review things and a different release cadence allowing us to dogfood things a bit.

More importantly, the original PRs often contained multiple ideas (fixes, breaking, optimizations, experiments, ...), whereas I want to narrow PRs as much as possible to make things easier to review and control.

**Is this PR breaking?**

A tiny bit. This is mostly an optimization.

Here is an example of code where the behavior does change:
```fsharp
[<Struct; CustomEquality; NoComparison>]
type Blah =
    interface IEquatable<Blah> with
        member lhs.Equals rhs = failwith "bang"

let eq x y = 
    printfn "hello" // long code insuring no inlining
    ...
    x = y // generic equality context

let result = eq (Blah()) (Blah())  // currently false, will be exception
```
We agreed that it's OK [here](https://github.com/dotnet/fsharp/pull/16615#issuecomment-1947440376).

**What's the source of inspiration here?**

This is essentially part of the #5112, with the following changes:
- Optimizer is not touched (there wasn't a consensus on that)
- tail calls are not touched (same, also partially was there to work around JIT issues that were resolved later)
- => hence IL is not changed
- some comparison optimizations are removed (I wasn't convinced by them)
- refactoring is removed (might be done in a followup)
- => hence diff is minimized
- benchmarks are added

**So where does this improve things?**

More theory and motivation is in [this document](https://github.com/fsharp/fslang-design/pull/765) - link will be updated once the PR merged.

*TL;DR: this improves things when `HashIdentity.Structural<'T>` comparison is used in non-inlined code.*

**Example optimization**

Let's look at the following code:

```fsharp
type Musician = {
    Name: string
    Surname: string
}

let musicians = [ 
    { Name = "Dave"; Surname = "Gahan" }
    { Name = "Jim"; Surname = "Morrisson" }
    { Name = "Robert"; Surname = "Smith" }
    { Name = "Dave"; Surname = "Grohl" }
    { Name = "Johnny"; Surname = "Marr" }
    { Name = "David"; Surname = "Gilmour" }
]

let getInitials musician =
    struct
        (musician.Name     |> Seq.head, 
         musician.Surname |> Seq.head)    

let result = 
    musicians 
    |> List.map getInitials
    |> List.distinct
```

---

How does `List.distinct` work?

There are 3 important parts of the algorithm to talk about.

1) Pick the comparer

The comparer is something implementing `IEqualityComparer<'T>` which means 2 methods: `GetHashCode(x)` and `Equals(x, y)`.

`List.distinct list` calls `List.distinctWithComparer HashIdentity.Structural<'T>` and the logic for picking `HashIdentity.Structural<'T>` (the comparer) is written in `prim-types.fs`.

2) Initialize the hash set for the distinct elements

This means calling `let hashSet = HashSet<'T>(comparer)` with the comparer picked above.

3) Add the elements to the hash set

So in our case,

```fsharp
hashSet.Add('D', 'G')
hashSet.Add('J', 'M')
hashSet.Add('R', 'S')
hashSet.Add('D', 'G')
hashSet.Add('J', 'M')
hashSet.Add('D', 'G')
```

---

Now, the `Add(element)` operation works in the following way:

1) Do all the bucket initialization stuff they teach about in the universities
2) Execute **GetHashCode** to get the hash of the element
3) Check if this hash is already present
4) If yes, execute **Equals** to see if this is the same element and decide on adding it to the hash set
5) Otherwise just add the element to the hash set

This means, in our case there will be:
- 6 `GetHashCode` calls (since there are 6 elements altogether)
- 3 `Equals` calls (since there are only 3 unique elements)

---

Now, what changes in this PR is that we become smarter at picking the faster comparer (step 1). This brings enormous benefit at doing all the things in the step 3.

Before, this is how the comparer picking would be executed:

```fsharp
List.distinct list
  List.distinctWithComparer HashIdentity.Structural<'T> list
    // check if this is a basic F# type - we optimize things for them
    FastGenericEqualityComparerTable<'T>.Function
      // no, this is not a basic type hence go the worst case - create generic equality comparer
      MakeGenericEqualityComparer<'T>
        // this is what it creates - we'll get to the consequences later
        { new IEqualityComparer<'T> with 
              member _.GetHashCode(x) = GenericHash x 
              member _.Equals(x,y) = GenericEquality x y }
```

Now, this is what is going on:

```fsharp
List.distinct list
  List.distinctWithComparer HashIdentity.Structural<'T> list
    // call "smart" `canUseDefaultEqualityComparer` to see if this is a type applicable for the default equality comparison
    FastGenericEqualityComparerTable<'T>.Function
      // yes it is
      EqualityComparer<'T>.Default
        // this is property but it basically creates kind of a "native" comparer for this type, like
        { new IEqualityComparer<(char, char)> with 
              member _.GetHashCode(x) = x.GetHashCode() 
              member _.Equals(x,y) = x.Equals(y) }
```

---

Hence, this is the difference for **each** of the 6 `GetHashCode` calls in question (taking first element ('D', 'G') as an example).

Before, using the generic equality comparer:

```fsharp
GetHashCode ('D', 'G')
  GenericHashIntrinsic ('D', 'G')
    GenericHashParamObj (object ('D', 'G'))                      // boxing!
      (IStructuralEquatable (ValueTuple ('D', 'G'))).GetHashCode()
        GetHashCodeCore ('D', 'G')
          comparer.GetHashCode('D')
            GenericHashParamObj (object ('D'))                    // boxing!
              (char 'D').GetHashCode()
          comparer.GetHashCode('G')
            GenericHashParamObj (object ('G'))                    // boxing!
              (char 'G').GetHashCode()
          HashCode.Combine
```

Now, using the "native" comparer:

```fsharp
GetHashCode ('D', 'G')
      (ValueTuple ('D', 'G').GetHashCode()
        GetHashCodeCore ('D', 'G')
          comparer.GetHashCode('D')
            (char 'D').GetHashCode()
          comparer.GetHashCode('G')
	    (char 'G').GetHashCode()
          HashCode.Combine
```

Now, this difference for **each** of the 3 `Equals` calls in question (taking the elements ('D', 'G') as an example).

Before, using the generic equality comparer:

```fsharp
Equals ('D', 'G') ('D', 'G')
  GenericEqualityIntrinsic ('D', 'G') ('D', 'G')
    GenericEqualityObj (object ('D', 'G')) (object ('D', 'G'))                               // boxing!
      (IStructuralEquatable (ValueTuple ('D', 'G'))).Equals(ValueTuple ('D', 'G'))
        comparer.Equals('D', 'D'))
          GenericEqualityObj (object ('D')) (object ('D'))                                         // boxing!
	    (char 'D').Equals(object 'D')
	      'D' == (char)'D'
        comparer.Equals('G', 'G'))
          GenericEqualityObj (object ('G')) (object ('G'))                                         // boxing!
	    (char 'G').Equals(object 'G')
	      'G' == (char)'G'
```

Now, using the "native" comparer:

```fsharp
Equals ('D', 'G') ('D', 'G')
      (ValueTuple ('D', 'G')).Equals(ValueTuple ('D', 'G'))
	      (char 'D').Equals(char 'D')
	        'D' == 'D'
	      (char 'G').Equals(char 'G')
	        'G' == 'G'
```

---

We can see that here we remove all the boxing and use the optimal call chain. This brings huge benefits for the tiny cost of executing the "smart" function on deciding about the comparer **once**.

The benefits of this approach vary based on the concrete algorithm and the elements in question. See the details about improved call chains in the spec mentioned above.

If we modify the example to have 1000 elements with 10 unique ones, we get the following results:

Before:
|       Method |     Mean |   Error |   StdDev |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|--------:|---------:|--------:|------:|------:|----------:|
| TheBenchmark | 142.4 us | 3.75 us | 10.82 us | 34.1797 |     - |     - | 210.49 KB |

After:
|       Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| TheBenchmark | 24.90 us | 0.871 us | 2.569 us | 0.1526 |     - |     - |     984 B |

Which means 6x faster and 213x less memory.

**Benchmarks**

Main targets: structs, enums, floats, and specia/l generic types:

<details>

<summary>Structs and enums</summary>

Before:
|       Method |     Mean |    Error |    StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------- |---------:|---------:|----------:|--------:|--------:|------:|----------:|
| FSharpStruct | 503.7 us | 36.91 us | 107.67 us | 68.3594 |       - |     - | 420.61 KB |
|   FSharpEnum | 142.7 us |  4.76 us |  13.73 us | 22.9492 |       - |     - | 140.65 KB |
| CSharpStruct | 148.2 us |  3.81 us |  10.94 us | 38.4521 | 12.8174 |     - | 237.58 KB |
|   CSharpEnum | 134.0 us |  8.43 us |  24.44 us | 22.8271 |       - |     - | 140.59 KB |

After:
|       Method |     Mean |    Error |    StdDev |   Median |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------- |---------:|---------:|----------:|---------:|--------:|-------:|------:|----------:|
| FSharpStruct | 73.44 us | 5.158 us | 15.046 us | 68.59 us |  0.1221 |      - |     - |     792 B |
|   FSharpEnum | 16.10 us | 0.396 us |  1.163 us | 16.35 us |  0.0458 |      - |     - |     336 B |
| CSharpStruct | 77.63 us | 2.285 us |  6.482 us | 79.15 us | 28.5645 | 9.4604 |     - |  179312 B |
|   CSharpEnum | 15.92 us | 0.638 us |  1.839 us | 16.21 us |  0.0916 |      - |     - |     656 B |

</details>

Huge improvements in both execution time and allocs, with especially remarkable results for native F# constructs.

<details>

<summary>Value tuples</summary>

Before:

|      Method |       Mean | Ratio |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------ |-----------:|------:|---------:|--------:|--------:|----------:|
| ValueTuple3 |   673.4 us |  1.00 |  61.5234 | 15.8691 |       - | 378.13 KB |
| ValueTuple4 |   812.2 us |  1.22 |  69.0918 | 19.7754 |       - | 424.98 KB |
| ValueTuple5 | 1,004.2 us |  1.50 |  84.9609 | 24.4141 |       - | 523.63 KB |
| ValueTuple6 | 1,100.7 us |  1.65 |  92.7734 | 23.4375 |       - | 570.48 KB |
| ValueTuple7 | 1,324.9 us |  1.97 | 117.1875 | 57.6172 | 29.2969 | 669.14 KB |
| ValueTuple8 | 1,461.9 us |  2.20 | 117.1875 | 58.1055 | 29.2969 | 762.85 KB |

After:

|      Method |     Mean | Ratio |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------ |---------:|------:|--------:|--------:|--------:|----------:|
| ValueTuple3 | 173.0 us |  1.00 | 28.5645 |  9.3994 |       - | 175.11 KB |
| ValueTuple4 | 174.9 us |  1.03 | 28.5645 |  9.4604 |       - | 175.11 KB |
| ValueTuple5 | 208.9 us |  1.22 | 34.4238 | 11.3525 |       - | 211.29 KB |
| ValueTuple6 | 217.0 us |  1.26 | 34.4238 | 11.3525 |       - | 211.29 KB |
| ValueTuple7 | 293.7 us |  1.73 | 29.2969 | 29.2969 | 29.2969 | 247.48 KB |
| ValueTuple8 | 293.8 us |  1.73 | 29.2969 | 29.2969 | 29.2969 | 247.48 KB |

</details>

~80% in speed and ~50% in memory reduction, also much steeper ratios' increase for both.

<details>

<summary>Options and co</summary>

Before:

|      Method |     Mean |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|--------:|------:|----------:|
|      Option | 165.0 us | 16.3574 |  3.1738 |     - | 101.74 KB |
| ValueOption | 157.1 us | 28.8086 |  4.3945 |     - | 177.02 KB |
|      Result | 186.3 us | 40.4053 | 10.0098 |     - | 248.25 KB |

After:

|      Method |     Mean |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|-------:|------:|----------:|
|      Option | 82.13 us | 12.6953 | 3.0518 |     - |  78.33 KB |
| ValueOption | 55.09 us |  9.7656 | 1.5869 |     - |  59.98 KB |
|      Result | 75.92 us | 22.5830 | 5.6152 |     - | 138.93 KB |

</details>

50-75% speed and 25-75% memory improvements.

<details>

<summary>Nullable<'T></summary>

Before:

|      Method |     Mean |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|--------:|------:|----------:|
|    Nullable | 443.7 us | 24.9023 |  3.9063 |     - | 153.66 KB |

After:

|      Method |     Mean |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|-------:|------:|----------:|
|    Nullable | 60.16 us |  9.7656 | 1.5869 |     - |  59.94 KB |

</details>

About 7x speed and 3x memory improvements.

<details>

<summary>Floats</summary>

Before:

|     Method |      Mean |    Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------- |----------:|---------:|----------:|--------:|-------:|------:|----------:|
|    FloatER |  51.47 us | 2.228 us |  6.570 us |  7.0801 | 0.3662 |     - |  43.68 KB |
|  Float32ER |  56.39 us | 2.566 us |  7.525 us |  7.1106 | 0.3662 |     - |  43.68 KB |
|   FloatPER | 149.49 us | 2.952 us |  7.513 us | 38.3301 | 2.6855 |     - | 231.34 KB |
| Float32PER | 136.09 us | 5.584 us | 16.201 us | 37.5977 | 2.4414 |     - | 227.01 KB |

After:

|     Method |     Mean |    Error |    StdDev |   Median |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------- |---------:|---------:|----------:|---------:|--------:|-------:|------:|----------:|
|    FloatER | 15.26 us | 0.487 us |  1.397 us | 15.38 us |  3.2806 | 0.1678 |     - |   20.1 KB |
|  Float32ER | 15.80 us | 0.316 us |  0.666 us | 15.82 us |  3.2806 | 0.1678 |     - |   20.1 KB |
|   FloatPER | 82.88 us | 5.580 us | 16.452 us | 93.36 us | 14.9536 | 1.2817 |     - |  90.46 KB |
| Float32PER | 94.22 us | 1.851 us |  3.904 us | 93.97 us | 14.1602 | 0.9766 |     - |  86.43 KB |

</details>

PER comparison still takes more time and memory but still the improvements are 2-3 times in all cases.

---

Also (positively) affected: basic types, arrays, reference types - due to shorter call chains and less casting:

<details>

<summary>Arrays</summary>

Before:

| Method |       Mean |    Error |   StdDev |
|------- |-----------:|---------:|---------:|
|  Int32 |   974.3 us | 73.48 us | 214.3 us |
|  Int64 | 1,090.7 us | 58.65 us | 172.9 us |
|   Byte | 1,075.3 us | 41.56 us | 121.9 us |
|    Obj | 1,451.8 us | 43.91 us | 128.8 us |

After:

| Method |     Mean |    Error |   StdDev |
|------- |---------:|---------:|---------:|
|  Int32 | 253.3 us | 18.09 us | 52.78 us |
|  Int64 | 312.3 us | 14.06 us | 41.45 us |
|   Byte | 246.5 us |  6.11 us | 17.82 us |
|    Obj | 489.3 us | 17.69 us | 51.61 us |

</details>

About 3x faster.

<details>

<summary>F# basic types</summary>

Before (`countBy`):
|  Method |      Mean |     Error |    StdDev |
|-------- |----------:|----------:|----------:|
|    Bool |  39.06 us |  1.936 us |  5.709 us |
|   SByte |  55.23 us |  2.032 us |  5.992 us |
|    Byte |  50.62 us |  1.617 us |  4.766 us |
|   Int16 |  85.46 us |  4.668 us | 13.764 us |
|  UInt16 |  86.66 us |  3.189 us |  9.351 us |
|   Int32 |  86.21 us |  4.690 us | 13.827 us |
|  UInt32 |  87.69 us |  4.911 us | 14.480 us |
|   Int64 | 112.81 us |  3.962 us | 11.681 us |
|  UInt64 | 112.66 us |  4.003 us | 11.550 us |
|  IntPtr | 114.61 us |  3.430 us | 10.114 us |
| UIntPtr | 109.40 us |  3.322 us |  9.796 us |
|    Char |  98.99 us |  2.825 us |  8.330 us |
|  String | 214.52 us |  5.968 us | 17.503 us |
| **Decimal** | 315.84 us | 12.545 us | 36.988 us |

After (`countBy`):

|  Method |      Mean |    Error |    StdDev |
|-------- |----------:|---------:|----------:|
|    Bool |  29.19 us | 1.608 us |  4.740 us |
|   SByte |  50.72 us | 2.167 us |  6.390 us |
|    Byte |  47.40 us | 1.719 us |  5.069 us |
|   Int16 |  83.50 us | 3.508 us | 10.342 us |
|  UInt16 |  84.48 us | 2.949 us |  8.649 us |
|   Int32 |  87.24 us | 2.670 us |  7.832 us |
|  UInt32 |  86.17 us | 3.630 us | 10.703 us |
|   Int64 |  95.78 us | 4.763 us | 14.044 us |
|  UInt64 | 113.86 us | 4.278 us | 12.479 us |
|  IntPtr | 110.92 us | 3.192 us |  9.412 us |
| UIntPtr | 105.11 us | 3.219 us |  9.440 us |
|    Char |  91.03 us | 4.164 us | 12.211 us |
|  String | 214.23 us | 5.859 us | 17.276 us |
| **Decimal** | 150.39 us | 3.703 us | 10.683 us |

Before (`distinct`):

|  Method |      Mean |     Error |    StdDev |
|-------- |----------:|----------:|----------:|
|    Bool |  9.489 us | 0.7345 us |  2.142 us |
|   SByte | 12.568 us | 0.4049 us |  1.168 us |
|    Byte | 12.393 us | 0.4176 us |  1.231 us |
|   Int16 | 23.539 us | 0.8906 us |  2.626 us |
|  UInt16 | 22.311 us | 0.8351 us |  2.449 us |
|   Int32 | 22.302 us | 0.4448 us |  1.180 us |
|  UInt32 | 22.092 us | 0.4760 us |  1.319 us |
|   Int64 | 25.567 us | 0.8679 us |  2.518 us |
|  UInt64 | 26.200 us | 1.4150 us |  4.172 us |
|  IntPtr | 25.528 us | 1.4250 us |  4.202 us |
| UIntPtr | 25.000 us | 0.8785 us |  2.590 us |
|    Char | 22.883 us | 0.8124 us |  2.383 us |
|  String | 47.659 us | 1.6451 us |  4.799 us |
| **Decimal** | 58.086 us | 4.7662 us | 13.828 us |

After:

|  Method |      Mean |     Error |   StdDev |
|-------- |----------:|----------:|---------:|
|    Bool |  9.408 us | 0.9121 us | 2.689 us |
|   SByte | 11.795 us | 0.3516 us | 1.020 us |
|    Byte | 11.225 us | 0.4078 us | 1.170 us |
|   Int16 | 23.211 us | 0.7982 us | 2.354 us |
|  UInt16 | 21.682 us | 1.0798 us | 3.184 us |
|   Int32 | 20.035 us | 0.6128 us | 1.787 us |
|  UInt32 | 20.123 us | 0.8883 us | 2.591 us |
|   Int64 | 22.967 us | 0.7908 us | 2.319 us |
|  UInt64 | 24.757 us | 1.3208 us | 3.832 us |
|  IntPtr | 26.448 us | 1.3528 us | 3.989 us |
| UIntPtr | 24.596 us | 1.1292 us | 3.330 us |
|    Char | 22.670 us | 0.8961 us | 2.642 us |
|  String | 40.480 us | 1.3767 us | 3.994 us |
| **Decimal** | 35.401 us | 1.4948 us | 4.289 us |

Note that decimals also show improvement in memory allocations:

Before (`countBy`)

|  Method |     Mean |    Error |   StdDev |   Median |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|---------:|--------:|--------:|------:|----------:|
| Decimal | 149.9 us | 13.45 us | 39.01 us | 136.1 us | 38.4521 | 12.8174 |     - | 237.55 KB |

After (`countBy`)

|  Method |     Mean |    Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|----------:|--------:|-------:|------:|----------:|
| Decimal | 65.17 us | 5.013 us | 13.807 us | 28.5645 | 9.4604 |     - | 175.09 KB |

Before (`distinct`)

|  Method |     Mean |    Error |    StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|----------:|--------:|-------:|------:|----------:|
| Decimal | 57.83 us | 6.097 us | 17.977 us | 26.3062 | 6.5308 |     - | 162.35 KB |

After (`distinct`)

|  Method |     Mean |    Error |   StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|--------:|-------:|------:|----------:|
| Decimal | 34.79 us | 1.572 us | 4.585 us | 21.2708 | 5.3101 |     - |  131.1 KB |

</details>

These mostly stay the same (as expected), apart from `decimal`, which show ~50% speed and ~25% alloc improvements. 

<details>

<summary>Records</summary>

Before:
|               Method |     Mean |   Error |   StdDev |
|--------------------- |---------:|--------:|---------:|
|                Record | 157.8 us | 8.98 us | 25.61 us |
| RecordStruct | 163.5 us |  5.87 us | 17.31 us |

After:
|               Method |     Mean |   Error |   StdDev |
|--------------------- |---------:|--------:|---------:|
|                 Record | 143.1 us | 7.13 us | 20.00 us |
| RecordStruct | 149.5 us | 3.68 us | 10.80 us |

</details>

Which is about 10% improvement.

<details>

<summary>Generic unions</summary>

Before:
|  Method |     Mean |    Error |   StdDev |   Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|--------:|--------:|------:|----------:|
| GenericUnion | 439.8 us | 17.85 us | 51.78 us | 41.9922 | 12.2070 |     - |    260 KB |

After:
|  Method |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|--------:|--------:|--------:|-------:|------:|----------:|
| GenericUnion | 167.1 us | 3.32 us | 7.22 us | 26.9775 | 8.9722 |     - |  166.3 KB |

</details>

About 60% and 30% improvements in speed and allocs.

<details>

<summary>Reference tuples</summary>

Before:
|               Method |     Mean |    Error |   StdDev |
|--------------------- |---------:|---------:|---------:|
| SmallNonGenericTuple | 306.0 us | 14.40 us | 42.45 us |
|    SmallGenericTuple | 360.9 us | 10.43 us | 30.74 us |
|   BigNonGenericTuple | 393.2 us | 13.33 us | 39.30 us |
|      BigGenericTuple | 480.1 us | 27.41 us | 80.81 us |
| SmallNonGenericTupleStruct | 167.4 us |  5.07 us |  14.62 us |
|    SmallGenericTupleStruct | 192.2 us |  3.55 us |   5.93 us |
|   BigNonGenericTupleStruct | 409.2 us | 16.19 us |  44.33 us |
|      BigGenericTupleStruct | 559.1 us | 52.00 us | 153.33 us |

After:
|               Method |     Mean |    Error |   StdDev |
|--------------------- |---------:|---------:|---------:|
| SmallNonGenericTuple | 268.7 us |  8.63 us | 25.45 us |
|    SmallGenericTuple | 349.7 us |  9.56 us | 28.20 us |
|   BigNonGenericTuple | 356.2 us | 12.56 us | 37.03 us |
|      BigGenericTuple | 451.0 us | 26.06 us | 76.83 us |
| SmallNonGenericTupleStruct | 132.3 us |  4.12 us | 11.96 us |
|    SmallGenericTupleStruct | 185.4 us |  6.08 us | 17.45 us |
| BigNonGenericTupleStruct | 350.0 us | 15.47 us | 44.63 us |
|      BigGenericTupleStruct | 405.4 us | 20.45 us | 54.58 us |

</details>

~5-15% faster execution.


---

Some (positive) implications for F#.Core.

<details>

<summary>F# core functions in question</summary>

Before:
|          Method |      Mean |     Error |    StdDev |    Median |
|---------------- |----------:|----------:|----------:|----------:|
|    ArrayCountBy | 230.20 us |  7.098 us | 20.929 us | 230.07 us |
|    ArrayGroupBy | 125.80 us |  5.344 us | 15.674 us | 127.24 us |
|   ArrayDistinct | 121.08 us |  8.648 us | 25.500 us | 127.72 us |
| ArrayDistinctBy | 113.45 us |  2.636 us |  7.732 us | 114.15 us |
|     ArrayExcept |  92.28 us |  1.835 us |  5.354 us |  92.66 us |
|     ListCountBy | 225.45 us | 11.730 us | 34.585 us | 230.79 us |
|     ListGroupBy | 167.40 us | 12.814 us | 37.783 us | 151.49 us |
|    ListDistinct | 125.20 us |  4.192 us | 12.229 us | 127.01 us |
|  ListDistinctBy | 109.52 us |  3.480 us | 10.097 us | 110.94 us |
|      ListExcept | 194.14 us | 20.467 us | 60.347 us | 164.68 us |
|      SeqCountBy | 460.13 us | 13.224 us | 38.575 us | 459.04 us |
|      SeqGroupBy | 354.81 us | 15.000 us | 43.992 us | 348.92 us |
|     SeqDistinct | 359.59 us | 12.339 us | 36.381 us | 361.93 us |
| SeqDistinctBy | 128.8 us | 5.70 us | 15.97 us | 127.2 us |
|     SeqExcept | 127.8 us | 5.03 us | 14.74 us | 128.1 us |

After:
|          Method |      Mean |     Error |    StdDev |    Median |
|---------------- |----------:|----------:|----------:|----------:|
|    ArrayCountBy | 137.30 us |  5.008 us | 14.767 us | 137.01 us |
|    ArrayGroupBy |  78.80 us |  4.673 us | 13.778 us |  80.87 us |
|   ArrayDistinct |  71.63 us |  3.698 us | 10.904 us |  73.49 us |
| ArrayDistinctBy |  69.93 us |  2.148 us |  6.299 us |  70.02 us |
|     ArrayExcept |  68.39 us |  3.071 us |  9.008 us |  69.59 us |
|     ListCountBy | 138.17 us |  6.708 us | 19.566 us | 142.05 us |
|     ListGroupBy | 129.57 us | 12.765 us | 37.639 us | 110.78 us |
|    ListDistinct |  85.99 us |  1.662 us |  3.683 us |  85.73 us |
|  ListDistinctBy |  67.36 us |  3.001 us |  8.707 us |  67.95 us |
|      ListExcept | 173.01 us | 21.536 us | 63.499 us | 138.14 us |
|      SeqCountBy | 289.70 us | 12.109 us | 35.514 us | 295.43 us |
|      SeqGroupBy | 245.97 us |  6.969 us | 20.329 us | 246.79 us |
|     SeqDistinct | 254.17 us | 14.776 us | 43.336 us | 257.62 us |
| SeqDistinctBy | 101.7 us | 5.35 us | 14.91 us | 102.4 us |
|     SeqExcept | 105.9 us | 5.20 us | 15.35 us | 102.1 us |

</details>

The improvement varies 20-40% in speed here.

---

Other considerations.

<details>

<summary> >64 bit value types</summary>

Before:

|    Method |     Mean |    Error |   StdDev |
|---------- |---------:|---------:|---------:|
| BigStruct | 47.43 ms | 3.136 ms | 9.098 ms |

After:

|    Method |     Mean |    Error |   StdDev |
|---------- |---------:|---------:|---------:|
| BigStruct | 44.57 ms | 3.243 ms | 9.562 ms |

</details>

This became marginally faster - but more importantly, it's here to address [concerns](https://github.com/dotnet/fsharp/pull/513#issuecomment-118555800) about 64 bit JIT. So likely the underlying JIT problem got fixed meanwhile.

**TODO**

- [x] AOT tests to see if startup performance is not too affected
- [x] Finish the design doc on equality
- [x] Describe the changed code flow

**Followups**

- Revive [equality devirtualization](https://github.com/dotnet/fsharp/pull/6175/files)
- Add optimizations for recently added primitive types, as suggested [here](https://github.com/dotnet/fsharp/pull/16615#discussion_r1488536336) 