### PR TITLE
Fix [<tailcall>] false positive with yield!

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix a false positive of the `[<TailCall>]` analysis in combination with `yield!`. ([PR #16882](https://github.com/dotnet/fsharp/pull/xxx))
 * Don't blow the stack when traversing deeply nested sequential expressions. ([PR #16882](https://github.com/dotnet/fsharp/pull/16882))
 * Fix wrong range start of INTERP_STRING_END. ([PR #16774](https://github.com/dotnet/fsharp/pull/16774), [PR #16785](https://github.com/dotnet/fsharp/pull/16785))
 * Fix missing warning for recursive calls in list comprehensions. ([PR #16652](https://github.com/dotnet/fsharp/pull/16652))

--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -1,6 +1,6 @@
 ### Fixed
 
-* Fix a false positive of the `[<TailCall>]` analysis in combination with `yield!`. ([PR #16882](https://github.com/dotnet/fsharp/pull/xxx))
+* Fix a false positive of the `[<TailCall>]` analysis in combination with `yield!`. ([PR #16933](https://github.com/dotnet/fsharp/pull/16933))
 * Don't blow the stack when traversing deeply nested sequential expressions. ([PR #16882](https://github.com/dotnet/fsharp/pull/16882))
 * Fix wrong range start of INTERP_STRING_END. ([PR #16774](https://github.com/dotnet/fsharp/pull/16774), [PR #16785](https://github.com/dotnet/fsharp/pull/16785))
 * Fix missing warning for recursive calls in list comprehensions. ([PR #16652](https://github.com/dotnet/fsharp/pull/16652))

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24154.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24162.2">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>936b4a4b4b8a74b65098983660c5814fb4afee15</Sha>
+      <Sha>c0b5d69a1a1513528c77fffff708c7502d57c35c</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->

--- a/src/Compiler/Checking/TailCallChecks.fs
+++ b/src/Compiler/Checking/TailCallChecks.fs
@@ -222,6 +222,13 @@ and CheckCall cenv args ctxts (tailCall: TailCall) =
             | Expr.App _ -> Some(TailCall.YesFromExpr cenv.g e)
             | IsAppInLambdaBody t -> Some t
             | _ -> None
+        | Expr.App(_funcExpr, _formalType, _typeArgs, args, _range) ->
+            args
+            |> List.tryPick (fun a ->
+                match a with
+                | IsAppInLambdaBody t -> Some t
+                | _ -> None)
+
         | _ -> None
 
     // if we haven't already decided this is no tail call, try to detect CPS-like expressions

--- a/src/Compiler/Checking/TailCallChecks.fs
+++ b/src/Compiler/Checking/TailCallChecks.fs
@@ -222,7 +222,7 @@ and CheckCall cenv args ctxts (tailCall: TailCall) =
             | Expr.App _ -> Some(TailCall.YesFromExpr cenv.g e)
             | IsAppInLambdaBody t -> Some t
             | _ -> None
-        | Expr.App(_funcExpr, _formalType, _typeArgs, args, _range) ->
+        | Expr.App(args = args) ->
             args
             |> List.tryPick (fun a ->
                 match a with

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TailCallAttribute.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/TailCallAttribute.fs
@@ -1524,7 +1524,7 @@ namespace N
         ]
 
     [<FSharp.Test.FactForNETCOREAPP>]
-    let ``Don't warn for yield! call of tail rec func`` () =
+    let ``Don't warn for yield! call of rec func in seq`` () =
         """
 namespace N
 
@@ -1561,3 +1561,58 @@ module M =
         |> withLangVersion80
         |> compile
         |> shouldSucceed
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``Warn for yield! call of rec func in list comprehension`` () =
+        """
+namespace N
+
+module M =
+
+    type SynExpr =
+        | Sequential of expr1 : SynExpr * expr2 : SynExpr
+        | NotSequential
+        member _.Range = 99
+
+    type SyntaxNode = SynExpr of SynExpr
+
+    type SyntaxVisitor () = member _.VisitExpr _ = None
+
+    let visitor = SyntaxVisitor ()
+    let dive expr range f = range, fun () -> Some expr
+    let traverseSynExpr _ expr = Some expr
+
+    [<TailCall>]
+    let rec traverseSequentials path expr =
+        [
+            match expr with
+            | SynExpr.Sequential(expr1 = expr1; expr2 = SynExpr.Sequential _ as expr2) ->
+                // It's a nested sequential expression.
+                // Visit it, but make defaultTraverse do nothing,
+                // since we're going to traverse its descendants ourselves.
+                yield dive expr expr.Range (fun expr -> visitor.VisitExpr(path, traverseSynExpr path, (fun _ -> None), expr))
+
+                // Now traverse its descendants.
+                let path = SyntaxNode.SynExpr expr :: path
+                yield dive expr1 expr1.Range (traverseSynExpr path)
+                yield! traverseSequentials path expr2   // should warn
+
+            | _ ->
+                // It's not a nested sequential expression.
+                // Traverse it normally.
+                yield dive expr expr.Range (traverseSynExpr path)
+        ]
+        """
+        |> FSharp
+        |> withLangVersion80
+        |> compile
+        |> shouldFail
+        |> withResults [
+            { Error = Warning 3569
+              Range = { StartLine = 32
+                        StartColumn = 24
+                        EndLine = 32
+                        EndColumn = 54 }
+              Message =
+                "The member or function 'traverseSequentials' has the 'TailCallAttribute' attribute, but is not being used in a tail recursive way." }
+        ]


### PR DESCRIPTION
## Description

Fixes a false positive that @brianrourkeboll came across in #16882 
Thanks @brianrourkeboll for providing the repro code!

## Checklist

- [X] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [X] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**