### PR TITLE
Move SB metadata to intermediates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24073.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>412264fd6c04712d1d31ff05d37c6919101ef4f4</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.7.0-preview-23217-02">
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>2cbc8b6aef648cf21c6a68a0dab7fe09a614e475</Sha>
@@ -35,6 +37,11 @@
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.xliff-tasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />


### PR DESCRIPTION
The changes in this pull request aim to [improve the UX and guideance around the SourceBuild metadata](https://github.com/dotnet/source-build/issues/3373) by placing the metadata on explicit source-build intermediates.

The changes include:

- Removing existing SourceBuild metadata from all non-intermediate dependencies.
- Defining new explicit intermediate dependencies and adding SourceBuild metadata to those dependencies.

Related to https://github.com/dotnet/source-build/issues/3373 and https://github.com/dotnet/source-build/issues/4073
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2023)