### PR TITLE
Unskip a few tests

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/flaterrors.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/flaterrors.fs
@@ -59,7 +59,7 @@ module flaterrors =
 
     [<InlineData("--FlatErrors")>]                          //Invalid case
     [<InlineData("--FLATERRORS")>]                          //Even more invalid case
-    [<InlineData("--flaterrors-")>]                         // no + allowed
+    [<InlineData("--flaterrors+")>]                         // no + allowed
     [<InlineData("--flaterrors-")>]                         // no - allowed
     [<Theory>]
     let ``E_MultiLine04_fs`` (option: string) =

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -96,7 +96,6 @@ let x = lb {1; 2; if true then 3;}
 
     [<Theory>]
     [<InlineData("preview","BindReturn")>]
-    [<InlineData("preview","BindReturn")>]
     [<InlineData("preview","WithoutBindReturn")>]
     [<InlineData("4.7","BindReturn")>]   
     [<InlineData("4.7","WithoutBindReturn")>]  


### PR DESCRIPTION
I noticed a few tests are skipped because of some typos - those resulted in test dupes and xUnit was confused. 

![image](https://github.com/dotnet/fsharp/assets/5451366/39d6e93a-4d14-419e-a268-0896eb28bd6a)

