### PR TITLE
Add InvalidateConfiguration endpoint with FSharpProjectSnapshot.

### DIFF
--- a/src/Compiler/Service/BackgroundCompiler.fs
+++ b/src/Compiler/Service/BackgroundCompiler.fs
@@ -133,6 +133,8 @@ type internal IBackgroundCompiler =
 
     abstract member InvalidateConfiguration: options: FSharpProjectOptions * userOpName: string -> unit
 
+    abstract InvalidateConfiguration: projectSnapshot: FSharpProjectSnapshot * userOpName: string -> unit
+
     abstract member NotifyFileChanged: fileName: string * options: FSharpProjectOptions * userOpName: string -> NodeCode<unit>
 
     abstract member NotifyProjectCleaned: options: FSharpProjectOptions * userOpName: string -> Async<unit>
@@ -1610,6 +1612,10 @@ type internal BackgroundCompiler
             self.GetSemanticClassificationForFile(fileName, snapshot.ToOptions(), userOpName)
 
         member _.InvalidateConfiguration(options: FSharpProjectOptions, userOpName: string) : unit =
+            self.InvalidateConfiguration(options, userOpName)
+
+        member this.InvalidateConfiguration(projectSnapshot: FSharpProjectSnapshot, userOpName: string) : unit =
+            let options = projectSnapshot.ToOptions()
             self.InvalidateConfiguration(options, userOpName)
 
         member _.NotifyFileChanged(fileName: string, options: FSharpProjectOptions, userOpName: string) : NodeCode<unit> =

--- a/src/Compiler/Service/BackgroundCompiler.fsi
+++ b/src/Compiler/Service/BackgroundCompiler.fsi
@@ -112,6 +112,8 @@ type internal IBackgroundCompiler =
 
     abstract InvalidateConfiguration: options: FSharpProjectOptions * userOpName: string -> unit
 
+    abstract InvalidateConfiguration: projectSnapshot: FSharpProjectSnapshot * userOpName: string -> unit
+
     abstract NotifyFileChanged: fileName: string * options: FSharpProjectOptions * userOpName: string -> NodeCode<unit>
 
     abstract NotifyProjectCleaned: options: FSharpProjectOptions * userOpName: string -> Async<unit>

--- a/src/Compiler/Service/TransparentCompiler.fs
+++ b/src/Compiler/Service/TransparentCompiler.fs
@@ -2136,6 +2136,12 @@ type internal TransparentCompiler
         member this.InvalidateConfiguration(options: FSharpProjectOptions, userOpName: string) : unit =
             backgroundCompiler.InvalidateConfiguration(options, userOpName)
 
+        member this.InvalidateConfiguration(projectSnapshot: FSharpProjectSnapshot, _userOpName: string) : unit =
+            let (FSharpProjectIdentifier(projectFileName, outputFileName)) =
+                projectSnapshot.Identifier
+
+            this.Caches.Clear(Set.singleton (ProjectIdentifier(projectFileName, outputFileName)))
+
         member this.NotifyFileChanged(fileName: string, options: FSharpProjectOptions, userOpName: string) : NodeCode<unit> =
             backgroundCompiler.NotifyFileChanged(fileName, options, userOpName)
 

--- a/src/Compiler/Service/service.fs
+++ b/src/Compiler/Service/service.fs
@@ -372,6 +372,10 @@ type FSharpChecker
         let userOpName = defaultArg userOpName "Unknown"
         backgroundCompiler.InvalidateConfiguration(options, userOpName)
 
+    member _.InvalidateConfiguration(projectSnapshot: FSharpProjectSnapshot, ?userOpName: string) =
+        let userOpName = defaultArg userOpName "Unknown"
+        backgroundCompiler.InvalidateConfiguration(projectSnapshot, userOpName)
+
     /// Clear the internal cache of the given projects.
     member _.ClearCache(options: seq<FSharpProjectOptions>, ?userOpName: string) =
         let userOpName = defaultArg userOpName "Unknown"

--- a/src/Compiler/Service/service.fsi
+++ b/src/Compiler/Service/service.fsi
@@ -405,7 +405,7 @@ type public FSharpChecker =
     member InvalidateConfiguration: options: FSharpProjectOptions * ?userOpName: string -> unit
 
     /// <summary>
-    ///  This function is called when the configuration is known to have changed for reasons not encoded in the ProjectOptions.
+    ///  This function is called when the configuration is known to have changed for reasons not encoded in the projectSnapshot.
     ///  For example, dependent references may have been deleted or created.
     /// </summary>
     [<Experimental("This FCS API is experimental and subject to change.")>]

--- a/src/Compiler/Service/service.fsi
+++ b/src/Compiler/Service/service.fsi
@@ -404,6 +404,13 @@ type public FSharpChecker =
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>
     member InvalidateConfiguration: options: FSharpProjectOptions * ?userOpName: string -> unit
 
+    /// <summary>
+    ///  This function is called when the configuration is known to have changed for reasons not encoded in the ProjectOptions.
+    ///  For example, dependent references may have been deleted or created.
+    /// </summary>
+    [<Experimental("This FCS API is experimental and subject to change.")>]
+    member InvalidateConfiguration: projectSnapshot: FSharpProjectSnapshot * ?userOpName: string -> unit
+
     /// <summary>Clear the internal cache of the given projects.</summary>
     /// <param name="options">The given project options.</param>
     /// <param name="userOpName">An optional string used for tracing compiler operations associated with this request.</param>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -2086,6 +2086,7 @@ FSharp.Compiler.CodeAnalysis.FSharpChecker: Void ClearCache(System.Collections.G
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Void ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateAll()
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateConfiguration(FSharp.Compiler.CodeAnalysis.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
+FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateConfiguration(FSharpProjectSnapshot, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsBindingALambdaAtPosition(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPosContainedInApplication(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPositionContainedInACurriedParameter(FSharp.Compiler.Text.Position)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -2086,6 +2086,7 @@ FSharp.Compiler.CodeAnalysis.FSharpChecker: Void ClearCache(System.Collections.G
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Void ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateAll()
 FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateConfiguration(FSharp.Compiler.CodeAnalysis.FSharpProjectOptions, Microsoft.FSharp.Core.FSharpOption`1[System.String])
+FSharp.Compiler.CodeAnalysis.FSharpChecker: Void InvalidateConfiguration(FSharpProjectSnapshot, Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsBindingALambdaAtPosition(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPosContainedInApplication(FSharp.Compiler.Text.Position)
 FSharp.Compiler.CodeAnalysis.FSharpParseFileResults: Boolean IsPositionContainedInACurriedParameter(FSharp.Compiler.Text.Position)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Hi there,

As some of you know, we take an interest in using the Transparent Compiler in Rider and Ionide.
Right now you can pass in `FSharpChecker.Create(..., useTransparentCompiler = bool)`.

The new world uses [FSharpProjectSnapshot](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-projectsnapshot-fsharpprojectsnapshot.html) instead of [FSharpProjectOptions](https://fsharp.github.io/fsharp-compiler-docs/reference/fsharp-compiler-codeanalysis-fsharpprojectoptions.html).

We would like to use the new snapshot APIs for everything. Imagine each editor has a setting for whether the end user is willing to use the new Transparent Compiler.

If the user says no (`useTransparentCompiler = false`), every call to a snapshot-based endpoint is forwarded to a projectOptions one in the old `BackgroundCompiler` ([example](https://github.com/dotnet/fsharp/blob/61e08cddda1ca13f6c5c4f1243bdc0f7fb6c6fe7/src/Compiler/Service/BackgroundCompiler.fs#L1631-L1646)).

We don't want to mix `FSharpProjectSnapshot` and `FSharpProjectOptions` so we would like to address some of the gaps as we go along.

This is a bit of a trade-off scenario but we want to avoid checks like [this](https://github.com/dotnet/fsharp/blob/15a6a64f92151782f409c0e500e572eaf63f6c76/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs#L451) for each consumer.


## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**