### PR TITLE
reset realsig for release/dev10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,8 @@
          Don't use it explicitly when building with plain .NET (without Proto or Arcade).
      -->
     <OtherFlags Condition="'$(Configuration)' != 'Proto' and '$(TestingLegacyInternalSignature)' != 'true'">$(OtherFlags) --realsig-</OtherFlags>
-    <OtherFlags Condition="'$(Configuration)' != 'Proto' and '$(TestingLegacyInternalSignature)' == 'true'">$(OtherFlags) --realsig+</OtherFlags>
+    <!-- TBD: Fix MEF Export visibility issues in VS -->
+    <OtherFlags Condition="'$(Configuration)' != 'Proto' and '$(TestingLegacyInternalSignature)' == 'true'">$(OtherFlags) --realsig-</OtherFlags>
 
   </PropertyGroup>
 


### PR DESCRIPTION
There are some places in the VS code where we Export private values to MEF.  This causes some issues when compiled with --realsig+ because the shipping existing FSharp compiler promotes them to internal.

This PR temporarily builds with --realsig- so that we can audit the codebase to eliminate those private exports and re-enable realsig .



