### PR TITLE
Disable AOT tests in Signed product builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ extends:
             - script: eng\CIBuild.cmd
                       -configuration $(_BuildConfig)
                       -prepareMachine
-                      -testAllButIntegration
+                      -testAllButIntegrationAndAot
                       -officialSkipTests $(SkipTests)
                       /p:SignType=$(_SignType)
                       /p:DotNetSignType=$(_SignType)

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -61,6 +61,7 @@ param (
     [switch]$testVs,
     [switch]$testAll,
     [switch]$testAllButIntegration,
+    [switch]$testAllButIntegrationAndAot,
     [switch]$testpack,
     [switch]$testAOT,
     [switch]$testBenchmarks,
@@ -104,6 +105,7 @@ function Print-Usage() {
     Write-Host "Test actions"
     Write-Host "  -testAll                      Run all tests"
     Write-Host "  -testAllButIntegration        Run all but integration tests"
+    Write-Host "  -testAllButIntegrationAndAot  Run all but integration and AOT tests"
     Write-Host "  -testCambridge                Run Cambridge tests"
     Write-Host "  -testCompiler                 Run FSharpCompiler unit tests"
     Write-Host "  -testCompilerService          Run FSharpCompilerService unit tests"
@@ -170,9 +172,19 @@ function Process-Arguments() {
         $script:testAOT = $True
     }
 
+    if($testAllButIntegrationAndAot) {
+        $script:testDesktop = $True
+        $script:testCoreClr = $True
+        $script:testFSharpQA = $True
+        $script:testIntegration = $False
+        $script:testVs = $True
+        $script:testAOT = $False
+    }
+
     if ([System.Boolean]::Parse($script:officialSkipTests)) {
         $script:testAll = $False
         $script:testAllButIntegration = $False
+        $script:testAllButIntegrationAndAot = $False
         $script:testCambridge = $False
         $script:testCompiler = $False
         $script:testCompilerService = $False
@@ -219,7 +231,7 @@ function Process-Arguments() {
     else {
         $script:buildnorealsig = $False
         $env:FSHARP_REALSIG="true"
-    }        
+    }
     if ($verifypackageshipstatus) {
         $script:verifypackageshipstatus = $True;
     }


### PR DESCRIPTION
Disable running AOT tests as part of signed build. This unblocks insertions.