### PR TITLE
Remove reference to local roslyn project

### DIFF
--- a/VisualFSharp.sln
+++ b/VisualFSharp.sln
@@ -201,8 +201,6 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.LanguageSer
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FSharp.VisualStudio.Extension", "src\FSharp.VisualStudio.Extension\FSharp.VisualStudio.Extension.csproj", "{E1013576-6257-47BA-AAFB-F95B68DAB1FF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CommonLanguageServerProtocol.Framework", "..\roslyn\src\Features\LanguageServer\Microsoft.CommonLanguageServerProtocol.Framework\Microsoft.CommonLanguageServerProtocol.Framework.csproj", "{A5C8D385-308E-4EBB-A15E-79CF58CD861C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1077,18 +1075,6 @@ Global
 		{E1013576-6257-47BA-AAFB-F95B68DAB1FF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E1013576-6257-47BA-AAFB-F95B68DAB1FF}.Release|x86.ActiveCfg = Release|Any CPU
 		{E1013576-6257-47BA-AAFB-F95B68DAB1FF}.Release|x86.Build.0 = Release|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Debug|x86.Build.0 = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Proto|Any CPU.Build.0 = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Proto|x86.ActiveCfg = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Proto|x86.Build.0 = Debug|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Release|x86.ActiveCfg = Release|Any CPU
-		{A5C8D385-308E-4EBB-A15E-79CF58CD861C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Useful for navigating to source code, but otherwise shouldn't be there