### PR TITLE
remove superseded test of TryGetRecentCheckResultsForFile

### DIFF
--- a/tests/service/ProjectAnalysisTests.fs
+++ b/tests/service/ProjectAnalysisTests.fs
@@ -5462,66 +5462,6 @@ type A(i:int) =
     | Some decl -> failwithf "unexpected declaration %A" decl
     | None -> failwith "declaration list is empty"
 
-[<Test>]
-// [<TestCase true>] // Flaky, reenable when stable
-[<TestCase false>]
-let ``TryGetRecentCheckResultsForFile called with snapshot returns cached result after ParseAndCheckFile`` useTransparentCompiler =
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
-    let dllName = Path.ChangeExtension(base2, ".dll")
-    let projFileName = Path.ChangeExtension(base2, ".fsproj")
-    let fileSource1Text = """
-type A(i:int) =
-    member x.Value = i
-"""
-    let fileSource1 = SourceText.ofString fileSource1Text
-    FileSystem.OpenFileForWriteShim(fileName1).Write(fileSource1Text)
-
-    let fileNames = [|fileName1|]
-    let args = mkProjectCommandLineArgs (dllName, [])
-    let checker = FSharpChecker.Create(useTransparentCompiler=useTransparentCompiler)
-    let options = { checker.GetProjectOptionsFromCommandLineArgs (projFileName, args) with SourceFiles = fileNames }
-    let snapshot = FSharpProjectSnapshot.FromOptions(options, DocumentSource.FileSystem) |> Async.RunImmediate
-
-    let rbefore = checker.TryGetRecentCheckResultsForFile(fileName1, snapshot)
-    match rbefore with
-    | Some(fileResults, checkFileResults) -> failwith "cached results before ParseAndCheckFileInProject was called"
-    | None -> ()
-    
-    checker.ParseAndCheckFileInProject(fileName1, snapshot)  |> Async.RunImmediate
-    |> function
-        | _, FSharpCheckFileAnswer.Succeeded(res) -> ()
-        | _ -> failwithf "Parsing aborted unexpectedly..."
-            
-    let rafterCheckResults = checker.TryGetRecentCheckResultsForFile(fileName1, snapshot)
-    match rafterCheckResults with
-    | Some(fileResults, checkFileResults) -> ()
-    | None -> failwith "no results from TryGetRecentCheckResultsForFile"
-   
-    let fileSource1TextEdited = """
-type A(i:int) =
-    member x.Value = i
-    member x.Value2 = 23
-"""
-    let fileSource1Edited = SourceText.ofString fileSource1TextEdited
-    FileSystem.OpenFileForWriteShim(fileName1).Write(fileSource1TextEdited)
-    let snapshotAfterFileEdit = FSharpProjectSnapshot.FromOptions(options, DocumentSource.FileSystem) |> Async.RunImmediate
-
-    let rafterEditBefore2ndCheckResults = checker.TryGetRecentCheckResultsForFile(fileName1, snapshotAfterFileEdit)
-    match rafterEditBefore2ndCheckResults with
-    | Some(fileResults, checkFileResults) -> failwith "stale cache results from TryGetRecentCheckResultsForFile after edit"
-    | None -> ()
-    
-    checker.ParseAndCheckFileInProject(fileName1, snapshotAfterFileEdit)  |> Async.RunImmediate
-    |> function
-        | _, FSharpCheckFileAnswer.Succeeded(res) -> ()
-        | _ -> failwithf "Parsing aborted unexpectedly..."
-        
-    let rafterEditAfter2ndCheckResults = checker.TryGetRecentCheckResultsForFile(fileName1, snapshotAfterFileEdit)
-    match rafterEditAfter2ndCheckResults with
-    | Some(fileResults, checkFileResults) -> ()
-    | None -> failwith "no results from TryGetRecentCheckResultsForFile"
-
 [<TestCase(([||]: string[]), ([||]: bool[]))>]
 [<TestCase([| "--times" |], [| false |])>]
 [<TestCase([| "--times"; "--nowarn:75" |], ([||]: bool[]))>]


### PR DESCRIPTION
## Description

This test is superseded by the tests in `tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs`

(No release notes needed)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**