### PR TITLE
Parens: undentation in sequentials

### DIFF
--- a/src/Compiler/Service/SynExpr.fs
+++ b/src/Compiler/Service/SynExpr.fs
@@ -977,6 +977,8 @@ module SynExpr =
                 ->
                 true
 
+            | SynExpr.Sequential _, Dangling.Problematic(SynExpr.Sequential _) -> true
+
             | SynExpr.Sequential(expr1 = SynExpr.Paren(expr = Is inner); expr2 = expr2), Dangling.Problematic _ when
                 problematic inner.Range expr2.Range
                 ->

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -886,6 +886,21 @@ in x
             """ printfn "1"; (printfn "2") """, """ printfn "1"; printfn "2" """
             "let x = 3; (5) in x", "let x = 3; 5 in x"
 
+            """
+            [
+                ()
+                (printfn "1"; ())
+                ()
+            ]
+            """,
+            """
+            [
+                ()
+                (printfn "1"; ())
+                ()
+            ]
+            """
+
             // Technically we could remove some parens in some of these,
             // but additional exprs above or below can suddenly move the offsides line,
             // and we don't want to do unbounded lookahead or lookbehind.
@@ -991,6 +1006,7 @@ in x
                     z
                 ]
             "
+
             "
             let _ =
                 let y = 100

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -886,6 +886,111 @@ in x
             """ printfn "1"; (printfn "2") """, """ printfn "1"; printfn "2" """
             "let x = 3; (5) in x", "let x = 3; 5 in x"
 
+            // Technically we could remove some parens in some of these,
+            // but additional exprs above or below can suddenly move the offsides line,
+            // and we don't want to do unbounded lookahead or lookbehind.
+
+            "
+            let _ =
+                [
+                   (if p then q else r);
+                    y
+                ]
+            ",
+            "
+            let _ =
+                [
+                   (if p then q else r);
+                    y
+                ]
+            "
+
+            "
+            let _ =
+                [
+                    (if p then q else r);
+                    y
+                ]
+            ",
+            "
+            let _ =
+                [
+                    if p then q else r;
+                    y
+                ]
+            "
+
+            "
+            let _ =
+                [
+                    x;
+                   (if p then q else r);
+                   (if foo then bar else baz);
+                ]
+            ",
+            "
+            let _ =
+                [
+                    x;
+                   (if p then q else r);
+                   if foo then bar else baz;
+                ]
+            "
+
+            "
+            let _ =
+                [
+                   (if p then q else r);
+                    y;
+                   (if foo then bar else baz);
+                ]
+            ",
+            "
+            let _ =
+                [
+                   (if p then q else r);
+                    y;
+                   if foo then bar else baz;
+                ]
+            "
+
+            "
+            let _ =
+                [
+                   (if p then q else r);
+                   (if foo then bar else baz);
+                    z
+                ]
+            ",
+            "
+            let _ =
+                [
+                   if p then q else r;
+                   (if foo then bar else baz);
+                    z
+                ]
+            "
+
+            "
+            let _ =
+                [
+                    x;
+                   (if a then b else c);
+                   (if p then q else r);
+                   (if foo then bar else baz);
+                    z
+                ]
+            ",
+            "
+            let _ =
+                [
+                    x;
+                   (if a then b else c);
+                   (if p then q else r);
+                   (if foo then bar else baz);
+                    z
+                ]
+            "
             "
             let _ =
                 let y = 100


### PR DESCRIPTION
Another followup to #16079.

## Description

- Handle some undentation oddities in sequential expressions. Adding the semicolon range to the AST as proposed in #16914 would probably still be useful in other scenarios, but I think this is a viable workaround for this particular problem.
- Keep parens around nested sequentials. This is technically only necessary if the outer sequential is itself nested inside of a list/array/sequence/computation expression where each "sequential" expression node is actually an implicit yield, but there is currently no easy, inexpensive way of knowing that (i.e., for each parenthesized nested sequential expression, we'd need to walk back up the chain of ancestor sequentials in search of an outer list/array/sequence/computation expression).

## Examples

### Undentation

```fsharp
[
   (if p then q else r); // Cannot remove in place because of the indentation of y below.
    y
]
```

```fsharp
[
    x;
   (if p then q else r); // Cannot remove in place because of the indentation of x above and the presence of z below.
    z
]
```

```fsharp
[
     x;                   // This line's indentation means we cannot remove anywhere below.
    (…);
    (…);
    (* 𝑛 more such lines. *)
    (…);
    (…);
    (if p then q else r); // Can no longer remove here because of the indentation of x above.
    z
]
```

### Nested sequentials

```fsharp
// [(); (); ()]
let xs =
    [
        ()
        (printfn "1"; ())
        ()
    ]
```

Before, the parens analyzer would suggest:

```fsharp
// [(); (); (); ()]
let xs =
    [
        ()
        printfn "1"; ()
        ()
    ]
```

## Checklist

- [x] Test cases added.
- [ ] Release notes entry updated.