### PR TITLE
Update test framework - improve baseline comparison and failure diagnosis

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/MethodResolution.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/MethodResolution.fs
@@ -76,8 +76,7 @@ extends [runtime]System.Object
 
   }
 
-  .method assembly specialname static class [runtime]System.Tuple`2<bool,int32>
-   get_patternInput@9() cil managed
+  .method assembly specialname static class [runtime]System.Tuple`2<bool,int32> get_patternInput@9() cil managed
   {
 
     .maxstack  8
@@ -85,8 +84,7 @@ extends [runtime]System.Object
     IL_0005:  ret
   }
 
-  .method assembly specialname static int32
-   get_outArg@9() cil managed
+  .method assembly specialname static int32 get_outArg@9() cil managed
   {
 
     .maxstack  8
@@ -94,8 +92,7 @@ extends [runtime]System.Object
     IL_0005:  ret
   }
 
-  .method assembly specialname static void
-   set_outArg@9(int32 'value') cil managed
+  .method assembly specialname static void set_outArg@9(int32 'value') cil managed
   {
 
     .maxstack  8
@@ -104,8 +101,7 @@ extends [runtime]System.Object
     IL_0006:  ret
   }
 
-  .method assembly specialname static class [runtime]System.Tuple`2<bool,int32>
-   'get_patternInput@10-1'() cil managed
+  .method assembly specialname static class [runtime]System.Tuple`2<bool,int32> 'get_patternInput@10-1'() cil managed
   {
 
     .maxstack  8
@@ -113,8 +109,7 @@ extends [runtime]System.Object
     IL_0005:  ret
   }
 
-  .method assembly specialname static int32
-   'get_outArg@10-1'() cil managed
+  .method assembly specialname static int32 'get_outArg@10-1'() cil managed
   {
 
     .maxstack  8
@@ -122,8 +117,7 @@ extends [runtime]System.Object
     IL_0005:  ret
   }
 
-  .method assembly specialname static void
-   'set_outArg@10-1'(int32 'value') cil managed
+  .method assembly specialname static void 'set_outArg@10-1'(int32 'value') cil managed
   {
 
     .maxstack  8
@@ -174,8 +168,7 @@ extends [runtime]System.Object
   .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 )
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
-  .method private specialname rtspecialname static
-   void  .cctor() cil managed
+  .method private specialname rtspecialname static void  .cctor() cil managed
   {
 
     .maxstack  4

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/TypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/TypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
@@ -723,8 +723,7 @@ let main _ =
         |> shouldSucceed
         |> verifyIL [
             """
-             .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>
-                      '|GoodPotato|_|'<(class [Potato]Potato.Lib/IPotato`1<!!T>) T>(!!T x) cil managed
+             .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpOption`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> '|GoodPotato|_|'<(class [Potato]Potato.Lib/IPotato`1<!!T>) T>(!!T x) cil managed
               {
 
                 .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
@@ -325,8 +325,7 @@ type C() =
        extends [System.Runtime]System.Attribute
 {
   .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
-  .method public specialname rtspecialname
-          instance void  .ctor() cil managed
+  .method public specialname rtspecialname instance void  .ctor() cil managed
   {
     .custom instance void [netstandard]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
     .custom instance void [netstandard]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -366,8 +365,7 @@ type C() =
           .get instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) System.Runtime.CompilerServices.C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) get_X() cil managed
         {
           .param [0]
           .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -377,8 +375,7 @@ type C() =
        extends [netstandard]System.Attribute
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
-  .method public specialname rtspecialname
-          instance void  .ctor() cil managed
+  .method public specialname rtspecialname instance void  .ctor() cil managed
   {
 
     .maxstack  8
@@ -408,8 +405,7 @@ type C<'T>() =
     member _.X<'U>(): inref<'T> = &x
             """
 
-        let verifyMethod = """.method public hidebysig instance !T& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                X<U>() cil managed
+        let verifyMethod = """.method public hidebysig instance !T& modreq([runtime]System.Runtime.InteropServices.InAttribute) X<U>() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -435,8 +431,7 @@ module Test =
         member _.X<'U>(): inref<'T> = &x
             """
 
-        let verifyMethod = """.method public hidebysig instance !T& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
-                X<U>() cil managed
+        let verifyMethod = """.method public hidebysig instance !T& modreq([netstandard]System.Runtime.InteropServices.InAttribute) X<U>() cil managed
         {
           .param [0]
           .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -463,7 +458,7 @@ type C<'T>() =
                 X<U>() cil managed
         {
           .param [0]
-          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 ) """
+          .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
 
         FSharp src
         |> compile

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CompilerGeneratedAttributeOnAccessors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CompilerGeneratedAttributeOnAccessors.fs
@@ -41,8 +41,7 @@ module ``Auto-generated accessors have CompilerGenerated attribute`` =
         |> compile
         |> verifyIL [
             """
-            .method public hidebysig specialname
-                        instance int32  get_Age() cil managed
+            .method public hidebysig specialname instance int32  get_Age() cil managed
                 {
                   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
                   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -53,8 +52,7 @@ module ``Auto-generated accessors have CompilerGenerated attribute`` =
                   IL_0006:  ret
                 }
 
-                .method public hidebysig specialname
-                        instance void  set_Age(int32 v) cil managed
+                .method public hidebysig specialname instance void  set_Age(int32 v) cil managed
                 {
                   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
                   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -84,8 +82,7 @@ module ``Auto-generated accessors have CompilerGenerated attribute`` =
         |> compile
         |> verifyIL [
             """
-             .method public specialname static int32
-                        get_Age() cil managed
+             .method public specialname static int32 get_Age() cil managed
                 {
                   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
                   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -103,8 +100,7 @@ module ``Auto-generated accessors have CompilerGenerated attribute`` =
                   IL_0016:  ret
                 }
 
-                .method public specialname static void
-                        set_Age(int32 v) cil managed
+                .method public specialname static void set_Age(int32 v) cil managed
                 {
                   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
                   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -202,5 +198,5 @@ module ``Let bindings in classes shoulnd't have DebuggerNonUserCodeAttribute`` =
             """
         |> compileAssembly
         |> getType "Test+User"
-        |> getPrivateMethod "moo"
+        |> getPrivateInstanceMethod "moo"
         |> shouldn't haveAttribute "DebuggerNonUserCodeAttribute"

--- a/tests/FSharp.Compiler.ComponentTests/Interop/StaticsInInterfaces.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Interop/StaticsInInterfaces.fs
@@ -193,8 +193,7 @@ extends [runtime]System.Object
 implements class [csLib]StaticsInInterfaces.IGetNext`1<class StaticsTesting/MyRepeatSequence>
     {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-instance void  .ctor() cil managed
+    .method public specialname rtspecialname instance void  .ctor() cil managed
     {
           
         .maxstack  8
@@ -205,8 +204,7 @@ instance void  .ctor() cil managed
         IL_0008:  ret
     } 
     
-    .method public hidebysig static class StaticsTesting/MyRepeatSequence 
-'StaticsInInterfaces.IGetNext<StaticsTesting.MyRepeatSequence>.Next'(class StaticsTesting/MyRepeatSequence other) cil managed
+    .method public hidebysig static class StaticsTesting/MyRepeatSequence 'StaticsInInterfaces.IGetNext<StaticsTesting.MyRepeatSequence>.Next'(class StaticsTesting/MyRepeatSequence other) cil managed
     {
         .override  method !0 class [csLib]StaticsInInterfaces.IGetNext`1<class StaticsTesting/MyRepeatSequence>::Next(!0)
           
@@ -222,8 +220,7 @@ extends [runtime]System.Object
 implements class [csLib]StaticsInInterfaces.IGetNext`1<class StaticsTesting/MyRepeatSequence2>
     {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
-    .method public specialname rtspecialname 
-instance void  .ctor() cil managed
+    .method public specialname rtspecialname instance void  .ctor() cil managed
     {
           
         .maxstack  8
@@ -234,8 +231,7 @@ instance void  .ctor() cil managed
         IL_0008:  ret
     } 
     
-    .method public static class StaticsTesting/MyRepeatSequence2 
-Next(class StaticsTesting/MyRepeatSequence2 other) cil managed
+    .method public static class StaticsTesting/MyRepeatSequence2 Next(class StaticsTesting/MyRepeatSequence2 other) cil managed
     {
           
         .maxstack  8
@@ -243,8 +239,7 @@ Next(class StaticsTesting/MyRepeatSequence2 other) cil managed
         IL_0001:  ret
     } 
     
-    .method public hidebysig static class StaticsTesting/MyRepeatSequence2 
-'StaticsInInterfaces.IGetNext<StaticsTesting.MyRepeatSequence2>.Next'(class StaticsTesting/MyRepeatSequence2 other) cil managed
+    .method public hidebysig static class StaticsTesting/MyRepeatSequence2 'StaticsInInterfaces.IGetNext<StaticsTesting.MyRepeatSequence2>.Next'(class StaticsTesting/MyRepeatSequence2 other) cil managed
     {
         .override  method !0 class [csLib]StaticsInInterfaces.IGetNext`1<class StaticsTesting/MyRepeatSequence2>::Next(!0)
           

--- a/tests/FSharp.Test.Utilities/DirectoryAttribute.fs
+++ b/tests/FSharp.Test.Utilities/DirectoryAttribute.fs
@@ -92,7 +92,7 @@ type DirectoryAttribute(dir: string) =
                         FSBaseline = { FilePath = fsOutFilePath; BslSource = fsBslFilePath; Content = fsBslSource }
                         ILBaseline = { FilePath = ilOutFilePath; BslSource = ilBslFilePath; Content = ilBslSource }
                     }
-            Options           = []
+            Options           = Compiler.defaultOptions
             OutputType        = Library
             Name              = Some filename
             IgnoreWarnings    = false

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -90,6 +90,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -29,12 +29,17 @@ module ILChecker =
             (fun me -> String.Empty)
         )
 
-    let private normalizeILText assemblyName (ilCode: string) =
+    let normalizeILText assemblyName (ilCode: string) =
         let blockComments = @"/\*(.*?)\*/"
         let lineComments = @"//(.*?)\r?\n"
         let lineCommentsEof = @"//(.*?)$"
         let strings = @"""((\\[^\n]|[^""\n])*)"""
         let verbatimStrings = @"@(""[^""]*"")+"
+        let methodSingleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(\s*\{)"
+        let methodMultiLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
+
+        let normalizeNewLines (text: string) = text.Replace("\r\n", "\n").Replace("\r\n", "\r")
+
         let stripComments (text:string) =
             Regex.Replace(text,
                 $"{blockComments}|{lineComments}|{lineCommentsEof}|{strings}|{verbatimStrings}",
@@ -44,6 +49,11 @@ module ILChecker =
                     else
                         me.Value), RegexOptions.Singleline)
             |> filterSpecialComment
+
+        let unifyMethodLine (text:string) =
+            let text1 = Regex.Replace(text, $"{methodSingleLine}", (fun me -> $"{me.Groups[1].Value}\n{me.Groups[2].Value}"), RegexOptions.Multiline)
+            let text2 = Regex.Replace(text1, $"{methodMultiLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value}\n{me.Groups[3].Value}"), RegexOptions.Multiline)
+            text2
 
         let replace input (pattern, replacement: string) = Regex.Replace(input, pattern, replacement, RegexOptions.Singleline)
 
@@ -62,8 +72,11 @@ module ILChecker =
             |> unifyRuntimeAssemblyName
             |> unifyImageBase
 
-        ilCode.Trim() |> stripComments |> unifyingAssemblyNames
-
+        ilCode.Trim()
+        |> normalizeNewLines
+        |> stripComments
+        |> unifyingAssemblyNames
+        |> unifyMethodLine
 
     let private generateIlFile dllFilePath ildasmArgs =
         let ilFilePath = Path.ChangeExtension(dllFilePath, ".il")
@@ -165,8 +178,8 @@ module ILChecker =
     let verifyIL (dllFilePath: string) (expectedIL: string) =
         checkIL dllFilePath [expectedIL]
 
-    let verifyILAndReturnActual (dllFilePath: string) (expectedIL: string) =
-        checkILPrim [] dllFilePath [expectedIL]
+    let verifyILAndReturnActual args dllFilePath expectedIL =
+        checkILPrim args dllFilePath expectedIL
 
     let checkILNotPresent dllFilePath unexpectedIL =
         let actualIL = generateIL dllFilePath []

--- a/tests/FSharp.Test.Utilities/ReflectionHelper.fs
+++ b/tests/FSharp.Test.Utilities/ReflectionHelper.fs
@@ -33,7 +33,13 @@ let getMethod methodName (ty: Type) =
     | methodInfo -> methodInfo
 
 /// Gets a type's private method
-let getPrivateMethod methodName (ty: Type) =
+let getPublicInstanceMethod methodName (ty: Type) =
+    match ty.GetMethod(methodName, BindingFlags.Public ||| BindingFlags.Instance) with
+    | null -> failwith $"Error: Type did not contain public method %s{methodName}"
+    | methodInfo -> methodInfo
+
+/// Gets a type's private method
+let getPrivateInstanceMethod methodName (ty: Type) =
     match ty.GetMethod(methodName, BindingFlags.NonPublic ||| BindingFlags.Instance) with
     | null -> failwith $"Error: Type did not contain private method %s{methodName}"
     | methodInfo -> methodInfo

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -38,6 +38,7 @@ type FactForDESKTOPAttribute() =
         do base.Skip <- "NETCOREAPP is not supported runtime for this kind of test, it is intended for DESKTOP only"
     #endif
 
+
 // This file mimics how Roslyn handles their compilation references for compilation testing
 module Utilities =
 
@@ -306,7 +307,7 @@ let main argv = 0"""
                     File.WriteAllText(directoryBuildPropsFileName, directoryBuildProps)
                     File.WriteAllText(directoryBuildTargetsFileName, directoryBuildTargets)
 
-                    let timeout = 30000
+                    let timeout = 120000
                     let exitCode, dotnetoutput, dotneterrors = Commands.executeProcess (Some config.DotNetExe) "build" projectDirectory timeout
                     
                     if exitCode <> 0 || errors.Length > 0 then

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
@@ -29,8 +29,7 @@ let foo = Try(){
             """,
             (fun verifier -> verifier.VerifyIL [
             """
-  .method public strict virtual instance int32
-          Invoke(class [runtime]System.Exception _arg1) cil managed
+  .method public strict virtual instance int32 Invoke(class [runtime]System.Exception _arg1) cil managed
   {
 
     .maxstack  5

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
@@ -56,8 +56,7 @@ x.ToString()
             """,
             (fun verifier -> verifier.VerifyIL [
             """
-  .method public specialname static valuetype [mscorlib]System.TimeSpan
-          get_x() cil managed
+  .method public specialname static valuetype [mscorlib]System.TimeSpan get_x() cil managed
   {
 
     .maxstack  8
@@ -106,8 +105,7 @@ x.Day
             """,
             (fun verifier -> verifier.VerifyIL [
             """
-  .method public specialname static valuetype [mscorlib]System.DateTime
-          get_x() cil managed
+  .method public specialname static valuetype [mscorlib]System.DateTime get_x() cil managed
   {
 
     .maxstack  8
@@ -155,8 +153,7 @@ x.ToString()
             """,
             (fun verifier -> verifier.VerifyIL [
             """
-  .method public specialname static valuetype [mscorlib]System.Decimal
-          get_x() cil managed
+  .method public specialname static valuetype [mscorlib]System.Decimal get_x() cil managed
   {
 
     .maxstack  8
@@ -221,8 +218,7 @@ type StaticC() =
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
     .field assembly int32 x
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.VolatileFieldAttribute::.ctor() = ( 01 00 00 00 )
-    .method public specialname rtspecialname
-            instance void  .ctor() cil managed
+    .method public specialname rtspecialname instance void  .ctor() cil managed
     {
 
       .maxstack  8
@@ -237,8 +233,7 @@ type StaticC() =
       IL_0011:  ret
     }
 
-    .method public hidebysig specialname
-            instance int32  get_X() cil managed
+    .method public hidebysig specialname instance int32  get_X() cil managed
     {
 
       .maxstack  8
@@ -248,8 +243,7 @@ type StaticC() =
       IL_0008:  ret
     }
 
-    .method public hidebysig specialname
-            instance void  set_X(int32 v) cil managed
+    .method public hidebysig specialname instance void  set_X(int32 v) cil managed
     {
 
       .maxstack  8
@@ -275,8 +269,7 @@ type StaticC() =
     .field static assembly int32 x
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.VolatileFieldAttribute::.ctor() = ( 01 00 00 00 )
     .field static assembly int32 init@10
-    .method public specialname rtspecialname
-            instance void  .ctor() cil managed
+    .method public specialname rtspecialname instance void  .ctor() cil managed
     {
 
       .maxstack  8
@@ -287,8 +280,7 @@ type StaticC() =
       IL_0008:  ret
     }
 
-    .method public specialname static int32
-            get_X() cil managed
+    .method public specialname static int32 get_X() cil managed
     {
 
       .maxstack  8
@@ -309,8 +301,7 @@ type StaticC() =
       IL_001c:  ret
     }
 
-    .method public specialname static void
-            set_X(int32 v) cil managed
+    .method public specialname static void set_X(int32 v) cil managed
     {
 
       .maxstack  8
@@ -332,8 +323,7 @@ type StaticC() =
       IL_001d:  ret
     }
 
-    .method private specialname rtspecialname static
-            void  .cctor() cil managed
+    .method private specialname rtspecialname static void  .cctor() cil managed
     {
 
       .maxstack  8

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
@@ -757,8 +757,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.NoComparisonAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.NoEqualityAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 02 00 00 00 00 00 ) 
-  .method public hidebysig specialname instance string 
-          get_Name() cil managed
+  .method public hidebysig specialname instance string get_Name() cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -768,8 +767,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public hidebysig specialname instance void 
-          set_Name(string 'value') cil managed
+  .method public hidebysig specialname instance void set_Name(string 'value') cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -779,8 +777,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public specialname rtspecialname 
-          instance void  .ctor(string name) cil managed
+  .method public specialname rtspecialname instance void  .ctor(string name) cil managed
   {
     .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                             class [runtime]System.Type) = ( 01 00 60 06 00 00 20 4E 65 74 37 46 53 68 61 72   
@@ -792,8 +789,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public specialname rtspecialname 
-          instance void  .ctor() cil managed
+  .method public specialname rtspecialname instance void  .ctor() cil managed
   {
     
     .maxstack  8
@@ -801,8 +797,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public strict virtual instance string 
-          ToString() cil managed
+  .method public strict virtual instance string ToString() cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     
@@ -827,8 +822,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.NoComparisonAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.NoEqualityAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 02 00 00 00 00 00 ) 
-  .method public hidebysig specialname instance string 
-          get_Name() cil managed
+  .method public hidebysig specialname instance string get_Name() cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -838,8 +832,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public hidebysig specialname instance void 
-          set_Name(string 'value') cil managed
+  .method public hidebysig specialname instance void set_Name(string 'value') cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -849,8 +842,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public specialname rtspecialname 
-          instance void  .ctor(string name) cil managed
+  .method public specialname rtspecialname instance void  .ctor(string name) cil managed
   {
     .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                             class [runtime]System.Type) = ( 01 00 60 06 00 00 20 4E 65 74 37 46 53 68 61 72   
@@ -862,8 +854,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public specialname rtspecialname 
-          instance void  .ctor() cil managed
+  .method public specialname rtspecialname instance void  .ctor() cil managed
   {
     
     .maxstack  8
@@ -871,8 +862,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
     IL_0001:  throw
   } 
 
-  .method public strict virtual instance string 
-          ToString() cil managed
+  .method public strict virtual instance string ToString() cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     
@@ -1170,8 +1160,7 @@ type Person(name : string, age : int) =
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.SealedAttribute::.ctor() = ( 01 00 00 00 )
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
     .field assembly bool smth
-    .method public specialname rtspecialname
-               instance void  .ctor(bool smth) cil managed
+    .method public specialname rtspecialname instance void  .ctor(bool smth) cil managed
     {
 
       .maxstack  8
@@ -1179,8 +1168,7 @@ type Person(name : string, age : int) =
       IL_0001:  throw
     }
 
-    .method assembly specialname rtspecialname
-               instance void  .ctor() cil managed
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
     {
 
       .maxstack  8
@@ -1188,8 +1176,7 @@ type Person(name : string, age : int) =
       IL_0001:  throw
     }
 
-    .method public hidebysig specialname
-               instance bool  get_Something() cil managed
+    .method public hidebysig specialname instance bool  get_Something() cil managed
     {
 
       .maxstack  8
@@ -1217,8 +1204,7 @@ type Person(name : string, age : int) =
       IL_0001:  throw
     }
 
-    .method public hidebysig specialname
-               instance string  get_Name() cil managed
+    .method public hidebysig specialname instance string  get_Name() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -1228,8 +1214,7 @@ type Person(name : string, age : int) =
       IL_0001:  throw
     }
 
-    .method public hidebysig specialname
-               instance void  set_Name(string v) cil managed
+    .method public hidebysig specialname instance void  set_Name(string v) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -1239,8 +1224,7 @@ type Person(name : string, age : int) =
       IL_0001:  throw
     }
 
-    .method public hidebysig specialname
-               instance int32  get_Age() cil managed
+    .method public hidebysig specialname instance int32  get_Age() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -1250,8 +1234,7 @@ type Person(name : string, age : int) =
       IL_0001:  throw
     }
 
-    .method public hidebysig specialname
-               instance void  set_Age(int32 v) cil managed
+    .method public hidebysig specialname instance void  set_Age(int32 v) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 )
@@ -1441,19 +1424,16 @@ type CompilerGoesBoom<'a>() =
                 """.class interface public abstract auto ansi serializable beforefieldinit Foobar.IHasStaticAbstractBase`1<a>
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
-  .method public hidebysig abstract virtual
-          instance !a  BoomInstance() cil managed
+  .method public hidebysig abstract virtual instance !a  BoomInstance() cil managed
   {
   }
 
-  .method public hidebysig static abstract virtual
-          !a  BoomStatic() cil managed
+  .method public hidebysig static abstract virtual !a  BoomStatic() cil managed
   {
   }
 
 }"""
-                """.method private hidebysig newslot virtual
-            instance !a  'Foobar.IHasStaticAbstractBase<\'a>.BoomInstance'() cil managed
+                """.method private hidebysig newslot virtual instance !a  'Foobar.IHasStaticAbstractBase<\'a>.BoomInstance'() cil managed
     {
       .override  method instance !0 class Foobar.IHasStaticAbstractBase`1<!a>::BoomInstance()
 
@@ -1509,19 +1489,16 @@ type CompilerGoesBoom<'a>() =
                 """.class interface public abstract auto ansi serializable beforefieldinit Foobar.IHasStaticAbstractBase`1<a>
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
-  .method public hidebysig abstract virtual
-          instance !a  BoomInstance() cil managed
+  .method public hidebysig abstract virtual instance !a  BoomInstance() cil managed
   {
   }
 
-  .method public hidebysig static abstract virtual
-          !a  BoomStatic() cil managed
+  .method public hidebysig static abstract virtual !a  BoomStatic() cil managed
   {
   }
 
 }"""
-                """.method private hidebysig newslot virtual
-            instance !a  'Foobar.IHasStaticAbstractBase<\'a>.BoomInstance'() cil managed
+                """.method private hidebysig newslot virtual instance !a  'Foobar.IHasStaticAbstractBase<\'a>.BoomInstance'() cil managed
     {
       .override  method instance !0 class Foobar.IHasStaticAbstractBase`1<!a>::BoomInstance()
 

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/TaskGeneratedCode.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/TaskGeneratedCode.fs
@@ -37,8 +37,7 @@ let testTask() = task { return 1 }
             """,
             (fun verifier -> verifier.VerifyIL [
             """
-.method public strict virtual instance void 
-MoveNext() cil managed
+.method public strict virtual instance void MoveNext() cil managed
 {
     .override [runtime]System.Runtime.CompilerServices.IAsyncStateMachine::MoveNext
           


### PR DESCRIPTION
I made a few changes tot the test framework in the accessibility PR.

I want to strip them out to here, because they make failure diagnosis a bit easier for me.  Also it will reduce the changes somewhat in theaccess PR.