### PR TITLE
Use TransparentCompiler cache for GetProjectOptionsFromScript

### DIFF
--- a/src/Compiler/Facilities/AsyncMemoize.fs
+++ b/src/Compiler/Facilities/AsyncMemoize.fs
@@ -551,6 +551,8 @@ type internal AsyncMemoize<'TKey, 'TVersion, 'TValue when 'TKey: equality and 'T
 
     member this.OnEvent = this.Event.Add
 
+    member this.Count = cache.Count
+
     member _.Locked = lock.Semaphore.CurrentCount < 1
 
     member _.Running =

--- a/src/Compiler/Facilities/AsyncMemoize.fsi
+++ b/src/Compiler/Facilities/AsyncMemoize.fsi
@@ -75,6 +75,8 @@ type internal AsyncMemoize<'TKey, 'TVersion, 'TValue when 'TKey: equality and 'T
 
     member OnEvent: ((JobEvent * (string * 'TKey * 'TVersion) -> unit) -> unit)
 
+    member Count: int
+
 /// A drop-in replacement for AsyncMemoize that disables caching and just runs the computation every time.
 type internal AsyncMemoizeDisabled<'TKey, 'TVersion, 'TValue when 'TKey: equality and 'TVersion: equality> =
 

--- a/src/Compiler/Service/TransparentCompiler.fs
+++ b/src/Compiler/Service/TransparentCompiler.fs
@@ -2151,19 +2151,27 @@ type internal TransparentCompiler
                 optionsStamp: int64 option,
                 userOpName: string
             ) : Async<FSharpProjectOptions * FSharpDiagnostic list> =
-            backgroundCompiler.GetProjectOptionsFromScript(
-                fileName,
-                sourceText,
-                previewEnabled,
-                loadedTimeStamp,
-                otherFlags,
-                useFsiAuxLib,
-                useSdkRefs,
-                sdkDirOverride,
-                assumeDotNetFramework,
-                optionsStamp,
-                userOpName
-            )
+            async {
+                let bc = this :> IBackgroundCompiler
+
+                let! snapshot, diagnostics =
+                    bc.GetProjectSnapshotFromScript(
+                        fileName,
+                        SourceTextNew.ofISourceText sourceText,
+                        previewEnabled,
+                        loadedTimeStamp,
+                        otherFlags,
+                        useFsiAuxLib,
+                        useSdkRefs,
+                        sdkDirOverride,
+                        assumeDotNetFramework,
+                        optionsStamp,
+                        userOpName
+                    )
+
+                let projectOptions = snapshot.ToOptions()
+                return projectOptions, diagnostics
+            }
 
         member this.GetProjectSnapshotFromScript
             (

--- a/src/Compiler/Utilities/LruCache.fs
+++ b/src/Compiler/Utilities/LruCache.fs
@@ -277,3 +277,5 @@ type internal LruCache<'TKey, 'TVersion, 'TValue when 'TKey: equality and 'TVers
                 match w.TryGetTarget() with
                 | true, value -> Some(label, version, value)
                 | _ -> None)
+
+    member this.Count = Seq.length (this.GetValues())

--- a/src/Compiler/Utilities/LruCache.fsi
+++ b/src/Compiler/Utilities/LruCache.fsi
@@ -38,6 +38,9 @@ type internal LruCache<'TKey, 'TVersion, 'TValue when 'TKey: equality and 'TVers
 
     member GetValues: unit -> (string * 'TVersion * 'TValue) seq
 
+    /// Gets the number of items in the cache
+    member Count: int
+
     member Remove: key: 'TKey -> unit
 
     member Remove: key: 'TKey * version: 'TVersion -> unit

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -1011,3 +1011,13 @@ printfn "Hello from F#"
     ProjectWorkflowBuilder(project, useTransparentCompiler = useTransparentCompiler) {
         checkFile "As 01" expectTwoWarnings
     }
+
+[<Fact>]
+let ``Transparent Compiler ScriptClosure cache is populated after GetProjectOptionsFromScript`` () =
+    async {
+        let transparentChecker = FSharpChecker.Create(useTransparentCompiler = true)
+        let scriptName = Path.Combine(__SOURCE_DIRECTORY__, "script.fsx")
+        let content = SourceTextNew.ofString ""
+        let! _ = transparentChecker.GetProjectOptionsFromScript(scriptName, content)
+        Assert.Equal(1, transparentChecker.Caches.ScriptClosure.Count)
+    }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This invokes the `GetProjectSnapshotFromScript` call from `GetProjectOptionsFromScript` so the load script closure is properly cached in the Transparent Compiler.

@0101 I've exposed the item count from `AsyncMemoize`, this seems slightly more convenient than the event route. I don't have a strong preference on this, so let me know if you wish to see this differently.

## Checklist

- [X] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**