### PR TITLE
Transparent compiler doesn't respect #nowarn in test.

### DIFF
--- a/Foo.fs
+++ b/Foo.fs
@@ -1,0 +1,13 @@
+module Meh
+
+let bar (name:string) : 'a = failwith<'a> "todo"
+
+#nowarn "40"
+
+type Foo () =
+    member __.Bar (name : string) : unit -> 'a =
+            let rec prov : (unit -> 'a) ref = ref (fun () ->
+                let p : (unit -> 'a) = bar name
+                prov := p
+                p())
+            fun () -> (!prov)()

--- a/Foo.rsp
+++ b/Foo.rsp
@@ -1,0 +1,7 @@
+--nowarn:FS3370,FS0075
+--warn:4
+--warnaserror
+--warnaserror:3239
+--warnaserror-:44
+-a
+Foo.fs

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -806,7 +806,8 @@ module Stuff =
 /// References projects are expected to have been built.
 let localResponseFiles =
     [|
-        @"C:\Projects\fantomas\src\Fantomas.Core.Tests\Fantomas.Core.Tests.rsp"
+        // @"C:\Projects\fantomas\src\Fantomas.Core.Tests\Fantomas.Core.Tests.rsp"
+        Path.Combine(__SOURCE_DIRECTORY__, "..", "..", "..", "Foo.rsp")
     |]
     |> Array.collect (fun f ->
         [|
@@ -816,7 +817,7 @@ let localResponseFiles =
     )
 
 // Uncomment this attribute if you want run this test against local response files.
-// [<Theory>]
+[<Theory>]
 [<MemberData(nameof(localResponseFiles))>]
 let ``TypeCheck last file in project with transparent compiler`` useTransparentCompiler responseFile =
     let responseFile = FileInfo responseFile


### PR DESCRIPTION
## Description

This is more of an issue than a PR but:

I'm able to compile this `fsc "@Foo.rsp` both with and without `--test:GraphBasedChecking`.
However, running this from `TypeCheck last file in project with transparent compiler` doesn't work for me with the transparent compiler.

I get

![image](https://github.com/dotnet/fsharp/assets/2621499/26c797a2-0e50-4725-a512-7e8b100aca7f)

while `Foo.fs` has the `#nowarn "40"`

```fsharp
module Meh

let bar (name:string) : 'a = failwith<'a> "todo"

#nowarn "40"

type Foo () =
    member __.Bar (name : string) : unit -> 'a =
            let rec prov : (unit -> 'a) ref = ref (fun () ->
                let p : (unit -> 'a) = bar name
                prov := p
                p())
            fun () -> (!prov)()
```

Fixes # (issue, if applicable)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**