### PR TITLE
Computed collections: simple count check

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -53,4 +53,4 @@
 * Reverted [#16348](https://github.com/dotnet/fsharp/pull/16348) `ThreadStatic` `CancellationToken` changes to improve test stability and prevent potential unwanted cancellations. ([PR #16536](https://github.com/dotnet/fsharp/pull/16536))
 * Refactored parenthesization API. ([PR #16461])(https://github.com/dotnet/fsharp/pull/16461))
 * Optimize some interpolated strings by lowering to string concatenation. ([PR #16556](https://github.com/dotnet/fsharp/pull/16556))
-* Integral range optimizations. ([PR #16650](https://github.com/dotnet/fsharp/pull/16650), [PR #16832](https://github.com/dotnet/fsharp/pull/16832))
+* Integral range optimizations. ([PR #16650](https://github.com/dotnet/fsharp/pull/16650), [PR #16832](https://github.com/dotnet/fsharp/pull/16832), [PR #16947](https://github.com/dotnet/fsharp/pull/16947))

--- a/src/Compiler/Optimize/LowerComputedCollections.fs
+++ b/src/Compiler/Optimize/LowerComputedCollections.fs
@@ -393,14 +393,7 @@ module Array =
                     mkCompGenLetIn m (nameof count) (tyOfExpr g count) count (fun (_, count) ->
                         let countTy = tyOfExpr g count
 
-                        // count < 1
-                        let countLtOne =
-                            if isSignedIntegerTy g countTy then
-                                mkILAsmClt g m count (mkTypedOne g m countTy)
-                            else
-                                mkAsmExpr ([AI_clt_un], [], [count; mkTypedOne g m countTy], [g.bool_ty], m)
-
-                        // if count < 1 then
+                        // if count = 0 then
                         //     [||]
                         // else
                         //     let array = (# "newarr !0" type ('T) count : 'T array #) in
@@ -410,7 +403,7 @@ module Array =
                             DebugPointAtBinding.NoneAtInvisible
                             m
                             arrayTy
-                            countLtOne
+                            (mkILAsmCeq g m count (mkTypedZero g m countTy))
                             (mkArray (overallElemTy, [], m))
                             (mkArrayInit count mkLoop)
                     )

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputedCollections/ForNInRangeArrays.fs.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputedCollections/ForNInRangeArrays.fs.il.bsl
@@ -541,159 +541,7 @@
     IL_0015:  ldloc.0
     IL_0016:  stloc.1
     IL_0017:  ldloc.1
-    IL_0018:  ldc.i4.1
-    IL_0019:  conv.i8
-    IL_001a:  bge.un.s   IL_0022
-
-    IL_001c:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0021:  ret
-
-    IL_0022:  ldloc.1
-    IL_0023:  conv.ovf.i.un
-    IL_0024:  newarr     [runtime]System.Int32
-    IL_0029:  stloc.2
-    IL_002a:  ldc.i4.0
-    IL_002b:  conv.i8
-    IL_002c:  stloc.3
-    IL_002d:  ldarg.0
-    IL_002e:  stloc.s    V_4
-    IL_0030:  br.s       IL_0047
-
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.3
-    IL_0034:  conv.i
-    IL_0035:  ldloc.s    V_4
-    IL_0037:  stloc.s    V_5
-    IL_0039:  ldloc.s    V_5
-    IL_003b:  stelem.i4
-    IL_003c:  ldloc.s    V_4
-    IL_003e:  ldc.i4.1
-    IL_003f:  add
-    IL_0040:  stloc.s    V_4
-    IL_0042:  ldloc.3
-    IL_0043:  ldc.i4.1
-    IL_0044:  conv.i8
-    IL_0045:  add
-    IL_0046:  stloc.3
-    IL_0047:  ldloc.3
-    IL_0048:  ldloc.0
-    IL_0049:  blt.un.s   IL_0032
-
-    IL_004b:  ldloc.2
-    IL_004c:  ret
-  } 
-
-  .method public static int32[]  f10(int32 finish) cil managed
-  {
-    
-    .maxstack  5
-    .locals init (uint64 V_0,
-             uint64 V_1,
-             int32[] V_2,
-             uint64 V_3,
-             int32 V_4,
-             int32 V_5)
-    IL_0000:  nop
-    IL_0001:  ldarg.0
-    IL_0002:  ldc.i4.1
-    IL_0003:  bge.s      IL_000a
-
-    IL_0005:  ldc.i4.0
-    IL_0006:  conv.i8
-    IL_0007:  nop
-    IL_0008:  br.s       IL_0012
-
-    IL_000a:  ldarg.0
-    IL_000b:  ldc.i4.1
-    IL_000c:  sub
-    IL_000d:  conv.i8
-    IL_000e:  ldc.i4.1
-    IL_000f:  conv.i8
-    IL_0010:  add
-    IL_0011:  nop
-    IL_0012:  stloc.0
-    IL_0013:  ldloc.0
-    IL_0014:  stloc.1
-    IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
-
-    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_001f:  ret
-
-    IL_0020:  ldloc.1
-    IL_0021:  conv.ovf.i.un
-    IL_0022:  newarr     [runtime]System.Int32
-    IL_0027:  stloc.2
-    IL_0028:  ldc.i4.0
-    IL_0029:  conv.i8
-    IL_002a:  stloc.3
-    IL_002b:  ldc.i4.1
-    IL_002c:  stloc.s    V_4
-    IL_002e:  br.s       IL_0045
-
-    IL_0030:  ldloc.2
-    IL_0031:  ldloc.3
-    IL_0032:  conv.i
-    IL_0033:  ldloc.s    V_4
-    IL_0035:  stloc.s    V_5
-    IL_0037:  ldloc.s    V_5
-    IL_0039:  stelem.i4
-    IL_003a:  ldloc.s    V_4
-    IL_003c:  ldc.i4.1
-    IL_003d:  add
-    IL_003e:  stloc.s    V_4
-    IL_0040:  ldloc.3
-    IL_0041:  ldc.i4.1
-    IL_0042:  conv.i8
-    IL_0043:  add
-    IL_0044:  stloc.3
-    IL_0045:  ldloc.3
-    IL_0046:  ldloc.0
-    IL_0047:  blt.un.s   IL_0030
-
-    IL_0049:  ldloc.2
-    IL_004a:  ret
-  } 
-
-  .method public static int32[]  f11(int32 start,
-                                     int32 finish) cil managed
-  {
-    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
-    
-    .maxstack  5
-    .locals init (uint64 V_0,
-             uint64 V_1,
-             int32[] V_2,
-             uint64 V_3,
-             int32 V_4,
-             int32 V_5)
-    IL_0000:  nop
-    IL_0001:  ldarg.1
-    IL_0002:  ldarg.0
-    IL_0003:  bge.s      IL_000a
-
-    IL_0005:  ldc.i4.0
-    IL_0006:  conv.i8
-    IL_0007:  nop
-    IL_0008:  br.s       IL_0012
-
-    IL_000a:  ldarg.1
-    IL_000b:  ldarg.0
-    IL_000c:  sub
-    IL_000d:  conv.i8
-    IL_000e:  ldc.i4.1
-    IL_000f:  conv.i8
-    IL_0010:  add
-    IL_0011:  nop
-    IL_0012:  stloc.0
-    IL_0013:  ldloc.0
-    IL_0014:  stloc.1
-    IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
+    IL_0018:  brtrue.s   IL_0020
 
     IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
     IL_001f:  ret
@@ -733,6 +581,152 @@
     IL_004a:  ret
   } 
 
+  .method public static int32[]  f10(int32 finish) cil managed
+  {
+    
+    .maxstack  5
+    .locals init (uint64 V_0,
+             uint64 V_1,
+             int32[] V_2,
+             uint64 V_3,
+             int32 V_4,
+             int32 V_5)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldc.i4.1
+    IL_0003:  bge.s      IL_000a
+
+    IL_0005:  ldc.i4.0
+    IL_0006:  conv.i8
+    IL_0007:  nop
+    IL_0008:  br.s       IL_0012
+
+    IL_000a:  ldarg.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  sub
+    IL_000d:  conv.i8
+    IL_000e:  ldc.i4.1
+    IL_000f:  conv.i8
+    IL_0010:  add
+    IL_0011:  nop
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  stloc.1
+    IL_0015:  ldloc.1
+    IL_0016:  brtrue.s   IL_001e
+
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
+
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldc.i4.1
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_0043
+
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stloc.s    V_5
+    IL_0035:  ldloc.s    V_5
+    IL_0037:  stelem.i4
+    IL_0038:  ldloc.s    V_4
+    IL_003a:  ldc.i4.1
+    IL_003b:  add
+    IL_003c:  stloc.s    V_4
+    IL_003e:  ldloc.3
+    IL_003f:  ldc.i4.1
+    IL_0040:  conv.i8
+    IL_0041:  add
+    IL_0042:  stloc.3
+    IL_0043:  ldloc.3
+    IL_0044:  ldloc.0
+    IL_0045:  blt.un.s   IL_002e
+
+    IL_0047:  ldloc.2
+    IL_0048:  ret
+  } 
+
+  .method public static int32[]  f11(int32 start,
+                                     int32 finish) cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
+    
+    .maxstack  5
+    .locals init (uint64 V_0,
+             uint64 V_1,
+             int32[] V_2,
+             uint64 V_3,
+             int32 V_4,
+             int32 V_5)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  ldarg.0
+    IL_0003:  bge.s      IL_000a
+
+    IL_0005:  ldc.i4.0
+    IL_0006:  conv.i8
+    IL_0007:  nop
+    IL_0008:  br.s       IL_0012
+
+    IL_000a:  ldarg.1
+    IL_000b:  ldarg.0
+    IL_000c:  sub
+    IL_000d:  conv.i8
+    IL_000e:  ldc.i4.1
+    IL_000f:  conv.i8
+    IL_0010:  add
+    IL_0011:  nop
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  stloc.1
+    IL_0015:  ldloc.1
+    IL_0016:  brtrue.s   IL_001e
+
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
+
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldarg.0
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_0043
+
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stloc.s    V_5
+    IL_0035:  ldloc.s    V_5
+    IL_0037:  stelem.i4
+    IL_0038:  ldloc.s    V_4
+    IL_003a:  ldc.i4.1
+    IL_003b:  add
+    IL_003c:  stloc.s    V_4
+    IL_003e:  ldloc.3
+    IL_003f:  ldc.i4.1
+    IL_0040:  conv.i8
+    IL_0041:  add
+    IL_0042:  stloc.3
+    IL_0043:  ldloc.3
+    IL_0044:  ldloc.0
+    IL_0045:  blt.un.s   IL_002e
+
+    IL_0047:  ldloc.2
+    IL_0048:  ret
+  } 
+
   .method public static int32[]  f12(int32 start) cil managed
   {
     
@@ -765,46 +759,44 @@
     IL_0015:  ldloc.0
     IL_0016:  stloc.1
     IL_0017:  ldloc.1
-    IL_0018:  ldc.i4.1
-    IL_0019:  conv.i8
-    IL_001a:  bge.un.s   IL_0022
+    IL_0018:  brtrue.s   IL_0020
 
-    IL_001c:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0021:  ret
+    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001f:  ret
 
-    IL_0022:  ldloc.1
-    IL_0023:  conv.ovf.i.un
-    IL_0024:  newarr     [runtime]System.Int32
-    IL_0029:  stloc.2
-    IL_002a:  ldc.i4.0
-    IL_002b:  conv.i8
-    IL_002c:  stloc.3
-    IL_002d:  ldarg.0
-    IL_002e:  stloc.s    V_4
-    IL_0030:  br.s       IL_0047
+    IL_0020:  ldloc.1
+    IL_0021:  conv.ovf.i.un
+    IL_0022:  newarr     [runtime]System.Int32
+    IL_0027:  stloc.2
+    IL_0028:  ldc.i4.0
+    IL_0029:  conv.i8
+    IL_002a:  stloc.3
+    IL_002b:  ldarg.0
+    IL_002c:  stloc.s    V_4
+    IL_002e:  br.s       IL_0045
 
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.3
-    IL_0034:  conv.i
-    IL_0035:  ldloc.s    V_4
-    IL_0037:  stloc.s    V_5
-    IL_0039:  ldloc.s    V_5
-    IL_003b:  stelem.i4
-    IL_003c:  ldloc.s    V_4
-    IL_003e:  ldc.i4.1
-    IL_003f:  add
-    IL_0040:  stloc.s    V_4
-    IL_0042:  ldloc.3
-    IL_0043:  ldc.i4.1
-    IL_0044:  conv.i8
-    IL_0045:  add
-    IL_0046:  stloc.3
-    IL_0047:  ldloc.3
-    IL_0048:  ldloc.0
-    IL_0049:  blt.un.s   IL_0032
+    IL_0030:  ldloc.2
+    IL_0031:  ldloc.3
+    IL_0032:  conv.i
+    IL_0033:  ldloc.s    V_4
+    IL_0035:  stloc.s    V_5
+    IL_0037:  ldloc.s    V_5
+    IL_0039:  stelem.i4
+    IL_003a:  ldloc.s    V_4
+    IL_003c:  ldc.i4.1
+    IL_003d:  add
+    IL_003e:  stloc.s    V_4
+    IL_0040:  ldloc.3
+    IL_0041:  ldc.i4.1
+    IL_0042:  conv.i8
+    IL_0043:  add
+    IL_0044:  stloc.3
+    IL_0045:  ldloc.3
+    IL_0046:  ldloc.0
+    IL_0047:  blt.un.s   IL_0030
 
-    IL_004b:  ldloc.2
-    IL_004c:  ret
+    IL_0049:  ldloc.2
+    IL_004a:  ret
   } 
 
   .method public static int32[]  f13(int32 step) cil managed
@@ -883,46 +875,44 @@
     IL_0046:  ldloc.0
     IL_0047:  stloc.1
     IL_0048:  ldloc.1
-    IL_0049:  ldc.i4.1
-    IL_004a:  conv.i8
-    IL_004b:  bge.un.s   IL_0053
+    IL_0049:  brtrue.s   IL_0051
 
-    IL_004d:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0052:  ret
+    IL_004b:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0050:  ret
 
-    IL_0053:  ldloc.1
-    IL_0054:  conv.ovf.i.un
-    IL_0055:  newarr     [runtime]System.Int32
-    IL_005a:  stloc.2
-    IL_005b:  ldc.i4.0
-    IL_005c:  conv.i8
-    IL_005d:  stloc.3
-    IL_005e:  ldc.i4.1
-    IL_005f:  stloc.s    V_4
-    IL_0061:  br.s       IL_0078
+    IL_0051:  ldloc.1
+    IL_0052:  conv.ovf.i.un
+    IL_0053:  newarr     [runtime]System.Int32
+    IL_0058:  stloc.2
+    IL_0059:  ldc.i4.0
+    IL_005a:  conv.i8
+    IL_005b:  stloc.3
+    IL_005c:  ldc.i4.1
+    IL_005d:  stloc.s    V_4
+    IL_005f:  br.s       IL_0076
 
-    IL_0063:  ldloc.2
-    IL_0064:  ldloc.3
-    IL_0065:  conv.i
-    IL_0066:  ldloc.s    V_4
-    IL_0068:  stloc.s    V_5
-    IL_006a:  ldloc.s    V_5
-    IL_006c:  stelem.i4
-    IL_006d:  ldloc.s    V_4
-    IL_006f:  ldarg.0
-    IL_0070:  add
-    IL_0071:  stloc.s    V_4
-    IL_0073:  ldloc.3
-    IL_0074:  ldc.i4.1
-    IL_0075:  conv.i8
-    IL_0076:  add
-    IL_0077:  stloc.3
-    IL_0078:  ldloc.3
-    IL_0079:  ldloc.0
-    IL_007a:  blt.un.s   IL_0063
+    IL_0061:  ldloc.2
+    IL_0062:  ldloc.3
+    IL_0063:  conv.i
+    IL_0064:  ldloc.s    V_4
+    IL_0066:  stloc.s    V_5
+    IL_0068:  ldloc.s    V_5
+    IL_006a:  stelem.i4
+    IL_006b:  ldloc.s    V_4
+    IL_006d:  ldarg.0
+    IL_006e:  add
+    IL_006f:  stloc.s    V_4
+    IL_0071:  ldloc.3
+    IL_0072:  ldc.i4.1
+    IL_0073:  conv.i8
+    IL_0074:  add
+    IL_0075:  stloc.3
+    IL_0076:  ldloc.3
+    IL_0077:  ldloc.0
+    IL_0078:  blt.un.s   IL_0061
 
-    IL_007c:  ldloc.2
-    IL_007d:  ret
+    IL_007a:  ldloc.2
+    IL_007b:  ret
   } 
 
   .method public static int32[]  f14(int32 finish) cil managed
@@ -957,46 +947,44 @@
     IL_0013:  ldloc.0
     IL_0014:  stloc.1
     IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
+    IL_0016:  brtrue.s   IL_001e
 
-    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_001f:  ret
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
 
-    IL_0020:  ldloc.1
-    IL_0021:  conv.ovf.i.un
-    IL_0022:  newarr     [runtime]System.Int32
-    IL_0027:  stloc.2
-    IL_0028:  ldc.i4.0
-    IL_0029:  conv.i8
-    IL_002a:  stloc.3
-    IL_002b:  ldc.i4.1
-    IL_002c:  stloc.s    V_4
-    IL_002e:  br.s       IL_0045
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldc.i4.1
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_0043
 
-    IL_0030:  ldloc.2
-    IL_0031:  ldloc.3
-    IL_0032:  conv.i
-    IL_0033:  ldloc.s    V_4
-    IL_0035:  stloc.s    V_5
-    IL_0037:  ldloc.s    V_5
-    IL_0039:  stelem.i4
-    IL_003a:  ldloc.s    V_4
-    IL_003c:  ldc.i4.1
-    IL_003d:  add
-    IL_003e:  stloc.s    V_4
-    IL_0040:  ldloc.3
-    IL_0041:  ldc.i4.1
-    IL_0042:  conv.i8
-    IL_0043:  add
-    IL_0044:  stloc.3
-    IL_0045:  ldloc.3
-    IL_0046:  ldloc.0
-    IL_0047:  blt.un.s   IL_0030
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stloc.s    V_5
+    IL_0035:  ldloc.s    V_5
+    IL_0037:  stelem.i4
+    IL_0038:  ldloc.s    V_4
+    IL_003a:  ldc.i4.1
+    IL_003b:  add
+    IL_003c:  stloc.s    V_4
+    IL_003e:  ldloc.3
+    IL_003f:  ldc.i4.1
+    IL_0040:  conv.i8
+    IL_0041:  add
+    IL_0042:  stloc.3
+    IL_0043:  ldloc.3
+    IL_0044:  ldloc.0
+    IL_0045:  blt.un.s   IL_002e
 
-    IL_0049:  ldloc.2
-    IL_004a:  ret
+    IL_0047:  ldloc.2
+    IL_0048:  ret
   } 
 
   .method public static int32[]  f15(int32 start,
@@ -1077,46 +1065,44 @@
     IL_0046:  ldloc.0
     IL_0047:  stloc.1
     IL_0048:  ldloc.1
-    IL_0049:  ldc.i4.1
-    IL_004a:  conv.i8
-    IL_004b:  bge.un.s   IL_0053
+    IL_0049:  brtrue.s   IL_0051
 
-    IL_004d:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0052:  ret
+    IL_004b:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0050:  ret
 
-    IL_0053:  ldloc.1
-    IL_0054:  conv.ovf.i.un
-    IL_0055:  newarr     [runtime]System.Int32
-    IL_005a:  stloc.2
-    IL_005b:  ldc.i4.0
-    IL_005c:  conv.i8
-    IL_005d:  stloc.3
-    IL_005e:  ldarg.0
-    IL_005f:  stloc.s    V_4
-    IL_0061:  br.s       IL_0078
+    IL_0051:  ldloc.1
+    IL_0052:  conv.ovf.i.un
+    IL_0053:  newarr     [runtime]System.Int32
+    IL_0058:  stloc.2
+    IL_0059:  ldc.i4.0
+    IL_005a:  conv.i8
+    IL_005b:  stloc.3
+    IL_005c:  ldarg.0
+    IL_005d:  stloc.s    V_4
+    IL_005f:  br.s       IL_0076
 
-    IL_0063:  ldloc.2
-    IL_0064:  ldloc.3
-    IL_0065:  conv.i
-    IL_0066:  ldloc.s    V_4
-    IL_0068:  stloc.s    V_5
-    IL_006a:  ldloc.s    V_5
-    IL_006c:  stelem.i4
-    IL_006d:  ldloc.s    V_4
-    IL_006f:  ldarg.1
-    IL_0070:  add
-    IL_0071:  stloc.s    V_4
-    IL_0073:  ldloc.3
-    IL_0074:  ldc.i4.1
-    IL_0075:  conv.i8
-    IL_0076:  add
-    IL_0077:  stloc.3
-    IL_0078:  ldloc.3
-    IL_0079:  ldloc.0
-    IL_007a:  blt.un.s   IL_0063
+    IL_0061:  ldloc.2
+    IL_0062:  ldloc.3
+    IL_0063:  conv.i
+    IL_0064:  ldloc.s    V_4
+    IL_0066:  stloc.s    V_5
+    IL_0068:  ldloc.s    V_5
+    IL_006a:  stelem.i4
+    IL_006b:  ldloc.s    V_4
+    IL_006d:  ldarg.1
+    IL_006e:  add
+    IL_006f:  stloc.s    V_4
+    IL_0071:  ldloc.3
+    IL_0072:  ldc.i4.1
+    IL_0073:  conv.i8
+    IL_0074:  add
+    IL_0075:  stloc.3
+    IL_0076:  ldloc.3
+    IL_0077:  ldloc.0
+    IL_0078:  blt.un.s   IL_0061
 
-    IL_007c:  ldloc.2
-    IL_007d:  ret
+    IL_007a:  ldloc.2
+    IL_007b:  ret
   } 
 
   .method public static int32[]  f16(int32 start,
@@ -1153,46 +1139,44 @@
     IL_0013:  ldloc.0
     IL_0014:  stloc.1
     IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
+    IL_0016:  brtrue.s   IL_001e
 
-    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_001f:  ret
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
 
-    IL_0020:  ldloc.1
-    IL_0021:  conv.ovf.i.un
-    IL_0022:  newarr     [runtime]System.Int32
-    IL_0027:  stloc.2
-    IL_0028:  ldc.i4.0
-    IL_0029:  conv.i8
-    IL_002a:  stloc.3
-    IL_002b:  ldarg.0
-    IL_002c:  stloc.s    V_4
-    IL_002e:  br.s       IL_0045
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldarg.0
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_0043
 
-    IL_0030:  ldloc.2
-    IL_0031:  ldloc.3
-    IL_0032:  conv.i
-    IL_0033:  ldloc.s    V_4
-    IL_0035:  stloc.s    V_5
-    IL_0037:  ldloc.s    V_5
-    IL_0039:  stelem.i4
-    IL_003a:  ldloc.s    V_4
-    IL_003c:  ldc.i4.1
-    IL_003d:  add
-    IL_003e:  stloc.s    V_4
-    IL_0040:  ldloc.3
-    IL_0041:  ldc.i4.1
-    IL_0042:  conv.i8
-    IL_0043:  add
-    IL_0044:  stloc.3
-    IL_0045:  ldloc.3
-    IL_0046:  ldloc.0
-    IL_0047:  blt.un.s   IL_0030
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stloc.s    V_5
+    IL_0035:  ldloc.s    V_5
+    IL_0037:  stelem.i4
+    IL_0038:  ldloc.s    V_4
+    IL_003a:  ldc.i4.1
+    IL_003b:  add
+    IL_003c:  stloc.s    V_4
+    IL_003e:  ldloc.3
+    IL_003f:  ldc.i4.1
+    IL_0040:  conv.i8
+    IL_0041:  add
+    IL_0042:  stloc.3
+    IL_0043:  ldloc.3
+    IL_0044:  ldloc.0
+    IL_0045:  blt.un.s   IL_002e
 
-    IL_0049:  ldloc.2
-    IL_004a:  ret
+    IL_0047:  ldloc.2
+    IL_0048:  ret
   } 
 
   .method public static int32[]  f17(int32 step,
@@ -1273,46 +1257,44 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     [runtime]System.Int32
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldc.i4.1
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_0073
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     [runtime]System.Int32
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldc.i4.1
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_0071
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stloc.s    V_5
-    IL_0065:  ldloc.s    V_5
-    IL_0067:  stelem.i4
-    IL_0068:  ldloc.s    V_4
-    IL_006a:  ldarg.0
-    IL_006b:  add
-    IL_006c:  stloc.s    V_4
-    IL_006e:  ldloc.3
-    IL_006f:  ldc.i4.1
-    IL_0070:  conv.i8
-    IL_0071:  add
-    IL_0072:  stloc.3
-    IL_0073:  ldloc.3
-    IL_0074:  ldloc.0
-    IL_0075:  blt.un.s   IL_005e
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stloc.s    V_5
+    IL_0063:  ldloc.s    V_5
+    IL_0065:  stelem.i4
+    IL_0066:  ldloc.s    V_4
+    IL_0068:  ldarg.0
+    IL_0069:  add
+    IL_006a:  stloc.s    V_4
+    IL_006c:  ldloc.3
+    IL_006d:  ldc.i4.1
+    IL_006e:  conv.i8
+    IL_006f:  add
+    IL_0070:  stloc.3
+    IL_0071:  ldloc.3
+    IL_0072:  ldloc.0
+    IL_0073:  blt.un.s   IL_005c
 
-    IL_0077:  ldloc.2
-    IL_0078:  ret
+    IL_0075:  ldloc.2
+    IL_0076:  ret
   } 
 
   .method public static int32[]  f18(int32 start,
@@ -1395,46 +1377,44 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     [runtime]System.Int32
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldarg.0
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_0073
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     [runtime]System.Int32
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_0071
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stloc.s    V_5
-    IL_0065:  ldloc.s    V_5
-    IL_0067:  stelem.i4
-    IL_0068:  ldloc.s    V_4
-    IL_006a:  ldarg.1
-    IL_006b:  add
-    IL_006c:  stloc.s    V_4
-    IL_006e:  ldloc.3
-    IL_006f:  ldc.i4.1
-    IL_0070:  conv.i8
-    IL_0071:  add
-    IL_0072:  stloc.3
-    IL_0073:  ldloc.3
-    IL_0074:  ldloc.0
-    IL_0075:  blt.un.s   IL_005e
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stloc.s    V_5
+    IL_0063:  ldloc.s    V_5
+    IL_0065:  stelem.i4
+    IL_0066:  ldloc.s    V_4
+    IL_0068:  ldarg.1
+    IL_0069:  add
+    IL_006a:  stloc.s    V_4
+    IL_006c:  ldloc.3
+    IL_006d:  ldc.i4.1
+    IL_006e:  conv.i8
+    IL_006f:  add
+    IL_0070:  stloc.3
+    IL_0071:  ldloc.3
+    IL_0072:  ldloc.0
+    IL_0073:  blt.un.s   IL_005c
 
-    IL_0077:  ldloc.2
-    IL_0078:  ret
+    IL_0075:  ldloc.2
+    IL_0076:  ret
   } 
 
   .method public static int32[]  f19(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1473,46 +1453,44 @@
     IL_001c:  ldloc.1
     IL_001d:  stloc.2
     IL_001e:  ldloc.2
-    IL_001f:  ldc.i4.1
-    IL_0020:  conv.i8
-    IL_0021:  bge.un.s   IL_0029
+    IL_001f:  brtrue.s   IL_0027
 
-    IL_0023:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0028:  ret
+    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0026:  ret
 
-    IL_0029:  ldloc.2
-    IL_002a:  conv.ovf.i.un
-    IL_002b:  newarr     [runtime]System.Int32
-    IL_0030:  stloc.3
-    IL_0031:  ldc.i4.0
-    IL_0032:  conv.i8
-    IL_0033:  stloc.s    V_4
-    IL_0035:  ldloc.0
-    IL_0036:  stloc.s    V_5
-    IL_0038:  br.s       IL_0052
+    IL_0027:  ldloc.2
+    IL_0028:  conv.ovf.i.un
+    IL_0029:  newarr     [runtime]System.Int32
+    IL_002e:  stloc.3
+    IL_002f:  ldc.i4.0
+    IL_0030:  conv.i8
+    IL_0031:  stloc.s    V_4
+    IL_0033:  ldloc.0
+    IL_0034:  stloc.s    V_5
+    IL_0036:  br.s       IL_0050
 
-    IL_003a:  ldloc.3
-    IL_003b:  ldloc.s    V_4
-    IL_003d:  conv.i
-    IL_003e:  ldloc.s    V_5
-    IL_0040:  stloc.s    V_6
-    IL_0042:  ldloc.s    V_6
-    IL_0044:  stelem.i4
-    IL_0045:  ldloc.s    V_5
-    IL_0047:  ldc.i4.1
-    IL_0048:  add
-    IL_0049:  stloc.s    V_5
-    IL_004b:  ldloc.s    V_4
-    IL_004d:  ldc.i4.1
-    IL_004e:  conv.i8
-    IL_004f:  add
-    IL_0050:  stloc.s    V_4
-    IL_0052:  ldloc.s    V_4
-    IL_0054:  ldloc.1
-    IL_0055:  blt.un.s   IL_003a
+    IL_0038:  ldloc.3
+    IL_0039:  ldloc.s    V_4
+    IL_003b:  conv.i
+    IL_003c:  ldloc.s    V_5
+    IL_003e:  stloc.s    V_6
+    IL_0040:  ldloc.s    V_6
+    IL_0042:  stelem.i4
+    IL_0043:  ldloc.s    V_5
+    IL_0045:  ldc.i4.1
+    IL_0046:  add
+    IL_0047:  stloc.s    V_5
+    IL_0049:  ldloc.s    V_4
+    IL_004b:  ldc.i4.1
+    IL_004c:  conv.i8
+    IL_004d:  add
+    IL_004e:  stloc.s    V_4
+    IL_0050:  ldloc.s    V_4
+    IL_0052:  ldloc.1
+    IL_0053:  blt.un.s   IL_0038
 
-    IL_0057:  ldloc.3
-    IL_0058:  ret
+    IL_0055:  ldloc.3
+    IL_0056:  ret
   } 
 
   .method public static int32[]  f20(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1551,46 +1529,44 @@
     IL_001a:  ldloc.1
     IL_001b:  stloc.2
     IL_001c:  ldloc.2
-    IL_001d:  ldc.i4.1
-    IL_001e:  conv.i8
-    IL_001f:  bge.un.s   IL_0027
+    IL_001d:  brtrue.s   IL_0025
 
-    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0026:  ret
+    IL_001f:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0024:  ret
 
-    IL_0027:  ldloc.2
-    IL_0028:  conv.ovf.i.un
-    IL_0029:  newarr     [runtime]System.Int32
-    IL_002e:  stloc.3
-    IL_002f:  ldc.i4.0
-    IL_0030:  conv.i8
-    IL_0031:  stloc.s    V_4
-    IL_0033:  ldc.i4.1
-    IL_0034:  stloc.s    V_5
-    IL_0036:  br.s       IL_0050
+    IL_0025:  ldloc.2
+    IL_0026:  conv.ovf.i.un
+    IL_0027:  newarr     [runtime]System.Int32
+    IL_002c:  stloc.3
+    IL_002d:  ldc.i4.0
+    IL_002e:  conv.i8
+    IL_002f:  stloc.s    V_4
+    IL_0031:  ldc.i4.1
+    IL_0032:  stloc.s    V_5
+    IL_0034:  br.s       IL_004e
 
-    IL_0038:  ldloc.3
-    IL_0039:  ldloc.s    V_4
-    IL_003b:  conv.i
-    IL_003c:  ldloc.s    V_5
-    IL_003e:  stloc.s    V_6
-    IL_0040:  ldloc.s    V_6
-    IL_0042:  stelem.i4
-    IL_0043:  ldloc.s    V_5
-    IL_0045:  ldc.i4.1
-    IL_0046:  add
-    IL_0047:  stloc.s    V_5
-    IL_0049:  ldloc.s    V_4
-    IL_004b:  ldc.i4.1
-    IL_004c:  conv.i8
-    IL_004d:  add
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloc.s    V_4
-    IL_0052:  ldloc.1
-    IL_0053:  blt.un.s   IL_0038
+    IL_0036:  ldloc.3
+    IL_0037:  ldloc.s    V_4
+    IL_0039:  conv.i
+    IL_003a:  ldloc.s    V_5
+    IL_003c:  stloc.s    V_6
+    IL_003e:  ldloc.s    V_6
+    IL_0040:  stelem.i4
+    IL_0041:  ldloc.s    V_5
+    IL_0043:  ldc.i4.1
+    IL_0044:  add
+    IL_0045:  stloc.s    V_5
+    IL_0047:  ldloc.s    V_4
+    IL_0049:  ldc.i4.1
+    IL_004a:  conv.i8
+    IL_004b:  add
+    IL_004c:  stloc.s    V_4
+    IL_004e:  ldloc.s    V_4
+    IL_0050:  ldloc.1
+    IL_0051:  blt.un.s   IL_0036
 
-    IL_0055:  ldloc.3
-    IL_0056:  ret
+    IL_0053:  ldloc.3
+    IL_0054:  ret
   } 
 
   .method public static int32[]  f21(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f,
@@ -1636,46 +1612,44 @@
     IL_0022:  ldloc.2
     IL_0023:  stloc.3
     IL_0024:  ldloc.3
-    IL_0025:  ldc.i4.1
-    IL_0026:  conv.i8
-    IL_0027:  bge.un.s   IL_002f
+    IL_0025:  brtrue.s   IL_002d
 
-    IL_0029:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_002e:  ret
+    IL_0027:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_002c:  ret
 
-    IL_002f:  ldloc.3
-    IL_0030:  conv.ovf.i.un
-    IL_0031:  newarr     [runtime]System.Int32
-    IL_0036:  stloc.s    V_4
-    IL_0038:  ldc.i4.0
-    IL_0039:  conv.i8
-    IL_003a:  stloc.s    V_5
-    IL_003c:  ldloc.0
-    IL_003d:  stloc.s    V_6
-    IL_003f:  br.s       IL_005a
+    IL_002d:  ldloc.3
+    IL_002e:  conv.ovf.i.un
+    IL_002f:  newarr     [runtime]System.Int32
+    IL_0034:  stloc.s    V_4
+    IL_0036:  ldc.i4.0
+    IL_0037:  conv.i8
+    IL_0038:  stloc.s    V_5
+    IL_003a:  ldloc.0
+    IL_003b:  stloc.s    V_6
+    IL_003d:  br.s       IL_0058
 
-    IL_0041:  ldloc.s    V_4
-    IL_0043:  ldloc.s    V_5
-    IL_0045:  conv.i
-    IL_0046:  ldloc.s    V_6
-    IL_0048:  stloc.s    V_7
-    IL_004a:  ldloc.s    V_7
-    IL_004c:  stelem.i4
-    IL_004d:  ldloc.s    V_6
-    IL_004f:  ldc.i4.1
-    IL_0050:  add
-    IL_0051:  stloc.s    V_6
-    IL_0053:  ldloc.s    V_5
-    IL_0055:  ldc.i4.1
-    IL_0056:  conv.i8
-    IL_0057:  add
-    IL_0058:  stloc.s    V_5
-    IL_005a:  ldloc.s    V_5
-    IL_005c:  ldloc.2
-    IL_005d:  blt.un.s   IL_0041
+    IL_003f:  ldloc.s    V_4
+    IL_0041:  ldloc.s    V_5
+    IL_0043:  conv.i
+    IL_0044:  ldloc.s    V_6
+    IL_0046:  stloc.s    V_7
+    IL_0048:  ldloc.s    V_7
+    IL_004a:  stelem.i4
+    IL_004b:  ldloc.s    V_6
+    IL_004d:  ldc.i4.1
+    IL_004e:  add
+    IL_004f:  stloc.s    V_6
+    IL_0051:  ldloc.s    V_5
+    IL_0053:  ldc.i4.1
+    IL_0054:  conv.i8
+    IL_0055:  add
+    IL_0056:  stloc.s    V_5
+    IL_0058:  ldloc.s    V_5
+    IL_005a:  ldloc.2
+    IL_005b:  blt.un.s   IL_003f
 
-    IL_005f:  ldloc.s    V_4
-    IL_0061:  ret
+    IL_005d:  ldloc.s    V_4
+    IL_005f:  ret
   } 
 
   .method public static int32[]  f22(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1714,46 +1688,44 @@
     IL_001c:  ldloc.1
     IL_001d:  stloc.2
     IL_001e:  ldloc.2
-    IL_001f:  ldc.i4.1
-    IL_0020:  conv.i8
-    IL_0021:  bge.un.s   IL_0029
+    IL_001f:  brtrue.s   IL_0027
 
-    IL_0023:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0028:  ret
+    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0026:  ret
 
-    IL_0029:  ldloc.2
-    IL_002a:  conv.ovf.i.un
-    IL_002b:  newarr     [runtime]System.Int32
-    IL_0030:  stloc.3
-    IL_0031:  ldc.i4.0
-    IL_0032:  conv.i8
-    IL_0033:  stloc.s    V_4
-    IL_0035:  ldloc.0
-    IL_0036:  stloc.s    V_5
-    IL_0038:  br.s       IL_0052
+    IL_0027:  ldloc.2
+    IL_0028:  conv.ovf.i.un
+    IL_0029:  newarr     [runtime]System.Int32
+    IL_002e:  stloc.3
+    IL_002f:  ldc.i4.0
+    IL_0030:  conv.i8
+    IL_0031:  stloc.s    V_4
+    IL_0033:  ldloc.0
+    IL_0034:  stloc.s    V_5
+    IL_0036:  br.s       IL_0050
 
-    IL_003a:  ldloc.3
-    IL_003b:  ldloc.s    V_4
-    IL_003d:  conv.i
-    IL_003e:  ldloc.s    V_5
-    IL_0040:  stloc.s    V_6
-    IL_0042:  ldloc.s    V_6
-    IL_0044:  stelem.i4
-    IL_0045:  ldloc.s    V_5
-    IL_0047:  ldc.i4.1
-    IL_0048:  add
-    IL_0049:  stloc.s    V_5
-    IL_004b:  ldloc.s    V_4
-    IL_004d:  ldc.i4.1
-    IL_004e:  conv.i8
-    IL_004f:  add
-    IL_0050:  stloc.s    V_4
-    IL_0052:  ldloc.s    V_4
-    IL_0054:  ldloc.1
-    IL_0055:  blt.un.s   IL_003a
+    IL_0038:  ldloc.3
+    IL_0039:  ldloc.s    V_4
+    IL_003b:  conv.i
+    IL_003c:  ldloc.s    V_5
+    IL_003e:  stloc.s    V_6
+    IL_0040:  ldloc.s    V_6
+    IL_0042:  stelem.i4
+    IL_0043:  ldloc.s    V_5
+    IL_0045:  ldc.i4.1
+    IL_0046:  add
+    IL_0047:  stloc.s    V_5
+    IL_0049:  ldloc.s    V_4
+    IL_004b:  ldc.i4.1
+    IL_004c:  conv.i8
+    IL_004d:  add
+    IL_004e:  stloc.s    V_4
+    IL_0050:  ldloc.s    V_4
+    IL_0052:  ldloc.1
+    IL_0053:  blt.un.s   IL_0038
 
-    IL_0057:  ldloc.3
-    IL_0058:  ret
+    IL_0055:  ldloc.3
+    IL_0056:  ret
   } 
 
   .method public static int32[]  f23(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1836,46 +1808,44 @@
     IL_004d:  ldloc.1
     IL_004e:  stloc.2
     IL_004f:  ldloc.2
-    IL_0050:  ldc.i4.1
-    IL_0051:  conv.i8
-    IL_0052:  bge.un.s   IL_005a
+    IL_0050:  brtrue.s   IL_0058
 
-    IL_0054:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0059:  ret
+    IL_0052:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0057:  ret
 
-    IL_005a:  ldloc.2
-    IL_005b:  conv.ovf.i.un
-    IL_005c:  newarr     [runtime]System.Int32
-    IL_0061:  stloc.3
-    IL_0062:  ldc.i4.0
-    IL_0063:  conv.i8
-    IL_0064:  stloc.s    V_4
-    IL_0066:  ldc.i4.1
-    IL_0067:  stloc.s    V_5
-    IL_0069:  br.s       IL_0083
+    IL_0058:  ldloc.2
+    IL_0059:  conv.ovf.i.un
+    IL_005a:  newarr     [runtime]System.Int32
+    IL_005f:  stloc.3
+    IL_0060:  ldc.i4.0
+    IL_0061:  conv.i8
+    IL_0062:  stloc.s    V_4
+    IL_0064:  ldc.i4.1
+    IL_0065:  stloc.s    V_5
+    IL_0067:  br.s       IL_0081
 
-    IL_006b:  ldloc.3
-    IL_006c:  ldloc.s    V_4
-    IL_006e:  conv.i
-    IL_006f:  ldloc.s    V_5
-    IL_0071:  stloc.s    V_6
-    IL_0073:  ldloc.s    V_6
-    IL_0075:  stelem.i4
-    IL_0076:  ldloc.s    V_5
-    IL_0078:  ldloc.0
-    IL_0079:  add
-    IL_007a:  stloc.s    V_5
-    IL_007c:  ldloc.s    V_4
-    IL_007e:  ldc.i4.1
-    IL_007f:  conv.i8
-    IL_0080:  add
-    IL_0081:  stloc.s    V_4
-    IL_0083:  ldloc.s    V_4
-    IL_0085:  ldloc.1
-    IL_0086:  blt.un.s   IL_006b
+    IL_0069:  ldloc.3
+    IL_006a:  ldloc.s    V_4
+    IL_006c:  conv.i
+    IL_006d:  ldloc.s    V_5
+    IL_006f:  stloc.s    V_6
+    IL_0071:  ldloc.s    V_6
+    IL_0073:  stelem.i4
+    IL_0074:  ldloc.s    V_5
+    IL_0076:  ldloc.0
+    IL_0077:  add
+    IL_0078:  stloc.s    V_5
+    IL_007a:  ldloc.s    V_4
+    IL_007c:  ldc.i4.1
+    IL_007d:  conv.i8
+    IL_007e:  add
+    IL_007f:  stloc.s    V_4
+    IL_0081:  ldloc.s    V_4
+    IL_0083:  ldloc.1
+    IL_0084:  blt.un.s   IL_0069
 
-    IL_0088:  ldloc.3
-    IL_0089:  ret
+    IL_0086:  ldloc.3
+    IL_0087:  ret
   } 
 
   .method public static int32[]  f24(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1914,46 +1884,44 @@
     IL_001a:  ldloc.1
     IL_001b:  stloc.2
     IL_001c:  ldloc.2
-    IL_001d:  ldc.i4.1
-    IL_001e:  conv.i8
-    IL_001f:  bge.un.s   IL_0027
+    IL_001d:  brtrue.s   IL_0025
 
-    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0026:  ret
+    IL_001f:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0024:  ret
 
-    IL_0027:  ldloc.2
-    IL_0028:  conv.ovf.i.un
-    IL_0029:  newarr     [runtime]System.Int32
-    IL_002e:  stloc.3
-    IL_002f:  ldc.i4.0
-    IL_0030:  conv.i8
-    IL_0031:  stloc.s    V_4
-    IL_0033:  ldc.i4.1
-    IL_0034:  stloc.s    V_5
-    IL_0036:  br.s       IL_0050
+    IL_0025:  ldloc.2
+    IL_0026:  conv.ovf.i.un
+    IL_0027:  newarr     [runtime]System.Int32
+    IL_002c:  stloc.3
+    IL_002d:  ldc.i4.0
+    IL_002e:  conv.i8
+    IL_002f:  stloc.s    V_4
+    IL_0031:  ldc.i4.1
+    IL_0032:  stloc.s    V_5
+    IL_0034:  br.s       IL_004e
 
-    IL_0038:  ldloc.3
-    IL_0039:  ldloc.s    V_4
-    IL_003b:  conv.i
-    IL_003c:  ldloc.s    V_5
-    IL_003e:  stloc.s    V_6
-    IL_0040:  ldloc.s    V_6
-    IL_0042:  stelem.i4
-    IL_0043:  ldloc.s    V_5
-    IL_0045:  ldc.i4.1
-    IL_0046:  add
-    IL_0047:  stloc.s    V_5
-    IL_0049:  ldloc.s    V_4
-    IL_004b:  ldc.i4.1
-    IL_004c:  conv.i8
-    IL_004d:  add
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloc.s    V_4
-    IL_0052:  ldloc.1
-    IL_0053:  blt.un.s   IL_0038
+    IL_0036:  ldloc.3
+    IL_0037:  ldloc.s    V_4
+    IL_0039:  conv.i
+    IL_003a:  ldloc.s    V_5
+    IL_003c:  stloc.s    V_6
+    IL_003e:  ldloc.s    V_6
+    IL_0040:  stelem.i4
+    IL_0041:  ldloc.s    V_5
+    IL_0043:  ldc.i4.1
+    IL_0044:  add
+    IL_0045:  stloc.s    V_5
+    IL_0047:  ldloc.s    V_4
+    IL_0049:  ldc.i4.1
+    IL_004a:  conv.i8
+    IL_004b:  add
+    IL_004c:  stloc.s    V_4
+    IL_004e:  ldloc.s    V_4
+    IL_0050:  ldloc.1
+    IL_0051:  blt.un.s   IL_0036
 
-    IL_0055:  ldloc.3
-    IL_0056:  ret
+    IL_0053:  ldloc.3
+    IL_0054:  ret
   } 
 
   .method public static int32[]  f25(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f,
@@ -2050,46 +2018,44 @@
     IL_0058:  ldloc.3
     IL_0059:  stloc.s    V_4
     IL_005b:  ldloc.s    V_4
-    IL_005d:  ldc.i4.1
-    IL_005e:  conv.i8
-    IL_005f:  bge.un.s   IL_0067
+    IL_005d:  brtrue.s   IL_0065
 
-    IL_0061:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0066:  ret
+    IL_005f:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0064:  ret
 
-    IL_0067:  ldloc.s    V_4
-    IL_0069:  conv.ovf.i.un
-    IL_006a:  newarr     [runtime]System.Int32
-    IL_006f:  stloc.s    V_5
-    IL_0071:  ldc.i4.0
-    IL_0072:  conv.i8
-    IL_0073:  stloc.s    V_6
-    IL_0075:  ldloc.0
-    IL_0076:  stloc.s    V_7
-    IL_0078:  br.s       IL_0093
+    IL_0065:  ldloc.s    V_4
+    IL_0067:  conv.ovf.i.un
+    IL_0068:  newarr     [runtime]System.Int32
+    IL_006d:  stloc.s    V_5
+    IL_006f:  ldc.i4.0
+    IL_0070:  conv.i8
+    IL_0071:  stloc.s    V_6
+    IL_0073:  ldloc.0
+    IL_0074:  stloc.s    V_7
+    IL_0076:  br.s       IL_0091
 
-    IL_007a:  ldloc.s    V_5
-    IL_007c:  ldloc.s    V_6
-    IL_007e:  conv.i
-    IL_007f:  ldloc.s    V_7
-    IL_0081:  stloc.s    V_8
-    IL_0083:  ldloc.s    V_8
-    IL_0085:  stelem.i4
-    IL_0086:  ldloc.s    V_7
-    IL_0088:  ldloc.1
-    IL_0089:  add
-    IL_008a:  stloc.s    V_7
-    IL_008c:  ldloc.s    V_6
-    IL_008e:  ldc.i4.1
-    IL_008f:  conv.i8
-    IL_0090:  add
-    IL_0091:  stloc.s    V_6
-    IL_0093:  ldloc.s    V_6
-    IL_0095:  ldloc.3
-    IL_0096:  blt.un.s   IL_007a
+    IL_0078:  ldloc.s    V_5
+    IL_007a:  ldloc.s    V_6
+    IL_007c:  conv.i
+    IL_007d:  ldloc.s    V_7
+    IL_007f:  stloc.s    V_8
+    IL_0081:  ldloc.s    V_8
+    IL_0083:  stelem.i4
+    IL_0084:  ldloc.s    V_7
+    IL_0086:  ldloc.1
+    IL_0087:  add
+    IL_0088:  stloc.s    V_7
+    IL_008a:  ldloc.s    V_6
+    IL_008c:  ldc.i4.1
+    IL_008d:  conv.i8
+    IL_008e:  add
+    IL_008f:  stloc.s    V_6
+    IL_0091:  ldloc.s    V_6
+    IL_0093:  ldloc.3
+    IL_0094:  blt.un.s   IL_0078
 
-    IL_0098:  ldloc.s    V_5
-    IL_009a:  ret
+    IL_0096:  ldloc.s    V_5
+    IL_0098:  ret
   } 
 
   .method public static class [runtime]System.Tuple`2<int32,float64>[] 
@@ -2173,50 +2139,48 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<class [runtime]System.Tuple`2<int32,float64>>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<class [runtime]System.Tuple`2<int32,float64>>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     class [runtime]System.Tuple`2<int32,float64>
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldarg.0
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_007f
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     class [runtime]System.Tuple`2<int32,float64>
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_007d
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stloc.s    V_5
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stloc.s    V_5
+    IL_0063:  ldloc.s    V_5
     IL_0065:  ldloc.s    V_5
-    IL_0067:  ldloc.s    V_5
-    IL_0069:  conv.r8
-    IL_006a:  newobj     instance void class [runtime]System.Tuple`2<int32,float64>::.ctor(!0,
+    IL_0067:  conv.r8
+    IL_0068:  newobj     instance void class [runtime]System.Tuple`2<int32,float64>::.ctor(!0,
                                                                                                   !1)
-    IL_006f:  stelem     class [runtime]System.Tuple`2<int32,float64>
-    IL_0074:  ldloc.s    V_4
-    IL_0076:  ldarg.1
-    IL_0077:  add
-    IL_0078:  stloc.s    V_4
-    IL_007a:  ldloc.3
-    IL_007b:  ldc.i4.1
-    IL_007c:  conv.i8
-    IL_007d:  add
-    IL_007e:  stloc.3
-    IL_007f:  ldloc.3
-    IL_0080:  ldloc.0
-    IL_0081:  blt.un.s   IL_005e
+    IL_006d:  stelem     class [runtime]System.Tuple`2<int32,float64>
+    IL_0072:  ldloc.s    V_4
+    IL_0074:  ldarg.1
+    IL_0075:  add
+    IL_0076:  stloc.s    V_4
+    IL_0078:  ldloc.3
+    IL_0079:  ldc.i4.1
+    IL_007a:  conv.i8
+    IL_007b:  add
+    IL_007c:  stloc.3
+    IL_007d:  ldloc.3
+    IL_007e:  ldloc.0
+    IL_007f:  blt.un.s   IL_005c
 
-    IL_0083:  ldloc.2
-    IL_0084:  ret
+    IL_0081:  ldloc.2
+    IL_0082:  ret
   } 
 
   .method public static valuetype [runtime]System.ValueTuple`2<int32,float64>[] 
@@ -2300,50 +2264,48 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<valuetype [runtime]System.ValueTuple`2<int32,float64>>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<valuetype [runtime]System.ValueTuple`2<int32,float64>>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     valuetype [runtime]System.ValueTuple`2<int32,float64>
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldarg.0
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_007f
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     valuetype [runtime]System.ValueTuple`2<int32,float64>
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_007d
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stloc.s    V_5
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stloc.s    V_5
+    IL_0063:  ldloc.s    V_5
     IL_0065:  ldloc.s    V_5
-    IL_0067:  ldloc.s    V_5
-    IL_0069:  conv.r8
-    IL_006a:  newobj     instance void valuetype [runtime]System.ValueTuple`2<int32,float64>::.ctor(!0,
+    IL_0067:  conv.r8
+    IL_0068:  newobj     instance void valuetype [runtime]System.ValueTuple`2<int32,float64>::.ctor(!0,
                                                                                                            !1)
-    IL_006f:  stelem     valuetype [runtime]System.ValueTuple`2<int32,float64>
-    IL_0074:  ldloc.s    V_4
-    IL_0076:  ldarg.1
-    IL_0077:  add
-    IL_0078:  stloc.s    V_4
-    IL_007a:  ldloc.3
-    IL_007b:  ldc.i4.1
-    IL_007c:  conv.i8
-    IL_007d:  add
-    IL_007e:  stloc.3
-    IL_007f:  ldloc.3
-    IL_0080:  ldloc.0
-    IL_0081:  blt.un.s   IL_005e
+    IL_006d:  stelem     valuetype [runtime]System.ValueTuple`2<int32,float64>
+    IL_0072:  ldloc.s    V_4
+    IL_0074:  ldarg.1
+    IL_0075:  add
+    IL_0076:  stloc.s    V_4
+    IL_0078:  ldloc.3
+    IL_0079:  ldc.i4.1
+    IL_007a:  conv.i8
+    IL_007b:  add
+    IL_007c:  stloc.3
+    IL_007d:  ldloc.3
+    IL_007e:  ldloc.0
+    IL_007f:  blt.un.s   IL_005c
 
-    IL_0083:  ldloc.2
-    IL_0084:  ret
+    IL_0081:  ldloc.2
+    IL_0082:  ret
   } 
 
   .method public static int32[]  f28(int32 start,
@@ -2426,49 +2388,47 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     [runtime]System.Int32
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldarg.0
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_0077
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     [runtime]System.Int32
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_0075
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stloc.s    V_5
-    IL_0065:  nop
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stloc.s    V_5
+    IL_0063:  nop
+    IL_0064:  ldloc.s    V_5
     IL_0066:  ldloc.s    V_5
-    IL_0068:  ldloc.s    V_5
-    IL_006a:  mul
-    IL_006b:  stelem.i4
-    IL_006c:  ldloc.s    V_4
-    IL_006e:  ldarg.1
-    IL_006f:  add
-    IL_0070:  stloc.s    V_4
-    IL_0072:  ldloc.3
-    IL_0073:  ldc.i4.1
-    IL_0074:  conv.i8
-    IL_0075:  add
-    IL_0076:  stloc.3
-    IL_0077:  ldloc.3
-    IL_0078:  ldloc.0
-    IL_0079:  blt.un.s   IL_005e
+    IL_0068:  mul
+    IL_0069:  stelem.i4
+    IL_006a:  ldloc.s    V_4
+    IL_006c:  ldarg.1
+    IL_006d:  add
+    IL_006e:  stloc.s    V_4
+    IL_0070:  ldloc.3
+    IL_0071:  ldc.i4.1
+    IL_0072:  conv.i8
+    IL_0073:  add
+    IL_0074:  stloc.3
+    IL_0075:  ldloc.3
+    IL_0076:  ldloc.0
+    IL_0077:  blt.un.s   IL_005c
 
-    IL_007b:  ldloc.2
-    IL_007c:  ret
+    IL_0079:  ldloc.2
+    IL_007a:  ret
   } 
 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputedCollections/Int32RangeArrays.fs.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputedCollections/Int32RangeArrays.fs.il.bsl
@@ -308,153 +308,7 @@
     IL_0015:  ldloc.0
     IL_0016:  stloc.1
     IL_0017:  ldloc.1
-    IL_0018:  ldc.i4.1
-    IL_0019:  conv.i8
-    IL_001a:  bge.un.s   IL_0022
-
-    IL_001c:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0021:  ret
-
-    IL_0022:  ldloc.1
-    IL_0023:  conv.ovf.i.un
-    IL_0024:  newarr     [runtime]System.Int32
-    IL_0029:  stloc.2
-    IL_002a:  ldc.i4.0
-    IL_002b:  conv.i8
-    IL_002c:  stloc.3
-    IL_002d:  ldarg.0
-    IL_002e:  stloc.s    V_4
-    IL_0030:  br.s       IL_0043
-
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.3
-    IL_0034:  conv.i
-    IL_0035:  ldloc.s    V_4
-    IL_0037:  stelem.i4
-    IL_0038:  ldloc.s    V_4
-    IL_003a:  ldc.i4.1
-    IL_003b:  add
-    IL_003c:  stloc.s    V_4
-    IL_003e:  ldloc.3
-    IL_003f:  ldc.i4.1
-    IL_0040:  conv.i8
-    IL_0041:  add
-    IL_0042:  stloc.3
-    IL_0043:  ldloc.3
-    IL_0044:  ldloc.0
-    IL_0045:  blt.un.s   IL_0032
-
-    IL_0047:  ldloc.2
-    IL_0048:  ret
-  } 
-
-  .method public static int32[]  f10(int32 finish) cil managed
-  {
-    
-    .maxstack  5
-    .locals init (uint64 V_0,
-             uint64 V_1,
-             int32[] V_2,
-             uint64 V_3,
-             int32 V_4)
-    IL_0000:  nop
-    IL_0001:  ldarg.0
-    IL_0002:  ldc.i4.1
-    IL_0003:  bge.s      IL_000a
-
-    IL_0005:  ldc.i4.0
-    IL_0006:  conv.i8
-    IL_0007:  nop
-    IL_0008:  br.s       IL_0012
-
-    IL_000a:  ldarg.0
-    IL_000b:  ldc.i4.1
-    IL_000c:  sub
-    IL_000d:  conv.i8
-    IL_000e:  ldc.i4.1
-    IL_000f:  conv.i8
-    IL_0010:  add
-    IL_0011:  nop
-    IL_0012:  stloc.0
-    IL_0013:  ldloc.0
-    IL_0014:  stloc.1
-    IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
-
-    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_001f:  ret
-
-    IL_0020:  ldloc.1
-    IL_0021:  conv.ovf.i.un
-    IL_0022:  newarr     [runtime]System.Int32
-    IL_0027:  stloc.2
-    IL_0028:  ldc.i4.0
-    IL_0029:  conv.i8
-    IL_002a:  stloc.3
-    IL_002b:  ldc.i4.1
-    IL_002c:  stloc.s    V_4
-    IL_002e:  br.s       IL_0041
-
-    IL_0030:  ldloc.2
-    IL_0031:  ldloc.3
-    IL_0032:  conv.i
-    IL_0033:  ldloc.s    V_4
-    IL_0035:  stelem.i4
-    IL_0036:  ldloc.s    V_4
-    IL_0038:  ldc.i4.1
-    IL_0039:  add
-    IL_003a:  stloc.s    V_4
-    IL_003c:  ldloc.3
-    IL_003d:  ldc.i4.1
-    IL_003e:  conv.i8
-    IL_003f:  add
-    IL_0040:  stloc.3
-    IL_0041:  ldloc.3
-    IL_0042:  ldloc.0
-    IL_0043:  blt.un.s   IL_0030
-
-    IL_0045:  ldloc.2
-    IL_0046:  ret
-  } 
-
-  .method public static int32[]  f11(int32 start,
-                                     int32 finish) cil managed
-  {
-    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
-    
-    .maxstack  5
-    .locals init (uint64 V_0,
-             uint64 V_1,
-             int32[] V_2,
-             uint64 V_3,
-             int32 V_4)
-    IL_0000:  nop
-    IL_0001:  ldarg.1
-    IL_0002:  ldarg.0
-    IL_0003:  bge.s      IL_000a
-
-    IL_0005:  ldc.i4.0
-    IL_0006:  conv.i8
-    IL_0007:  nop
-    IL_0008:  br.s       IL_0012
-
-    IL_000a:  ldarg.1
-    IL_000b:  ldarg.0
-    IL_000c:  sub
-    IL_000d:  conv.i8
-    IL_000e:  ldc.i4.1
-    IL_000f:  conv.i8
-    IL_0010:  add
-    IL_0011:  nop
-    IL_0012:  stloc.0
-    IL_0013:  ldloc.0
-    IL_0014:  stloc.1
-    IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
+    IL_0018:  brtrue.s   IL_0020
 
     IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
     IL_001f:  ret
@@ -492,6 +346,146 @@
     IL_0046:  ret
   } 
 
+  .method public static int32[]  f10(int32 finish) cil managed
+  {
+    
+    .maxstack  5
+    .locals init (uint64 V_0,
+             uint64 V_1,
+             int32[] V_2,
+             uint64 V_3,
+             int32 V_4)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  ldc.i4.1
+    IL_0003:  bge.s      IL_000a
+
+    IL_0005:  ldc.i4.0
+    IL_0006:  conv.i8
+    IL_0007:  nop
+    IL_0008:  br.s       IL_0012
+
+    IL_000a:  ldarg.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  sub
+    IL_000d:  conv.i8
+    IL_000e:  ldc.i4.1
+    IL_000f:  conv.i8
+    IL_0010:  add
+    IL_0011:  nop
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  stloc.1
+    IL_0015:  ldloc.1
+    IL_0016:  brtrue.s   IL_001e
+
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
+
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldc.i4.1
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_003f
+
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stelem.i4
+    IL_0034:  ldloc.s    V_4
+    IL_0036:  ldc.i4.1
+    IL_0037:  add
+    IL_0038:  stloc.s    V_4
+    IL_003a:  ldloc.3
+    IL_003b:  ldc.i4.1
+    IL_003c:  conv.i8
+    IL_003d:  add
+    IL_003e:  stloc.3
+    IL_003f:  ldloc.3
+    IL_0040:  ldloc.0
+    IL_0041:  blt.un.s   IL_002e
+
+    IL_0043:  ldloc.2
+    IL_0044:  ret
+  } 
+
+  .method public static int32[]  f11(int32 start,
+                                     int32 finish) cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
+    
+    .maxstack  5
+    .locals init (uint64 V_0,
+             uint64 V_1,
+             int32[] V_2,
+             uint64 V_3,
+             int32 V_4)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  ldarg.0
+    IL_0003:  bge.s      IL_000a
+
+    IL_0005:  ldc.i4.0
+    IL_0006:  conv.i8
+    IL_0007:  nop
+    IL_0008:  br.s       IL_0012
+
+    IL_000a:  ldarg.1
+    IL_000b:  ldarg.0
+    IL_000c:  sub
+    IL_000d:  conv.i8
+    IL_000e:  ldc.i4.1
+    IL_000f:  conv.i8
+    IL_0010:  add
+    IL_0011:  nop
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  stloc.1
+    IL_0015:  ldloc.1
+    IL_0016:  brtrue.s   IL_001e
+
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
+
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldarg.0
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_003f
+
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stelem.i4
+    IL_0034:  ldloc.s    V_4
+    IL_0036:  ldc.i4.1
+    IL_0037:  add
+    IL_0038:  stloc.s    V_4
+    IL_003a:  ldloc.3
+    IL_003b:  ldc.i4.1
+    IL_003c:  conv.i8
+    IL_003d:  add
+    IL_003e:  stloc.3
+    IL_003f:  ldloc.3
+    IL_0040:  ldloc.0
+    IL_0041:  blt.un.s   IL_002e
+
+    IL_0043:  ldloc.2
+    IL_0044:  ret
+  } 
+
   .method public static int32[]  f12(int32 start) cil managed
   {
     
@@ -523,44 +517,42 @@
     IL_0015:  ldloc.0
     IL_0016:  stloc.1
     IL_0017:  ldloc.1
-    IL_0018:  ldc.i4.1
-    IL_0019:  conv.i8
-    IL_001a:  bge.un.s   IL_0022
+    IL_0018:  brtrue.s   IL_0020
 
-    IL_001c:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0021:  ret
+    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001f:  ret
 
-    IL_0022:  ldloc.1
-    IL_0023:  conv.ovf.i.un
-    IL_0024:  newarr     [runtime]System.Int32
-    IL_0029:  stloc.2
-    IL_002a:  ldc.i4.0
-    IL_002b:  conv.i8
-    IL_002c:  stloc.3
-    IL_002d:  ldarg.0
-    IL_002e:  stloc.s    V_4
-    IL_0030:  br.s       IL_0043
+    IL_0020:  ldloc.1
+    IL_0021:  conv.ovf.i.un
+    IL_0022:  newarr     [runtime]System.Int32
+    IL_0027:  stloc.2
+    IL_0028:  ldc.i4.0
+    IL_0029:  conv.i8
+    IL_002a:  stloc.3
+    IL_002b:  ldarg.0
+    IL_002c:  stloc.s    V_4
+    IL_002e:  br.s       IL_0041
 
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.3
-    IL_0034:  conv.i
-    IL_0035:  ldloc.s    V_4
-    IL_0037:  stelem.i4
-    IL_0038:  ldloc.s    V_4
-    IL_003a:  ldc.i4.1
-    IL_003b:  add
-    IL_003c:  stloc.s    V_4
-    IL_003e:  ldloc.3
-    IL_003f:  ldc.i4.1
-    IL_0040:  conv.i8
-    IL_0041:  add
-    IL_0042:  stloc.3
-    IL_0043:  ldloc.3
-    IL_0044:  ldloc.0
-    IL_0045:  blt.un.s   IL_0032
+    IL_0030:  ldloc.2
+    IL_0031:  ldloc.3
+    IL_0032:  conv.i
+    IL_0033:  ldloc.s    V_4
+    IL_0035:  stelem.i4
+    IL_0036:  ldloc.s    V_4
+    IL_0038:  ldc.i4.1
+    IL_0039:  add
+    IL_003a:  stloc.s    V_4
+    IL_003c:  ldloc.3
+    IL_003d:  ldc.i4.1
+    IL_003e:  conv.i8
+    IL_003f:  add
+    IL_0040:  stloc.3
+    IL_0041:  ldloc.3
+    IL_0042:  ldloc.0
+    IL_0043:  blt.un.s   IL_0030
 
-    IL_0047:  ldloc.2
-    IL_0048:  ret
+    IL_0045:  ldloc.2
+    IL_0046:  ret
   } 
 
   .method public static int32[]  f13(int32 step) cil managed
@@ -638,44 +630,42 @@
     IL_0046:  ldloc.0
     IL_0047:  stloc.1
     IL_0048:  ldloc.1
-    IL_0049:  ldc.i4.1
-    IL_004a:  conv.i8
-    IL_004b:  bge.un.s   IL_0053
+    IL_0049:  brtrue.s   IL_0051
 
-    IL_004d:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0052:  ret
+    IL_004b:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0050:  ret
 
-    IL_0053:  ldloc.1
-    IL_0054:  conv.ovf.i.un
-    IL_0055:  newarr     [runtime]System.Int32
-    IL_005a:  stloc.2
-    IL_005b:  ldc.i4.0
-    IL_005c:  conv.i8
-    IL_005d:  stloc.3
-    IL_005e:  ldc.i4.1
-    IL_005f:  stloc.s    V_4
-    IL_0061:  br.s       IL_0074
+    IL_0051:  ldloc.1
+    IL_0052:  conv.ovf.i.un
+    IL_0053:  newarr     [runtime]System.Int32
+    IL_0058:  stloc.2
+    IL_0059:  ldc.i4.0
+    IL_005a:  conv.i8
+    IL_005b:  stloc.3
+    IL_005c:  ldc.i4.1
+    IL_005d:  stloc.s    V_4
+    IL_005f:  br.s       IL_0072
 
-    IL_0063:  ldloc.2
-    IL_0064:  ldloc.3
-    IL_0065:  conv.i
-    IL_0066:  ldloc.s    V_4
-    IL_0068:  stelem.i4
-    IL_0069:  ldloc.s    V_4
-    IL_006b:  ldarg.0
-    IL_006c:  add
-    IL_006d:  stloc.s    V_4
-    IL_006f:  ldloc.3
-    IL_0070:  ldc.i4.1
-    IL_0071:  conv.i8
-    IL_0072:  add
-    IL_0073:  stloc.3
-    IL_0074:  ldloc.3
-    IL_0075:  ldloc.0
-    IL_0076:  blt.un.s   IL_0063
+    IL_0061:  ldloc.2
+    IL_0062:  ldloc.3
+    IL_0063:  conv.i
+    IL_0064:  ldloc.s    V_4
+    IL_0066:  stelem.i4
+    IL_0067:  ldloc.s    V_4
+    IL_0069:  ldarg.0
+    IL_006a:  add
+    IL_006b:  stloc.s    V_4
+    IL_006d:  ldloc.3
+    IL_006e:  ldc.i4.1
+    IL_006f:  conv.i8
+    IL_0070:  add
+    IL_0071:  stloc.3
+    IL_0072:  ldloc.3
+    IL_0073:  ldloc.0
+    IL_0074:  blt.un.s   IL_0061
 
-    IL_0078:  ldloc.2
-    IL_0079:  ret
+    IL_0076:  ldloc.2
+    IL_0077:  ret
   } 
 
   .method public static int32[]  f14(int32 finish) cil managed
@@ -709,44 +699,42 @@
     IL_0013:  ldloc.0
     IL_0014:  stloc.1
     IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
+    IL_0016:  brtrue.s   IL_001e
 
-    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_001f:  ret
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
 
-    IL_0020:  ldloc.1
-    IL_0021:  conv.ovf.i.un
-    IL_0022:  newarr     [runtime]System.Int32
-    IL_0027:  stloc.2
-    IL_0028:  ldc.i4.0
-    IL_0029:  conv.i8
-    IL_002a:  stloc.3
-    IL_002b:  ldc.i4.1
-    IL_002c:  stloc.s    V_4
-    IL_002e:  br.s       IL_0041
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldc.i4.1
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_003f
 
-    IL_0030:  ldloc.2
-    IL_0031:  ldloc.3
-    IL_0032:  conv.i
-    IL_0033:  ldloc.s    V_4
-    IL_0035:  stelem.i4
-    IL_0036:  ldloc.s    V_4
-    IL_0038:  ldc.i4.1
-    IL_0039:  add
-    IL_003a:  stloc.s    V_4
-    IL_003c:  ldloc.3
-    IL_003d:  ldc.i4.1
-    IL_003e:  conv.i8
-    IL_003f:  add
-    IL_0040:  stloc.3
-    IL_0041:  ldloc.3
-    IL_0042:  ldloc.0
-    IL_0043:  blt.un.s   IL_0030
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stelem.i4
+    IL_0034:  ldloc.s    V_4
+    IL_0036:  ldc.i4.1
+    IL_0037:  add
+    IL_0038:  stloc.s    V_4
+    IL_003a:  ldloc.3
+    IL_003b:  ldc.i4.1
+    IL_003c:  conv.i8
+    IL_003d:  add
+    IL_003e:  stloc.3
+    IL_003f:  ldloc.3
+    IL_0040:  ldloc.0
+    IL_0041:  blt.un.s   IL_002e
 
-    IL_0045:  ldloc.2
-    IL_0046:  ret
+    IL_0043:  ldloc.2
+    IL_0044:  ret
   } 
 
   .method public static int32[]  f15(int32 start,
@@ -826,44 +814,42 @@
     IL_0046:  ldloc.0
     IL_0047:  stloc.1
     IL_0048:  ldloc.1
-    IL_0049:  ldc.i4.1
-    IL_004a:  conv.i8
-    IL_004b:  bge.un.s   IL_0053
+    IL_0049:  brtrue.s   IL_0051
 
-    IL_004d:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0052:  ret
+    IL_004b:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0050:  ret
 
-    IL_0053:  ldloc.1
-    IL_0054:  conv.ovf.i.un
-    IL_0055:  newarr     [runtime]System.Int32
-    IL_005a:  stloc.2
-    IL_005b:  ldc.i4.0
-    IL_005c:  conv.i8
-    IL_005d:  stloc.3
-    IL_005e:  ldarg.0
-    IL_005f:  stloc.s    V_4
-    IL_0061:  br.s       IL_0074
+    IL_0051:  ldloc.1
+    IL_0052:  conv.ovf.i.un
+    IL_0053:  newarr     [runtime]System.Int32
+    IL_0058:  stloc.2
+    IL_0059:  ldc.i4.0
+    IL_005a:  conv.i8
+    IL_005b:  stloc.3
+    IL_005c:  ldarg.0
+    IL_005d:  stloc.s    V_4
+    IL_005f:  br.s       IL_0072
 
-    IL_0063:  ldloc.2
-    IL_0064:  ldloc.3
-    IL_0065:  conv.i
-    IL_0066:  ldloc.s    V_4
-    IL_0068:  stelem.i4
-    IL_0069:  ldloc.s    V_4
-    IL_006b:  ldarg.1
-    IL_006c:  add
-    IL_006d:  stloc.s    V_4
-    IL_006f:  ldloc.3
-    IL_0070:  ldc.i4.1
-    IL_0071:  conv.i8
-    IL_0072:  add
-    IL_0073:  stloc.3
-    IL_0074:  ldloc.3
-    IL_0075:  ldloc.0
-    IL_0076:  blt.un.s   IL_0063
+    IL_0061:  ldloc.2
+    IL_0062:  ldloc.3
+    IL_0063:  conv.i
+    IL_0064:  ldloc.s    V_4
+    IL_0066:  stelem.i4
+    IL_0067:  ldloc.s    V_4
+    IL_0069:  ldarg.1
+    IL_006a:  add
+    IL_006b:  stloc.s    V_4
+    IL_006d:  ldloc.3
+    IL_006e:  ldc.i4.1
+    IL_006f:  conv.i8
+    IL_0070:  add
+    IL_0071:  stloc.3
+    IL_0072:  ldloc.3
+    IL_0073:  ldloc.0
+    IL_0074:  blt.un.s   IL_0061
 
-    IL_0078:  ldloc.2
-    IL_0079:  ret
+    IL_0076:  ldloc.2
+    IL_0077:  ret
   } 
 
   .method public static int32[]  f16(int32 start,
@@ -899,44 +885,42 @@
     IL_0013:  ldloc.0
     IL_0014:  stloc.1
     IL_0015:  ldloc.1
-    IL_0016:  ldc.i4.1
-    IL_0017:  conv.i8
-    IL_0018:  bge.un.s   IL_0020
+    IL_0016:  brtrue.s   IL_001e
 
-    IL_001a:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_001f:  ret
+    IL_0018:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_001d:  ret
 
-    IL_0020:  ldloc.1
-    IL_0021:  conv.ovf.i.un
-    IL_0022:  newarr     [runtime]System.Int32
-    IL_0027:  stloc.2
-    IL_0028:  ldc.i4.0
-    IL_0029:  conv.i8
-    IL_002a:  stloc.3
-    IL_002b:  ldarg.0
-    IL_002c:  stloc.s    V_4
-    IL_002e:  br.s       IL_0041
+    IL_001e:  ldloc.1
+    IL_001f:  conv.ovf.i.un
+    IL_0020:  newarr     [runtime]System.Int32
+    IL_0025:  stloc.2
+    IL_0026:  ldc.i4.0
+    IL_0027:  conv.i8
+    IL_0028:  stloc.3
+    IL_0029:  ldarg.0
+    IL_002a:  stloc.s    V_4
+    IL_002c:  br.s       IL_003f
 
-    IL_0030:  ldloc.2
-    IL_0031:  ldloc.3
-    IL_0032:  conv.i
-    IL_0033:  ldloc.s    V_4
-    IL_0035:  stelem.i4
-    IL_0036:  ldloc.s    V_4
-    IL_0038:  ldc.i4.1
-    IL_0039:  add
-    IL_003a:  stloc.s    V_4
-    IL_003c:  ldloc.3
-    IL_003d:  ldc.i4.1
-    IL_003e:  conv.i8
-    IL_003f:  add
-    IL_0040:  stloc.3
-    IL_0041:  ldloc.3
-    IL_0042:  ldloc.0
-    IL_0043:  blt.un.s   IL_0030
+    IL_002e:  ldloc.2
+    IL_002f:  ldloc.3
+    IL_0030:  conv.i
+    IL_0031:  ldloc.s    V_4
+    IL_0033:  stelem.i4
+    IL_0034:  ldloc.s    V_4
+    IL_0036:  ldc.i4.1
+    IL_0037:  add
+    IL_0038:  stloc.s    V_4
+    IL_003a:  ldloc.3
+    IL_003b:  ldc.i4.1
+    IL_003c:  conv.i8
+    IL_003d:  add
+    IL_003e:  stloc.3
+    IL_003f:  ldloc.3
+    IL_0040:  ldloc.0
+    IL_0041:  blt.un.s   IL_002e
 
-    IL_0045:  ldloc.2
-    IL_0046:  ret
+    IL_0043:  ldloc.2
+    IL_0044:  ret
   } 
 
   .method public static int32[]  f17(int32 step,
@@ -1016,44 +1000,42 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     [runtime]System.Int32
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldc.i4.1
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_006f
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     [runtime]System.Int32
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldc.i4.1
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_006d
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stelem.i4
-    IL_0064:  ldloc.s    V_4
-    IL_0066:  ldarg.0
-    IL_0067:  add
-    IL_0068:  stloc.s    V_4
-    IL_006a:  ldloc.3
-    IL_006b:  ldc.i4.1
-    IL_006c:  conv.i8
-    IL_006d:  add
-    IL_006e:  stloc.3
-    IL_006f:  ldloc.3
-    IL_0070:  ldloc.0
-    IL_0071:  blt.un.s   IL_005e
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stelem.i4
+    IL_0062:  ldloc.s    V_4
+    IL_0064:  ldarg.0
+    IL_0065:  add
+    IL_0066:  stloc.s    V_4
+    IL_0068:  ldloc.3
+    IL_0069:  ldc.i4.1
+    IL_006a:  conv.i8
+    IL_006b:  add
+    IL_006c:  stloc.3
+    IL_006d:  ldloc.3
+    IL_006e:  ldloc.0
+    IL_006f:  blt.un.s   IL_005c
 
-    IL_0073:  ldloc.2
-    IL_0074:  ret
+    IL_0071:  ldloc.2
+    IL_0072:  ret
   } 
 
   .method public static int32[]  f18(int32 start,
@@ -1135,44 +1117,42 @@
     IL_0041:  ldloc.0
     IL_0042:  stloc.1
     IL_0043:  ldloc.1
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  bge.un.s   IL_004e
+    IL_0044:  brtrue.s   IL_004c
 
-    IL_0048:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_004d:  ret
+    IL_0046:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_004b:  ret
 
-    IL_004e:  ldloc.1
-    IL_004f:  conv.ovf.i.un
-    IL_0050:  newarr     [runtime]System.Int32
-    IL_0055:  stloc.2
-    IL_0056:  ldc.i4.0
-    IL_0057:  conv.i8
-    IL_0058:  stloc.3
-    IL_0059:  ldarg.0
-    IL_005a:  stloc.s    V_4
-    IL_005c:  br.s       IL_006f
+    IL_004c:  ldloc.1
+    IL_004d:  conv.ovf.i.un
+    IL_004e:  newarr     [runtime]System.Int32
+    IL_0053:  stloc.2
+    IL_0054:  ldc.i4.0
+    IL_0055:  conv.i8
+    IL_0056:  stloc.3
+    IL_0057:  ldarg.0
+    IL_0058:  stloc.s    V_4
+    IL_005a:  br.s       IL_006d
 
-    IL_005e:  ldloc.2
-    IL_005f:  ldloc.3
-    IL_0060:  conv.i
-    IL_0061:  ldloc.s    V_4
-    IL_0063:  stelem.i4
-    IL_0064:  ldloc.s    V_4
-    IL_0066:  ldarg.1
-    IL_0067:  add
-    IL_0068:  stloc.s    V_4
-    IL_006a:  ldloc.3
-    IL_006b:  ldc.i4.1
-    IL_006c:  conv.i8
-    IL_006d:  add
-    IL_006e:  stloc.3
-    IL_006f:  ldloc.3
-    IL_0070:  ldloc.0
-    IL_0071:  blt.un.s   IL_005e
+    IL_005c:  ldloc.2
+    IL_005d:  ldloc.3
+    IL_005e:  conv.i
+    IL_005f:  ldloc.s    V_4
+    IL_0061:  stelem.i4
+    IL_0062:  ldloc.s    V_4
+    IL_0064:  ldarg.1
+    IL_0065:  add
+    IL_0066:  stloc.s    V_4
+    IL_0068:  ldloc.3
+    IL_0069:  ldc.i4.1
+    IL_006a:  conv.i8
+    IL_006b:  add
+    IL_006c:  stloc.3
+    IL_006d:  ldloc.3
+    IL_006e:  ldloc.0
+    IL_006f:  blt.un.s   IL_005c
 
-    IL_0073:  ldloc.2
-    IL_0074:  ret
+    IL_0071:  ldloc.2
+    IL_0072:  ret
   } 
 
   .method public static int32[]  f19(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1210,44 +1190,42 @@
     IL_001c:  ldloc.1
     IL_001d:  stloc.2
     IL_001e:  ldloc.2
-    IL_001f:  ldc.i4.1
-    IL_0020:  conv.i8
-    IL_0021:  bge.un.s   IL_0029
+    IL_001f:  brtrue.s   IL_0027
 
-    IL_0023:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0028:  ret
+    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0026:  ret
 
-    IL_0029:  ldloc.2
-    IL_002a:  conv.ovf.i.un
-    IL_002b:  newarr     [runtime]System.Int32
-    IL_0030:  stloc.3
-    IL_0031:  ldc.i4.0
-    IL_0032:  conv.i8
-    IL_0033:  stloc.s    V_4
-    IL_0035:  ldloc.0
-    IL_0036:  stloc.s    V_5
-    IL_0038:  br.s       IL_004e
+    IL_0027:  ldloc.2
+    IL_0028:  conv.ovf.i.un
+    IL_0029:  newarr     [runtime]System.Int32
+    IL_002e:  stloc.3
+    IL_002f:  ldc.i4.0
+    IL_0030:  conv.i8
+    IL_0031:  stloc.s    V_4
+    IL_0033:  ldloc.0
+    IL_0034:  stloc.s    V_5
+    IL_0036:  br.s       IL_004c
 
-    IL_003a:  ldloc.3
-    IL_003b:  ldloc.s    V_4
-    IL_003d:  conv.i
-    IL_003e:  ldloc.s    V_5
-    IL_0040:  stelem.i4
-    IL_0041:  ldloc.s    V_5
-    IL_0043:  ldc.i4.1
-    IL_0044:  add
-    IL_0045:  stloc.s    V_5
-    IL_0047:  ldloc.s    V_4
-    IL_0049:  ldc.i4.1
-    IL_004a:  conv.i8
-    IL_004b:  add
-    IL_004c:  stloc.s    V_4
-    IL_004e:  ldloc.s    V_4
-    IL_0050:  ldloc.1
-    IL_0051:  blt.un.s   IL_003a
+    IL_0038:  ldloc.3
+    IL_0039:  ldloc.s    V_4
+    IL_003b:  conv.i
+    IL_003c:  ldloc.s    V_5
+    IL_003e:  stelem.i4
+    IL_003f:  ldloc.s    V_5
+    IL_0041:  ldc.i4.1
+    IL_0042:  add
+    IL_0043:  stloc.s    V_5
+    IL_0045:  ldloc.s    V_4
+    IL_0047:  ldc.i4.1
+    IL_0048:  conv.i8
+    IL_0049:  add
+    IL_004a:  stloc.s    V_4
+    IL_004c:  ldloc.s    V_4
+    IL_004e:  ldloc.1
+    IL_004f:  blt.un.s   IL_0038
 
-    IL_0053:  ldloc.3
-    IL_0054:  ret
+    IL_0051:  ldloc.3
+    IL_0052:  ret
   } 
 
   .method public static int32[]  f20(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1285,44 +1263,42 @@
     IL_001a:  ldloc.1
     IL_001b:  stloc.2
     IL_001c:  ldloc.2
-    IL_001d:  ldc.i4.1
-    IL_001e:  conv.i8
-    IL_001f:  bge.un.s   IL_0027
+    IL_001d:  brtrue.s   IL_0025
 
-    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0026:  ret
+    IL_001f:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0024:  ret
 
-    IL_0027:  ldloc.2
-    IL_0028:  conv.ovf.i.un
-    IL_0029:  newarr     [runtime]System.Int32
-    IL_002e:  stloc.3
-    IL_002f:  ldc.i4.0
-    IL_0030:  conv.i8
-    IL_0031:  stloc.s    V_4
-    IL_0033:  ldc.i4.1
-    IL_0034:  stloc.s    V_5
-    IL_0036:  br.s       IL_004c
+    IL_0025:  ldloc.2
+    IL_0026:  conv.ovf.i.un
+    IL_0027:  newarr     [runtime]System.Int32
+    IL_002c:  stloc.3
+    IL_002d:  ldc.i4.0
+    IL_002e:  conv.i8
+    IL_002f:  stloc.s    V_4
+    IL_0031:  ldc.i4.1
+    IL_0032:  stloc.s    V_5
+    IL_0034:  br.s       IL_004a
 
-    IL_0038:  ldloc.3
-    IL_0039:  ldloc.s    V_4
-    IL_003b:  conv.i
-    IL_003c:  ldloc.s    V_5
-    IL_003e:  stelem.i4
-    IL_003f:  ldloc.s    V_5
-    IL_0041:  ldc.i4.1
-    IL_0042:  add
-    IL_0043:  stloc.s    V_5
-    IL_0045:  ldloc.s    V_4
-    IL_0047:  ldc.i4.1
-    IL_0048:  conv.i8
-    IL_0049:  add
-    IL_004a:  stloc.s    V_4
-    IL_004c:  ldloc.s    V_4
-    IL_004e:  ldloc.1
-    IL_004f:  blt.un.s   IL_0038
+    IL_0036:  ldloc.3
+    IL_0037:  ldloc.s    V_4
+    IL_0039:  conv.i
+    IL_003a:  ldloc.s    V_5
+    IL_003c:  stelem.i4
+    IL_003d:  ldloc.s    V_5
+    IL_003f:  ldc.i4.1
+    IL_0040:  add
+    IL_0041:  stloc.s    V_5
+    IL_0043:  ldloc.s    V_4
+    IL_0045:  ldc.i4.1
+    IL_0046:  conv.i8
+    IL_0047:  add
+    IL_0048:  stloc.s    V_4
+    IL_004a:  ldloc.s    V_4
+    IL_004c:  ldloc.1
+    IL_004d:  blt.un.s   IL_0036
 
-    IL_0051:  ldloc.3
-    IL_0052:  ret
+    IL_004f:  ldloc.3
+    IL_0050:  ret
   } 
 
   .method public static int32[]  f21(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f,
@@ -1367,44 +1343,42 @@
     IL_0022:  ldloc.2
     IL_0023:  stloc.3
     IL_0024:  ldloc.3
-    IL_0025:  ldc.i4.1
-    IL_0026:  conv.i8
-    IL_0027:  bge.un.s   IL_002f
+    IL_0025:  brtrue.s   IL_002d
 
-    IL_0029:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_002e:  ret
+    IL_0027:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_002c:  ret
 
-    IL_002f:  ldloc.3
-    IL_0030:  conv.ovf.i.un
-    IL_0031:  newarr     [runtime]System.Int32
-    IL_0036:  stloc.s    V_4
-    IL_0038:  ldc.i4.0
-    IL_0039:  conv.i8
-    IL_003a:  stloc.s    V_5
-    IL_003c:  ldloc.0
-    IL_003d:  stloc.s    V_6
-    IL_003f:  br.s       IL_0056
+    IL_002d:  ldloc.3
+    IL_002e:  conv.ovf.i.un
+    IL_002f:  newarr     [runtime]System.Int32
+    IL_0034:  stloc.s    V_4
+    IL_0036:  ldc.i4.0
+    IL_0037:  conv.i8
+    IL_0038:  stloc.s    V_5
+    IL_003a:  ldloc.0
+    IL_003b:  stloc.s    V_6
+    IL_003d:  br.s       IL_0054
 
-    IL_0041:  ldloc.s    V_4
-    IL_0043:  ldloc.s    V_5
-    IL_0045:  conv.i
-    IL_0046:  ldloc.s    V_6
-    IL_0048:  stelem.i4
-    IL_0049:  ldloc.s    V_6
-    IL_004b:  ldc.i4.1
-    IL_004c:  add
-    IL_004d:  stloc.s    V_6
-    IL_004f:  ldloc.s    V_5
-    IL_0051:  ldc.i4.1
-    IL_0052:  conv.i8
-    IL_0053:  add
-    IL_0054:  stloc.s    V_5
-    IL_0056:  ldloc.s    V_5
-    IL_0058:  ldloc.2
-    IL_0059:  blt.un.s   IL_0041
+    IL_003f:  ldloc.s    V_4
+    IL_0041:  ldloc.s    V_5
+    IL_0043:  conv.i
+    IL_0044:  ldloc.s    V_6
+    IL_0046:  stelem.i4
+    IL_0047:  ldloc.s    V_6
+    IL_0049:  ldc.i4.1
+    IL_004a:  add
+    IL_004b:  stloc.s    V_6
+    IL_004d:  ldloc.s    V_5
+    IL_004f:  ldc.i4.1
+    IL_0050:  conv.i8
+    IL_0051:  add
+    IL_0052:  stloc.s    V_5
+    IL_0054:  ldloc.s    V_5
+    IL_0056:  ldloc.2
+    IL_0057:  blt.un.s   IL_003f
 
-    IL_005b:  ldloc.s    V_4
-    IL_005d:  ret
+    IL_0059:  ldloc.s    V_4
+    IL_005b:  ret
   } 
 
   .method public static int32[]  f22(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1442,44 +1416,42 @@
     IL_001c:  ldloc.1
     IL_001d:  stloc.2
     IL_001e:  ldloc.2
-    IL_001f:  ldc.i4.1
-    IL_0020:  conv.i8
-    IL_0021:  bge.un.s   IL_0029
+    IL_001f:  brtrue.s   IL_0027
 
-    IL_0023:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0028:  ret
+    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0026:  ret
 
-    IL_0029:  ldloc.2
-    IL_002a:  conv.ovf.i.un
-    IL_002b:  newarr     [runtime]System.Int32
-    IL_0030:  stloc.3
-    IL_0031:  ldc.i4.0
-    IL_0032:  conv.i8
-    IL_0033:  stloc.s    V_4
-    IL_0035:  ldloc.0
-    IL_0036:  stloc.s    V_5
-    IL_0038:  br.s       IL_004e
+    IL_0027:  ldloc.2
+    IL_0028:  conv.ovf.i.un
+    IL_0029:  newarr     [runtime]System.Int32
+    IL_002e:  stloc.3
+    IL_002f:  ldc.i4.0
+    IL_0030:  conv.i8
+    IL_0031:  stloc.s    V_4
+    IL_0033:  ldloc.0
+    IL_0034:  stloc.s    V_5
+    IL_0036:  br.s       IL_004c
 
-    IL_003a:  ldloc.3
-    IL_003b:  ldloc.s    V_4
-    IL_003d:  conv.i
-    IL_003e:  ldloc.s    V_5
-    IL_0040:  stelem.i4
-    IL_0041:  ldloc.s    V_5
-    IL_0043:  ldc.i4.1
-    IL_0044:  add
-    IL_0045:  stloc.s    V_5
-    IL_0047:  ldloc.s    V_4
-    IL_0049:  ldc.i4.1
-    IL_004a:  conv.i8
-    IL_004b:  add
-    IL_004c:  stloc.s    V_4
-    IL_004e:  ldloc.s    V_4
-    IL_0050:  ldloc.1
-    IL_0051:  blt.un.s   IL_003a
+    IL_0038:  ldloc.3
+    IL_0039:  ldloc.s    V_4
+    IL_003b:  conv.i
+    IL_003c:  ldloc.s    V_5
+    IL_003e:  stelem.i4
+    IL_003f:  ldloc.s    V_5
+    IL_0041:  ldc.i4.1
+    IL_0042:  add
+    IL_0043:  stloc.s    V_5
+    IL_0045:  ldloc.s    V_4
+    IL_0047:  ldc.i4.1
+    IL_0048:  conv.i8
+    IL_0049:  add
+    IL_004a:  stloc.s    V_4
+    IL_004c:  ldloc.s    V_4
+    IL_004e:  ldloc.1
+    IL_004f:  blt.un.s   IL_0038
 
-    IL_0053:  ldloc.3
-    IL_0054:  ret
+    IL_0051:  ldloc.3
+    IL_0052:  ret
   } 
 
   .method public static int32[]  f23(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1561,44 +1533,42 @@
     IL_004d:  ldloc.1
     IL_004e:  stloc.2
     IL_004f:  ldloc.2
-    IL_0050:  ldc.i4.1
-    IL_0051:  conv.i8
-    IL_0052:  bge.un.s   IL_005a
+    IL_0050:  brtrue.s   IL_0058
 
-    IL_0054:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0059:  ret
+    IL_0052:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0057:  ret
 
-    IL_005a:  ldloc.2
-    IL_005b:  conv.ovf.i.un
-    IL_005c:  newarr     [runtime]System.Int32
-    IL_0061:  stloc.3
-    IL_0062:  ldc.i4.0
-    IL_0063:  conv.i8
-    IL_0064:  stloc.s    V_4
-    IL_0066:  ldc.i4.1
-    IL_0067:  stloc.s    V_5
-    IL_0069:  br.s       IL_007f
+    IL_0058:  ldloc.2
+    IL_0059:  conv.ovf.i.un
+    IL_005a:  newarr     [runtime]System.Int32
+    IL_005f:  stloc.3
+    IL_0060:  ldc.i4.0
+    IL_0061:  conv.i8
+    IL_0062:  stloc.s    V_4
+    IL_0064:  ldc.i4.1
+    IL_0065:  stloc.s    V_5
+    IL_0067:  br.s       IL_007d
 
-    IL_006b:  ldloc.3
-    IL_006c:  ldloc.s    V_4
-    IL_006e:  conv.i
-    IL_006f:  ldloc.s    V_5
-    IL_0071:  stelem.i4
-    IL_0072:  ldloc.s    V_5
-    IL_0074:  ldloc.0
-    IL_0075:  add
-    IL_0076:  stloc.s    V_5
-    IL_0078:  ldloc.s    V_4
-    IL_007a:  ldc.i4.1
-    IL_007b:  conv.i8
-    IL_007c:  add
-    IL_007d:  stloc.s    V_4
-    IL_007f:  ldloc.s    V_4
-    IL_0081:  ldloc.1
-    IL_0082:  blt.un.s   IL_006b
+    IL_0069:  ldloc.3
+    IL_006a:  ldloc.s    V_4
+    IL_006c:  conv.i
+    IL_006d:  ldloc.s    V_5
+    IL_006f:  stelem.i4
+    IL_0070:  ldloc.s    V_5
+    IL_0072:  ldloc.0
+    IL_0073:  add
+    IL_0074:  stloc.s    V_5
+    IL_0076:  ldloc.s    V_4
+    IL_0078:  ldc.i4.1
+    IL_0079:  conv.i8
+    IL_007a:  add
+    IL_007b:  stloc.s    V_4
+    IL_007d:  ldloc.s    V_4
+    IL_007f:  ldloc.1
+    IL_0080:  blt.un.s   IL_0069
 
-    IL_0084:  ldloc.3
-    IL_0085:  ret
+    IL_0082:  ldloc.3
+    IL_0083:  ret
   } 
 
   .method public static int32[]  f24(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f) cil managed
@@ -1636,44 +1606,42 @@
     IL_001a:  ldloc.1
     IL_001b:  stloc.2
     IL_001c:  ldloc.2
-    IL_001d:  ldc.i4.1
-    IL_001e:  conv.i8
-    IL_001f:  bge.un.s   IL_0027
+    IL_001d:  brtrue.s   IL_0025
 
-    IL_0021:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0026:  ret
+    IL_001f:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0024:  ret
 
-    IL_0027:  ldloc.2
-    IL_0028:  conv.ovf.i.un
-    IL_0029:  newarr     [runtime]System.Int32
-    IL_002e:  stloc.3
-    IL_002f:  ldc.i4.0
-    IL_0030:  conv.i8
-    IL_0031:  stloc.s    V_4
-    IL_0033:  ldc.i4.1
-    IL_0034:  stloc.s    V_5
-    IL_0036:  br.s       IL_004c
+    IL_0025:  ldloc.2
+    IL_0026:  conv.ovf.i.un
+    IL_0027:  newarr     [runtime]System.Int32
+    IL_002c:  stloc.3
+    IL_002d:  ldc.i4.0
+    IL_002e:  conv.i8
+    IL_002f:  stloc.s    V_4
+    IL_0031:  ldc.i4.1
+    IL_0032:  stloc.s    V_5
+    IL_0034:  br.s       IL_004a
 
-    IL_0038:  ldloc.3
-    IL_0039:  ldloc.s    V_4
-    IL_003b:  conv.i
-    IL_003c:  ldloc.s    V_5
-    IL_003e:  stelem.i4
-    IL_003f:  ldloc.s    V_5
-    IL_0041:  ldc.i4.1
-    IL_0042:  add
-    IL_0043:  stloc.s    V_5
-    IL_0045:  ldloc.s    V_4
-    IL_0047:  ldc.i4.1
-    IL_0048:  conv.i8
-    IL_0049:  add
-    IL_004a:  stloc.s    V_4
-    IL_004c:  ldloc.s    V_4
-    IL_004e:  ldloc.1
-    IL_004f:  blt.un.s   IL_0038
+    IL_0036:  ldloc.3
+    IL_0037:  ldloc.s    V_4
+    IL_0039:  conv.i
+    IL_003a:  ldloc.s    V_5
+    IL_003c:  stelem.i4
+    IL_003d:  ldloc.s    V_5
+    IL_003f:  ldc.i4.1
+    IL_0040:  add
+    IL_0041:  stloc.s    V_5
+    IL_0043:  ldloc.s    V_4
+    IL_0045:  ldc.i4.1
+    IL_0046:  conv.i8
+    IL_0047:  add
+    IL_0048:  stloc.s    V_4
+    IL_004a:  ldloc.s    V_4
+    IL_004c:  ldloc.1
+    IL_004d:  blt.un.s   IL_0036
 
-    IL_0051:  ldloc.3
-    IL_0052:  ret
+    IL_004f:  ldloc.3
+    IL_0050:  ret
   } 
 
   .method public static int32[]  f25(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,int32> f,
@@ -1769,44 +1737,42 @@
     IL_0058:  ldloc.3
     IL_0059:  stloc.s    V_4
     IL_005b:  ldloc.s    V_4
-    IL_005d:  ldc.i4.1
-    IL_005e:  conv.i8
-    IL_005f:  bge.un.s   IL_0067
+    IL_005d:  brtrue.s   IL_0065
 
-    IL_0061:  call       !!0[] [runtime]System.Array::Empty<int32>()
-    IL_0066:  ret
+    IL_005f:  call       !!0[] [runtime]System.Array::Empty<int32>()
+    IL_0064:  ret
 
-    IL_0067:  ldloc.s    V_4
-    IL_0069:  conv.ovf.i.un
-    IL_006a:  newarr     [runtime]System.Int32
-    IL_006f:  stloc.s    V_5
-    IL_0071:  ldc.i4.0
-    IL_0072:  conv.i8
-    IL_0073:  stloc.s    V_6
-    IL_0075:  ldloc.0
-    IL_0076:  stloc.s    V_7
-    IL_0078:  br.s       IL_008f
+    IL_0065:  ldloc.s    V_4
+    IL_0067:  conv.ovf.i.un
+    IL_0068:  newarr     [runtime]System.Int32
+    IL_006d:  stloc.s    V_5
+    IL_006f:  ldc.i4.0
+    IL_0070:  conv.i8
+    IL_0071:  stloc.s    V_6
+    IL_0073:  ldloc.0
+    IL_0074:  stloc.s    V_7
+    IL_0076:  br.s       IL_008d
 
-    IL_007a:  ldloc.s    V_5
-    IL_007c:  ldloc.s    V_6
-    IL_007e:  conv.i
-    IL_007f:  ldloc.s    V_7
-    IL_0081:  stelem.i4
-    IL_0082:  ldloc.s    V_7
-    IL_0084:  ldloc.1
-    IL_0085:  add
-    IL_0086:  stloc.s    V_7
-    IL_0088:  ldloc.s    V_6
-    IL_008a:  ldc.i4.1
-    IL_008b:  conv.i8
-    IL_008c:  add
-    IL_008d:  stloc.s    V_6
-    IL_008f:  ldloc.s    V_6
-    IL_0091:  ldloc.3
-    IL_0092:  blt.un.s   IL_007a
+    IL_0078:  ldloc.s    V_5
+    IL_007a:  ldloc.s    V_6
+    IL_007c:  conv.i
+    IL_007d:  ldloc.s    V_7
+    IL_007f:  stelem.i4
+    IL_0080:  ldloc.s    V_7
+    IL_0082:  ldloc.1
+    IL_0083:  add
+    IL_0084:  stloc.s    V_7
+    IL_0086:  ldloc.s    V_6
+    IL_0088:  ldc.i4.1
+    IL_0089:  conv.i8
+    IL_008a:  add
+    IL_008b:  stloc.s    V_6
+    IL_008d:  ldloc.s    V_6
+    IL_008f:  ldloc.3
+    IL_0090:  blt.un.s   IL_0078
 
-    IL_0094:  ldloc.s    V_5
-    IL_0096:  ret
+    IL_0092:  ldloc.s    V_5
+    IL_0094:  ret
   } 
 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputedCollections/UInt64RangeArrays.fs.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputedCollections/UInt64RangeArrays.fs.il.bsl
@@ -223,45 +223,43 @@
     IL_0016:  ldloc.0
     IL_0017:  stloc.1
     IL_0018:  ldloc.1
-    IL_0019:  ldc.i4.1
-    IL_001a:  conv.i8
-    IL_001b:  bge.un.s   IL_0023
+    IL_0019:  brtrue.s   IL_0021
 
-    IL_001d:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0022:  ret
+    IL_001b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0020:  ret
 
-    IL_0023:  ldloc.1
-    IL_0024:  conv.ovf.i.un
-    IL_0025:  newarr     [runtime]System.UInt64
-    IL_002a:  stloc.2
-    IL_002b:  ldc.i4.0
-    IL_002c:  conv.i8
-    IL_002d:  stloc.3
-    IL_002e:  ldarg.0
-    IL_002f:  stloc.s    V_4
-    IL_0031:  br.s       IL_0045
+    IL_0021:  ldloc.1
+    IL_0022:  conv.ovf.i.un
+    IL_0023:  newarr     [runtime]System.UInt64
+    IL_0028:  stloc.2
+    IL_0029:  ldc.i4.0
+    IL_002a:  conv.i8
+    IL_002b:  stloc.3
+    IL_002c:  ldarg.0
+    IL_002d:  stloc.s    V_4
+    IL_002f:  br.s       IL_0043
 
-    IL_0033:  ldloc.2
-    IL_0034:  ldloc.3
-    IL_0035:  conv.i
-    IL_0036:  ldloc.s    V_4
-    IL_0038:  stelem.i8
-    IL_0039:  ldloc.s    V_4
-    IL_003b:  ldc.i4.1
-    IL_003c:  conv.i8
-    IL_003d:  add
-    IL_003e:  stloc.s    V_4
-    IL_0040:  ldloc.3
-    IL_0041:  ldc.i4.1
-    IL_0042:  conv.i8
-    IL_0043:  add
-    IL_0044:  stloc.3
-    IL_0045:  ldloc.3
-    IL_0046:  ldloc.0
-    IL_0047:  blt.un.s   IL_0033
+    IL_0031:  ldloc.2
+    IL_0032:  ldloc.3
+    IL_0033:  conv.i
+    IL_0034:  ldloc.s    V_4
+    IL_0036:  stelem.i8
+    IL_0037:  ldloc.s    V_4
+    IL_0039:  ldc.i4.1
+    IL_003a:  conv.i8
+    IL_003b:  add
+    IL_003c:  stloc.s    V_4
+    IL_003e:  ldloc.3
+    IL_003f:  ldc.i4.1
+    IL_0040:  conv.i8
+    IL_0041:  add
+    IL_0042:  stloc.3
+    IL_0043:  ldloc.3
+    IL_0044:  ldloc.0
+    IL_0045:  blt.un.s   IL_0031
 
-    IL_0049:  ldloc.2
-    IL_004a:  ret
+    IL_0047:  ldloc.2
+    IL_0048:  ret
   } 
 
   .method public static uint64[]  f7(uint64 finish) cil managed
@@ -296,46 +294,44 @@
     IL_0014:  ldloc.0
     IL_0015:  stloc.1
     IL_0016:  ldloc.1
-    IL_0017:  ldc.i4.1
-    IL_0018:  conv.i8
-    IL_0019:  bge.un.s   IL_0021
+    IL_0017:  brtrue.s   IL_001f
 
-    IL_001b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0020:  ret
+    IL_0019:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_001e:  ret
 
-    IL_0021:  ldloc.1
-    IL_0022:  conv.ovf.i.un
-    IL_0023:  newarr     [runtime]System.UInt64
-    IL_0028:  stloc.2
-    IL_0029:  ldc.i4.0
-    IL_002a:  conv.i8
-    IL_002b:  stloc.3
-    IL_002c:  ldc.i4.1
-    IL_002d:  conv.i8
-    IL_002e:  stloc.s    V_4
-    IL_0030:  br.s       IL_0044
+    IL_001f:  ldloc.1
+    IL_0020:  conv.ovf.i.un
+    IL_0021:  newarr     [runtime]System.UInt64
+    IL_0026:  stloc.2
+    IL_0027:  ldc.i4.0
+    IL_0028:  conv.i8
+    IL_0029:  stloc.3
+    IL_002a:  ldc.i4.1
+    IL_002b:  conv.i8
+    IL_002c:  stloc.s    V_4
+    IL_002e:  br.s       IL_0042
 
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.3
-    IL_0034:  conv.i
-    IL_0035:  ldloc.s    V_4
-    IL_0037:  stelem.i8
-    IL_0038:  ldloc.s    V_4
-    IL_003a:  ldc.i4.1
-    IL_003b:  conv.i8
-    IL_003c:  add
-    IL_003d:  stloc.s    V_4
-    IL_003f:  ldloc.3
-    IL_0040:  ldc.i4.1
-    IL_0041:  conv.i8
-    IL_0042:  add
-    IL_0043:  stloc.3
-    IL_0044:  ldloc.3
-    IL_0045:  ldloc.0
-    IL_0046:  blt.un.s   IL_0032
+    IL_0030:  ldloc.2
+    IL_0031:  ldloc.3
+    IL_0032:  conv.i
+    IL_0033:  ldloc.s    V_4
+    IL_0035:  stelem.i8
+    IL_0036:  ldloc.s    V_4
+    IL_0038:  ldc.i4.1
+    IL_0039:  conv.i8
+    IL_003a:  add
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldloc.3
+    IL_003e:  ldc.i4.1
+    IL_003f:  conv.i8
+    IL_0040:  add
+    IL_0041:  stloc.3
+    IL_0042:  ldloc.3
+    IL_0043:  ldloc.0
+    IL_0044:  blt.un.s   IL_0030
 
-    IL_0048:  ldloc.2
-    IL_0049:  ret
+    IL_0046:  ldloc.2
+    IL_0047:  ret
   } 
 
   .method public static uint64[]  f8(uint64 start,
@@ -390,101 +386,99 @@
     IL_0024:  nop
     IL_0025:  stloc.2
     IL_0026:  ldloc.2
-    IL_0027:  ldc.i4.1
-    IL_0028:  conv.i8
-    IL_0029:  bge.un.s   IL_0031
+    IL_0027:  brtrue.s   IL_002f
 
-    IL_002b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0030:  ret
+    IL_0029:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_002e:  ret
 
-    IL_0031:  ldloc.2
-    IL_0032:  conv.ovf.i.un
-    IL_0033:  newarr     [runtime]System.UInt64
-    IL_0038:  stloc.3
-    IL_0039:  ldloc.1
-    IL_003a:  brfalse.s  IL_006c
+    IL_002f:  ldloc.2
+    IL_0030:  conv.ovf.i.un
+    IL_0031:  newarr     [runtime]System.UInt64
+    IL_0036:  stloc.3
+    IL_0037:  ldloc.1
+    IL_0038:  brfalse.s  IL_006a
 
-    IL_003c:  ldc.i4.1
-    IL_003d:  stloc.s    V_4
-    IL_003f:  ldc.i4.0
-    IL_0040:  conv.i8
-    IL_0041:  stloc.s    V_5
-    IL_0043:  ldarg.0
-    IL_0044:  stloc.s    V_6
-    IL_0046:  br.s       IL_0065
+    IL_003a:  ldc.i4.1
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldc.i4.0
+    IL_003e:  conv.i8
+    IL_003f:  stloc.s    V_5
+    IL_0041:  ldarg.0
+    IL_0042:  stloc.s    V_6
+    IL_0044:  br.s       IL_0063
 
-    IL_0048:  ldloc.3
-    IL_0049:  ldloc.s    V_5
-    IL_004b:  conv.i
-    IL_004c:  ldloc.s    V_6
-    IL_004e:  stelem.i8
-    IL_004f:  ldloc.s    V_6
-    IL_0051:  ldc.i4.1
-    IL_0052:  conv.i8
-    IL_0053:  add
-    IL_0054:  stloc.s    V_6
-    IL_0056:  ldloc.s    V_5
-    IL_0058:  ldc.i4.1
-    IL_0059:  conv.i8
-    IL_005a:  add
-    IL_005b:  stloc.s    V_5
-    IL_005d:  ldloc.s    V_5
-    IL_005f:  ldc.i4.0
-    IL_0060:  conv.i8
-    IL_0061:  cgt.un
-    IL_0063:  stloc.s    V_4
-    IL_0065:  ldloc.s    V_4
-    IL_0067:  brtrue.s   IL_0048
+    IL_0046:  ldloc.3
+    IL_0047:  ldloc.s    V_5
+    IL_0049:  conv.i
+    IL_004a:  ldloc.s    V_6
+    IL_004c:  stelem.i8
+    IL_004d:  ldloc.s    V_6
+    IL_004f:  ldc.i4.1
+    IL_0050:  conv.i8
+    IL_0051:  add
+    IL_0052:  stloc.s    V_6
+    IL_0054:  ldloc.s    V_5
+    IL_0056:  ldc.i4.1
+    IL_0057:  conv.i8
+    IL_0058:  add
+    IL_0059:  stloc.s    V_5
+    IL_005b:  ldloc.s    V_5
+    IL_005d:  ldc.i4.0
+    IL_005e:  conv.i8
+    IL_005f:  cgt.un
+    IL_0061:  stloc.s    V_4
+    IL_0063:  ldloc.s    V_4
+    IL_0065:  brtrue.s   IL_0046
 
-    IL_0069:  nop
-    IL_006a:  br.s       IL_00a3
+    IL_0067:  nop
+    IL_0068:  br.s       IL_00a1
 
-    IL_006c:  ldarg.1
-    IL_006d:  ldarg.0
-    IL_006e:  bge.un.s   IL_0075
+    IL_006a:  ldarg.1
+    IL_006b:  ldarg.0
+    IL_006c:  bge.un.s   IL_0073
 
-    IL_0070:  ldc.i4.0
-    IL_0071:  conv.i8
-    IL_0072:  nop
-    IL_0073:  br.s       IL_007c
+    IL_006e:  ldc.i4.0
+    IL_006f:  conv.i8
+    IL_0070:  nop
+    IL_0071:  br.s       IL_007a
 
-    IL_0075:  ldarg.1
-    IL_0076:  ldarg.0
-    IL_0077:  sub
-    IL_0078:  ldc.i4.1
-    IL_0079:  conv.i8
-    IL_007a:  add.ovf.un
-    IL_007b:  nop
-    IL_007c:  stloc.s    V_5
-    IL_007e:  ldc.i4.0
-    IL_007f:  conv.i8
-    IL_0080:  stloc.s    V_6
-    IL_0082:  ldarg.0
-    IL_0083:  stloc.s    V_7
-    IL_0085:  br.s       IL_009c
+    IL_0073:  ldarg.1
+    IL_0074:  ldarg.0
+    IL_0075:  sub
+    IL_0076:  ldc.i4.1
+    IL_0077:  conv.i8
+    IL_0078:  add.ovf.un
+    IL_0079:  nop
+    IL_007a:  stloc.s    V_5
+    IL_007c:  ldc.i4.0
+    IL_007d:  conv.i8
+    IL_007e:  stloc.s    V_6
+    IL_0080:  ldarg.0
+    IL_0081:  stloc.s    V_7
+    IL_0083:  br.s       IL_009a
 
-    IL_0087:  ldloc.3
-    IL_0088:  ldloc.s    V_6
-    IL_008a:  conv.i
-    IL_008b:  ldloc.s    V_7
-    IL_008d:  stelem.i8
-    IL_008e:  ldloc.s    V_7
-    IL_0090:  ldc.i4.1
-    IL_0091:  conv.i8
-    IL_0092:  add
-    IL_0093:  stloc.s    V_7
-    IL_0095:  ldloc.s    V_6
-    IL_0097:  ldc.i4.1
-    IL_0098:  conv.i8
-    IL_0099:  add
-    IL_009a:  stloc.s    V_6
-    IL_009c:  ldloc.s    V_6
-    IL_009e:  ldloc.s    V_5
-    IL_00a0:  blt.un.s   IL_0087
+    IL_0085:  ldloc.3
+    IL_0086:  ldloc.s    V_6
+    IL_0088:  conv.i
+    IL_0089:  ldloc.s    V_7
+    IL_008b:  stelem.i8
+    IL_008c:  ldloc.s    V_7
+    IL_008e:  ldc.i4.1
+    IL_008f:  conv.i8
+    IL_0090:  add
+    IL_0091:  stloc.s    V_7
+    IL_0093:  ldloc.s    V_6
+    IL_0095:  ldc.i4.1
+    IL_0096:  conv.i8
+    IL_0097:  add
+    IL_0098:  stloc.s    V_6
+    IL_009a:  ldloc.s    V_6
+    IL_009c:  ldloc.s    V_5
+    IL_009e:  blt.un.s   IL_0085
 
-    IL_00a2:  nop
-    IL_00a3:  ldloc.3
-    IL_00a4:  ret
+    IL_00a0:  nop
+    IL_00a1:  ldloc.3
+    IL_00a2:  ret
   } 
 
   .method public static uint64[]  f9(uint64 start) cil managed
@@ -519,45 +513,43 @@
     IL_0016:  ldloc.0
     IL_0017:  stloc.1
     IL_0018:  ldloc.1
-    IL_0019:  ldc.i4.1
-    IL_001a:  conv.i8
-    IL_001b:  bge.un.s   IL_0023
+    IL_0019:  brtrue.s   IL_0021
 
-    IL_001d:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0022:  ret
+    IL_001b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0020:  ret
 
-    IL_0023:  ldloc.1
-    IL_0024:  conv.ovf.i.un
-    IL_0025:  newarr     [runtime]System.UInt64
-    IL_002a:  stloc.2
-    IL_002b:  ldc.i4.0
-    IL_002c:  conv.i8
-    IL_002d:  stloc.3
-    IL_002e:  ldarg.0
-    IL_002f:  stloc.s    V_4
-    IL_0031:  br.s       IL_0045
+    IL_0021:  ldloc.1
+    IL_0022:  conv.ovf.i.un
+    IL_0023:  newarr     [runtime]System.UInt64
+    IL_0028:  stloc.2
+    IL_0029:  ldc.i4.0
+    IL_002a:  conv.i8
+    IL_002b:  stloc.3
+    IL_002c:  ldarg.0
+    IL_002d:  stloc.s    V_4
+    IL_002f:  br.s       IL_0043
 
-    IL_0033:  ldloc.2
-    IL_0034:  ldloc.3
-    IL_0035:  conv.i
-    IL_0036:  ldloc.s    V_4
-    IL_0038:  stelem.i8
-    IL_0039:  ldloc.s    V_4
-    IL_003b:  ldc.i4.1
-    IL_003c:  conv.i8
-    IL_003d:  add
-    IL_003e:  stloc.s    V_4
-    IL_0040:  ldloc.3
-    IL_0041:  ldc.i4.1
-    IL_0042:  conv.i8
-    IL_0043:  add
-    IL_0044:  stloc.3
-    IL_0045:  ldloc.3
-    IL_0046:  ldloc.0
-    IL_0047:  blt.un.s   IL_0033
+    IL_0031:  ldloc.2
+    IL_0032:  ldloc.3
+    IL_0033:  conv.i
+    IL_0034:  ldloc.s    V_4
+    IL_0036:  stelem.i8
+    IL_0037:  ldloc.s    V_4
+    IL_0039:  ldc.i4.1
+    IL_003a:  conv.i8
+    IL_003b:  add
+    IL_003c:  stloc.s    V_4
+    IL_003e:  ldloc.3
+    IL_003f:  ldc.i4.1
+    IL_0040:  conv.i8
+    IL_0041:  add
+    IL_0042:  stloc.3
+    IL_0043:  ldloc.3
+    IL_0044:  ldloc.0
+    IL_0045:  blt.un.s   IL_0031
 
-    IL_0049:  ldloc.2
-    IL_004a:  ret
+    IL_0047:  ldloc.2
+    IL_0048:  ret
   } 
 
   .method public static uint64[]  f10(uint64 step) cil managed
@@ -612,45 +604,43 @@
     IL_002d:  ldloc.0
     IL_002e:  stloc.1
     IL_002f:  ldloc.1
-    IL_0030:  ldc.i4.1
-    IL_0031:  conv.i8
-    IL_0032:  bge.un.s   IL_003a
+    IL_0030:  brtrue.s   IL_0038
 
-    IL_0034:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0039:  ret
+    IL_0032:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0037:  ret
 
-    IL_003a:  ldloc.1
-    IL_003b:  conv.ovf.i.un
-    IL_003c:  newarr     [runtime]System.UInt64
-    IL_0041:  stloc.2
-    IL_0042:  ldc.i4.0
-    IL_0043:  conv.i8
-    IL_0044:  stloc.3
-    IL_0045:  ldc.i4.1
-    IL_0046:  conv.i8
-    IL_0047:  stloc.s    V_4
-    IL_0049:  br.s       IL_005c
+    IL_0038:  ldloc.1
+    IL_0039:  conv.ovf.i.un
+    IL_003a:  newarr     [runtime]System.UInt64
+    IL_003f:  stloc.2
+    IL_0040:  ldc.i4.0
+    IL_0041:  conv.i8
+    IL_0042:  stloc.3
+    IL_0043:  ldc.i4.1
+    IL_0044:  conv.i8
+    IL_0045:  stloc.s    V_4
+    IL_0047:  br.s       IL_005a
 
-    IL_004b:  ldloc.2
-    IL_004c:  ldloc.3
-    IL_004d:  conv.i
-    IL_004e:  ldloc.s    V_4
-    IL_0050:  stelem.i8
-    IL_0051:  ldloc.s    V_4
-    IL_0053:  ldarg.0
-    IL_0054:  add
-    IL_0055:  stloc.s    V_4
-    IL_0057:  ldloc.3
-    IL_0058:  ldc.i4.1
-    IL_0059:  conv.i8
-    IL_005a:  add
-    IL_005b:  stloc.3
-    IL_005c:  ldloc.3
-    IL_005d:  ldloc.0
-    IL_005e:  blt.un.s   IL_004b
+    IL_0049:  ldloc.2
+    IL_004a:  ldloc.3
+    IL_004b:  conv.i
+    IL_004c:  ldloc.s    V_4
+    IL_004e:  stelem.i8
+    IL_004f:  ldloc.s    V_4
+    IL_0051:  ldarg.0
+    IL_0052:  add
+    IL_0053:  stloc.s    V_4
+    IL_0055:  ldloc.3
+    IL_0056:  ldc.i4.1
+    IL_0057:  conv.i8
+    IL_0058:  add
+    IL_0059:  stloc.3
+    IL_005a:  ldloc.3
+    IL_005b:  ldloc.0
+    IL_005c:  blt.un.s   IL_0049
 
-    IL_0060:  ldloc.2
-    IL_0061:  ret
+    IL_005e:  ldloc.2
+    IL_005f:  ret
   } 
 
   .method public static uint64[]  f11(uint64 finish) cil managed
@@ -685,46 +675,44 @@
     IL_0014:  ldloc.0
     IL_0015:  stloc.1
     IL_0016:  ldloc.1
-    IL_0017:  ldc.i4.1
-    IL_0018:  conv.i8
-    IL_0019:  bge.un.s   IL_0021
+    IL_0017:  brtrue.s   IL_001f
 
-    IL_001b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0020:  ret
+    IL_0019:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_001e:  ret
 
-    IL_0021:  ldloc.1
-    IL_0022:  conv.ovf.i.un
-    IL_0023:  newarr     [runtime]System.UInt64
-    IL_0028:  stloc.2
-    IL_0029:  ldc.i4.0
-    IL_002a:  conv.i8
-    IL_002b:  stloc.3
-    IL_002c:  ldc.i4.1
-    IL_002d:  conv.i8
-    IL_002e:  stloc.s    V_4
-    IL_0030:  br.s       IL_0044
+    IL_001f:  ldloc.1
+    IL_0020:  conv.ovf.i.un
+    IL_0021:  newarr     [runtime]System.UInt64
+    IL_0026:  stloc.2
+    IL_0027:  ldc.i4.0
+    IL_0028:  conv.i8
+    IL_0029:  stloc.3
+    IL_002a:  ldc.i4.1
+    IL_002b:  conv.i8
+    IL_002c:  stloc.s    V_4
+    IL_002e:  br.s       IL_0042
 
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.3
-    IL_0034:  conv.i
-    IL_0035:  ldloc.s    V_4
-    IL_0037:  stelem.i8
-    IL_0038:  ldloc.s    V_4
-    IL_003a:  ldc.i4.1
-    IL_003b:  conv.i8
-    IL_003c:  add
-    IL_003d:  stloc.s    V_4
-    IL_003f:  ldloc.3
-    IL_0040:  ldc.i4.1
-    IL_0041:  conv.i8
-    IL_0042:  add
-    IL_0043:  stloc.3
-    IL_0044:  ldloc.3
-    IL_0045:  ldloc.0
-    IL_0046:  blt.un.s   IL_0032
+    IL_0030:  ldloc.2
+    IL_0031:  ldloc.3
+    IL_0032:  conv.i
+    IL_0033:  ldloc.s    V_4
+    IL_0035:  stelem.i8
+    IL_0036:  ldloc.s    V_4
+    IL_0038:  ldc.i4.1
+    IL_0039:  conv.i8
+    IL_003a:  add
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldloc.3
+    IL_003e:  ldc.i4.1
+    IL_003f:  conv.i8
+    IL_0040:  add
+    IL_0041:  stloc.3
+    IL_0042:  ldloc.3
+    IL_0043:  ldloc.0
+    IL_0044:  blt.un.s   IL_0030
 
-    IL_0048:  ldloc.2
-    IL_0049:  ret
+    IL_0046:  ldloc.2
+    IL_0047:  ret
   } 
 
   .method public static uint64[]  f12(uint64 start,
@@ -778,44 +766,42 @@
     IL_002a:  ldloc.0
     IL_002b:  stloc.1
     IL_002c:  ldloc.1
-    IL_002d:  ldc.i4.1
-    IL_002e:  conv.i8
-    IL_002f:  bge.un.s   IL_0037
+    IL_002d:  brtrue.s   IL_0035
 
-    IL_0031:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0036:  ret
+    IL_002f:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0034:  ret
 
-    IL_0037:  ldloc.1
-    IL_0038:  conv.ovf.i.un
-    IL_0039:  newarr     [runtime]System.UInt64
-    IL_003e:  stloc.2
-    IL_003f:  ldc.i4.0
-    IL_0040:  conv.i8
-    IL_0041:  stloc.3
-    IL_0042:  ldarg.0
-    IL_0043:  stloc.s    V_4
-    IL_0045:  br.s       IL_0058
+    IL_0035:  ldloc.1
+    IL_0036:  conv.ovf.i.un
+    IL_0037:  newarr     [runtime]System.UInt64
+    IL_003c:  stloc.2
+    IL_003d:  ldc.i4.0
+    IL_003e:  conv.i8
+    IL_003f:  stloc.3
+    IL_0040:  ldarg.0
+    IL_0041:  stloc.s    V_4
+    IL_0043:  br.s       IL_0056
 
-    IL_0047:  ldloc.2
-    IL_0048:  ldloc.3
-    IL_0049:  conv.i
-    IL_004a:  ldloc.s    V_4
-    IL_004c:  stelem.i8
-    IL_004d:  ldloc.s    V_4
-    IL_004f:  ldarg.1
-    IL_0050:  add
-    IL_0051:  stloc.s    V_4
-    IL_0053:  ldloc.3
-    IL_0054:  ldc.i4.1
-    IL_0055:  conv.i8
-    IL_0056:  add
-    IL_0057:  stloc.3
-    IL_0058:  ldloc.3
-    IL_0059:  ldloc.0
-    IL_005a:  blt.un.s   IL_0047
+    IL_0045:  ldloc.2
+    IL_0046:  ldloc.3
+    IL_0047:  conv.i
+    IL_0048:  ldloc.s    V_4
+    IL_004a:  stelem.i8
+    IL_004b:  ldloc.s    V_4
+    IL_004d:  ldarg.1
+    IL_004e:  add
+    IL_004f:  stloc.s    V_4
+    IL_0051:  ldloc.3
+    IL_0052:  ldc.i4.1
+    IL_0053:  conv.i8
+    IL_0054:  add
+    IL_0055:  stloc.3
+    IL_0056:  ldloc.3
+    IL_0057:  ldloc.0
+    IL_0058:  blt.un.s   IL_0045
 
-    IL_005c:  ldloc.2
-    IL_005d:  ret
+    IL_005a:  ldloc.2
+    IL_005b:  ret
   } 
 
   .method public static uint64[]  f13(uint64 start,
@@ -870,101 +856,99 @@
     IL_0024:  nop
     IL_0025:  stloc.2
     IL_0026:  ldloc.2
-    IL_0027:  ldc.i4.1
-    IL_0028:  conv.i8
-    IL_0029:  bge.un.s   IL_0031
+    IL_0027:  brtrue.s   IL_002f
 
-    IL_002b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0030:  ret
+    IL_0029:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_002e:  ret
 
-    IL_0031:  ldloc.2
-    IL_0032:  conv.ovf.i.un
-    IL_0033:  newarr     [runtime]System.UInt64
-    IL_0038:  stloc.3
-    IL_0039:  ldloc.1
-    IL_003a:  brfalse.s  IL_006c
+    IL_002f:  ldloc.2
+    IL_0030:  conv.ovf.i.un
+    IL_0031:  newarr     [runtime]System.UInt64
+    IL_0036:  stloc.3
+    IL_0037:  ldloc.1
+    IL_0038:  brfalse.s  IL_006a
 
-    IL_003c:  ldc.i4.1
-    IL_003d:  stloc.s    V_4
-    IL_003f:  ldc.i4.0
-    IL_0040:  conv.i8
-    IL_0041:  stloc.s    V_5
-    IL_0043:  ldarg.0
-    IL_0044:  stloc.s    V_6
-    IL_0046:  br.s       IL_0065
+    IL_003a:  ldc.i4.1
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldc.i4.0
+    IL_003e:  conv.i8
+    IL_003f:  stloc.s    V_5
+    IL_0041:  ldarg.0
+    IL_0042:  stloc.s    V_6
+    IL_0044:  br.s       IL_0063
 
-    IL_0048:  ldloc.3
-    IL_0049:  ldloc.s    V_5
-    IL_004b:  conv.i
-    IL_004c:  ldloc.s    V_6
-    IL_004e:  stelem.i8
-    IL_004f:  ldloc.s    V_6
-    IL_0051:  ldc.i4.1
-    IL_0052:  conv.i8
-    IL_0053:  add
-    IL_0054:  stloc.s    V_6
-    IL_0056:  ldloc.s    V_5
-    IL_0058:  ldc.i4.1
-    IL_0059:  conv.i8
-    IL_005a:  add
-    IL_005b:  stloc.s    V_5
-    IL_005d:  ldloc.s    V_5
-    IL_005f:  ldc.i4.0
-    IL_0060:  conv.i8
-    IL_0061:  cgt.un
-    IL_0063:  stloc.s    V_4
-    IL_0065:  ldloc.s    V_4
-    IL_0067:  brtrue.s   IL_0048
+    IL_0046:  ldloc.3
+    IL_0047:  ldloc.s    V_5
+    IL_0049:  conv.i
+    IL_004a:  ldloc.s    V_6
+    IL_004c:  stelem.i8
+    IL_004d:  ldloc.s    V_6
+    IL_004f:  ldc.i4.1
+    IL_0050:  conv.i8
+    IL_0051:  add
+    IL_0052:  stloc.s    V_6
+    IL_0054:  ldloc.s    V_5
+    IL_0056:  ldc.i4.1
+    IL_0057:  conv.i8
+    IL_0058:  add
+    IL_0059:  stloc.s    V_5
+    IL_005b:  ldloc.s    V_5
+    IL_005d:  ldc.i4.0
+    IL_005e:  conv.i8
+    IL_005f:  cgt.un
+    IL_0061:  stloc.s    V_4
+    IL_0063:  ldloc.s    V_4
+    IL_0065:  brtrue.s   IL_0046
 
-    IL_0069:  nop
-    IL_006a:  br.s       IL_00a3
+    IL_0067:  nop
+    IL_0068:  br.s       IL_00a1
 
-    IL_006c:  ldarg.1
-    IL_006d:  ldarg.0
-    IL_006e:  bge.un.s   IL_0075
+    IL_006a:  ldarg.1
+    IL_006b:  ldarg.0
+    IL_006c:  bge.un.s   IL_0073
 
-    IL_0070:  ldc.i4.0
-    IL_0071:  conv.i8
-    IL_0072:  nop
-    IL_0073:  br.s       IL_007c
+    IL_006e:  ldc.i4.0
+    IL_006f:  conv.i8
+    IL_0070:  nop
+    IL_0071:  br.s       IL_007a
 
-    IL_0075:  ldarg.1
-    IL_0076:  ldarg.0
-    IL_0077:  sub
-    IL_0078:  ldc.i4.1
-    IL_0079:  conv.i8
-    IL_007a:  add.ovf.un
-    IL_007b:  nop
-    IL_007c:  stloc.s    V_5
-    IL_007e:  ldc.i4.0
-    IL_007f:  conv.i8
-    IL_0080:  stloc.s    V_6
-    IL_0082:  ldarg.0
-    IL_0083:  stloc.s    V_7
-    IL_0085:  br.s       IL_009c
+    IL_0073:  ldarg.1
+    IL_0074:  ldarg.0
+    IL_0075:  sub
+    IL_0076:  ldc.i4.1
+    IL_0077:  conv.i8
+    IL_0078:  add.ovf.un
+    IL_0079:  nop
+    IL_007a:  stloc.s    V_5
+    IL_007c:  ldc.i4.0
+    IL_007d:  conv.i8
+    IL_007e:  stloc.s    V_6
+    IL_0080:  ldarg.0
+    IL_0081:  stloc.s    V_7
+    IL_0083:  br.s       IL_009a
 
-    IL_0087:  ldloc.3
-    IL_0088:  ldloc.s    V_6
-    IL_008a:  conv.i
-    IL_008b:  ldloc.s    V_7
-    IL_008d:  stelem.i8
-    IL_008e:  ldloc.s    V_7
-    IL_0090:  ldc.i4.1
-    IL_0091:  conv.i8
-    IL_0092:  add
-    IL_0093:  stloc.s    V_7
-    IL_0095:  ldloc.s    V_6
-    IL_0097:  ldc.i4.1
-    IL_0098:  conv.i8
-    IL_0099:  add
-    IL_009a:  stloc.s    V_6
-    IL_009c:  ldloc.s    V_6
-    IL_009e:  ldloc.s    V_5
-    IL_00a0:  blt.un.s   IL_0087
+    IL_0085:  ldloc.3
+    IL_0086:  ldloc.s    V_6
+    IL_0088:  conv.i
+    IL_0089:  ldloc.s    V_7
+    IL_008b:  stelem.i8
+    IL_008c:  ldloc.s    V_7
+    IL_008e:  ldc.i4.1
+    IL_008f:  conv.i8
+    IL_0090:  add
+    IL_0091:  stloc.s    V_7
+    IL_0093:  ldloc.s    V_6
+    IL_0095:  ldc.i4.1
+    IL_0096:  conv.i8
+    IL_0097:  add
+    IL_0098:  stloc.s    V_6
+    IL_009a:  ldloc.s    V_6
+    IL_009c:  ldloc.s    V_5
+    IL_009e:  blt.un.s   IL_0085
 
-    IL_00a2:  nop
-    IL_00a3:  ldloc.3
-    IL_00a4:  ret
+    IL_00a0:  nop
+    IL_00a1:  ldloc.3
+    IL_00a2:  ret
   } 
 
   .method public static uint64[]  f14(uint64 step,
@@ -1018,45 +1002,43 @@
     IL_0027:  ldloc.0
     IL_0028:  stloc.1
     IL_0029:  ldloc.1
-    IL_002a:  ldc.i4.1
-    IL_002b:  conv.i8
-    IL_002c:  bge.un.s   IL_0034
+    IL_002a:  brtrue.s   IL_0032
 
-    IL_002e:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0033:  ret
+    IL_002c:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0031:  ret
 
-    IL_0034:  ldloc.1
-    IL_0035:  conv.ovf.i.un
-    IL_0036:  newarr     [runtime]System.UInt64
-    IL_003b:  stloc.2
-    IL_003c:  ldc.i4.0
-    IL_003d:  conv.i8
-    IL_003e:  stloc.3
-    IL_003f:  ldc.i4.1
-    IL_0040:  conv.i8
-    IL_0041:  stloc.s    V_4
-    IL_0043:  br.s       IL_0056
+    IL_0032:  ldloc.1
+    IL_0033:  conv.ovf.i.un
+    IL_0034:  newarr     [runtime]System.UInt64
+    IL_0039:  stloc.2
+    IL_003a:  ldc.i4.0
+    IL_003b:  conv.i8
+    IL_003c:  stloc.3
+    IL_003d:  ldc.i4.1
+    IL_003e:  conv.i8
+    IL_003f:  stloc.s    V_4
+    IL_0041:  br.s       IL_0054
 
-    IL_0045:  ldloc.2
-    IL_0046:  ldloc.3
-    IL_0047:  conv.i
-    IL_0048:  ldloc.s    V_4
-    IL_004a:  stelem.i8
-    IL_004b:  ldloc.s    V_4
-    IL_004d:  ldarg.0
-    IL_004e:  add
-    IL_004f:  stloc.s    V_4
-    IL_0051:  ldloc.3
-    IL_0052:  ldc.i4.1
-    IL_0053:  conv.i8
-    IL_0054:  add
-    IL_0055:  stloc.3
-    IL_0056:  ldloc.3
-    IL_0057:  ldloc.0
-    IL_0058:  blt.un.s   IL_0045
+    IL_0043:  ldloc.2
+    IL_0044:  ldloc.3
+    IL_0045:  conv.i
+    IL_0046:  ldloc.s    V_4
+    IL_0048:  stelem.i8
+    IL_0049:  ldloc.s    V_4
+    IL_004b:  ldarg.0
+    IL_004c:  add
+    IL_004d:  stloc.s    V_4
+    IL_004f:  ldloc.3
+    IL_0050:  ldc.i4.1
+    IL_0051:  conv.i8
+    IL_0052:  add
+    IL_0053:  stloc.3
+    IL_0054:  ldloc.3
+    IL_0055:  ldloc.0
+    IL_0056:  blt.un.s   IL_0043
 
-    IL_005a:  ldloc.2
-    IL_005b:  ret
+    IL_0058:  ldloc.2
+    IL_0059:  ret
   } 
 
   .method public static uint64[]  f15(uint64 start,
@@ -1131,101 +1113,99 @@
     IL_0038:  nop
     IL_0039:  stloc.2
     IL_003a:  ldloc.2
-    IL_003b:  ldc.i4.1
-    IL_003c:  conv.i8
-    IL_003d:  bge.un.s   IL_0045
+    IL_003b:  brtrue.s   IL_0043
 
-    IL_003f:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0044:  ret
+    IL_003d:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0042:  ret
 
-    IL_0045:  ldloc.2
-    IL_0046:  conv.ovf.i.un
-    IL_0047:  newarr     [runtime]System.UInt64
-    IL_004c:  stloc.3
-    IL_004d:  ldloc.1
-    IL_004e:  brfalse.s  IL_007f
+    IL_0043:  ldloc.2
+    IL_0044:  conv.ovf.i.un
+    IL_0045:  newarr     [runtime]System.UInt64
+    IL_004a:  stloc.3
+    IL_004b:  ldloc.1
+    IL_004c:  brfalse.s  IL_007d
 
-    IL_0050:  ldc.i4.1
-    IL_0051:  stloc.s    V_4
-    IL_0053:  ldc.i4.0
-    IL_0054:  conv.i8
-    IL_0055:  stloc.s    V_5
-    IL_0057:  ldarg.0
-    IL_0058:  stloc.s    V_6
-    IL_005a:  br.s       IL_0078
+    IL_004e:  ldc.i4.1
+    IL_004f:  stloc.s    V_4
+    IL_0051:  ldc.i4.0
+    IL_0052:  conv.i8
+    IL_0053:  stloc.s    V_5
+    IL_0055:  ldarg.0
+    IL_0056:  stloc.s    V_6
+    IL_0058:  br.s       IL_0076
 
-    IL_005c:  ldloc.3
-    IL_005d:  ldloc.s    V_5
-    IL_005f:  conv.i
-    IL_0060:  ldloc.s    V_6
-    IL_0062:  stelem.i8
-    IL_0063:  ldloc.s    V_6
-    IL_0065:  ldarg.1
-    IL_0066:  add
-    IL_0067:  stloc.s    V_6
-    IL_0069:  ldloc.s    V_5
-    IL_006b:  ldc.i4.1
-    IL_006c:  conv.i8
-    IL_006d:  add
-    IL_006e:  stloc.s    V_5
-    IL_0070:  ldloc.s    V_5
-    IL_0072:  ldc.i4.0
-    IL_0073:  conv.i8
-    IL_0074:  cgt.un
-    IL_0076:  stloc.s    V_4
-    IL_0078:  ldloc.s    V_4
-    IL_007a:  brtrue.s   IL_005c
+    IL_005a:  ldloc.3
+    IL_005b:  ldloc.s    V_5
+    IL_005d:  conv.i
+    IL_005e:  ldloc.s    V_6
+    IL_0060:  stelem.i8
+    IL_0061:  ldloc.s    V_6
+    IL_0063:  ldarg.1
+    IL_0064:  add
+    IL_0065:  stloc.s    V_6
+    IL_0067:  ldloc.s    V_5
+    IL_0069:  ldc.i4.1
+    IL_006a:  conv.i8
+    IL_006b:  add
+    IL_006c:  stloc.s    V_5
+    IL_006e:  ldloc.s    V_5
+    IL_0070:  ldc.i4.0
+    IL_0071:  conv.i8
+    IL_0072:  cgt.un
+    IL_0074:  stloc.s    V_4
+    IL_0076:  ldloc.s    V_4
+    IL_0078:  brtrue.s   IL_005a
 
-    IL_007c:  nop
-    IL_007d:  br.s       IL_00b7
+    IL_007a:  nop
+    IL_007b:  br.s       IL_00b5
 
-    IL_007f:  ldarg.2
-    IL_0080:  ldarg.0
-    IL_0081:  bge.un.s   IL_0088
+    IL_007d:  ldarg.2
+    IL_007e:  ldarg.0
+    IL_007f:  bge.un.s   IL_0086
 
-    IL_0083:  ldc.i4.0
-    IL_0084:  conv.i8
-    IL_0085:  nop
-    IL_0086:  br.s       IL_0091
+    IL_0081:  ldc.i4.0
+    IL_0082:  conv.i8
+    IL_0083:  nop
+    IL_0084:  br.s       IL_008f
 
-    IL_0088:  ldarg.2
-    IL_0089:  ldarg.0
-    IL_008a:  sub
-    IL_008b:  ldarg.1
-    IL_008c:  div.un
-    IL_008d:  ldc.i4.1
-    IL_008e:  conv.i8
-    IL_008f:  add.ovf.un
-    IL_0090:  nop
-    IL_0091:  stloc.s    V_5
-    IL_0093:  ldc.i4.0
-    IL_0094:  conv.i8
-    IL_0095:  stloc.s    V_6
-    IL_0097:  ldarg.0
-    IL_0098:  stloc.s    V_7
-    IL_009a:  br.s       IL_00b0
+    IL_0086:  ldarg.2
+    IL_0087:  ldarg.0
+    IL_0088:  sub
+    IL_0089:  ldarg.1
+    IL_008a:  div.un
+    IL_008b:  ldc.i4.1
+    IL_008c:  conv.i8
+    IL_008d:  add.ovf.un
+    IL_008e:  nop
+    IL_008f:  stloc.s    V_5
+    IL_0091:  ldc.i4.0
+    IL_0092:  conv.i8
+    IL_0093:  stloc.s    V_6
+    IL_0095:  ldarg.0
+    IL_0096:  stloc.s    V_7
+    IL_0098:  br.s       IL_00ae
 
-    IL_009c:  ldloc.3
-    IL_009d:  ldloc.s    V_6
-    IL_009f:  conv.i
-    IL_00a0:  ldloc.s    V_7
-    IL_00a2:  stelem.i8
-    IL_00a3:  ldloc.s    V_7
-    IL_00a5:  ldarg.1
-    IL_00a6:  add
-    IL_00a7:  stloc.s    V_7
-    IL_00a9:  ldloc.s    V_6
-    IL_00ab:  ldc.i4.1
-    IL_00ac:  conv.i8
-    IL_00ad:  add
-    IL_00ae:  stloc.s    V_6
-    IL_00b0:  ldloc.s    V_6
-    IL_00b2:  ldloc.s    V_5
-    IL_00b4:  blt.un.s   IL_009c
+    IL_009a:  ldloc.3
+    IL_009b:  ldloc.s    V_6
+    IL_009d:  conv.i
+    IL_009e:  ldloc.s    V_7
+    IL_00a0:  stelem.i8
+    IL_00a1:  ldloc.s    V_7
+    IL_00a3:  ldarg.1
+    IL_00a4:  add
+    IL_00a5:  stloc.s    V_7
+    IL_00a7:  ldloc.s    V_6
+    IL_00a9:  ldc.i4.1
+    IL_00aa:  conv.i8
+    IL_00ab:  add
+    IL_00ac:  stloc.s    V_6
+    IL_00ae:  ldloc.s    V_6
+    IL_00b0:  ldloc.s    V_5
+    IL_00b2:  blt.un.s   IL_009a
 
-    IL_00b6:  nop
-    IL_00b7:  ldloc.3
-    IL_00b8:  ret
+    IL_00b4:  nop
+    IL_00b5:  ldloc.3
+    IL_00b6:  ret
   } 
 
   .method public static uint64[]  f16(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f) cil managed
@@ -1264,45 +1244,43 @@
     IL_001d:  ldloc.1
     IL_001e:  stloc.2
     IL_001f:  ldloc.2
-    IL_0020:  ldc.i4.1
-    IL_0021:  conv.i8
-    IL_0022:  bge.un.s   IL_002a
+    IL_0020:  brtrue.s   IL_0028
 
-    IL_0024:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0029:  ret
+    IL_0022:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0027:  ret
 
-    IL_002a:  ldloc.2
-    IL_002b:  conv.ovf.i.un
-    IL_002c:  newarr     [runtime]System.UInt64
-    IL_0031:  stloc.3
-    IL_0032:  ldc.i4.0
-    IL_0033:  conv.i8
-    IL_0034:  stloc.s    V_4
-    IL_0036:  ldloc.0
-    IL_0037:  stloc.s    V_5
-    IL_0039:  br.s       IL_0050
+    IL_0028:  ldloc.2
+    IL_0029:  conv.ovf.i.un
+    IL_002a:  newarr     [runtime]System.UInt64
+    IL_002f:  stloc.3
+    IL_0030:  ldc.i4.0
+    IL_0031:  conv.i8
+    IL_0032:  stloc.s    V_4
+    IL_0034:  ldloc.0
+    IL_0035:  stloc.s    V_5
+    IL_0037:  br.s       IL_004e
 
-    IL_003b:  ldloc.3
-    IL_003c:  ldloc.s    V_4
-    IL_003e:  conv.i
-    IL_003f:  ldloc.s    V_5
-    IL_0041:  stelem.i8
-    IL_0042:  ldloc.s    V_5
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  add
-    IL_0047:  stloc.s    V_5
-    IL_0049:  ldloc.s    V_4
-    IL_004b:  ldc.i4.1
-    IL_004c:  conv.i8
-    IL_004d:  add
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloc.s    V_4
-    IL_0052:  ldloc.1
-    IL_0053:  blt.un.s   IL_003b
+    IL_0039:  ldloc.3
+    IL_003a:  ldloc.s    V_4
+    IL_003c:  conv.i
+    IL_003d:  ldloc.s    V_5
+    IL_003f:  stelem.i8
+    IL_0040:  ldloc.s    V_5
+    IL_0042:  ldc.i4.1
+    IL_0043:  conv.i8
+    IL_0044:  add
+    IL_0045:  stloc.s    V_5
+    IL_0047:  ldloc.s    V_4
+    IL_0049:  ldc.i4.1
+    IL_004a:  conv.i8
+    IL_004b:  add
+    IL_004c:  stloc.s    V_4
+    IL_004e:  ldloc.s    V_4
+    IL_0050:  ldloc.1
+    IL_0051:  blt.un.s   IL_0039
 
-    IL_0055:  ldloc.3
-    IL_0056:  ret
+    IL_0053:  ldloc.3
+    IL_0054:  ret
   } 
 
   .method public static uint64[]  f17(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f) cil managed
@@ -1341,46 +1319,44 @@
     IL_001b:  ldloc.1
     IL_001c:  stloc.2
     IL_001d:  ldloc.2
-    IL_001e:  ldc.i4.1
-    IL_001f:  conv.i8
-    IL_0020:  bge.un.s   IL_0028
+    IL_001e:  brtrue.s   IL_0026
 
-    IL_0022:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0027:  ret
+    IL_0020:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0025:  ret
 
-    IL_0028:  ldloc.2
-    IL_0029:  conv.ovf.i.un
-    IL_002a:  newarr     [runtime]System.UInt64
-    IL_002f:  stloc.3
-    IL_0030:  ldc.i4.0
-    IL_0031:  conv.i8
-    IL_0032:  stloc.s    V_4
-    IL_0034:  ldc.i4.1
-    IL_0035:  conv.i8
-    IL_0036:  stloc.s    V_5
-    IL_0038:  br.s       IL_004f
+    IL_0026:  ldloc.2
+    IL_0027:  conv.ovf.i.un
+    IL_0028:  newarr     [runtime]System.UInt64
+    IL_002d:  stloc.3
+    IL_002e:  ldc.i4.0
+    IL_002f:  conv.i8
+    IL_0030:  stloc.s    V_4
+    IL_0032:  ldc.i4.1
+    IL_0033:  conv.i8
+    IL_0034:  stloc.s    V_5
+    IL_0036:  br.s       IL_004d
 
-    IL_003a:  ldloc.3
-    IL_003b:  ldloc.s    V_4
-    IL_003d:  conv.i
-    IL_003e:  ldloc.s    V_5
-    IL_0040:  stelem.i8
-    IL_0041:  ldloc.s    V_5
-    IL_0043:  ldc.i4.1
-    IL_0044:  conv.i8
-    IL_0045:  add
-    IL_0046:  stloc.s    V_5
-    IL_0048:  ldloc.s    V_4
-    IL_004a:  ldc.i4.1
-    IL_004b:  conv.i8
-    IL_004c:  add
-    IL_004d:  stloc.s    V_4
-    IL_004f:  ldloc.s    V_4
-    IL_0051:  ldloc.1
-    IL_0052:  blt.un.s   IL_003a
+    IL_0038:  ldloc.3
+    IL_0039:  ldloc.s    V_4
+    IL_003b:  conv.i
+    IL_003c:  ldloc.s    V_5
+    IL_003e:  stelem.i8
+    IL_003f:  ldloc.s    V_5
+    IL_0041:  ldc.i4.1
+    IL_0042:  conv.i8
+    IL_0043:  add
+    IL_0044:  stloc.s    V_5
+    IL_0046:  ldloc.s    V_4
+    IL_0048:  ldc.i4.1
+    IL_0049:  conv.i8
+    IL_004a:  add
+    IL_004b:  stloc.s    V_4
+    IL_004d:  ldloc.s    V_4
+    IL_004f:  ldloc.1
+    IL_0050:  blt.un.s   IL_0038
 
-    IL_0054:  ldloc.3
-    IL_0055:  ret
+    IL_0052:  ldloc.3
+    IL_0053:  ret
   } 
 
   .method public static uint64[]  f18(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f,
@@ -1444,101 +1420,99 @@
     IL_0033:  nop
     IL_0034:  stloc.s    V_4
     IL_0036:  ldloc.s    V_4
-    IL_0038:  ldc.i4.1
-    IL_0039:  conv.i8
-    IL_003a:  bge.un.s   IL_0042
+    IL_0038:  brtrue.s   IL_0040
 
-    IL_003c:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0041:  ret
+    IL_003a:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_003f:  ret
 
-    IL_0042:  ldloc.s    V_4
-    IL_0044:  conv.ovf.i.un
-    IL_0045:  newarr     [runtime]System.UInt64
-    IL_004a:  stloc.s    V_5
-    IL_004c:  ldloc.3
-    IL_004d:  brfalse.s  IL_0080
+    IL_0040:  ldloc.s    V_4
+    IL_0042:  conv.ovf.i.un
+    IL_0043:  newarr     [runtime]System.UInt64
+    IL_0048:  stloc.s    V_5
+    IL_004a:  ldloc.3
+    IL_004b:  brfalse.s  IL_007e
 
-    IL_004f:  ldc.i4.1
-    IL_0050:  stloc.s    V_6
-    IL_0052:  ldc.i4.0
-    IL_0053:  conv.i8
-    IL_0054:  stloc.s    V_7
-    IL_0056:  ldloc.0
-    IL_0057:  stloc.s    V_8
-    IL_0059:  br.s       IL_0079
+    IL_004d:  ldc.i4.1
+    IL_004e:  stloc.s    V_6
+    IL_0050:  ldc.i4.0
+    IL_0051:  conv.i8
+    IL_0052:  stloc.s    V_7
+    IL_0054:  ldloc.0
+    IL_0055:  stloc.s    V_8
+    IL_0057:  br.s       IL_0077
 
-    IL_005b:  ldloc.s    V_5
-    IL_005d:  ldloc.s    V_7
-    IL_005f:  conv.i
-    IL_0060:  ldloc.s    V_8
-    IL_0062:  stelem.i8
-    IL_0063:  ldloc.s    V_8
-    IL_0065:  ldc.i4.1
-    IL_0066:  conv.i8
-    IL_0067:  add
-    IL_0068:  stloc.s    V_8
-    IL_006a:  ldloc.s    V_7
-    IL_006c:  ldc.i4.1
-    IL_006d:  conv.i8
-    IL_006e:  add
-    IL_006f:  stloc.s    V_7
-    IL_0071:  ldloc.s    V_7
-    IL_0073:  ldc.i4.0
-    IL_0074:  conv.i8
-    IL_0075:  cgt.un
-    IL_0077:  stloc.s    V_6
-    IL_0079:  ldloc.s    V_6
-    IL_007b:  brtrue.s   IL_005b
+    IL_0059:  ldloc.s    V_5
+    IL_005b:  ldloc.s    V_7
+    IL_005d:  conv.i
+    IL_005e:  ldloc.s    V_8
+    IL_0060:  stelem.i8
+    IL_0061:  ldloc.s    V_8
+    IL_0063:  ldc.i4.1
+    IL_0064:  conv.i8
+    IL_0065:  add
+    IL_0066:  stloc.s    V_8
+    IL_0068:  ldloc.s    V_7
+    IL_006a:  ldc.i4.1
+    IL_006b:  conv.i8
+    IL_006c:  add
+    IL_006d:  stloc.s    V_7
+    IL_006f:  ldloc.s    V_7
+    IL_0071:  ldc.i4.0
+    IL_0072:  conv.i8
+    IL_0073:  cgt.un
+    IL_0075:  stloc.s    V_6
+    IL_0077:  ldloc.s    V_6
+    IL_0079:  brtrue.s   IL_0059
 
-    IL_007d:  nop
-    IL_007e:  br.s       IL_00b8
+    IL_007b:  nop
+    IL_007c:  br.s       IL_00b6
 
-    IL_0080:  ldloc.1
-    IL_0081:  ldloc.0
-    IL_0082:  bge.un.s   IL_0089
+    IL_007e:  ldloc.1
+    IL_007f:  ldloc.0
+    IL_0080:  bge.un.s   IL_0087
 
-    IL_0084:  ldc.i4.0
-    IL_0085:  conv.i8
-    IL_0086:  nop
-    IL_0087:  br.s       IL_0090
+    IL_0082:  ldc.i4.0
+    IL_0083:  conv.i8
+    IL_0084:  nop
+    IL_0085:  br.s       IL_008e
 
-    IL_0089:  ldloc.1
-    IL_008a:  ldloc.0
-    IL_008b:  sub
-    IL_008c:  ldc.i4.1
-    IL_008d:  conv.i8
-    IL_008e:  add.ovf.un
-    IL_008f:  nop
-    IL_0090:  stloc.s    V_7
-    IL_0092:  ldc.i4.0
-    IL_0093:  conv.i8
-    IL_0094:  stloc.s    V_8
-    IL_0096:  ldloc.0
-    IL_0097:  stloc.s    V_9
-    IL_0099:  br.s       IL_00b1
+    IL_0087:  ldloc.1
+    IL_0088:  ldloc.0
+    IL_0089:  sub
+    IL_008a:  ldc.i4.1
+    IL_008b:  conv.i8
+    IL_008c:  add.ovf.un
+    IL_008d:  nop
+    IL_008e:  stloc.s    V_7
+    IL_0090:  ldc.i4.0
+    IL_0091:  conv.i8
+    IL_0092:  stloc.s    V_8
+    IL_0094:  ldloc.0
+    IL_0095:  stloc.s    V_9
+    IL_0097:  br.s       IL_00af
 
-    IL_009b:  ldloc.s    V_5
-    IL_009d:  ldloc.s    V_8
-    IL_009f:  conv.i
-    IL_00a0:  ldloc.s    V_9
-    IL_00a2:  stelem.i8
-    IL_00a3:  ldloc.s    V_9
-    IL_00a5:  ldc.i4.1
-    IL_00a6:  conv.i8
-    IL_00a7:  add
-    IL_00a8:  stloc.s    V_9
-    IL_00aa:  ldloc.s    V_8
-    IL_00ac:  ldc.i4.1
-    IL_00ad:  conv.i8
-    IL_00ae:  add
-    IL_00af:  stloc.s    V_8
-    IL_00b1:  ldloc.s    V_8
-    IL_00b3:  ldloc.s    V_7
-    IL_00b5:  blt.un.s   IL_009b
+    IL_0099:  ldloc.s    V_5
+    IL_009b:  ldloc.s    V_8
+    IL_009d:  conv.i
+    IL_009e:  ldloc.s    V_9
+    IL_00a0:  stelem.i8
+    IL_00a1:  ldloc.s    V_9
+    IL_00a3:  ldc.i4.1
+    IL_00a4:  conv.i8
+    IL_00a5:  add
+    IL_00a6:  stloc.s    V_9
+    IL_00a8:  ldloc.s    V_8
+    IL_00aa:  ldc.i4.1
+    IL_00ab:  conv.i8
+    IL_00ac:  add
+    IL_00ad:  stloc.s    V_8
+    IL_00af:  ldloc.s    V_8
+    IL_00b1:  ldloc.s    V_7
+    IL_00b3:  blt.un.s   IL_0099
 
-    IL_00b7:  nop
-    IL_00b8:  ldloc.s    V_5
-    IL_00ba:  ret
+    IL_00b5:  nop
+    IL_00b6:  ldloc.s    V_5
+    IL_00b8:  ret
   } 
 
   .method public static uint64[]  f19(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f) cil managed
@@ -1577,45 +1551,43 @@
     IL_001d:  ldloc.1
     IL_001e:  stloc.2
     IL_001f:  ldloc.2
-    IL_0020:  ldc.i4.1
-    IL_0021:  conv.i8
-    IL_0022:  bge.un.s   IL_002a
+    IL_0020:  brtrue.s   IL_0028
 
-    IL_0024:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0029:  ret
+    IL_0022:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0027:  ret
 
-    IL_002a:  ldloc.2
-    IL_002b:  conv.ovf.i.un
-    IL_002c:  newarr     [runtime]System.UInt64
-    IL_0031:  stloc.3
-    IL_0032:  ldc.i4.0
-    IL_0033:  conv.i8
-    IL_0034:  stloc.s    V_4
-    IL_0036:  ldloc.0
-    IL_0037:  stloc.s    V_5
-    IL_0039:  br.s       IL_0050
+    IL_0028:  ldloc.2
+    IL_0029:  conv.ovf.i.un
+    IL_002a:  newarr     [runtime]System.UInt64
+    IL_002f:  stloc.3
+    IL_0030:  ldc.i4.0
+    IL_0031:  conv.i8
+    IL_0032:  stloc.s    V_4
+    IL_0034:  ldloc.0
+    IL_0035:  stloc.s    V_5
+    IL_0037:  br.s       IL_004e
 
-    IL_003b:  ldloc.3
-    IL_003c:  ldloc.s    V_4
-    IL_003e:  conv.i
-    IL_003f:  ldloc.s    V_5
-    IL_0041:  stelem.i8
-    IL_0042:  ldloc.s    V_5
-    IL_0044:  ldc.i4.1
-    IL_0045:  conv.i8
-    IL_0046:  add
-    IL_0047:  stloc.s    V_5
-    IL_0049:  ldloc.s    V_4
-    IL_004b:  ldc.i4.1
-    IL_004c:  conv.i8
-    IL_004d:  add
-    IL_004e:  stloc.s    V_4
-    IL_0050:  ldloc.s    V_4
-    IL_0052:  ldloc.1
-    IL_0053:  blt.un.s   IL_003b
+    IL_0039:  ldloc.3
+    IL_003a:  ldloc.s    V_4
+    IL_003c:  conv.i
+    IL_003d:  ldloc.s    V_5
+    IL_003f:  stelem.i8
+    IL_0040:  ldloc.s    V_5
+    IL_0042:  ldc.i4.1
+    IL_0043:  conv.i8
+    IL_0044:  add
+    IL_0045:  stloc.s    V_5
+    IL_0047:  ldloc.s    V_4
+    IL_0049:  ldc.i4.1
+    IL_004a:  conv.i8
+    IL_004b:  add
+    IL_004c:  stloc.s    V_4
+    IL_004e:  ldloc.s    V_4
+    IL_0050:  ldloc.1
+    IL_0051:  blt.un.s   IL_0039
 
-    IL_0055:  ldloc.3
-    IL_0056:  ret
+    IL_0053:  ldloc.3
+    IL_0054:  ret
   } 
 
   .method public static uint64[]  f20(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f) cil managed
@@ -1674,45 +1646,43 @@
     IL_0034:  ldloc.1
     IL_0035:  stloc.2
     IL_0036:  ldloc.2
-    IL_0037:  ldc.i4.1
-    IL_0038:  conv.i8
-    IL_0039:  bge.un.s   IL_0041
+    IL_0037:  brtrue.s   IL_003f
 
-    IL_003b:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0040:  ret
+    IL_0039:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_003e:  ret
 
-    IL_0041:  ldloc.2
-    IL_0042:  conv.ovf.i.un
-    IL_0043:  newarr     [runtime]System.UInt64
-    IL_0048:  stloc.3
-    IL_0049:  ldc.i4.0
-    IL_004a:  conv.i8
-    IL_004b:  stloc.s    V_4
-    IL_004d:  ldc.i4.1
-    IL_004e:  conv.i8
-    IL_004f:  stloc.s    V_5
-    IL_0051:  br.s       IL_0067
+    IL_003f:  ldloc.2
+    IL_0040:  conv.ovf.i.un
+    IL_0041:  newarr     [runtime]System.UInt64
+    IL_0046:  stloc.3
+    IL_0047:  ldc.i4.0
+    IL_0048:  conv.i8
+    IL_0049:  stloc.s    V_4
+    IL_004b:  ldc.i4.1
+    IL_004c:  conv.i8
+    IL_004d:  stloc.s    V_5
+    IL_004f:  br.s       IL_0065
 
-    IL_0053:  ldloc.3
-    IL_0054:  ldloc.s    V_4
-    IL_0056:  conv.i
-    IL_0057:  ldloc.s    V_5
-    IL_0059:  stelem.i8
-    IL_005a:  ldloc.s    V_5
-    IL_005c:  ldloc.0
-    IL_005d:  add
-    IL_005e:  stloc.s    V_5
-    IL_0060:  ldloc.s    V_4
-    IL_0062:  ldc.i4.1
-    IL_0063:  conv.i8
-    IL_0064:  add
-    IL_0065:  stloc.s    V_4
-    IL_0067:  ldloc.s    V_4
-    IL_0069:  ldloc.1
-    IL_006a:  blt.un.s   IL_0053
+    IL_0051:  ldloc.3
+    IL_0052:  ldloc.s    V_4
+    IL_0054:  conv.i
+    IL_0055:  ldloc.s    V_5
+    IL_0057:  stelem.i8
+    IL_0058:  ldloc.s    V_5
+    IL_005a:  ldloc.0
+    IL_005b:  add
+    IL_005c:  stloc.s    V_5
+    IL_005e:  ldloc.s    V_4
+    IL_0060:  ldc.i4.1
+    IL_0061:  conv.i8
+    IL_0062:  add
+    IL_0063:  stloc.s    V_4
+    IL_0065:  ldloc.s    V_4
+    IL_0067:  ldloc.1
+    IL_0068:  blt.un.s   IL_0051
 
-    IL_006c:  ldloc.3
-    IL_006d:  ret
+    IL_006a:  ldloc.3
+    IL_006b:  ret
   } 
 
   .method public static uint64[]  f21(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f) cil managed
@@ -1751,46 +1721,44 @@
     IL_001b:  ldloc.1
     IL_001c:  stloc.2
     IL_001d:  ldloc.2
-    IL_001e:  ldc.i4.1
-    IL_001f:  conv.i8
-    IL_0020:  bge.un.s   IL_0028
+    IL_001e:  brtrue.s   IL_0026
 
-    IL_0022:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_0027:  ret
+    IL_0020:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_0025:  ret
 
-    IL_0028:  ldloc.2
-    IL_0029:  conv.ovf.i.un
-    IL_002a:  newarr     [runtime]System.UInt64
-    IL_002f:  stloc.3
-    IL_0030:  ldc.i4.0
-    IL_0031:  conv.i8
-    IL_0032:  stloc.s    V_4
-    IL_0034:  ldc.i4.1
-    IL_0035:  conv.i8
-    IL_0036:  stloc.s    V_5
-    IL_0038:  br.s       IL_004f
+    IL_0026:  ldloc.2
+    IL_0027:  conv.ovf.i.un
+    IL_0028:  newarr     [runtime]System.UInt64
+    IL_002d:  stloc.3
+    IL_002e:  ldc.i4.0
+    IL_002f:  conv.i8
+    IL_0030:  stloc.s    V_4
+    IL_0032:  ldc.i4.1
+    IL_0033:  conv.i8
+    IL_0034:  stloc.s    V_5
+    IL_0036:  br.s       IL_004d
 
-    IL_003a:  ldloc.3
-    IL_003b:  ldloc.s    V_4
-    IL_003d:  conv.i
-    IL_003e:  ldloc.s    V_5
-    IL_0040:  stelem.i8
-    IL_0041:  ldloc.s    V_5
-    IL_0043:  ldc.i4.1
-    IL_0044:  conv.i8
-    IL_0045:  add
-    IL_0046:  stloc.s    V_5
-    IL_0048:  ldloc.s    V_4
-    IL_004a:  ldc.i4.1
-    IL_004b:  conv.i8
-    IL_004c:  add
-    IL_004d:  stloc.s    V_4
-    IL_004f:  ldloc.s    V_4
-    IL_0051:  ldloc.1
-    IL_0052:  blt.un.s   IL_003a
+    IL_0038:  ldloc.3
+    IL_0039:  ldloc.s    V_4
+    IL_003b:  conv.i
+    IL_003c:  ldloc.s    V_5
+    IL_003e:  stelem.i8
+    IL_003f:  ldloc.s    V_5
+    IL_0041:  ldc.i4.1
+    IL_0042:  conv.i8
+    IL_0043:  add
+    IL_0044:  stloc.s    V_5
+    IL_0046:  ldloc.s    V_4
+    IL_0048:  ldc.i4.1
+    IL_0049:  conv.i8
+    IL_004a:  add
+    IL_004b:  stloc.s    V_4
+    IL_004d:  ldloc.s    V_4
+    IL_004f:  ldloc.1
+    IL_0050:  blt.un.s   IL_0038
 
-    IL_0054:  ldloc.3
-    IL_0055:  ret
+    IL_0052:  ldloc.3
+    IL_0053:  ret
   } 
 
   .method public static uint64[]  f22(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,uint64> f,
@@ -1879,101 +1847,99 @@
     IL_0050:  nop
     IL_0051:  stloc.s    V_5
     IL_0053:  ldloc.s    V_5
-    IL_0055:  ldc.i4.1
-    IL_0056:  conv.i8
-    IL_0057:  bge.un.s   IL_005f
+    IL_0055:  brtrue.s   IL_005d
 
-    IL_0059:  call       !!0[] [runtime]System.Array::Empty<uint64>()
-    IL_005e:  ret
+    IL_0057:  call       !!0[] [runtime]System.Array::Empty<uint64>()
+    IL_005c:  ret
 
-    IL_005f:  ldloc.s    V_5
-    IL_0061:  conv.ovf.i.un
-    IL_0062:  newarr     [runtime]System.UInt64
-    IL_0067:  stloc.s    V_6
-    IL_0069:  ldloc.s    V_4
-    IL_006b:  brfalse.s  IL_009d
+    IL_005d:  ldloc.s    V_5
+    IL_005f:  conv.ovf.i.un
+    IL_0060:  newarr     [runtime]System.UInt64
+    IL_0065:  stloc.s    V_6
+    IL_0067:  ldloc.s    V_4
+    IL_0069:  brfalse.s  IL_009b
 
-    IL_006d:  ldc.i4.1
-    IL_006e:  stloc.s    V_7
-    IL_0070:  ldc.i4.0
-    IL_0071:  conv.i8
-    IL_0072:  stloc.s    V_8
-    IL_0074:  ldloc.0
-    IL_0075:  stloc.s    V_9
-    IL_0077:  br.s       IL_0096
+    IL_006b:  ldc.i4.1
+    IL_006c:  stloc.s    V_7
+    IL_006e:  ldc.i4.0
+    IL_006f:  conv.i8
+    IL_0070:  stloc.s    V_8
+    IL_0072:  ldloc.0
+    IL_0073:  stloc.s    V_9
+    IL_0075:  br.s       IL_0094
 
-    IL_0079:  ldloc.s    V_6
-    IL_007b:  ldloc.s    V_8
-    IL_007d:  conv.i
-    IL_007e:  ldloc.s    V_9
-    IL_0080:  stelem.i8
-    IL_0081:  ldloc.s    V_9
-    IL_0083:  ldloc.1
-    IL_0084:  add
-    IL_0085:  stloc.s    V_9
-    IL_0087:  ldloc.s    V_8
-    IL_0089:  ldc.i4.1
-    IL_008a:  conv.i8
-    IL_008b:  add
-    IL_008c:  stloc.s    V_8
-    IL_008e:  ldloc.s    V_8
-    IL_0090:  ldc.i4.0
-    IL_0091:  conv.i8
-    IL_0092:  cgt.un
-    IL_0094:  stloc.s    V_7
-    IL_0096:  ldloc.s    V_7
-    IL_0098:  brtrue.s   IL_0079
+    IL_0077:  ldloc.s    V_6
+    IL_0079:  ldloc.s    V_8
+    IL_007b:  conv.i
+    IL_007c:  ldloc.s    V_9
+    IL_007e:  stelem.i8
+    IL_007f:  ldloc.s    V_9
+    IL_0081:  ldloc.1
+    IL_0082:  add
+    IL_0083:  stloc.s    V_9
+    IL_0085:  ldloc.s    V_8
+    IL_0087:  ldc.i4.1
+    IL_0088:  conv.i8
+    IL_0089:  add
+    IL_008a:  stloc.s    V_8
+    IL_008c:  ldloc.s    V_8
+    IL_008e:  ldc.i4.0
+    IL_008f:  conv.i8
+    IL_0090:  cgt.un
+    IL_0092:  stloc.s    V_7
+    IL_0094:  ldloc.s    V_7
+    IL_0096:  brtrue.s   IL_0077
 
-    IL_009a:  nop
-    IL_009b:  br.s       IL_00d6
+    IL_0098:  nop
+    IL_0099:  br.s       IL_00d4
 
-    IL_009d:  ldloc.2
-    IL_009e:  ldloc.0
-    IL_009f:  bge.un.s   IL_00a6
+    IL_009b:  ldloc.2
+    IL_009c:  ldloc.0
+    IL_009d:  bge.un.s   IL_00a4
 
-    IL_00a1:  ldc.i4.0
-    IL_00a2:  conv.i8
-    IL_00a3:  nop
-    IL_00a4:  br.s       IL_00af
+    IL_009f:  ldc.i4.0
+    IL_00a0:  conv.i8
+    IL_00a1:  nop
+    IL_00a2:  br.s       IL_00ad
 
-    IL_00a6:  ldloc.2
-    IL_00a7:  ldloc.0
-    IL_00a8:  sub
-    IL_00a9:  ldloc.1
-    IL_00aa:  div.un
-    IL_00ab:  ldc.i4.1
-    IL_00ac:  conv.i8
-    IL_00ad:  add.ovf.un
-    IL_00ae:  nop
-    IL_00af:  stloc.s    V_8
-    IL_00b1:  ldc.i4.0
-    IL_00b2:  conv.i8
-    IL_00b3:  stloc.s    V_9
-    IL_00b5:  ldloc.0
-    IL_00b6:  stloc.s    V_10
-    IL_00b8:  br.s       IL_00cf
+    IL_00a4:  ldloc.2
+    IL_00a5:  ldloc.0
+    IL_00a6:  sub
+    IL_00a7:  ldloc.1
+    IL_00a8:  div.un
+    IL_00a9:  ldc.i4.1
+    IL_00aa:  conv.i8
+    IL_00ab:  add.ovf.un
+    IL_00ac:  nop
+    IL_00ad:  stloc.s    V_8
+    IL_00af:  ldc.i4.0
+    IL_00b0:  conv.i8
+    IL_00b1:  stloc.s    V_9
+    IL_00b3:  ldloc.0
+    IL_00b4:  stloc.s    V_10
+    IL_00b6:  br.s       IL_00cd
 
-    IL_00ba:  ldloc.s    V_6
-    IL_00bc:  ldloc.s    V_9
-    IL_00be:  conv.i
-    IL_00bf:  ldloc.s    V_10
-    IL_00c1:  stelem.i8
-    IL_00c2:  ldloc.s    V_10
-    IL_00c4:  ldloc.1
-    IL_00c5:  add
-    IL_00c6:  stloc.s    V_10
-    IL_00c8:  ldloc.s    V_9
-    IL_00ca:  ldc.i4.1
-    IL_00cb:  conv.i8
-    IL_00cc:  add
-    IL_00cd:  stloc.s    V_9
-    IL_00cf:  ldloc.s    V_9
-    IL_00d1:  ldloc.s    V_8
-    IL_00d3:  blt.un.s   IL_00ba
+    IL_00b8:  ldloc.s    V_6
+    IL_00ba:  ldloc.s    V_9
+    IL_00bc:  conv.i
+    IL_00bd:  ldloc.s    V_10
+    IL_00bf:  stelem.i8
+    IL_00c0:  ldloc.s    V_10
+    IL_00c2:  ldloc.1
+    IL_00c3:  add
+    IL_00c4:  stloc.s    V_10
+    IL_00c6:  ldloc.s    V_9
+    IL_00c8:  ldc.i4.1
+    IL_00c9:  conv.i8
+    IL_00ca:  add
+    IL_00cb:  stloc.s    V_9
+    IL_00cd:  ldloc.s    V_9
+    IL_00cf:  ldloc.s    V_8
+    IL_00d1:  blt.un.s   IL_00b8
 
-    IL_00d5:  nop
-    IL_00d6:  ldloc.s    V_6
-    IL_00d8:  ret
+    IL_00d3:  nop
+    IL_00d4:  ldloc.s    V_6
+    IL_00d6:  ret
   } 
 
 } 


### PR DESCRIPTION
## Description

Followup to #16650 and #16832.

- Use `count = 0` instead of `count < 1`. The `count < 1` check was a vestige of an older approach for computing the count and isn't needed.

## Checklist

- [x] Test cases added.
- [x] Release notes entry updated.