### PR TITLE
Don't split resumable code

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
@@ -5,3 +5,4 @@
 * Various parenthesization API fixes. ([PR #16977](https://github.com/dotnet/fsharp/pull/16977)) 
 * Fix bug in optimization of for-loops over integral ranges with steps and units of measure. ([Issue #17025](https://github.com/dotnet/fsharp/issues/17025), [PR #17040](https://github.com/dotnet/fsharp/pull/17040), [PR #17048](https://github.com/dotnet/fsharp/pull/17048))
 * Fix calling an overridden virtual static method via the interface ([PR #17013](https://github.com/dotnet/fsharp/pull/17013))
+* Fix state machines compilation, when big decision trees are involved, by removing code split when resumable code is detected ([PR #17076](https://github.com/dotnet/fsharp/pull/17076))

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -2329,7 +2329,7 @@ let rec IsDebugPipeRightExpr cenv expr =
         else false
     | _ -> false
 
-let IsStateMachineExpr g overallExpr =
+let inline IsStateMachineExpr g overallExpr =
     //printfn "%s" (DebugPrint.showExpr overallExpr)
     match overallExpr with
     | Expr.App(funcExpr = Expr.Val(valRef = valRef)) ->

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -2314,7 +2314,7 @@ let IsILMethodRefSystemStringConcatArray (mref: ILMethodRef) =
                                               ilTy.IsNominal &&
                                               ilTy.TypeRef.Name = "System.String" -> true
             | _ -> false))
-    
+
 let rec IsDebugPipeRightExpr cenv expr =
     let g = cenv.g
     match expr with
@@ -2327,6 +2327,13 @@ let rec IsDebugPipeRightExpr cenv expr =
             | OpPipeRight3 g _  -> true
             | _ -> false
         else false
+    | _ -> false
+
+let IsStateMachineExpr g overallExpr =
+    //printfn "%s" (DebugPrint.showExpr overallExpr)
+    match overallExpr with
+    | Expr.App(funcExpr = Expr.Val(valRef = valRef)) ->
+        isReturnsResumableCodeTy g valRef.TauType
     | _ -> false
 
 /// Optimize/analyze an expression
@@ -2342,6 +2349,10 @@ let rec OptimizeExpr cenv (env: IncrementalOptimizationEnv) expr =
     let expr = stripExpr expr
 
     if IsDebugPipeRightExpr cenv expr then OptimizeDebugPipeRights cenv env expr else 
+
+    let isStateMachineE = IsStateMachineExpr g expr
+
+    let env = { env with disableMethodSplitting = env.disableMethodSplitting || isStateMachineE }
 
     match expr with
     // treat the common linear cases to avoid stack overflows, using an explicit continuation 

--- a/tests/FSharp.Compiler.ComponentTests/Language/StateMachineTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/StateMachineTests.fs
@@ -106,3 +106,58 @@ for i in 1 .. 100 do
         |> withOptimize
         |> compileExeAndRun
         |> shouldSucceed
+
+    [<Fact>] // https://github.com/dotnet/fsharp/issues/16068
+    let ``Decision tree with 32+ binds with nested expression is not getting splitted and state machine is successfully statically compiles``() = 
+        FSharp """
+module Testing
+
+let test () =
+    task {
+        if true then
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            let c = failwith ""
+            ()
+    }
+
+[<EntryPoint>]
+let main _ =
+    test () |> ignore
+    printfn "Hello, World!"
+    0
+"""
+        |> ignoreWarnings
+        |> withOptimize
+        |> compileExeAndRun
+        |> shouldSucceed


### PR DESCRIPTION
## Description

Decision tree splitting during optimisation had some low-ish thresholds, here we make sure we don't ever split if we see resumable code invocation (in this case we check for the application for Run/Delay, etc).

Fixes https://github.com/dotnet/fsharp/issues/16068

## Checklist

- [x] Test cases added
- [x] Release notes entry updated