### PR TITLE
Parser: recover on unfinished isConst patterns

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -28,6 +28,7 @@
 * Allow object expression without overrides. ([Language suggestion #632](https://github.com/fsharp/fslang-suggestions/issues/632), [PR #17387](https://github.com/dotnet/fsharp/pull/17387))
 * Enable FSharp 9.0 Language Version ([Issue #17497](https://github.com/dotnet/fsharp/issues/17438)), [PR](https://github.com/dotnet/fsharp/pull/17500)))
 * Enable LanguageFeature.EnforceAttributeTargets in F# 9.0. ([Issue #17514](https://github.com/dotnet/fsharp/issues/17558), [PR #17516](https://github.com/dotnet/fsharp/pull/17558))
+* Parser: better recovery for unfinished patterns ([PR #17231](https://github.com/dotnet/fsharp/pull/17231), [PR #17232](https://github.com/dotnet/fsharp/pull/17232)))
 
 ### Changed
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3551,7 +3551,7 @@ headBindingPattern:
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }
 
-  | headBindingPattern COLON_COLON recover
+  | headBindingPattern COLON_COLON ends_coming_soon_or_recover 
       { let mColonColon = rhs parseState 2
         let pat2 = SynPat.Wild(mColonColon.EndRange)
         SynPat.ListCons($1, pat2, rhs2 parseState 1 2, { ColonColonRange = mColonColon }) }
@@ -3683,8 +3683,9 @@ constrPattern:
       { let m = unionRanges (rhs parseState 1) $2.Range
         SynPat.IsInst($2, m) }
 
-  | COLON_QMARK recover %prec pat_isinst
+  | COLON_QMARK ends_coming_soon_or_recover %prec pat_isinst
       { let mColon = rhs parseState 1
+        reportParseErrorAt mColon (FSComp.SR.parsExpectingPattern ())
         let ty = SynType.FromParseError(mColon.EndRange)
         SynPat.IsInst(ty, mColon) }
 
@@ -3867,8 +3868,9 @@ parenPattern:
       { let mLhs = lhs parseState
         SynPat.Typed($1, $3, mLhs) }
 
-  | parenPattern COLON recover
+  | parenPattern COLON ends_coming_soon_or_recover
       { let mColon = rhs parseState 2
+        reportParseErrorAt mColon (FSComp.SR.parsExpectingPattern ())
         let ty = SynType.FromParseError(mColon.EndRange)
         SynPat.Typed($1, ty, unionRanges $1.Range mColon) }
 
@@ -3880,8 +3882,9 @@ parenPattern:
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }
 
-  | parenPattern COLON_COLON recover
+  | parenPattern COLON_COLON ends_coming_soon_or_recover
       { let mColonColon = rhs parseState 2
+        reportParseErrorAt mColonColon (FSComp.SR.parsExpectingPattern ())
         let pat2 = SynPat.Wild(mColonColon.EndRange)
         SynPat.ListCons($1, pat2, rhs2 parseState 1 2, { ColonColonRange = mColonColon }) }
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3547,17 +3547,6 @@ headBindingPattern:
       { let mBar = rhs parseState 2
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
-  | headBindingPattern BAR recover
-      { let mBar = rhs parseState 2
-        let pat2 = SynPat.Wild(mBar.EndRange)
-        SynPat.Or($1, pat2, rhs2 parseState 1 2, { BarRange = mBar }) }
-
-  | headBindingPattern BAR
-      { let mBar = rhs parseState 2
-        reportParseErrorAt mBar (FSComp.SR.parsExpectingPattern ())
-        let pat2 = SynPat.Wild(mBar.EndRange)
-        SynPat.Or($1, pat2, rhs2 parseState 1 2, { BarRange = mBar }) }
-
   | headBindingPattern COLON_COLON headBindingPattern
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -172,6 +172,7 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 %type <SynPat> headBindingPattern
 %type <SynType> appTypeNullableInParens
 %type <SynType> atomTypeNonAtomicDeprecated
+%type <SynType> atomTypeOrAnonRecdType
 %type <SynExpr> atomicExprAfterType
 %type <SynExpr> typedSequentialExprBlock
 %type <SynExpr * bool> atomicExpr
@@ -3546,6 +3547,17 @@ headBindingPattern:
       { let mBar = rhs parseState 2
         SynPat.Or($1, $3, rhs2 parseState 1 3, { BarRange = mBar }) }
 
+  | headBindingPattern BAR recover
+      { let mBar = rhs parseState 2
+        let pat2 = SynPat.Wild(mBar.EndRange)
+        SynPat.Or($1, pat2, rhs2 parseState 1 2, { BarRange = mBar }) }
+
+  | headBindingPattern BAR
+      { let mBar = rhs parseState 2
+        reportParseErrorAt mBar (FSComp.SR.parsExpectingPattern ())
+        let pat2 = SynPat.Wild(mBar.EndRange)
+        SynPat.Or($1, pat2, rhs2 parseState 1 2, { BarRange = mBar }) }
+
   | headBindingPattern COLON_COLON headBindingPattern
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }
@@ -3679,7 +3691,19 @@ constrPattern:
         SynPat.LongIdent(lid, None, None, args, vis, m) }
 
   | COLON_QMARK atomTypeOrAnonRecdType %prec pat_isinst
-      { SynPat.IsInst($2, lhs parseState) }
+      { let m = unionRanges (rhs parseState 1) $2.Range
+        SynPat.IsInst($2, m) }
+
+  | COLON_QMARK recover %prec pat_isinst
+      { let mColon = rhs parseState 1
+        let ty = SynType.FromParseError(mColon.EndRange)
+        SynPat.IsInst(ty, mColon) }
+
+  | COLON_QMARK %prec pat_isinst
+      { let mColon = rhs parseState 1
+        let ty = SynType.FromParseError(mColon.EndRange)
+        reportParseErrorAt mColon (FSComp.SR.parsExpectingType ())
+        SynPat.IsInst(ty, mColon) }
 
   | atomicPattern
       { $1 }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -3683,9 +3683,10 @@ constrPattern:
       { let m = unionRanges (rhs parseState 1) $2.Range
         SynPat.IsInst($2, m) }
 
-  | COLON_QMARK ends_coming_soon_or_recover %prec pat_isinst
+  | COLON_QMARK recover %prec pat_isinst
       { let mColon = rhs parseState 1
-        reportParseErrorAt mColon (FSComp.SR.parsExpectingPattern ())
+        if not $2 then
+            reportParseErrorAt mColon (FSComp.SR.parsExpectingPattern ())
         let ty = SynType.FromParseError(mColon.EndRange)
         SynPat.IsInst(ty, mColon) }
 
@@ -3868,9 +3869,10 @@ parenPattern:
       { let mLhs = lhs parseState
         SynPat.Typed($1, $3, mLhs) }
 
-  | parenPattern COLON ends_coming_soon_or_recover
+  | parenPattern COLON recover
       { let mColon = rhs parseState 2
-        reportParseErrorAt mColon (FSComp.SR.parsExpectingPattern ())
+        if not $3 then
+            reportParseErrorAt mColon (FSComp.SR.parsExpectingPattern ())
         let ty = SynType.FromParseError(mColon.EndRange)
         SynPat.Typed($1, ty, unionRanges $1.Range mColon) }
 
@@ -3882,9 +3884,10 @@ parenPattern:
       { let mColonColon = rhs parseState 2
         SynPat.ListCons($1, $3, rhs2 parseState 1 3, { ColonColonRange = mColonColon }) }
 
-  | parenPattern COLON_COLON ends_coming_soon_or_recover
+  | parenPattern COLON_COLON recover
       { let mColonColon = rhs parseState 2
-        reportParseErrorAt mColonColon (FSComp.SR.parsExpectingPattern ())
+        if not $3 then
+            reportParseErrorAt mColonColon (FSComp.SR.parsExpectingPattern ())
         let pat2 = SynPat.Wild(mColonColon.EndRange)
         SynPat.ListCons($1, pat2, rhs2 parseState 1 2, { ColonColonRange = mColonColon }) }
 

--- a/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
@@ -702,9 +702,9 @@ let z as =
         "(8,29--8,30): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
         "(9,26--9,27): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
         "(10,14--10,15): This expression was expected to have type\u001d    ''a * 'b'    \u001dbut here has type\u001d    'int'";
-        "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
         "(12,16--12,18): This expression was expected to have type\u001d    ''a list'    \u001dbut here has type\u001d    'int'";
         "(12,4--12,13): Incomplete pattern matches on this expression. For example, the value '[]' may indicate a case not covered by the pattern(s).";
+        "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
         "(15,4--15,5): The pattern discriminator 'r' is not defined.";
         "(15,4--15,12): Incomplete pattern matches on this expression."
     ]
@@ -1115,11 +1115,11 @@ let as :? z =
         "(9,22--9,26): The type 'unit' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(10,13--10,14): The type 'i' is not defined.";
         "(10,10--10,14): The type ''a * 'b' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
+        "(12,15--12,16): The type 'm' is not defined.";
+        "(12,12--12,16): The type ''a list' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
         "(14,14--14,15): The type 'q' is not defined.";
         "(14,11--14,15): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(12,15--12,16): The type 'm' is not defined.";
-        "(12,12--12,16): The type ''a list' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(16,4--16,5): The pattern discriminator 't' is not defined.";
         "(16,14--16,15): The type 'u' is not defined.";
         "(16,11--16,15): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed."

--- a/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
@@ -687,22 +687,22 @@ let z as =
         "(14,8--14,10): Unexpected keyword 'as' in binding";
         "(15,8--15,10): Unexpected keyword 'as' in pattern. Expected ')' or other token.";
         "(15,6--15,7): Unmatched '('";
-        "(16,0--16,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (15:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(16,0--16,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (15:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
         "(16,0--16,3): Unexpected keyword 'let' or 'use' in binding. Expected incomplete structured construct at or before this point or other token.";
         "(15,0--15,3): Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.";
         "(17,0--17,3): Incomplete structured construct at or before this point in implementation file";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(3,13--3,17): This expression was expected to have type    'int'    but here has type    'bool'";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(3,13--3,17): This expression was expected to have type\u001d    'int'    \u001dbut here has type\u001d    'bool'";
         "(3,4--3,10): Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).";
-        "(4,16--4,17): This expression was expected to have type    'bool'    but here has type    'int'";
+        "(4,16--4,17): This expression was expected to have type\u001d    'bool'    \u001dbut here has type\u001d    'int'";
         "(4,4--4,13): Incomplete pattern matches on this expression. For example, the value 'false' may indicate a case not covered by the pattern(s).";
-        "(5,4--5,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(6,4--6,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(8,29--8,30): This expression was expected to have type    'unit'    but here has type    'int'";
-        "(9,26--9,27): This expression was expected to have type    'unit'    but here has type    'int'";
-        "(10,14--10,15): This expression was expected to have type    ''a * 'b'    but here has type    'int'";
-        "(12,16--12,18): This expression was expected to have type    ''a list'    but here has type    'int'";
+        "(5,4--5,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(6,4--6,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(8,29--8,30): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
+        "(9,26--9,27): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
+        "(10,14--10,15): This expression was expected to have type\u001d    ''a * 'b'    \u001dbut here has type\u001d    'int'";
+        "(12,16--12,18): This expression was expected to have type\u001d    ''a list'    \u001dbut here has type\u001d    'int'";
         "(12,4--12,13): Incomplete pattern matches on this expression. For example, the value '[]' may indicate a case not covered by the pattern(s).";
         "(15,4--15,5): The pattern discriminator 'r' is not defined.";
         "(15,4--15,12): Incomplete pattern matches on this expression."
@@ -1092,22 +1092,22 @@ let as :? z =
         "(15,13--15,15): Unexpected keyword 'as' in pattern. Expected '(' or other token.";
         "(16,8--16,10): Unexpected keyword 'as' in pattern. Expected ')' or other token.";
         "(16,6--16,7): Unmatched '('";
-        "(17,0--17,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (16:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(17,0--17,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (16:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
         "(17,0--17,3): Unexpected keyword 'let' or 'use' in binding. Expected incomplete structured construct at or before this point or other token.";
         "(16,0--16,3): Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.";
         "(17,8--17,10): Unexpected keyword 'as' in pattern. Expected ']' or other token.";
-        "(18,0--18,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (17:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(19,0--19,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (18:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(18,0--18,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (17:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(19,0--19,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (18:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
         "(3,12--3,13): The type 'a' is not defined.";
         "(3,9--3,13): The type 'int' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(4,15--4,16): The type 'b' is not defined.";
         "(4,12--4,16): The type 'bool' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
-        "(5,4--5,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(6,4--6,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(5,4--5,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(6,4--6,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
         "(7,27--7,28): The type 'e' is not defined.";
-        "(7,24--7,28): This runtime coercion or type test from type    'a     to     'b    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(7,24--7,28): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
         "(8,28--8,29): The type 'f' is not defined.";
         "(8,25--8,29): The type 'unit' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(9,25--9,26): The type 'g' is not defined.";
@@ -1118,7 +1118,7 @@ let as :? z =
         "(12,12--12,16): The type ''a list' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(16,4--16,5): The pattern discriminator 't' is not defined.";
         "(16,14--16,15): The type 'u' is not defined.";
-        "(16,11--16,15): This runtime coercion or type test from type    'a     to     'b    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed."
+        "(16,11--16,15): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed."
     ]
 
 [<FactForNETCOREAPP>]

--- a/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
@@ -684,27 +684,26 @@ let z as =
         "(11,10--11,12): Unexpected keyword 'as' in binding. Expected '=' or other token.";
         "(12,6--12,8): Expecting pattern";
         "(13,8--13,10): Unexpected keyword 'as' in binding";
-        "(14,6--14,7): Expecting pattern";
+        "(14,8--14,10): Unexpected keyword 'as' in binding";
         "(15,8--15,10): Unexpected keyword 'as' in pattern. Expected ')' or other token.";
         "(15,6--15,7): Unmatched '('";
-        "(16,0--16,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (15:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(16,0--16,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (15:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
         "(16,0--16,3): Unexpected keyword 'let' or 'use' in binding. Expected incomplete structured construct at or before this point or other token.";
         "(15,0--15,3): Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.";
         "(17,0--17,3): Incomplete structured construct at or before this point in implementation file";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(3,13--3,17): This expression was expected to have type\u001d    'int'    \u001dbut here has type\u001d    'bool'";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(3,13--3,17): This expression was expected to have type    'int'    but here has type    'bool'";
         "(3,4--3,10): Incomplete pattern matches on this expression. For example, the value '0' may indicate a case not covered by the pattern(s).";
-        "(4,16--4,17): This expression was expected to have type\u001d    'bool'    \u001dbut here has type\u001d    'int'";
+        "(4,16--4,17): This expression was expected to have type    'bool'    but here has type    'int'";
         "(4,4--4,13): Incomplete pattern matches on this expression. For example, the value 'false' may indicate a case not covered by the pattern(s).";
-        "(5,4--5,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(6,4--6,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(8,29--8,30): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
-        "(9,26--9,27): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
-        "(10,14--10,15): This expression was expected to have type\u001d    ''a * 'b'    \u001dbut here has type\u001d    'int'";
-        "(12,16--12,18): This expression was expected to have type\u001d    ''a list'    \u001dbut here has type\u001d    'int'";
+        "(5,4--5,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(6,4--6,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(8,29--8,30): This expression was expected to have type    'unit'    but here has type    'int'";
+        "(9,26--9,27): This expression was expected to have type    'unit'    but here has type    'int'";
+        "(10,14--10,15): This expression was expected to have type    ''a * 'b'    but here has type    'int'";
+        "(12,16--12,18): This expression was expected to have type    ''a list'    but here has type    'int'";
         "(12,4--12,13): Incomplete pattern matches on this expression. For example, the value '[]' may indicate a case not covered by the pattern(s).";
-        "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
         "(15,4--15,5): The pattern discriminator 'r' is not defined.";
         "(15,4--15,12): Incomplete pattern matches on this expression."
     ]
@@ -1089,26 +1088,26 @@ let as :? z =
         "(11,10--11,12): Unexpected keyword 'as' in binding. Expected '=' or other token.";
         "(12,6--12,8): Expecting pattern";
         "(13,8--13,10): Unexpected keyword 'as' in binding";
-        "(14,6--14,7): Expecting pattern";
+        "(14,8--14,10): Unexpected keyword 'as' in binding";
         "(15,13--15,15): Unexpected keyword 'as' in pattern. Expected '(' or other token.";
         "(16,8--16,10): Unexpected keyword 'as' in pattern. Expected ')' or other token.";
         "(16,6--16,7): Unmatched '('";
-        "(17,0--17,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (16:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(17,0--17,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (16:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
         "(17,0--17,3): Unexpected keyword 'let' or 'use' in binding. Expected incomplete structured construct at or before this point or other token.";
         "(16,0--16,3): Incomplete value or function definition. If this is in an expression, the body of the expression must be indented to the same column as the 'let' keyword.";
         "(17,8--17,10): Unexpected keyword 'as' in pattern. Expected ']' or other token.";
-        "(18,0--18,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (17:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(19,0--19,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (18:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
-        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(18,0--18,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (17:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(19,0--19,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (18:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
+        "(20,0--20,0): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (19:1). Try indenting this further.To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
         "(3,12--3,13): The type 'a' is not defined.";
         "(3,9--3,13): The type 'int' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(4,15--4,16): The type 'b' is not defined.";
         "(4,12--4,16): The type 'bool' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
-        "(5,4--5,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
-        "(6,4--6,10): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    int    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(5,4--5,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(6,4--6,10): This runtime coercion or type test from type    'a     to     int    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
         "(7,27--7,28): The type 'e' is not defined.";
-        "(7,24--7,28): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
+        "(7,24--7,28): This runtime coercion or type test from type    'a     to     'b    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
         "(8,28--8,29): The type 'f' is not defined.";
         "(8,25--8,29): The type 'unit' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(9,25--9,26): The type 'g' is not defined.";
@@ -1117,12 +1116,9 @@ let as :? z =
         "(10,10--10,14): The type ''a * 'b' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(12,15--12,16): The type 'm' is not defined.";
         "(12,12--12,16): The type ''a list' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
-        "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
-        "(14,14--14,15): The type 'q' is not defined.";
-        "(14,11--14,15): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
         "(16,4--16,5): The pattern discriminator 't' is not defined.";
         "(16,14--16,15): The type 'u' is not defined.";
-        "(16,11--16,15): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed."
+        "(16,11--16,15): This runtime coercion or type test from type    'a     to     'b    involves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed."
     ]
 
 [<FactForNETCOREAPP>]

--- a/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
@@ -684,7 +684,7 @@ let z as =
         "(11,10--11,12): Unexpected keyword 'as' in binding. Expected '=' or other token.";
         "(12,6--12,8): Expecting pattern";
         "(13,8--13,10): Unexpected keyword 'as' in binding";
-        "(14,8--14,10): Unexpected keyword 'as' in binding";
+        "(14,6--14,7): Expecting pattern";
         "(15,8--15,10): Unexpected keyword 'as' in pattern. Expected ')' or other token.";
         "(15,6--15,7): Unmatched '('";
         "(16,0--16,3): Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (15:1). Try indenting this further.\u001dTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.";
@@ -702,6 +702,7 @@ let z as =
         "(8,29--8,30): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
         "(9,26--9,27): This expression was expected to have type\u001d    'unit'    \u001dbut here has type\u001d    'int'";
         "(10,14--10,15): This expression was expected to have type\u001d    ''a * 'b'    \u001dbut here has type\u001d    'int'";
+        "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
         "(12,16--12,18): This expression was expected to have type\u001d    ''a list'    \u001dbut here has type\u001d    'int'";
         "(12,4--12,13): Incomplete pattern matches on this expression. For example, the value '[]' may indicate a case not covered by the pattern(s).";
         "(15,4--15,5): The pattern discriminator 'r' is not defined.";
@@ -1088,7 +1089,7 @@ let as :? z =
         "(11,10--11,12): Unexpected keyword 'as' in binding. Expected '=' or other token.";
         "(12,6--12,8): Expecting pattern";
         "(13,8--13,10): Unexpected keyword 'as' in binding";
-        "(14,8--14,10): Unexpected keyword 'as' in binding";
+        "(14,6--14,7): Expecting pattern";
         "(15,13--15,15): Unexpected keyword 'as' in pattern. Expected '(' or other token.";
         "(16,8--16,10): Unexpected keyword 'as' in pattern. Expected ')' or other token.";
         "(16,6--16,7): Unmatched '('";
@@ -1114,6 +1115,9 @@ let as :? z =
         "(9,22--9,26): The type 'unit' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(10,13--10,14): The type 'i' is not defined.";
         "(10,10--10,14): The type ''a * 'b' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
+        "(14,4--14,7): The two sides of this 'or' pattern bind different sets of variables";
+        "(14,14--14,15): The type 'q' is not defined.";
+        "(14,11--14,15): This runtime coercion or type test from type\u001d    'a    \u001d to \u001d    'b    \u001dinvolves an indeterminate type based on information prior to this program point. Runtime type tests are not allowed on some types. Further type annotations are needed.";
         "(12,15--12,16): The type 'm' is not defined.";
         "(12,12--12,16): The type ''a list' does not have any proper subtypes and cannot be used as the source of a type test or runtime coercion.";
         "(16,4--16,5): The pattern discriminator 't' is not defined.";

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 05.fs
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 05.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+|
+
+()

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 05.fs.bsl
@@ -1,0 +1,18 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/MatchClause/Missing pat 05.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)), [], (3,0--4,1),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--4,1));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in expression

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 01.fs
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+| :? T -> ()
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 01.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/IsInst 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (IsInst
+                       (LongIdent (SynLongIdent ([T], [], [None])), (4,2--4,6)),
+                     None, Const (Unit, (4,10--4,12)), (4,2--4,12), Yes,
+                     { ArrowRange = Some (4,7--4,9)
+                       BarRange = Some (4,0--4,1) })], (3,0--4,12),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--4,12));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 02.fs
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 02.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+| :? T
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 02.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/IsInst 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (IsInst
+                       (LongIdent (SynLongIdent ([T], [], [None])), (4,2--4,6)),
+                     None, ArbitraryAfterError ("patternClauses2", (4,6--4,6)),
+                     (4,2--4,6), Yes, { ArrowRange = None
+                                        BarRange = Some (4,0--4,1) })],
+                 (3,0--4,6), { MatchKeyword = (3,0--3,5)
+                               WithKeyword = (3,9--3,13) }), (3,0--4,6));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in pattern matching. Expected '->' or other token.

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 03.fs
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+| :? -> ()
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 03.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/IsInst 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (IsInst (FromParseError (4,4--4,4), (4,2--4,4)), None,
+                     Const (Unit, (4,8--4,10)), (4,2--4,10), Yes,
+                     { ArrowRange = Some (4,5--4,7)
+                       BarRange = Some (4,0--4,1) })], (3,0--4,10),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--4,10));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,2)-(4,4) parse error Expecting type

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 04.fs
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+| :?
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 04.fs.bsl
@@ -1,0 +1,23 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/IsInst 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (IsInst (FromParseError (4,4--4,4), (4,2--4,4)), None,
+                     ArbitraryAfterError ("patternClauses2", (4,4--4,4)),
+                     (4,2--4,4), Yes, { ArrowRange = None
+                                        BarRange = Some (4,0--4,1) })],
+                 (3,0--4,4), { MatchKeyword = (3,0--3,5)
+                               WithKeyword = (3,9--3,13) }), (3,0--4,4));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,2)-(4,4) parse error Expecting type
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in pattern matching. Expected '->' or other token.

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 05.fs
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 05.fs
@@ -1,0 +1,7 @@
+module Module
+
+match () with
+| :?
+| _ -> ()
+
+()

--- a/tests/service/data/SyntaxTree/Pattern/IsInst 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/IsInst 05.fs.bsl
@@ -1,0 +1,24 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Pattern/IsInst 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Or
+                       (IsInst (FromParseError (4,4--4,4), (4,2--4,4)),
+                        Wild (5,2--5,3), (4,2--5,3), { BarRange = (5,0--5,1) }),
+                     None, Const (Unit, (5,7--5,9)), (4,2--5,9), Yes,
+                     { ArrowRange = Some (5,4--5,6)
+                       BarRange = Some (4,0--4,1) })], (3,0--5,9),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--5,9));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,2)-(4,4) parse error Expecting type


### PR DESCRIPTION
Adds recovery for unfinished IsInstance patterns:
```fsharp
match () with
| :? T
```
```fsharp
match () with
| :?
```