### PR TITLE
Remove benchmarks from FCS solution + fix setting LKG flag + no nulls

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,8 +24,6 @@
   <Import Project="$(RepoRoot)/Directory.Build.props.user" Condition = "Exists('$(RepoRoot)/Directory.Build.props.user')" />
 
   <PropertyGroup Condition="'$(BUILDING_USING_DOTNET)' == 'true'">
-    <BUILDING_WITH_LKG>true</BUILDING_WITH_LKG>
-    <BUILD_FROM_SOURCE>true</BUILD_FROM_SOURCE>
     <DisableAutoSetFscCompilerPath>false</DisableAutoSetFscCompilerPath>
     <FSHARPCORE_USE_PACKAGE Condition="'$(FSHARPCORE_USE_PACKAGE)' == ''">true</FSHARPCORE_USE_PACKAGE>
     <DISABLE_ARCADE Condition="'$(DISABLE_ARCADE)' == ''">true</DISABLE_ARCADE>
@@ -34,6 +32,7 @@
     <IntermediateOutputPath>$(ArtifactsDir)obj/$(MSBuildProjectName)/$(Configuration)/</IntermediateOutputPath>
     <FsLexPath>$(ArtifactsDir)/bin/fslex/$(Configuration)/net8.0/fslex.dll</FsLexPath>
     <FsYaccPath>$(ArtifactsDir)/bin/fsyacc/$(Configuration)/net8.0/fsyacc.dll</FsYaccPath>
+    <DefineConstants>NO_CHECKNULLS;BUILDING_WITH_LKG;NO_NULLCHECKING_LIB_SUPPORT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)/eng/Versions.props" Condition="'$(DISABLE_ARCADE)' == 'true'"/>

--- a/FSharp.Compiler.Service.sln
+++ b/FSharp.Compiler.Service.sln
@@ -29,12 +29,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", 
 		tests\benchmarks\FCSBenchmarks\SmokeTestAllBenchmarks.ps1 = tests\benchmarks\FCSBenchmarks\SmokeTestAllBenchmarks.ps1
 	EndProjectSection
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "HistoricalBenchmark", "tests\benchmarks\FCSBenchmarks\BenchmarkComparison\HistoricalBenchmark.fsproj", "{35F5F1C5-AE4F-4B5A-8D94-1AF708724FD5}"
-EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.Benchmarks", "tests\benchmarks\FCSBenchmarks\CompilerServiceBenchmarks\FSharp.Compiler.Benchmarks.fsproj", "{C1950E28-1CB7-4DEC-BB3A-8A0443A17282}"
-EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "HistoricalBenchmark.Runner", "tests\benchmarks\FCSBenchmarks\BenchmarkComparison\HistoricalBenchmark.Runner\HistoricalBenchmark.Runner.fsproj", "{07CD957A-3C31-4F75-A735-16CE72E1BD71}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD4D4A7E-D519-4409-89DA-16DCA3EF80AA}"
 	ProjectSection(SolutionItems) = preProject
 		src\Compiler\FSComp.txt = src\Compiler\FSComp.txt
@@ -60,8 +54,6 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Compiler.Interactive.Settings", "src\FSharp.Compiler.Interactive.Settings\FSharp.Compiler.Interactive.Settings.fsproj", "{AF887C2E-640D-4CD6-A0BD-88AE1517797D}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.UnitTests", "tests\FSharp.Compiler.UnitTests\FSharp.Compiler.UnitTests.fsproj", "{0C0BDAF4-7D47-4BDA-9992-077F63D6B494}"
-EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Benchmarks.Common", "tests\benchmarks\FSharp.Benchmarks.Common\FSharp.Benchmarks.Common.fsproj", "{A7ACFD1F-D1B8-483A-A210-200BB6B4BD7E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,18 +89,6 @@ Global
 		{2A182B7D-EDA3-4BF2-84B8-C7553BB7A5A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A182B7D-EDA3-4BF2-84B8-C7553BB7A5A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A182B7D-EDA3-4BF2-84B8-C7553BB7A5A7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{35F5F1C5-AE4F-4B5A-8D94-1AF708724FD5}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{35F5F1C5-AE4F-4B5A-8D94-1AF708724FD5}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{35F5F1C5-AE4F-4B5A-8D94-1AF708724FD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{35F5F1C5-AE4F-4B5A-8D94-1AF708724FD5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C1950E28-1CB7-4DEC-BB3A-8A0443A17282}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1950E28-1CB7-4DEC-BB3A-8A0443A17282}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1950E28-1CB7-4DEC-BB3A-8A0443A17282}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1950E28-1CB7-4DEC-BB3A-8A0443A17282}.Release|Any CPU.Build.0 = Release|Any CPU
-		{07CD957A-3C31-4F75-A735-16CE72E1BD71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{07CD957A-3C31-4F75-A735-16CE72E1BD71}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{07CD957A-3C31-4F75-A735-16CE72E1BD71}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{07CD957A-3C31-4F75-A735-16CE72E1BD71}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A6995088-3C1D-42BC-B3DD-72B1EEAB23F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A6995088-3C1D-42BC-B3DD-72B1EEAB23F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6995088-3C1D-42BC-B3DD-72B1EEAB23F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -145,10 +125,6 @@ Global
 		{0C0BDAF4-7D47-4BDA-9992-077F63D6B494}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C0BDAF4-7D47-4BDA-9992-077F63D6B494}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C0BDAF4-7D47-4BDA-9992-077F63D6B494}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A7ACFD1F-D1B8-483A-A210-200BB6B4BD7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A7ACFD1F-D1B8-483A-A210-200BB6B4BD7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A7ACFD1F-D1B8-483A-A210-200BB6B4BD7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A7ACFD1F-D1B8-483A-A210-200BB6B4BD7E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,10 +133,6 @@ Global
 		{BFE6E6F1-1B73-404F-A3A5-30B57E5E0731} = {875D91AC-BA4C-4191-AB11-AE461DB9B8DB}
 		{2EF674B9-8B56-4796-9933-42B2629E52C3} = {875D91AC-BA4C-4191-AB11-AE461DB9B8DB}
 		{38A23D53-E2BF-4B76-907F-49F41D60C88E} = {875D91AC-BA4C-4191-AB11-AE461DB9B8DB}
-		{35F5F1C5-AE4F-4B5A-8D94-1AF708724FD5} = {AF321816-B4A0-41DD-9A1D-484E8A20C6F6}
-		{C1950E28-1CB7-4DEC-BB3A-8A0443A17282} = {AF321816-B4A0-41DD-9A1D-484E8A20C6F6}
-		{07CD957A-3C31-4F75-A735-16CE72E1BD71} = {AF321816-B4A0-41DD-9A1D-484E8A20C6F6}
-		{A7ACFD1F-D1B8-483A-A210-200BB6B4BD7E} = {AF321816-B4A0-41DD-9A1D-484E8A20C6F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F9A60F3B-D894-4C8E-BA0F-C51115B25A5A}


### PR DESCRIPTION
1. Remove benchmarks from FCS solutions because
  a. We have a separate solution for them, and can keep minimum needed to develop and test compiler in FCS solution.
  b. They were unconditionally using FSharp.Core project.
2. Fix `BUILDING_WITH_LKG` and nullabillity-related defines. This will fix building FCS in nullability branches (and all branches which rely on LKG flags).