### PR TITLE
Fix 16071 --- FSharp.DependencyManager.Nuget ignoring sources

### DIFF
--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Utilities.fs
@@ -320,7 +320,7 @@ module internal Utilities =
             //      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json
             // Use enabled feeds only (see NuGet.Commands.ListSourceRunner.Run) and strip off the flags.
             let pattern =
-                @"(\s*\d+\.+\s*)(?'name'\S*)(\s*)\[(?'enabled'Enabled|Disabled)\](\s*)$(\s*)(?'uri'\S*)"
+                @"(\s*\d+\.+\s*)(?'name'\S*)(\s*)\[(?'enabled'Enabled|Disabled)\](\s*)$(\s*)(?'uri'[^\0]+)*$"
 
             let regex =
                 new Regex(pattern, RegexOptions.Multiline ||| RegexOptions.ExplicitCapture)


### PR DESCRIPTION
One of the mechanisms for providing sources to a project file for nuget package resolution is to add a Nuget.config file with add source elements.

In the package manager we use ````dotnet nuget list sources -format detailed```` to retrieve these sources.  The regex for retrieving the uri from the output did not allow for paths containing spaces.  This PR fixes the regex to allow for spaces.

Todo:
- Add tests