### PR TITLE
Parens: only check for sensitive indentation when really needed

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.300.md
@@ -7,7 +7,7 @@
 * Code generated files with > 64K methods and generated symbols crash when loaded. Use infered sequence points for debugging. ([Issue #16399](https://github.com/dotnet/fsharp/issues/16399), [#PR 16514](https://github.com/dotnet/fsharp/pull/16514))
 * `nameof Module` expressions and patterns are processed to link files in `--test:GraphBasedChecking`. ([PR #16550](https://github.com/dotnet/fsharp/pull/16550), [PR #16743](https://github.com/dotnet/fsharp/pull/16743))
 * Graph Based Checking doesn't throw on invalid parsed input so it can be used for IDE scenarios ([PR #16575](https://github.com/dotnet/fsharp/pull/16575), [PR #16588](https://github.com/dotnet/fsharp/pull/16588), [PR #16643](https://github.com/dotnet/fsharp/pull/16643))
-* Various parenthesization API fixes. ([PR #16578](https://github.com/dotnet/fsharp/pull/16578), [PR #16666](https://github.com/dotnet/fsharp/pull/16666), [PR #16901](https://github.com/dotnet/fsharp/pull/16901))
+* Various parenthesization API fixes. ([PR #16578](https://github.com/dotnet/fsharp/pull/16578), [PR #16666](https://github.com/dotnet/fsharp/pull/16666), [PR #16901](https://github.com/dotnet/fsharp/pull/16901), [PR #16973](https://github.com/dotnet/fsharp/pull/16973))
 * Keep parens for problematic exprs (`if`, `match`, etc.) in `$"{(…):N0}"`, `$"{(…),-3}"`, etc. ([PR #16578](https://github.com/dotnet/fsharp/pull/16578))
 * Fix crash in DOTNET_SYSTEM_GLOBALIZATION_INVARIANT mode [#PR 16471](https://github.com/dotnet/fsharp/pull/16471))
 * Fix16572 - Fixed the preview feature enabling Is properties for union case did not work correctly with let .rec and .fsi files ([PR #16657](https://github.com/dotnet/fsharp/pull/16657))

--- a/src/Compiler/Service/SynExpr.fs
+++ b/src/Compiler/Service/SynExpr.fs
@@ -661,7 +661,7 @@ module SynExpr =
         | _, SyntaxNode.SynExpr(SynExpr.YieldOrReturnFrom _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.Assert _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.Lazy _ as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.App(isInfix = false; argExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.App(argExpr = SynExpr.Paren(expr = Is expr)) as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.LetOrUse _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.LetOrUseBang _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.TryWith _ as outer) :: _
@@ -670,13 +670,13 @@ module SynExpr =
         | _, SyntaxNode.SynExpr(SynExpr.ForEach _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.IfThenElse _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.New _ as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.Set(rhsExpr = Is expr) as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.DotIndexedSet(valueExpr = Is expr) as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.DotNamedIndexedPropertySet(rhsExpr = Is expr) as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.DotSet(rhsExpr = Is expr) as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.LibraryOnlyUnionCaseFieldSet(rhsExpr = Is expr) as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.LongIdentSet(expr = Is expr) as outer) :: _
-        | _, SyntaxNode.SynExpr(SynExpr.NamedIndexedPropertySet(expr2 = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Set(rhsExpr = SynExpr.Paren(expr = Is expr)) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DotIndexedSet(valueExpr = SynExpr.Paren(expr = Is expr)) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DotNamedIndexedPropertySet(rhsExpr = SynExpr.Paren(expr = Is expr)) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DotSet(rhsExpr = SynExpr.Paren(expr = Is expr)) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.LibraryOnlyUnionCaseFieldSet(rhsExpr = SynExpr.Paren(expr = Is expr)) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.LongIdentSet(expr = SynExpr.Paren(expr = Is expr)) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.NamedIndexedPropertySet(expr2 = SynExpr.Paren(expr = Is expr)) as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.InferredUpcast _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.InferredDowncast _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.Match _ as outer) :: _

--- a/src/Compiler/Service/SynExpr.fs
+++ b/src/Compiler/Service/SynExpr.fs
@@ -657,7 +657,39 @@ module SynExpr =
         //     return (
         //     x
         //     )
-        | _, SyntaxNode.SynExpr outer :: _ when containsSensitiveIndentation outer.Range.StartColumn expr.Range -> true
+        | _, SyntaxNode.SynExpr(SynExpr.YieldOrReturn _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.YieldOrReturnFrom _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Assert _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Lazy _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.App(isInfix = false; argExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.LetOrUse _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.LetOrUseBang _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.TryWith _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.TryFinally _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.For _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.ForEach _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.IfThenElse _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.New _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Set(rhsExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DotIndexedSet(valueExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DotNamedIndexedPropertySet(rhsExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DotSet(rhsExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.LibraryOnlyUnionCaseFieldSet(rhsExpr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.LongIdentSet(expr = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.NamedIndexedPropertySet(expr2 = Is expr) as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.InferredUpcast _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.InferredDowncast _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Match _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.MatchBang _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.While _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.WhileBang _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Do _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.DoBang _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Fixed _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.InterpolatedString _ as outer) :: _ when
+            containsSensitiveIndentation outer.Range.StartColumn expr.Range
+            ->
+            true
 
         // Check for nested matches, e.g.,
         //

--- a/src/Compiler/Service/SynExpr.fs
+++ b/src/Compiler/Service/SynExpr.fs
@@ -686,6 +686,8 @@ module SynExpr =
         | _, SyntaxNode.SynExpr(SynExpr.Do _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.DoBang _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.Fixed _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.Record _ as outer) :: _
+        | _, SyntaxNode.SynExpr(SynExpr.AnonRecd _ as outer) :: _
         | _, SyntaxNode.SynExpr(SynExpr.InterpolatedString _ as outer) :: _ when
             containsSensitiveIndentation outer.Range.StartColumn expr.Range
             ->


### PR DESCRIPTION
Another followup to #16079.

## Description

- Only check for sensitive indentation when actually needed, i.e., when there is a possibility that the inner construct is valid in context with parentheses but would be invalid in context without parentheses. This enables easier use of the `SynExpr.shouldBeParenthesizedInContext` API for hypothetical scenarios where the `SynExpr` being passed in is not already parenthesized; see https://github.com/fsharp/FsAutoComplete/pull/1253#discussion_r1544717550.

## Notes

- I have not considered every aspect of the "would this expression need to be parenthesized if it were in this hypothetical context?" use-case, and it is likely that there are other scenarios where the current `SynExpr.shouldBeParenthesizedInContext` API would behave imperfectly if used for that. I am only addressing one fairly obvious and easily mitigated shortcoming in this PR.
- The set of "indentation-sensitive" constructs is not perfectly homogeneous — some of these constructs allow the (unparenthesized) inner offsides line to match the outer, while others require that the inner be rightward of the outer by at least one space — but the expense of treating them individually does not seem warranted.

## Checklist

- [x] Test cases added.
- [x] Release notes entry updated.