### PR TITLE
Don't consider parse warnings as errors in ComputeTcIntermediate

### DIFF
--- a/src/Compiler/Service/FSharpProjectSnapshot.fs
+++ b/src/Compiler/Service/FSharpProjectSnapshot.fs
@@ -149,13 +149,13 @@ type internal FSharpParsedFile
         SyntaxTreeHash: byte array,
         SourceText: ISourceText,
         ParsedInput: ParsedInput,
-        ParseErrors: (PhasedDiagnostic * FSharpDiagnosticSeverity)[]
+        ParseDiagnostics: (PhasedDiagnostic * FSharpDiagnosticSeverity)[]
     ) =
 
     member _.FileName = FileName
     member _.SourceText = SourceText
     member _.ParsedInput = ParsedInput
-    member _.ParseErrors = ParseErrors
+    member _.ParseDiagnostics = ParseDiagnostics
 
     member val IsSignatureFile = FileName |> isSignatureFile
 

--- a/src/Compiler/Service/TransparentCompiler.fs
+++ b/src/Compiler/Service/TransparentCompiler.fs
@@ -1251,7 +1251,9 @@ type internal TransparentCompiler
 
                 let sink = TcResultsSinkImpl(tcGlobals, file.SourceText)
 
-                let hadParseErrors = not (Array.isEmpty file.ParseErrors)
+                let hadParseErrors =
+                    file.ParseDiagnostics
+                    |> Array.exists (snd >> (=) FSharpDiagnosticSeverity.Error)
 
                 let input, moduleNamesDict =
                     DeduplicateParsedInputModuleName prevTcInfo.moduleNamesDict input
@@ -1448,7 +1450,7 @@ type internal TransparentCompiler
                     tcConfig.diagnosticsOptions,
                     false,
                     file.FileName,
-                    parsedFile.ParseErrors,
+                    parsedFile.ParseDiagnostics,
                     suggestNamesForErrors,
                     tcConfig.flatErrors,
                     None

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -960,3 +960,54 @@ let ``Background compiler and Transparent compiler return the same options`` () 
         Assert.Equal<string list>(backgroundSnapshot.OtherOptions, transparentSnapshot.OtherOptions)
         Assert.Equal<ProjectSnapshot.ReferenceOnDisk list>(backgroundSnapshot.ReferencesOnDisk, transparentSnapshot.ReferencesOnDisk)
     }
+
+[<Theory>]
+[<InlineData(false)>]
+[<InlineData(true)>]
+let ``Unused warning should still produce after parse warning`` useTransparentCompiler =
+
+    // There should be parse warning because of the space in the file name:
+    //   warning FS0221: The declarations in this file will be placed in an implicit module 'As 01' based on the file name 'As 01.fs'.
+    //   However this is not a valid F# identifier, so the contents will not be accessible from other files. Consider renaming the file or adding a 'module' or 'namespace' declaration at the top of the file.
+    
+    let project =
+        { SyntheticProject.Create(
+            { sourceFile "As 01" [] with
+                Source = """
+do
+    let _ as b = ()
+    ()
+
+// For more information see https://aka.ms/fsharp-console-apps
+printfn "Hello from F#"
+"""
+                SignatureFile = No
+                
+            }) with
+            AutoAddModules = false
+            OtherOptions = [
+                "--target:exe"
+                "--warn:3"
+                "--warnon:1182"
+                "--warnaserror:3239"
+                "--noframework"
+            ]
+        }
+
+    let expectTwoWarnings (_parseResult:FSharpParseFileResults, checkAnswer: FSharpCheckFileAnswer) (_, _) =
+        match checkAnswer with
+        | FSharpCheckFileAnswer.Aborted -> failwith "Should not have aborted"
+        | FSharpCheckFileAnswer.Succeeded checkResults ->
+            let hasParseWarning =
+                checkResults.Diagnostics
+                |> Array.exists (fun diag -> diag.Severity = FSharpDiagnosticSeverity.Warning && diag.ErrorNumber = 221)
+            Assert.True(hasParseWarning, "Expected parse warning FS0221")
+
+            let hasCheckWarning =
+                checkResults.Diagnostics
+                |> Array.exists (fun diag -> diag.Severity = FSharpDiagnosticSeverity.Warning && diag.ErrorNumber = 1182)
+            Assert.True(hasCheckWarning, "Expected post inference warning FS1182")
+    
+    ProjectWorkflowBuilder(project, useTransparentCompiler = useTransparentCompiler) {
+        checkFile "As 01" expectTwoWarnings
+    }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Boy this was a headscratcher:

When a file with a space in the name is the last in the project (with `--target:exe`) it will lead to parse warning `FS0221: The declarations in this file will be placed in an implicit module 'As 01' based on the file name 'As 01.fs'. However, this is not a valid F# identifier, so the contents will not be accessible from other files. Consider renaming the file o 
r adding a 'module' or 'namespace' declaration at the top of the file.`

The transparent compiler interpreted this warning as an error, leading to `reportErrors` in `PostInferenceChecks` to be false and no longer reporting warnings like `warning FS1182: The value 'b' is unused`.

This PR aligns the behaviour with the background compiler, where the background compiler won't perceive the warning as error in `parseFile` (`FSharpCheckerResults.fs L2706)

![image](https://github.com/dotnet/fsharp/assets/2621499/194b35fb-f9f8-4000-bc26-5a993567bffa)


//cc @0101

## Checklist

- [X] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**