### PR TITLE
Don't cause index out of range exn in completion

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix internal error when dotting into delegates with multiple type parameters. ([PR #17227](https://github.com/dotnet/fsharp/pull/17227))
 * Error for partial implementation of interface with static and non-static abstract members. ([Issue #17138](https://github.com/dotnet/fsharp/issues/17138), [PR #17160](https://github.com/dotnet/fsharp/pull/17160))
 * Optimize simple mappings with preludes in computed collections. ([PR #17067](https://github.com/dotnet/fsharp/pull/17067))
 * Improve error reporting for abstract members when used in classes. ([PR #17063](https://github.com/dotnet/fsharp/pull/17063))

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -1105,7 +1105,7 @@ let GetNestedTyconRefsOfType (infoReader: InfoReader) (amap: Import.ImportMap) (
 /// Handle the .NET/C# business where nested generic types implicitly accumulate the type parameters
 /// from their enclosing types.
 let MakeNestedType (ncenv: NameResolver) (tinst: TType list) m (tcrefNested: TyconRef) =
-    let tps = match tcrefNested.Typars m with [] -> [] | l -> List.skip tinst.Length l
+    let tps = match tcrefNested.Typars m with [] -> [] | l -> l[tinst.Length..]
     let tinstNested = ncenv.InstantiationGenerator m tps
     mkAppTy tcrefNested (tinst @ tinstNested)
 


### PR DESCRIPTION
## Description

Fixes #17226.

- Dotting into delegates with multiple type arguments would trigger an index out of range exception. Now it doesn't.

## Checklist

- Tests: I spent a while trying to get a test for this to work, but it seems like it might be rather difficult, since this pathway only seems to be called sometimes. Compare:
  https://github.com/dotnet/fsharp/blob/ef2307d18b2d97312680187b3d189a0076fdaa94/src/Compiler/Service/FSharpCheckerResults.fs#L1316-L1318

  But here's a recording of the fix working:

  https://github.com/dotnet/fsharp/assets/14795984/977083b5-5018-422a-bb54-ba87d5779bbe

- [x] Release notes entry updated.