### PR TITLE
Remove some dead code

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -920,11 +920,6 @@ module MutRecBindingChecking =
       /// A 'member' definition in a class
       | Phase2AMember of PreCheckingRecursiveBinding
 
-#if OPEN_IN_TYPE_DECLARATIONS
-      /// A dummy declaration, should we ever support 'open' in type definitions
-      | Phase2AOpen of SynOpenDeclTarget * range
-#endif
-
       /// Indicates the super init has just been called, 'this' may now be published
       | Phase2AIncrClassCtorJustAfterSuperInit 
 
@@ -1142,13 +1137,6 @@ module MutRecBindingChecking =
 
                             let innerState = (incrCtorInfoOpt, envForTycon, tpenv, recBindIdx, List.rev binds @ uncheckedBindsRev)
                             cbinds, innerState
-                        
-#if OPEN_IN_TYPE_DECLARATIONS
-                        | Some (SynMemberDefn.Open (target, m)), _ ->
-                            let innerState = (incrCtorInfoOpt, env, tpenv, recBindIdx, prelimRecValuesRev, uncheckedBindsRev)
-                            [ Phase2AOpen (target, m) ], innerState
-#endif
-                        
                         | definition -> 
                             error(InternalError(sprintf "Unexpected definition %A" definition, m)))
 
@@ -1196,9 +1184,6 @@ module MutRecBindingChecking =
                         let rest = 
                             let isAfter b = 
                                 match b with 
-#if OPEN_IN_TYPE_DECLARATIONS
-                                | Phase2AOpen _ 
-#endif
                                 | Phase2AIncrClassCtor _ | Phase2AInherit _ | Phase2AIncrClassCtorJustAfterSuperInit -> false
                                 | Phase2AIncrClassBindings (_, binds, _, _, _) -> binds |> List.exists (function SynBinding (kind=SynBindingKind.Do) -> true | _ -> false)
                                 | Phase2AIncrClassCtorJustAfterLastLet
@@ -1417,16 +1402,6 @@ module MutRecBindingChecking =
                         | Phase2AIncrClassCtorJustAfterLastLet -> 
                             let innerState = (tpenv, envInstance, envStatic, envNonRec, generalizedRecBinds, preGeneralizationRecBinds, uncheckedRecBindsTable)
                             Phase2BIncrClassCtorJustAfterLastLet, innerState
-                            
-                            
-#if OPEN_IN_TYPE_DECLARATIONS
-                        | Phase2AOpen(target, m) -> 
-                            let envInstance = TcOpenDecl cenv m scopem envInstance target
-                            let envStatic = TcOpenDecl cenv m scopem envStatic target
-                            let innerState = (tpenv, envInstance, envStatic, envNonRec, generalizedRecBinds, preGeneralizationRecBinds, uncheckedRecBindsTable)
-                            Phase2BOpen, innerState
-#endif
-
 
                         // Note: this path doesn't add anything the environment, because the member is already available off via its type 
                         

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -2614,13 +2614,8 @@ module EventDeclarationNormalization =
 let FreshenObjectArgType (cenv: cenv) m rigid tcref isExtrinsic declaredTyconTypars =
     let g = cenv.g
 
-#if EXTENDED_EXTENSION_MEMBERS // indicates if extension members can add additional constraints to type parameters
-    let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy =
-        FreshenTyconRef g m (if isExtrinsic then TyparRigidity.Flexible else rigid) tcref declaredTyconTypars
-#else
     let tcrefObjTy, enclosingDeclaredTypars, renaming, objTy =
         FreshenTyconRef g m rigid tcref declaredTyconTypars
-#endif
 
     // Struct members have a byref 'this' type (unless they are extrinsic extension members)
     let thisTy =
@@ -12386,11 +12381,7 @@ and FixupLetrecBind (cenv: cenv) denv generalizedTyparsForRecursiveBlock (bind: 
 
     // Check coherence of generalization of variables for memberInfo members in generic classes
     match vspec.MemberInfo with
-#if EXTENDED_EXTENSION_MEMBERS // indicates if extension members can add additional constraints to type parameters
-    | Some _ when not vspec.IsExtensionMember ->
-#else
     | Some _ ->
-#endif
        match PartitionValTyparsForApparentEnclosingType g vspec with
        | Some(parentTypars, memberParentTypars, _, _, _) ->
           ignore(SignatureConformance.Checker(g, cenv.amap, denv, SignatureRepackageInfo.Empty, false).CheckTypars vspec.Range TypeEquivEnv.Empty memberParentTypars parentTypars)

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -1058,10 +1058,6 @@ and SolveTypeEqualsType (csenv: ConstraintSolverEnv) ndeep m2 (trace: OptionalTr
     let aenv = csenv.EquivEnv
     let g = csenv.g
 
-    // Pre F# 6.0 we asssert the trait solution here
-#if TRAIT_CONSTRAINT_CORRECTIONS
-    if not (csenv.g.langVersion.SupportsFeature LanguageFeature.TraitConstraintCorrections) then
-#endif
     match cxsln with
     | Some (traitInfo, traitSln) when traitInfo.Solution.IsNone -> 
         // If this is an overload resolution at this point it's safe to assume the candidate member being evaluated solves this member constraint.
@@ -2895,22 +2891,11 @@ and ReportNoCandidatesErrorSynExpr csenv callerArgCounts methodName ad calledMet
 ///
 /// In F# 5.0 and 6.0 we assert this late by passing the cxsln parameter around. However this
 /// relies on not checking return types for SRTP constraints eagerly
-///
-/// Post F# 6.0 (TraitConstraintCorrections) we will assert this early and add a proper check that return types match for SRTP constraint solving
-/// (see alwaysCheckReturn)
-and AssumeMethodSolvesTrait (csenv: ConstraintSolverEnv) (cx: TraitConstraintInfo option) m trace (calledMeth: CalledMeth<_>) = 
+and AssumeMethodSolvesTrait (csenv: ConstraintSolverEnv) (cx: TraitConstraintInfo option) m _trace (calledMeth: CalledMeth<_>) = 
     match cx with
     | Some traitInfo when traitInfo.Solution.IsNone -> 
         let staticTyOpt = if calledMeth.Method.IsInstance then None else calledMeth.OptionalStaticType
         let traitSln = MemberConstraintSolutionOfMethInfo csenv.SolverState m calledMeth.Method calledMeth.CalledTyArgs staticTyOpt
-#if TRAIT_CONSTRAINT_CORRECTIONS
-        if csenv.g.langVersion.SupportsFeature LanguageFeature.TraitConstraintCorrections then
-            TransactMemberConstraintSolution traitInfo trace traitSln
-            None
-        else
-#else
-        ignore trace
-#endif
         Some (traitInfo, traitSln)
     | _ -> 
         None
@@ -2971,13 +2956,9 @@ and ResolveOverloading
           // Always take the return type into account for
           //    -- op_Explicit, op_Implicit
           //    -- candidate method sets that potentially use tupling of unfilled out args
-          ///   -- if TraitConstraintCorrections is enabled, also check return types for SRTP constraints
           let alwaysCheckReturn =
               isOpConversion ||
               candidates |> List.exists (fun cmeth -> cmeth.HasOutArgs) 
-#if TRAIT_CONSTRAINT_CORRECTIONS
-              || (csenv.g.langVersion.SupportsFeature LanguageFeature.TraitConstraintCorrections && cx.IsSome)
-#endif
 
           // Exact match rule.
           //

--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -430,14 +430,7 @@ let AdjustCalledArgType (infoReader: InfoReader) ad isConstraint enforceNullable
 
         // If the called method argument is an inref type, then the caller may provide a byref or value
         if isInByrefTy g calledArgTy then
-#if IMPLICIT_ADDRESS_OF
-            if isByrefTy g callerArgTy then 
-                calledArgTy
-            else 
-                destByrefTy g calledArgTy
-#else
             calledArgTy, TypeDirectedConversionUsed.No, None
-#endif
 
         // If the called method argument is a (non inref) byref type, then the caller may provide a byref or ref.
         elif isByrefTy g calledArgTy then
@@ -1371,12 +1364,6 @@ let AdjustCallerArgExpr tcVal (g: TcGlobals) amap infoReader ad isOutArg calledA
    if isByrefTy g calledArgTy && isRefCellTy g callerArgTy then 
        None, Expr.Op (TOp.RefAddrGet false, [destRefCellTy g callerArgTy], [callerArgExpr], m) 
 
-#if IMPLICIT_ADDRESS_OF
-   elif isInByrefTy g calledArgTy && not (isByrefTy g callerArgTy) then 
-       let wrap, callerArgExprAddress, _readonly, _writeonly = mkExprAddrOfExpr g true false NeverMutates callerArgExpr None m
-       Some wrap, callerArgExprAddress
-#endif
-
    // auto conversions to quotations (to match auto conversions to LINQ expressions)
    elif reflArgInfo.AutoQuote && isQuotedExprTy g calledArgTy && not (isQuotedExprTy g callerArgTy) then 
        match reflArgInfo with 
@@ -1943,13 +1930,6 @@ module ProvidedMethodCalls =
                 let infoReader = InfoReader(g, amap)
                 let exprR = CoerceFromFSharpFuncToDelegate g amap infoReader AccessorDomain.AccessibleFromSomewhere lambdaExprTy m lambdaExpr delegateTyR
                 None, (exprR, tyOfExpr g exprR)
-#if PROVIDED_ADDRESS_OF
-            | ProvidedAddressOfExpr e ->
-                let eR =  exprToExpr (exprType.PApply((fun _ -> e), m))
-                let wrap,exprR, _readonly, _writeonly = mkExprAddrOfExpr g true false DefinitelyMutates eR None m
-                let exprR = wrap exprR
-                None, (exprR, tyOfExpr g exprR)
-#endif
             | ProvidedDefaultExpr pty ->
                 let ty = Import.ImportProvidedType amap m (exprType.PApply((fun _ -> pty), m))
                 let exprR = mkDefault (m, ty)

--- a/src/Compiler/Checking/PostInferenceChecks.fs
+++ b/src/Compiler/Checking/PostInferenceChecks.fs
@@ -2144,10 +2144,6 @@ let CheckModuleBinding cenv env (TBind(v, e, _) as bind) =
 
                     error(Duplicate(kind, v.DisplayName, v.Range))
 
-#if CASES_IN_NESTED_CLASS
-                if tcref.IsUnionTycon && nm = "Cases" then
-                    errorR(NameClash(nm, kind, v.DisplayName, v.Range, "generated type", "Cases", tcref.Range))
-#endif
                 if tcref.IsUnionTycon then
                     match nm with
                     | "Tag" -> errorR(NameClash(nm, kind, v.DisplayName, v.Range, FSComp.SR.typeInfoGeneratedProperty(), "Tag", tcref.Range))

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2368,7 +2368,6 @@ and [<Sealed>] TcImports
                             // Note, if mode=ResolveAssemblyReferenceMode.Speculative and the resolution failed then TryResolveLibsUsingMSBuildRules returns
                             // the empty list and we convert the failure into an AssemblyNotResolved here.
                             ErrorD(AssemblyNotResolved(assemblyReference.Text, assemblyReference.Range))
-#endif
         )
 
     member tcImports.ResolveAssemblyReference(ctok, assemblyReference, mode) : AssemblyResolution list =

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2336,12 +2336,6 @@ and [<Sealed>] TcImports
             match resolutions.TryFindByOriginalReference assemblyReference with
             | Some assemblyResolution -> ResultD [ assemblyResolution ]
             | None ->
-#if NO_MSBUILD_REFERENCE_RESOLUTION
-                try
-                    ResultD [ tcConfig.ResolveLibWithDirectories assemblyReference ]
-                with e ->
-                    ErrorD e
-#else
                 // Next try to lookup up by the exact full resolved path.
                 match resolutions.TryFindByResolvedPath assemblyReference.Text with
                 | Some assemblyResolution -> ResultD [ assemblyResolution ]

--- a/src/Compiler/Facilities/BuildGraph.fs
+++ b/src/Compiler/Facilities/BuildGraph.fs
@@ -229,11 +229,7 @@ module GraphNode =
         match preferredUiLang with
         | Some s ->
             culture <- CultureInfo s
-#if FX_RESHAPED_GLOBALIZATION
-            CultureInfo.CurrentUICulture <- culture
-#else
             Thread.CurrentThread.CurrentUICulture <- culture
-#endif
         | None -> ()
 
 [<Sealed>]

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -2521,13 +2521,6 @@ and MakeOptimizedSystemStringConcatCall cenv env m args =
           when IsILMethodRefSystemStringConcat ilMethRef ->
             optimizeArgs args accArgs
 
-// String constant folding requires a bit more work as we cannot quadratically concat strings at compile time.
-#if STRING_CONSTANT_FOLDING
-        // Optimize string constants, e.g. "1" + "2" will turn into "12"
-        | Expr.Const (Const.String str1, _, _), Expr.Const (Const.String str2, _, _) :: accArgs ->
-            mkString g m (str1 + str2) :: accArgs
-#endif
-
         | arg, _ -> arg :: accArgs
 
     and optimizeArgs args accArgs =

--- a/src/Compiler/TypedTree/TypeProviders.fs
+++ b/src/Compiler/TypedTree/TypeProviders.fs
@@ -854,9 +854,6 @@ type ProvidedConstructorInfo (x: ConstructorInfo, ctxt) =
 
 type ProvidedExprType =
     | ProvidedNewArrayExpr of ProvidedType * ProvidedExpr[]
-#if PROVIDED_ADDRESS_OF
-    | ProvidedAddressOfExpr of ProvidedExpr
-#endif
     | ProvidedNewObjectExpr of ProvidedConstructorInfo * ProvidedExpr[]
     | ProvidedWhileLoopExpr of ProvidedExpr * ProvidedExpr
     | ProvidedNewDelegateExpr of ProvidedType * ProvidedVar[] * ProvidedExpr
@@ -919,9 +916,6 @@ type ProvidedExpr (x: Expr, ctxt) =
             Some (ProvidedTryFinallyExpr (ProvidedExpr.Create ctxt b1, ProvidedExpr.Create ctxt b2))
         | Patterns.TryWith(b, v1, e1, v2, e2) ->
             Some (ProvidedTryWithExpr (ProvidedExpr.Create ctxt b, ProvidedVar.Create ctxt v1, ProvidedExpr.Create ctxt e1, ProvidedVar.Create ctxt v2, ProvidedExpr.Create ctxt e2))
-#if PROVIDED_ADDRESS_OF
-        | Patterns.AddressOf e -> Some (ProvidedAddressOfExpr (ProvidedExpr.Create ctxt e))
-#endif
         | Patterns.TypeTest(e, ty) ->
             Some (ProvidedTypeTestExpr(ProvidedExpr.Create ctxt e, ProvidedType.Create ctxt ty))
         | Patterns.Let(v, e, b) ->

--- a/src/Compiler/TypedTree/TypeProviders.fsi
+++ b/src/Compiler/TypedTree/TypeProviders.fsi
@@ -374,10 +374,6 @@ type ProvidedExprType =
 
     | ProvidedNewArrayExpr of ProvidedType * ProvidedExpr[]
 
-#if PROVIDED_ADDRESS_OF
-    | ProvidedAddressOfExpr of ProvidedExpr
-#endif
-
     | ProvidedNewObjectExpr of ProvidedConstructorInfo * ProvidedExpr[]
 
     | ProvidedWhileLoopExpr of ProvidedExpr * ProvidedExpr

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -540,18 +540,7 @@ let u_list_ext extra f st =
     let list = u_list_core f (n &&& 0x7FFFFFFF) st
     extraItem, list
 
-#if FLAT_LIST_AS_LIST
-#else
 let u_List f st = u_list f st // new List<_> (u_array f st)
-#endif
-#if FLAT_LIST_AS_ARRAY_STRUCT
-//#else
-let u_List f st = List(u_array f st)
-#endif
-#if FLAT_LIST_AS_ARRAY
-//#else
-let u_List f st = u_array f st
-#endif
 
 // Mark up default constraints with a priority in reverse order: last gets 0 etc. See comment on TyparConstraint.DefaultsTo
 let u_list_revi f st =
@@ -569,12 +558,6 @@ let u_option f st =
     | 1 -> Some (f st)
     | n -> ufailwith st ("u_option: found number " + string n)
 
-// Boobytrap an OSGN node with a force of a lazy load of a bunch of pickled data
-#if LAZY_UNPICKLE
-let wire (x: osgn<_>) (res: Lazy<_>) =
-    x.osgnTripWire <- Some(fun () -> res.Force() |> ignore)
-#endif
-
 let u_lazy u st =
 
     // Read the number of bytes in the record
@@ -587,26 +570,8 @@ let u_lazy u st =
     let ovalsIdx1   = prim_u_int32 st // fixupPos6
     let ovalsIdx2   = prim_u_int32 st // fixupPos7
 
-#if LAZY_UNPICKLE
-    // Record the position in the bytestream to use when forcing the read of the data
-    let idx1 = st.is.Position
-    // Skip the length of data
-    st.is.Skip len
-    // This is the lazy computation that wil force the unpickling of the term.
-    // This term must contain OSGN definitions of the given nodes.
-    let res =
-        lazy (let st = { st with is = st.is.CloneAndSeek idx1 }
-              u st)
-    // Force the reading of the data as a "tripwire" for each of the OSGN thunks
-    for i = otyconsIdx1 to otyconsIdx2-1 do wire (st.ientities.Get i) res done
-    for i = ovalsIdx1   to ovalsIdx2-1   do wire (st.ivals.Get i)   res done
-    for i = otyparsIdx1 to otyparsIdx2-1 do wire (st.itypars.Get i) res done
-    res
-#else
     ignore (len, otyconsIdx1, otyconsIdx2, otyparsIdx1, otyparsIdx2, ovalsIdx1, ovalsIdx2)
     InterruptibleLazy.FromValue(u st)
-#endif
-
 
 let u_hole () =
     let mutable h = None

--- a/src/Compiler/Utilities/FileSystem.fs
+++ b/src/Compiler/Utilities/FileSystem.fs
@@ -920,16 +920,6 @@ type internal ByteStream =
         res
 
     member b.Position = b.pos
-#if LAZY_UNPICKLE
-    member b.CloneAndSeek =
-        {
-            bytes = b.bytes
-            pos = pos
-            max = b.max
-        }
-
-    member b.Skip = b.pos <- b.pos + n
-#endif
 
 type internal ByteBuffer =
     {

--- a/src/Compiler/Utilities/FileSystem.fsi
+++ b/src/Compiler/Utilities/FileSystem.fsi
@@ -353,12 +353,6 @@ type internal ByteStream =
 
     static member FromBytes: ReadOnlyByteMemory * start: int * length: int -> ByteStream
 
-#if LAZY_UNPICKLE
-    member CloneAndSeek: int -> ByteStream
-
-    member Skip: int -> unit
-#endif
-
 /// Imperative buffers and streams of byte[]
 /// Not thread safe.
 [<Sealed>]

--- a/src/Compiler/Utilities/InternalCollections.fs
+++ b/src/Compiler/Utilities/InternalCollections.fs
@@ -7,11 +7,7 @@ open System
 [<StructuralEquality; NoComparison>]
 type internal ValueStrength<'T when 'T: not struct> =
     | Strong of 'T
-#if FX_NO_GENERIC_WEAKREFERENCE
-    | Weak of WeakReference
-#else
     | Weak of WeakReference<'T>
-#endif
 
 type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStrongly: int, areSimilar, ?requiredToKeep, ?keepMax: int) =
     /// The list of items stored. Youngest is at the end of the list.
@@ -78,17 +74,10 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStron
                 match value with
                 | Strong(value) -> yield (key, value)
                 | Weak(weakReference) ->
-#if FX_NO_GENERIC_WEAKREFERENCE
-                    match weakReference.Target with
-                    | Null -> ()
-                    | NonNull value -> yield key, (value :?> 'Value)
-        ]
-#else
                     match weakReference.TryGetTarget() with
                     | false, _ -> ()
                     | true, value -> yield key, value
         ]
-#endif
 
     let AssignWithStrength (tok, newData) =
         let actualLength = List.length newData
@@ -106,11 +95,7 @@ type internal AgedLookup<'Token, 'Key, 'Value when 'Value: not struct>(keepStron
             |> List.map (fun (n: int, (k, v)) ->
                 let handle =
                     if n < weakThreshold && not (requiredToKeep v) then
-#if FX_NO_GENERIC_WEAKREFERENCE
-                        Weak(WeakReference(v))
-#else
                         Weak(WeakReference<_>(v))
-#endif
                     else
                         Strong(v)
 

--- a/src/FSharp.Core/reflect.fs
+++ b/src/FSharp.Core/reflect.fs
@@ -372,9 +372,6 @@ module internal Impl =
     //-----------------------------------------------------------------
     // UNION DECOMPILATION
 
-    // Get the type where the type definitions are stored
-    let getUnionCasesTyp (typ: Type, _bindingFlags) = typ
-
     let getUnionTypeTagNameMap (typ: Type, bindingFlags) =
         let enumTyp = typ.GetNestedType("Tags", bindingFlags)
         // Unions with a singleton case do not get a Tags type (since there is only one tag), hence enumTyp may be null in this case
@@ -431,12 +428,11 @@ module internal Impl =
             if isTwoCasedDU then
                 typ
             else
-                let casesTyp = getUnionCasesTyp (typ, bindingFlags)
-                let caseTyp = casesTyp.GetNestedType(tagField, bindingFlags) // if this is null then the union is nullary
+                let caseTyp = typ.GetNestedType(tagField, bindingFlags) // if this is null then the union is nullary
 
                 match caseTyp with
                 | null -> null
-                | _ when caseTyp.IsGenericTypeDefinition -> caseTyp.MakeGenericType(casesTyp.GetGenericArguments())
+                | _ when caseTyp.IsGenericTypeDefinition -> caseTyp.MakeGenericType(castypesTyp.GetGenericArguments())
                 | _ -> caseTyp
 
     let getUnionTagConverter (typ: Type, bindingFlags) =

--- a/src/FSharp.Core/reflect.fs
+++ b/src/FSharp.Core/reflect.fs
@@ -432,7 +432,7 @@ module internal Impl =
 
                 match caseTyp with
                 | null -> null
-                | _ when caseTyp.IsGenericTypeDefinition -> caseTyp.MakeGenericType(castypesTyp.GetGenericArguments())
+                | _ when caseTyp.IsGenericTypeDefinition -> caseTyp.MakeGenericType(typ.GetGenericArguments())
                 | _ -> caseTyp
 
     let getUnionTagConverter (typ: Type, bindingFlags) =

--- a/src/FSharp.Core/reflect.fs
+++ b/src/FSharp.Core/reflect.fs
@@ -373,17 +373,7 @@ module internal Impl =
     // UNION DECOMPILATION
 
     // Get the type where the type definitions are stored
-    let getUnionCasesTyp (typ: Type, _bindingFlags) =
-#if CASES_IN_NESTED_CLASS
-        let casesTyp = typ.GetNestedType("Cases", bindingFlags)
-
-        if casesTyp.IsGenericTypeDefinition then
-            casesTyp.MakeGenericType(typ.GetGenericArguments())
-        else
-            casesTyp
-#else
-        typ
-#endif
+    let getUnionCasesTyp (typ: Type, _bindingFlags) = typ
 
     let getUnionTypeTagNameMap (typ: Type, bindingFlags) =
         let enumTyp = typ.GetNestedType("Tags", bindingFlags)


### PR DESCRIPTION
Removing some dead code guarded by a bunch of ifdefs, which we never set.

Not removing some of them:
    - `NO_INLINE_IL_PARSER` and `FX_NO_WEAKTABLE` are set by Fable,
    - `CHECK_LINE0_TYPES` we can use it for checking 0-based to 1-based line numbers transformation, and can be useful.
    - `CHECKING` and `STATISTICS` can be used ad-hoc to debug ilreading
    - `LOGGING_GUI` for debugging fsi
    - I am not certain about `TRAIT_CONSTRAINT_CORRECTIONS`, it seems like it should've been turned on in F# 6, but neither feature nor define exist or set, cc @dsyme