### PR TITLE
Enable Visualizer Support for F# in VS

### DIFF
--- a/docs/release-notes/.VisualStudio/17.11.md
+++ b/docs/release-notes/.VisualStudio/17.11.md
@@ -4,4 +4,5 @@
 
 ### Changed
 
-* Use AsyncLocal diagnostics context. ([PR #16779])(https://github.com/dotnet/fsharp/pull/16779))
+* Use AsyncLocal diagnostics context. ([PR #16779](https://github.com/dotnet/fsharp/pull/16779))
+* Add Custom Visualizer support for F# in Visual Studio 2022 ([Issue #361](https://github.com/microsoft/VSExtensibility/issues/361), [PR #17239](https://github.com/dotnet/fsharp/pull/17239)).

--- a/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
+++ b/vsintegration/Vsix/RegisterFsharpPackage.pkgdef
@@ -27,6 +27,7 @@
 "Name"="F#"
 "PreloadModules"="1" 
 "CacheFile"="attribcache90.bin" 
+"ClrCustomVisualizerVSHost"="{E82F32A8-074E-465A-86E5-D68A87284F61}"
 "GlobalVisualizersDirectory"="$(reg.MODULE_DIR)" 
 "HelperObject"="{5749A995-CBC2-4de4-86AF-C934D5E57BB9}" 
 "HostAssemblyName"="$(reg.VisualizerAssemblyName)" 


### PR DESCRIPTION
## Description

This PR addresses bug [361](https://github.com/microsoft/VSExtensibility/issues/361) from the VS Extensibility repo, where a customer is complaining about the lack of support of Custom Visualizers in VS for the F# language. I tested F#'s support of this scenario and did not notice any issues with it, so I feel it can be safely enabled for VS 2022. The only required change is to register the appropriate EE metric that gets consumed by VS to indicate the visualizers are supported. 

## Checklist

- [X] Test cases added *Not tests were added since there was no change to the language itself.*
- [X] Performance benchmarks added in case of performance changes. *This change should have 0 performance impact on the language.*
- [X] Release notes entry updated:

* Add Custom Visualizer support for F# in Visual Studio 2022 ([Issue #361](https://github.com/microsoft/VSExtensibility/issues/361), [PR #17239](https://github.com/dotnet/fsharp/pull/17239)).