### PR TITLE
Fix plain dotnet build

### DIFF
--- a/src/FSharp.Core/FSharp.Core.fsproj
+++ b/src/FSharp.Core/FSharp.Core.fsproj
@@ -26,7 +26,7 @@
     <OtherFlags>$(OtherFlags) --nowarn:3513</OtherFlags>
     <OtherFlags>$(OtherFlags) --compiling-fslib --compiling-fslib-40 --maxerrors:100 --extraoptimizationloops:1</OtherFlags>
     <!-- .FSharp.Core always uses the old style initialization mechanism because of SQL CLR requirements -->
-    <OtherFlags Condition="'$(Configuration)' != 'Proto'">$(OtherFlags) --realsig-</OtherFlags>
+    <OtherFlags Condition="'$(BUILDING_USING_DOTNET)' != 'true' and '$(Configuration)' != 'Proto'">$(OtherFlags) --realsig-</OtherFlags>
     <!-- .tail annotations always emitted for this binary, even in debug mode -->
     <Tailcalls>true</Tailcalls>
     <NGenBinary>true</NGenBinary>


### PR DESCRIPTION
This fixes building with just `dotnet build` - do not pass `realsig` flag. Can be removed when compiler with that flag releases.