### PR TITLE
Parser: recover on empty match clause

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
@@ -20,6 +20,7 @@
 
 * Generate new `Equals` overload to avoid boxing for structural comparison ([PR #16857](https://github.com/dotnet/fsharp/pull/16857))
 * Parser: better recovery for unfinished patterns ([PR #17231](https://github.com/dotnet/fsharp/pull/17231))
+* Parser: recover on empty match clause ([PR #17233](https://github.com/dotnet/fsharp/pull/17233))
 
 ### Changed
 * Enforce `AttributeTargets.Interface` ([PR #17173](https://github.com/dotnet/fsharp/pull/17173))

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -1074,8 +1074,7 @@ let (|Get_OrSet_Ident|_|) (ident: Ident) =
 let addEmptyMatchClause (mBar1: range) (mBar2: range) (clauses: SynMatchClause list) =
     let rec addOrPat (pat: SynPat) =
         match pat with
-        | SynPat.As(lhsPat, rhsPat, range) ->
-            SynPat.As(addOrPat lhsPat, rhsPat, range)
+        | SynPat.As(lhsPat, rhsPat, range) -> SynPat.As(addOrPat lhsPat, rhsPat, range)
         | _ ->
             let mPat1 = mBar1.EndRange
             let pat1 = SynPat.Wild(mPat1)
@@ -1084,4 +1083,5 @@ let addEmptyMatchClause (mBar1: range) (mBar2: range) (clauses: SynMatchClause l
     match clauses with
     | [] -> []
     | SynMatchClause(pat, whenExpr, resultExpr, range, debugPoint, trivia) :: restClauses ->
-        SynMatchClause(addOrPat pat, whenExpr, resultExpr, range, debugPoint, trivia) :: restClauses
+        SynMatchClause(addOrPat pat, whenExpr, resultExpr, range, debugPoint, trivia)
+        :: restClauses

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -1070,3 +1070,18 @@ let (|Get_OrSet_Ident|_|) (ident: Ident) =
     if ident.idText.StartsWithOrdinal("get_") then ValueSome()
     elif ident.idText.StartsWithOrdinal("set_") then ValueSome()
     else ValueNone
+
+let addEmptyMatchClause (mBar1: range) (mBar2: range) (clauses: SynMatchClause list) =
+    let rec addOrPat (pat: SynPat) =
+        match pat with
+        | SynPat.As(lhsPat, rhsPat, range) ->
+            SynPat.As(addOrPat lhsPat, rhsPat, range)
+        | _ ->
+            let mPat1 = mBar1.EndRange
+            let pat1 = SynPat.Wild(mPat1)
+            SynPat.Or(pat1, pat, unionRanges mPat1 pat.Range, { BarRange = mBar2 })
+
+    match clauses with
+    | [] -> []
+    | SynMatchClause(pat, whenExpr, resultExpr, range, debugPoint, trivia) :: restClauses ->
+        SynMatchClause(addOrPat pat, whenExpr, resultExpr, range, debugPoint, trivia) :: restClauses

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
@@ -359,3 +359,6 @@ val (|TypesForTypar|): t: SynType -> SynType list
 /// Generated get_XYZ or set_XYZ ident text
 [<return: Struct>]
 val (|Get_OrSet_Ident|_|): Ident -> unit voption
+
+/// Adds SynPat.Or pattern for unfinished empty clause above
+val addEmptyMatchClause: mBar1: range -> mBar2: range -> clauses: SynMatchClause list -> SynMatchClause list

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4633,6 +4633,14 @@ withPatternClauses:
       { let mBar = rhs parseState 1 |> Some
         $2 mBar }
 
+  | BAR BAR patternClauses
+     { let mBar1 = rhs parseState 1
+       let mBar2 = rhs parseState 2
+       reportParseErrorAt mBar2 (FSComp.SR.parsExpectingPattern ())
+       let clauses, mLast = Some mBar1 |> $3
+       let clauses = addEmptyMatchClause mBar1 mBar2 clauses
+       clauses, mLast }
+
   | BAR error
       { // silent recovery
         let mLast = rhs parseState 1
@@ -4665,6 +4673,20 @@ patternClauses:
        let m = unionRanges resultExpr.Range pat.Range
        fun mBar ->
            (SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar }) :: clauses), mLast }
+
+  | patternAndGuard patternResult BAR BAR patternClauses
+     { let pat, guard = $1
+       let mArrow, resultExpr = $2
+       let mBar1 = rhs parseState 3
+       let mBar2 = rhs parseState 4
+       reportParseErrorAt mBar2 (FSComp.SR.parsExpectingPattern ())
+       let clauses, mLast = Some mBar1 |> $5
+       let clauses = addEmptyMatchClause mBar1 mBar2 clauses
+
+       fun mBar ->
+           let m = unionRanges resultExpr.Range pat.Range
+           let trivia = { ArrowRange = Some mArrow; BarRange = mBar }
+           SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, trivia) :: clauses, mLast }
 
   | patternAndGuard error BAR patternClauses
      { let pat, guard = $1

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 01.fs
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+| _ -> ()
+| 
+| _ -> ()

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 01.fs.bsl
@@ -1,0 +1,28 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/MatchClause/Missing pat 01.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Wild (4,2--4,3), None, Const (Unit, (4,7--4,9)), (4,2--4,9),
+                     Yes, { ArrowRange = Some (4,4--4,6)
+                            BarRange = Some (4,0--4,1) });
+                  SynMatchClause
+                    (Or
+                       (Wild (5,1--5,1), Wild (6,2--6,3), (5,1--6,3),
+                        { BarRange = (6,0--6,1) }), None,
+                     Const (Unit, (6,7--6,9)), (6,2--6,9), Yes,
+                     { ArrowRange = Some (6,4--6,6)
+                       BarRange = Some (5,0--5,1) })], (3,0--6,9),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--6,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Expecting pattern

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 02.fs
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 02.fs
@@ -1,0 +1,5 @@
+module Module
+
+match () with
+| 
+| _ -> ()

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 02.fs.bsl
@@ -1,0 +1,24 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/MatchClause/Missing pat 02.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Or
+                       (Wild (4,1--4,1), Wild (5,2--5,3), (4,1--5,3),
+                        { BarRange = (5,0--5,1) }), None,
+                     Const (Unit, (5,7--5,9)), (5,2--5,9), Yes,
+                     { ArrowRange = Some (5,4--5,6)
+                       BarRange = Some (4,0--4,1) })], (3,0--5,9),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--5,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,1) parse error Expecting pattern

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 03.fs
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 03.fs
@@ -1,0 +1,5 @@
+module Module
+
+match () with
+| 
+| _ as _ -> ()

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 03.fs.bsl
@@ -1,0 +1,25 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/MatchClause/Missing pat 03.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (As
+                       (Or
+                          (Wild (4,1--4,1), Wild (5,2--5,3), (4,1--5,3),
+                           { BarRange = (5,0--5,1) }), Wild (5,7--5,8),
+                        (5,2--5,8)), None, Const (Unit, (5,12--5,14)),
+                     (5,2--5,14), Yes, { ArrowRange = Some (5,9--5,11)
+                                         BarRange = Some (4,0--4,1) })],
+                 (3,0--5,14), { MatchKeyword = (3,0--3,5)
+                                WithKeyword = (3,9--3,13) }), (3,0--5,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,1) parse error Expecting pattern

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 04.fs
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+match () with
+|
+| _ as _
+| _ as _ -> ()

--- a/tests/service/data/SyntaxTree/MatchClause/Missing pat 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/MatchClause/Missing pat 04.fs.bsl
@@ -1,0 +1,29 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/MatchClause/Missing pat 04.fs", false, QualifiedNameOfFile Module,
+      [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (As
+                       (Or
+                          (Wild (4,1--4,1),
+                           Or
+                             (As (Wild (5,2--5,3), Wild (5,7--5,8), (5,2--5,8)),
+                              Wild (6,2--6,3), (5,2--6,3),
+                              { BarRange = (6,0--6,1) }), (4,1--6,3),
+                           { BarRange = (5,0--5,1) }), Wild (6,7--6,8),
+                        (5,2--6,8)), None, Const (Unit, (6,12--6,14)),
+                     (5,2--6,14), Yes, { ArrowRange = Some (6,9--6,11)
+                                         BarRange = Some (4,0--4,1) })],
+                 (3,0--6,14), { MatchKeyword = (3,0--3,5)
+                                WithKeyword = (3,9--3,13) }), (3,0--6,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,1) parse error Expecting pattern


### PR DESCRIPTION
Adds recovery for empty match clauses like these:
```fsharp
match () with
|
| _ -> ()
```

```fsharp
match () with
|
| _ as _ -> ()
```