### PR TITLE
Allow calling method with both Optional and ParamArray

### DIFF
--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -556,6 +556,13 @@ type CalledMeth<'T>
                 let nUnnamedCalledArgs = unnamedCalledArgs.Length
                 if allowOutAndOptArgs && nUnnamedCallerArgs < nUnnamedCalledArgs then
                     let unnamedCalledArgsTrimmed, unnamedCalledOptOrOutArgs = List.splitAt nUnnamedCallerArgs unnamedCalledArgs
+
+                    // take the last ParamArray arg out, make it not break the optional/out params check
+                    let unnamedCalledArgsTrimmed, unnamedCalledOptOrOutArgs =
+                        match List.rev unnamedCalledOptOrOutArgs with
+                        | [] -> unnamedCalledArgsTrimmed, []
+                        | h :: t when h.IsParamArray -> unnamedCalledArgsTrimmed @ [h], List.rev t
+                        | _ -> unnamedCalledArgsTrimmed, unnamedCalledOptOrOutArgs
                     
                     let isOpt x = x.OptArgInfo.IsOptional
                     let isOut x = x.IsOutArg && isByrefTy g x.CalledArgumentType

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/MethodResolution.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/MethodResolution.fs
@@ -262,3 +262,34 @@ let _, _ = Thing.Do()
             (Error 501, Line 6, Col 12, Line 6, Col 22, "The member or object constructor 'Do' takes 1 argument(s) but is here given 0. The required signature is 'static member Thing.Do: [<Optional>] i: outref<bool> -> bool'.")
         ]
 
+    [<Fact>]
+    let ``optional and ParamArray parameter resolves correctly `` () =
+        Fsx """
+open System.Runtime.InteropServices
+    
+type Thing =
+    static member Do(
+        [<Optional; DefaultParameterValue "">] something: string, 
+        [<System.ParamArray>] args: obj[]) = something, args
+    static member Do2(
+        [<Optional; DefaultParameterValue "">] something: string, 
+        outvar: outref<int>,
+        [<System.ParamArray>] args: obj[]) = 
+        
+        outvar <- 1
+        something, args
+let _, _ = Thing.Do()
+let _, _ = Thing.Do("123")
+let _, _ = Thing.Do("123", 1, 2, 3, 4)
+
+let _, _ = Thing.Do2()
+let _, _ = Thing.Do2("123")
+let _ =
+    let mutable x = 0
+    Thing.Do2("123", &x)
+let _ =
+    let mutable x = 0
+    Thing.Do2("123", &x, 1, 2, 3, 4)
+    """
+        |> typecheck
+        |> shouldSucceed


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes fsharp/fslang-suggestions#1120 by removing the last `ParamArray` arg out of optional/out params check

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**