### PR TITLE
A few super-minor compiler perf improvements

### DIFF
--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -90,22 +90,23 @@ let rec splitNamespaceAux (nm: string) =
     | -1 -> [ nm ]
     | idx ->
         let s1, s2 = splitNameAt nm idx
-        let s1 = memoizeNamespacePartTable.GetOrAdd(s1, id)
+        let s1 = memoizeNamespacePartTable.GetOrAdd(s1, s1)
         s1 :: splitNamespaceAux s2
 
+// Cache this as a delegate.
+let splitNamespaceAuxDelegate = Func<string, string list> splitNamespaceAux
+
 let splitNamespace nm =
-    memoizeNamespaceTable.GetOrAdd(nm, splitNamespaceAux)
+    memoizeNamespaceTable.GetOrAdd(nm, splitNamespaceAuxDelegate)
 
 // ++GLOBAL MUTABLE STATE (concurrency-safe)
 let memoizeNamespaceArrayTable = ConcurrentDictionary<string, string[]>()
 
+// Cache this as a delegate.
+let splitNamespaceToArrayDelegate = Func<string, string array>(splitNamespace >> Array.ofList)
+
 let splitNamespaceToArray nm =
-    memoizeNamespaceArrayTable.GetOrAdd(
-        nm,
-        fun nm ->
-            let x = Array.ofList (splitNamespace nm)
-            x
-    )
+    memoizeNamespaceArrayTable.GetOrAdd(nm, splitNamespaceToArrayDelegate)
 
 let splitILTypeName (nm: string) =
     match nm.LastIndexOf '.' with
@@ -156,8 +157,11 @@ let splitTypeNameRightAux (nm: string) =
         let s1, s2 = splitNameAt nm idx
         Some s1, s2
 
+// Cache this as a delegate.
+let splitTypeNameRightDelegate = Func<string, string option * string> splitTypeNameRightAux
+
 let splitTypeNameRight nm =
-    memoizeNamespaceRightTable.GetOrAdd(nm, splitTypeNameRightAux)
+    memoizeNamespaceRightTable.GetOrAdd(nm, splitTypeNameRightDelegate)
 
 // --------------------------------------------------------------------
 // Ordered lists with a lookup table

--- a/src/Compiler/AbstractIL/il.fs
+++ b/src/Compiler/AbstractIL/il.fs
@@ -158,10 +158,10 @@ let splitTypeNameRightAux (nm: string) =
         Some s1, s2
 
 // Cache this as a delegate.
-let splitTypeNameRightDelegate = Func<string, string option * string> splitTypeNameRightAux
+let splitTypeNameRightAuxDelegate = Func<string, string option * string> splitTypeNameRightAux
 
 let splitTypeNameRight nm =
-    memoizeNamespaceRightTable.GetOrAdd(nm, splitTypeNameRightDelegate)
+    memoizeNamespaceRightTable.GetOrAdd(nm, splitTypeNameRightAuxDelegate)
 
 // --------------------------------------------------------------------
 // Ordered lists with a lookup table

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -220,6 +220,20 @@ type BuildPhase =
     | Output
     | Interactive // An error seen during interactive execution
 
+    override this.ToString() =
+        match this with
+        | DefaultPhase -> nameof DefaultPhase
+        | Compile -> nameof Compile
+        | Parameter -> nameof Parameter
+        | Parse -> nameof Parse
+        | TypeCheck -> nameof TypeCheck
+        | CodeGen -> nameof CodeGen
+        | Optimize -> nameof Optimize
+        | IlxGen -> nameof IlxGen
+        | IlGen -> nameof IlGen
+        | Output -> nameof Output
+        | Interactive -> nameof Interactive
+
 /// Literal build phase subcategory strings.
 module BuildPhaseSubcategory =
     [<Literal>]

--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -389,29 +389,30 @@ let compileCustomOpName =
     /// They're typically used more than once so this avoids some CPU and GC overhead.
     let compiledOperators = ConcurrentDictionary<_, string> StringComparer.Ordinal
 
+    // Cache this as a delegate.
+    let compiledOperatorsAddDelegate =
+        Func<string, string>(fun (op: string) ->
+            let opLength = op.Length
+    
+            let sb =
+                StringBuilder(opNamePrefix, opNamePrefix.Length + (opLength * maxOperatorNameLength))
+    
+            for i = 0 to opLength - 1 do
+                let c = op[i]
+    
+                match t2.TryGetValue c with
+                | true, x -> sb.Append(x) |> ignore
+                | false, _ -> sb.Append(c) |> ignore
+    
+            /// The compiled (mangled) operator name.
+            let opName = sb.ToString()
+    
+            // Cache the compiled name so it can be reused.
+            opName)
+
     fun opp ->
         // Has this operator already been compiled?
-        compiledOperators.GetOrAdd(
-            opp,
-            fun (op: string) ->
-                let opLength = op.Length
-
-                let sb =
-                    StringBuilder(opNamePrefix, opNamePrefix.Length + (opLength * maxOperatorNameLength))
-
-                for i = 0 to opLength - 1 do
-                    let c = op[i]
-
-                    match t2.TryGetValue c with
-                    | true, x -> sb.Append(x) |> ignore
-                    | false, _ -> sb.Append(c) |> ignore
-
-                /// The compiled (mangled) operator name.
-                let opName = sb.ToString()
-
-                // Cache the compiled name so it can be reused.
-                opName
-        )
+        compiledOperators.GetOrAdd(opp, compiledOperatorsAddDelegate)
 
 /// Maps the built-in F# operators to their mangled operator names.
 let standardOpNames =

--- a/src/FSharp.Core/QueryExtensions.fs
+++ b/src/FSharp.Core/QueryExtensions.fs
@@ -38,8 +38,10 @@ module internal Adapters =
 
     let memoize f =
         let d = new ConcurrentDictionary<Type, 'b>(HashIdentity.Structural)
+        // Cache this as a delegate.
+        let valueFactory = Func<Type, 'b> f
 
-        fun x -> d.GetOrAdd(x, (fun r -> f r))
+        fun x -> d.GetOrAdd(x, valueFactory)
 
     let isPartiallyImmutableRecord: Type -> bool =
         memoize (fun t ->


### PR DESCRIPTION
## Description

I saw some of these show up when I did a quick profile of FSharp.Compiler.ComponentTests, which take the longest to run of all the tests.

- Override `ToString` on `BuildPhase`.
- Cache the delegate passed into `ConcurrentDictionary.GetOrAdd` where possible. See #14582, fsharp/fslang-suggestions#1083, etc.

## Checklist

- [ ] Release notes entry updated.