### PR TITLE
Make tooltips work in VS in file with no solution

### DIFF
--- a/docs/release-notes/.VisualStudio/17.11.md
+++ b/docs/release-notes/.VisualStudio/17.11.md
@@ -1,0 +1,3 @@
+### Fixed
+
+* Make tooltips work in file with no solution. ([PR #17054](https://github.com/dotnet/fsharp/pull/17054))

--- a/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
+++ b/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs
@@ -44,7 +44,8 @@ type internal FSharpAsyncQuickInfoSource
 
                     [
                         Path.GetRelativePath(projectDir, filePath)
-                        Path.GetRelativePath(solutionDir, filePath)
+                        if not (isNull solutionDir) then
+                            Path.GetRelativePath(solutionDir, filePath)
                     ]
                     |> List.minBy String.length
 


### PR DESCRIPTION
## Description

* Previously, if you opened Visual Studio with no solution and then opened an F# script file, tooltips would not work. This was because the quick info provider did not account for the possibility of a non-existent solution. This change updates the quick info provider so that it no longer tries (and fails) to get the relative path of a solution that does not exist.


#### Before

https://github.com/dotnet/fsharp/assets/14795984/6de41e08-e2e6-4029-9138-53d9fa094852

#### After

https://github.com/dotnet/fsharp/assets/14795984/06325f56-91f0-49b6-9ef2-2ded4180ef04

## Checklist

- [ ] Test cases added.

  The tests in `QuickInfoProviderTests` only test `TryGetTooltip`:
  https://github.com/dotnet/fsharp/blob/f6ae54bb81b807e36d7d2eae6ad8904d33dc46a4/vsintegration/tests/FSharp.Editor.Tests/QuickInfoProviderTests.fs#L100

  There are no tests that test `FSharpAsyncQuickInfoSource`'s [implementation of `GetQuickInfoItemAsync`](https://github.com/dotnet/fsharp/blob/f6ae54bb81b807e36d7d2eae6ad8904d33dc46a4/vsintegration/src/FSharp.Editor/QuickInfo/QuickInfoProvider.fs#L136), which calls the private `getQuickInfoItem` function, which is where the bug was.

  It would be nice if such tests existed, but I am not sure how willing I am to spend the time to figure out how to wire everything up for them so that I can test this particular bug.
- [x] Release notes entry updated.