### PR TITLE
Update build depencencies + SDK

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 {
     "name": "F#",
-    "image": "mcr.microsoft.com/dotnet/sdk:9.0.100-preview.2",
+    "image": "mcr.microsoft.com/dotnet/sdk:9.0.100-preview.3",
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2.4.2": {},
         "ghcr.io/devcontainers/features/git:1.2.0": {},

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -538,7 +538,7 @@ try {
     $nativeTools = InitializeNativeTools
 
     if (-not (Test-Path variable:NativeToolsOnMachine)) {
-        $env:PERL5Path = Join-Path $nativeTools "perl\5.38.0.1\perl\bin\perl.exe"
+        $env:PERL5Path = Join-Path $nativeTools "perl\5.38.2.2\perl\bin\perl.exe"
         write-host "variable:NativeToolsOnMachine = unset or false"
         $nativeTools
         write-host "Path = $env:PERL5Path"

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -9,9 +9,9 @@
       These will go away when repo updates targeting to net8.0
       Tracked with https://github.com/dotnet/fsharp/issues/14765
     -->
-    <UsagePattern IdentityGlob="Microsoft.AspNetCore.App.Ref/8.0.1" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Host.linux-x64/8.0.1" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/8.0.1" />
+    <UsagePattern IdentityGlob="Microsoft.AspNetCore.App.Ref/8.0.2" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Host.linux-x64/8.0.2" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/8.0.2" />
     <UsagePattern IdentityGlob="System.Configuration.ConfigurationManager/7.0.0" />
     <UsagePattern IdentityGlob="System.Diagnostics.EventLog/7.0.0" />
     <UsagePattern IdentityGlob="System.Security.Cryptography.ProtectedData/7.0.0" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,9 +30,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24204.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24225.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>188340e12c0a372b1681ad6a5e72c608021efdba</Sha>
+      <Sha>67d23f4ba1813b315e7e33c71d18b63475f5c5f8</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/global.json
+++ b/global.json
@@ -17,7 +17,7 @@
     "perl": "5.38.0.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24204.3",
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24225.1",
     "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23255.2"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.100-preview.2.24157.14",
+    "version": "9.0.100-preview.3.24204.13",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "9.0.100-preview.2.24157.14",
+    "dotnet": "9.0.100-preview.3.24204.13",
     "vs": {
       "version": "17.8",
       "components": [
@@ -14,7 +14,7 @@
     "xcopy-msbuild": "17.8.5"
   },
   "native-tools": {
-    "perl": "5.38.0.1"
+    "perl": "5.38.2.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24225.1",


### PR DESCRIPTION
- Updates SDK to preview 3
- Updates Perl to match latest one on build machines. This fixes current issue with FSharpQA tests.