### PR TITLE
Parser: more 'as' pattern recovery

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3720,6 +3720,12 @@ parenPattern:
         let pat2 = SynPat.Wild(mAs.EndRange)
         SynPat.As($1, pat2, rhs2 parseState 1 2) }
 
+  | parenPattern AS
+      { let mAs = rhs parseState 2
+        let pat2 = SynPat.Wild(mAs.EndRange)
+        reportParseErrorAt mAs (FSComp.SR.parsExpectingPattern ())
+        SynPat.As($1, pat2, rhs2 parseState 1 2) }
+
   | parenPattern BAR parenPattern
       { let mBar = rhs parseState 2
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }

--- a/tests/service/data/SyntaxTree/Pattern/As 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/As 02.fs.bsl
@@ -21,4 +21,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(4,7)-(4,9) parse error Unexpected symbol '->' in pattern
+(4,4)-(4,6) parse error Expecting pattern

--- a/tests/service/data/SyntaxTree/Pattern/As 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/As 05.fs.bsl
@@ -21,5 +21,5 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,0)-(5,0) parse error Incomplete structured construct at or before this point in pattern
-(3,13)-(3,17) parse error Unexpected end of input in 'match' or 'try' expression
+(4,4)-(4,6) parse error Expecting pattern
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in pattern matching. Expected '->' or other token.

--- a/tests/service/data/SyntaxTree/Pattern/As 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/As 08.fs.bsl
@@ -20,4 +20,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(5,0)-(5,1) parse error Unexpected symbol '|' in pattern
+(4,4)-(4,6) parse error Expecting pattern

--- a/tests/service/data/SyntaxTree/Pattern/As 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/As 10.fs.bsl
@@ -22,4 +22,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,10)-(3,11) parse error Unexpected symbol ')' in pattern
+(3,7)-(3,9) parse error Expecting pattern

--- a/tests/service/data/SyntaxTree/Pattern/As 12.fs
+++ b/tests/service/data/SyntaxTree/Pattern/As 12.fs
@@ -1,0 +1,6 @@
+module Module
+
+match a with
+| :? T as
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/As 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/As 12.fs.bsl
@@ -1,0 +1,26 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/As 12.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,12), Ident a,
+                 [SynMatchClause
+                    (As
+                       (IsInst
+                          (LongIdent (SynLongIdent ([T], [], [None])),
+                           (4,2--4,6)), Wild (4,9--4,9), (4,2--4,9)), None,
+                     ArbitraryAfterError ("patternClauses2", (4,9--4,9)),
+                     (4,2--4,9), Yes, { ArrowRange = None
+                                        BarRange = Some (4,0--4,1) })],
+                 (3,0--4,9), { MatchKeyword = (3,0--3,5)
+                               WithKeyword = (3,8--3,12) }), (3,0--4,9));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,7)-(4,9) parse error Expecting pattern
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in pattern matching. Expected '->' or other token.


### PR DESCRIPTION
More recovery for cases like this:

```fsharp
match a with
| _ as

()
```