### PR TITLE
Clean up the fixes from 16774 and 16785 to not spill over into pars.fsy

### DIFF
--- a/src/Compiler/Service/ServiceLexing.fs
+++ b/src/Compiler/Service/ServiceLexing.fs
@@ -35,8 +35,8 @@ module FSharpTokenTag =
     let INTERP_STRING_BEGIN_PART =
         tagOfToken (INTERP_STRING_BEGIN_PART("a", SynStringKind.Regular, LexCont.Default))
 
-    let INTERP_STRING_PART = tagOfToken (INTERP_STRING_PART("a", None, LexCont.Default))
-    let INTERP_STRING_END = tagOfToken (INTERP_STRING_END("a", None, LexCont.Default))
+    let INTERP_STRING_PART = tagOfToken (INTERP_STRING_PART("a", LexCont.Default))
+    let INTERP_STRING_END = tagOfToken (INTERP_STRING_END("a", LexCont.Default))
     let LPAREN = tagOfToken LPAREN
     let RPAREN = tagOfToken RPAREN
     let LBRACK = tagOfToken LBRACK
@@ -491,9 +491,9 @@ module internal LexerStateEncoding =
         | STRING_TEXT cont
         | EOF cont
         | INTERP_STRING_BEGIN_PART(_, _, cont)
-        | INTERP_STRING_PART(_, _, cont)
+        | INTERP_STRING_PART(_, cont)
         | INTERP_STRING_BEGIN_END(_, _, cont)
-        | INTERP_STRING_END(_, _, cont)
+        | INTERP_STRING_END(_, cont)
         | LBRACE cont
         | RBRACE cont
         | BYTEARRAY(_, _, cont)

--- a/src/Compiler/SyntaxTree/LexHelpers.fs
+++ b/src/Compiler/SyntaxTree/LexHelpers.fs
@@ -188,9 +188,9 @@ type LexerStringFinisher =
                     else
                         INTERP_STRING_BEGIN_END(s, synStringKind, cont)
                 else if isPart then
-                    INTERP_STRING_PART(s, None, cont)
+                    INTERP_STRING_PART(s, cont)
                 else
-                    INTERP_STRING_END(s, None, cont)
+                    INTERP_STRING_END(s, cont)
             elif kind.IsByteString then
                 let synByteStringKind =
                     if isVerbatim then

--- a/src/Compiler/lex.fsl
+++ b/src/Compiler/lex.fsl
@@ -120,7 +120,7 @@ let checkExprGreaterColonOp (lexbuf:UnicodeLexing.Lexbuf) =
 let unexpectedChar lexbuf =
     LEX_FAILURE (FSComp.SR.lexUnexpectedChar(lexeme lexbuf))
 
-let startString args (lexbuf: UnicodeLexing.Lexbuf) altStartForStringPartOrEnd =
+let startString args (lexbuf: UnicodeLexing.Lexbuf) =
     let buf = ByteBuffer.Create StringCapacity
     let m = lexbuf.LexemeRange
     let startp = lexbuf.StartPos
@@ -158,9 +158,9 @@ let startString args (lexbuf: UnicodeLexing.Lexbuf) altStartForStringPartOrEnd =
                         INTERP_STRING_BEGIN_END (s, synStringKind, cont)
                 else
                     if isPart then
-                        INTERP_STRING_PART (s, altStartForStringPartOrEnd, cont)
+                        INTERP_STRING_PART (s, cont)
                     else
-                        INTERP_STRING_END (s, altStartForStringPartOrEnd, cont)
+                        INTERP_STRING_END (s, cont)
             else
                 let s = Lexhelp.stringBufferAsString buf
                 let synStringKind =
@@ -587,7 +587,7 @@ rule token (args: LexArgs) (skip: bool) = parse
        else mlOnly m args skip lexbuf }
 
  | '"'
-     { let buf, fin, m = startString args lexbuf None
+     { let buf, fin, m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
@@ -600,7 +600,7 @@ rule token (args: LexArgs) (skip: bool) = parse
        else singleQuoteString (buf, fin, m, LexerStringKind.String, args) skip lexbuf }
 
  | '$' '"' '"' '"'
-     { let buf, fin, m = startString args lexbuf None
+     { let buf, fin, m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
@@ -612,7 +612,7 @@ rule token (args: LexArgs) (skip: bool) = parse
        else tripleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringFirst, args) skip lexbuf }
 
  | ('$'+) '"' '"' '"'
-     { let buf, fin, m = startString args lexbuf None
+     { let buf, fin, m = startString args lexbuf
 
        if lexbuf.SupportsFeature LanguageFeature.ExtendedStringInterpolation then
            // Single quote in triple quote ok, others disallowed
@@ -635,7 +635,7 @@ rule token (args: LexArgs) (skip: bool) = parse
      }
 
  | '$' '"'
-     { let buf,fin,m = startString args lexbuf None
+     { let buf,fin,m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
@@ -649,7 +649,7 @@ rule token (args: LexArgs) (skip: bool) = parse
            singleQuoteString (buf, fin, m, LexerStringKind.InterpolatedStringFirst, args) skip lexbuf }
 
  | '"' '"' '"'
-     { let buf, fin, m = startString args lexbuf None
+     { let buf, fin, m = startString args lexbuf
 
        args.interpolationDelimiterLength <- 0
 
@@ -664,7 +664,7 @@ rule token (args: LexArgs) (skip: bool) = parse
            tripleQuoteString (buf, fin, m, LexerStringKind.String, args) skip lexbuf }
 
  | '@' '"'
-     { let buf, fin, m = startString args lexbuf None
+     { let buf, fin, m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
@@ -679,7 +679,7 @@ rule token (args: LexArgs) (skip: bool) = parse
            verbatimString (buf, fin, m, LexerStringKind.String, args) skip lexbuf }
 
  | ("$@" | "@$") '"'
-     { let buf, fin, m = startString args lexbuf None
+     { let buf, fin, m = startString args lexbuf
 
        // Single quote in triple quote ok, others disallowed
        match args.stringNest with
@@ -914,7 +914,11 @@ rule token (args: LexArgs) (skip: bool) = parse
            token args skip lexbuf
        | (1, style, _, altR, _r) :: rest ->
            args.stringNest <- rest
-           let buf, fin, m = startString args lexbuf altR
+           altR
+           |> Option.iter (fun r ->
+               let n = r.StartColumn - lexbuf.StartPos.Column 
+               lexbuf.StartPos <- lexbuf.StartPos.ShiftColumnBy(n)) 
+           let buf, fin, m = startString args lexbuf
            if not skip then
                STRING_TEXT (LexCont.String(args.ifdefStack, args.stringNest, style, LexerStringKind.InterpolatedStringPart, args.interpolationDelimiterLength, m))
            else

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -37,8 +37,8 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 %token <string * SynStringKind * ParseHelpers.LexerContinuation> STRING
 %token <string * SynStringKind * ParseHelpers.LexerContinuation> INTERP_STRING_BEGIN_END
 %token <string * SynStringKind * ParseHelpers.LexerContinuation> INTERP_STRING_BEGIN_PART
-%token <string * range option * ParseHelpers.LexerContinuation> INTERP_STRING_PART
-%token <string * range option * ParseHelpers.LexerContinuation> INTERP_STRING_END
+%token <string * ParseHelpers.LexerContinuation> INTERP_STRING_PART
+%token <string * ParseHelpers.LexerContinuation> INTERP_STRING_END
 %token <ParseHelpers.LexerContinuation> LBRACE RBRACE
 
 %token <string * string> KEYWORD_STRING // Like __SOURCE_DIRECTORY__
@@ -6774,35 +6774,16 @@ interpolatedStringFill:
 
 interpolatedStringParts:
   | INTERP_STRING_END
-     {
-       let (s, altStart, _) = $1
-       let mOrig = rhs parseState 1
-       let m =
-           match altStart with
-           | Some r -> unionRanges r mOrig
-           | None -> mOrig
-       [ SynInterpolatedStringPart.String(s, m) ] }
+     { [ SynInterpolatedStringPart.String(fst $1, rhs parseState 1) ] }
 
   | INTERP_STRING_PART interpolatedStringFill interpolatedStringParts
-     { let (s, altStart, _) = $1
-       let mOrig = rhs parseState 1
-       let m =
-           match altStart with
-           | Some r -> unionRanges r mOrig
-           | None -> mOrig
-       SynInterpolatedStringPart.String(s, m) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
+     { SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: SynInterpolatedStringPart.FillExpr $2 :: $3 }
 
   | INTERP_STRING_PART interpolatedStringParts
      { let rbrace = parseState.InputEndPosition 1
        let lbrace = parseState.InputStartPosition 2
        reportParseErrorAt (mkSynRange rbrace lbrace) (FSComp.SR.parsEmptyFillInInterpolatedString())
-       let (s, altStart, _) = $1
-       let mOrig = rhs parseState 1
-       let m =
-           match altStart with
-           | Some r -> unionRanges r mOrig
-           | None -> mOrig
-       SynInterpolatedStringPart.String(s, m) :: $2 }
+       SynInterpolatedStringPart.String(fst $1, rhs parseState 1) :: $2 }
 
 /* INTERP_STRING_BEGIN_END */
 /* INTERP_STRING_BEGIN_PART int32 INTERP_STRING_END */

--- a/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/InterpolatedStringsTests.fs
@@ -70,7 +70,7 @@ printfn \"%s\" s"
         |> withLangVersion80
         |> compile
         |> shouldFail
-        |> withSingleDiagnostic (Error 1249, Line 1, Col 15, Line 1, Col 21, "The interpolated string contains unmatched closing braces.")
+        |> withSingleDiagnostic (Error 1249, Line 1, Col 14, Line 1, Col 21, "The interpolated string contains unmatched closing braces.")
 
     [<Fact>]
     let ``Percent sign characters in interpolated strings`` () =


### PR DESCRIPTION
## Description

As promised, here's a cleanup for [#16774](https://github.com/dotnet/fsharp/pull/16774) and [#16785](https://github.com/dotnet/fsharp/pull/16785)
There's now no spillover into pars.fsy which was by far the worst part of these PRs.

(No release notes needed, I think)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**