### PR TITLE
Fix 12677  --  Default F# XUnit test project fails to build when targeting net48

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.Overrides.NetSdk.targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Overrides.NetSdk.targets
@@ -17,6 +17,15 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
+  <!-- The test sdk automagically forces OutputType to Exe for netcoreapp target frameworks
+       unfortunately it doesn't do that for desktop framework targets which causes build errors
+       with the shipping templates, that require a manual edit.
+       This just forces it for F# test projects where GenerateProgramFile is false.
+  -->
+  <PropertyGroup Condition="'$(IsTestProject)'=='true' and '$(GenerateProgramFile)'=='false'">
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <Target Name="CoreGenerateAssemblyInfo"
           Condition="'$(Language)'=='F#'"
           DependsOnTargets="CreateGeneratedAssemblyInfoInputsCacheFile"


### PR DESCRIPTION
Fixes #12677 

The test sdk automagically forces OutputType to Exe for netcoreapp target frameworks unfortunately it doesn't do that for desktop framework targets which causes build errors with the shipping templates, that require a manual edit.  This PR. just forces it for F# test projects where GenerateProgramFile is false.

The change is made in the Microsoft.FSharp.Net.Overrides.targets is where we add this kind of FSharp fix to the SDK type issues.  