### PR TITLE
Fix AOT

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ extends:
             - script: eng\CIBuild.cmd
                       -configuration $(_BuildConfig)
                       -prepareMachine
-                      -testAllButIntegrationAndAot
+                      -testAllButIntegration
                       -officialSkipTests $(SkipTests)
                       /p:SignType=$(_SignType)
                       /p:DotNetSignType=$(_SignType)

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -48,9 +48,6 @@
     <DependentProjects Include="$(MSBuildThisFileDirectory)..\Compiler\FSharp.Compiler.Service.fsproj">
         <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
     </DependentProjects>
-    <DependentProjects Include="$(MSBuildThisFileDirectory)..\Compiler\FSharp.Compiler.Service.fsproj">
-        <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
-    </DependentProjects>
   </ItemGroup>
 
    <ItemGroup>

--- a/tests/AheadOfTime/check.ps1
+++ b/tests/AheadOfTime/check.ps1
@@ -1,4 +1,10 @@
 Write-Host "AheadOfTime: check1.ps1"
 
+$savedNUGET_PACKAGES=$env:NUGET_PACKAGES
+
+$env:NUGET_PACKAGES=Join-Path $PSScriptRoot "../../artifacts/nuget/AOT/"
+dotnet nuget locals global-packages --clear
+
 Equality\check.ps1
 Trimming\check.ps1
+$env:NUGET_PACKAGES=$savedNUGET_PACKAGES


### PR DESCRIPTION
The AOT tests built differently when run with cibuild.cmd compared to build.cmd.

This change ensures that the AOT tests build identically for each build command.

