### PR TITLE
AttributeTargets.Class and AttributeTargets.Struct can be targeted in an enum incorrectly

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -20,6 +20,7 @@
 * Enforce AttributeTargets on structs and classes ([PR #16790](https://github.com/dotnet/fsharp/pull/16790))
 * Parser: fix pattern range for idents with trivia ([PR #16824](https://github.com/dotnet/fsharp/pull/16824))
 * Fix broken code completion after a record type declaration ([PR #16813](https://github.com/dotnet/fsharp/pull/16813))
+* Enforce AttributeTargets on enums ([PR #16887](https://github.com/dotnet/fsharp/pull/16887))
 
 ### Added
 

--- a/docs/release-notes/.FSharp.Core/8.0.300.md
+++ b/docs/release-notes/.FSharp.Core/8.0.300.md
@@ -7,3 +7,4 @@
 
 * Preserve original stack traces in resumable state machines generated code if available. ([PR #16568](https://github.com/dotnet/fsharp/pull/16568))
 * Enforce AttributeTargets on structs and classes. Also update `RequireQualifiedAccessAttribute` and `AutoOpenAttribute` to use `AttributeTargets.Struct` ([PR #16790](https://github.com/dotnet/fsharp/pull/16790))
+* Enforce AttributeTargets on enums. Also update `RequireQualifiedAccessAttribute` to use `AttributeTargets.Enum` ([PR #16887](https://github.com/dotnet/fsharp/pull/16887))

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -2940,7 +2940,9 @@ module EstablishTypeDefinitionCores =
 
                     TFSharpTyconRepr (Construct.NewEmptyFSharpTyconData kind)
 
-            | SynTypeDefnSimpleRepr.Enum _ -> 
+            | SynTypeDefnSimpleRepr.Enum _ ->
+                if g.langVersion.SupportsFeature(LanguageFeature.EnforceAttributeTargets) then
+                    TcAttributesWithPossibleTargets false cenv envinner AttributeTargets.Enum synAttrs |> ignore
                 TFSharpTyconRepr (Construct.NewEmptyFSharpTyconData TFSharpEnum)
 
         // OK, now fill in the (partially computed) type representation

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -350,7 +350,7 @@ namespace Microsoft.FSharp.Core
     type RequiresExplicitTypeArgumentsAttribute() =
         inherit Attribute()
       
-    [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct, AllowMultiple=false)>]
+    [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct ||| AttributeTargets.Enum, AllowMultiple=false)>]
     [<Sealed>]
     type RequireQualifiedAccessAttribute() =
         inherit Attribute()

--- a/src/FSharp.Core/prim-types.fsi
+++ b/src/FSharp.Core/prim-types.fsi
@@ -898,7 +898,7 @@ namespace Microsoft.FSharp.Core
     /// type require explicit qualified access.</summary>
     ///
     /// <category>Attributes</category>
-    [<AttributeUsage (AttributeTargets.Class ||| AttributeTargets.Struct, AllowMultiple=false)>]  
+    [<AttributeUsage (AttributeTargets.Class ||| AttributeTargets.Struct ||| AttributeTargets.Enum, AllowMultiple=false)>]  
     [<Sealed>]
     type RequireQualifiedAccessAttribute =
         inherit Attribute

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeTargetsIsEnum01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeTargetsIsEnum01.fs
@@ -1,0 +1,11 @@
+open System
+
+[<AttributeUsage(AttributeTargets.Enum)>]
+type CustomEnumAttribute() =
+    inherit Attribute()
+
+[<CustomEnum>]
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -520,3 +520,39 @@ module CustomAttributes_AttributeUsage =
             (Error 842, Line 14, Col 15, Line 14, Col 27, "This attribute is not valid for use on this language element")
             (Error 842, Line 17, Col 16, Line 17, Col 28, "This attribute is not valid for use on this language element")
         ]
+        
+    // SOURCE=AttributeTargetsIsEnum01.fs	# AttributeTargetsIsEnum01.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AttributeTargetsIsEnum01.fs"|])>]
+    let ``AttributeTargetsIsEnum01_fs`` compilation =
+        compilation
+        |> verifyCompile
+        |> shouldSucceed
+    
+    // SOURCE=AttributeTargetsIsEnum01.fs	# AttributeTargetsIsEnum01.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AttributeTargetsIsEnum01.fs"|])>]
+    let ``AttributeTargetsIsEnum01_fs preview`` compilation =
+        compilation
+        |> withLangVersionPreview
+        |> verifyCompile
+        |> shouldSucceed
+        
+    // SOURCE=E_AttributeTargetIsEnum01.fs	# E_AttributeTargetIsEnum01.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsEnum01.fs"|])>]
+    let ``E_AttributeTargetIsEnum01_fs`` compilation =
+        compilation
+        |> verifyCompile
+        |> shouldSucceed
+    
+    // SOURCE=E_AttributeTargetIsEnum01.fs	# E_AttributeTargetIsEnum01.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsEnum01.fs"|])>]
+    let ``E_AttributeTargetIsEnum01_fs preview`` compilation =
+        compilation
+        |> withLangVersionPreview
+        |> verifyCompile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 842, Line 19, Col 3, Line 19, Col 15, "This attribute is not valid for use on this language element")
+            (Error 842, Line 20, Col 3, Line 20, Col 14, "This attribute is not valid for use on this language element")
+            (Error 842, Line 21, Col 3, Line 21, Col 18, "This attribute is not valid for use on this language element")
+            (Error 842, Line 22, Col 3, Line 22, Col 17, "This attribute is not valid for use on this language element")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/E_AttributeTargetIsEnum01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/E_AttributeTargetIsEnum01.fs
@@ -1,0 +1,26 @@
+open System
+
+[<AttributeUsage(AttributeTargets.Struct)>]
+type CustomStructAttribute() =
+    inherit Attribute()
+
+[<AttributeUsage(AttributeTargets.Class)>]
+type CustomClassAttribute() =
+    inherit Attribute()
+
+[<AttributeUsage(AttributeTargets.Interface)>]
+type CustomInterfaceAttribute() =
+    inherit Attribute()
+
+[<AttributeUsage(AttributeTargets.Delegate)>]
+type CustomDelegateAttribute() =
+    inherit Attribute()
+
+[<CustomStruct>]
+[<CustomClass>]
+[<CustomInterface>]
+[<CustomDelegate>]
+type Color =
+    | Red = 0
+    | Green = 1
+    | Blue = 2


### PR DESCRIPTION
## Description

Fixes #16843

### Before
```csharp
[CompilationMapping(SourceConstructFlags.Module)]
public static class @_
{
    [Serializable]
    [AttributeUsage(AttributeTargets.Struct)]
    [CompilationMapping(SourceConstructFlags.ObjectType)]
    public class CustomStructAttribute : Attribute
    {
    }


    [Serializable]
    [AttributeUsage(AttributeTargets.Class)]
    [CompilationMapping(SourceConstructFlags.ObjectType)]
    public class CustomClassAttribute : Attribute
    {
    }


    [Serializable]
    [CustomStruct]
    [CustomClass]
    [CompilationMapping(SourceConstructFlags.ObjectType)]
    public enum Color
    {
        Red,
        Green,
        Blue
    }
}
```

### After
`Error 842 "This attribute is not valid for use on this language element" should be reported.`

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**