### PR TITLE
Wrong expression is ignored wraning range

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -5293,7 +5293,13 @@ and TcStmtThatCantBeCtorBody (cenv: cenv) env tpenv synExpr =
 and TcStmt (cenv: cenv) env tpenv synExpr =
     let g = cenv.g
     let expr, ty, tpenv = TcExprOfUnknownType cenv env tpenv synExpr
-    let m = synExpr.Range
+
+    let rec getInnerRange synExpr =
+        match synExpr with
+        | SynExpr.Sequential(expr2 = expr2)  -> getInnerRange expr2
+        | synExpr -> synExpr.Range
+    
+    let m = getInnerRange synExpr
     let wasUnit = UnifyUnitType cenv env m ty expr
     if wasUnit then
         expr, tpenv

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -735,6 +735,8 @@ let UnifyUnitType (cenv: cenv) (env: TcEnv) ty expr =
     let rec getInnerRange expr =
         match expr with
         | Expr.Sequential(expr2 = expr2)  -> getInnerRange expr2
+        | Expr.Let(_, DebugPoints(expr, _), _, _) -> getInnerRange expr
+        | Expr.App(_funcExpr, _, _typeArgs, _args, m) -> m
         | expr -> expr.Range
         
     let m = getInnerRange expr

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/Basic/Basic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/Basic/Basic.fs
@@ -82,7 +82,7 @@ module CustomAttributes_Basic =
         |> shouldFail
         |> withDiagnostics [
             (Error 842, Line 8, Col 7, Line 8, Col 8, "This attribute is not valid for use on this language element")
-            (Warning 20, Line 8, Col 1, Line 8, Col 31, "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+            (Warning 20, Line 8, Col 26, Line 8, Col 31, "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
         ]
 
     // SOURCE=E_AttributeApplication06.fs     SCFLAGS="--test:ErrorRanges"	# E_AttributeApplication06.fs
@@ -93,7 +93,7 @@ module CustomAttributes_Basic =
         |> shouldFail
         |> withDiagnostics [
             (Error 824, Line 8, Col 5, Line 8, Col 20, "Attributes are not permitted on 'let' bindings in expressions")
-            (Warning 20, Line 8, Col 1, Line 8, Col 41, "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+            (Warning 20, Line 8, Col 28, Line 8, Col 41, "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
         ]
 
     // SOURCE=E_AttributeApplication07.fs					# E_AttributeApplication07.fs

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExpressionIgnoredRange.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExpressionIgnoredRange.fs
@@ -12,4 +12,10 @@ for i in 1 .. 10 do
     printfn "" |> ignore
     {| A = 4 |}
 
-// TODO Add more cases
+for i in 1 .. 10 do 
+    printfn "" 
+    3 
+    true 
+    {| A = 4 |}
+
+// TODO Add more test cases

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExpressionIgnoredRange.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExpressionIgnoredRange.fs
@@ -1,0 +1,15 @@
+for i in 1 .. 10 do
+    printfn ""
+    printfn ""
+
+for i in 1 .. 10 do
+    printfn ""
+    printfn "" |> ignore
+    true
+
+for i in 1 .. 10 do
+    printfn ""
+    printfn "" |> ignore
+    {| A = 4 |}
+
+// TODO Add more cases

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
@@ -2,6 +2,7 @@
 
 namespace ErrorMessages
 
+open FSharp.Test
 open Xunit
 open FSharp.Test.Compiler
 
@@ -225,3 +226,15 @@ let main _argv =
         """
         |> typecheck
         |> shouldSucceed
+
+    // SOURCE=ExpressionIgnoredRange.fs							# ExpressionIgnoredRange.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"ExpressionIgnoredRange.fs"|])>]
+    let ``ExpressionIgnoredRange.fs`` compilation =
+        compilation
+        |> asFs
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Warning 20, Line 8, Col 5, Line 8, Col 9, "The result of this expression has type 'bool' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+            (Warning 20, Line 13, Col 5, Line 13, Col 16, "The result of this expression has type '{| A: int |}' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
@@ -237,4 +237,7 @@ let main _argv =
         |> withDiagnostics [
             (Warning 20, Line 8, Col 5, Line 8, Col 9, "The result of this expression has type 'bool' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
             (Warning 20, Line 13, Col 5, Line 13, Col 16, "The result of this expression has type '{| A: int |}' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+            (Warning 20, Line 17, Col 5, Line 17, Col 6, "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+            (Warning 20, Line 18, Col 5, Line 18, Col 9, "The result of this expression has type 'bool' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+            (Warning 20, Line 19, Col 5, Line 19, Col 16, "The result of this expression has type '{| A: int |}' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
         ]


### PR DESCRIPTION
## Description

Find a more accurate range for `TcStmt`

Fixes #5418 

## Checklist

- [x] Test cases added
- [ ] Release notes entry updated