### PR TITLE
Parser: more recovery on unfinished binary expressions

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4435,7 +4435,12 @@ declExpr:
   | declExpr EQUALS ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "=")
-       mkSynInfix mOp $1 "=" (arbExpr ("declExprInfixEquals", mOp.EndRange)) }
+       mkSynInfix mOp $1 "=" (arbExpr ("declExprInfixEquals1", mOp.EndRange)) }
+
+  | declExpr EQUALS
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "=")
+       mkSynInfix mOp $1 "=" (arbExpr ("declExprInfixEquals2", mOp.EndRange)) }
 
   | declExpr INFIX_COMPARE_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4443,7 +4448,12 @@ declExpr:
   | declExpr INFIX_COMPARE_OP ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
-       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix", mOp.EndRange)) }
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix1", mOp.EndRange)) }
+
+  | declExpr INFIX_COMPARE_OP
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix2", mOp.EndRange)) }
 
   | declExpr DOLLAR declExpr
      { mkSynInfix (rhs parseState 2) $1 "$" $3 }
@@ -4451,7 +4461,12 @@ declExpr:
   | declExpr DOLLAR ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "$")
-       mkSynInfix mOp $1 "$" (arbExpr ("declExprInfixDollar", mOp.EndRange)) }
+       mkSynInfix mOp $1 "$" (arbExpr ("declExprInfixDollar1", mOp.EndRange)) }
+
+  | declExpr DOLLAR
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "$")
+       mkSynInfix mOp $1 "$" (arbExpr ("declExprInfixDollar2", mOp.EndRange)) }
 
   | declExpr LESS declExpr
      { mkSynInfix (rhs parseState 2) $1 "<" $3 }
@@ -4459,7 +4474,12 @@ declExpr:
   | declExpr LESS ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "<")
-       mkSynInfix mOp $1 "<" (arbExpr ("declExprInfixLess", mOp.EndRange)) }
+       mkSynInfix mOp $1 "<" (arbExpr ("declExprInfixLess1", mOp.EndRange)) }
+
+  | declExpr LESS
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "<")
+       mkSynInfix mOp $1 "<" (arbExpr ("declExprInfixLess2", mOp.EndRange)) }
 
   | declExpr GREATER declExpr
      { mkSynInfix (rhs parseState 2) $1 ">" $3 }
@@ -4467,7 +4487,12 @@ declExpr:
   | declExpr GREATER ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression ">")
-       mkSynInfix mOp $1 ">" (arbExpr ("declExprInfixGreater", mOp.EndRange)) }
+       mkSynInfix mOp $1 ">" (arbExpr ("declExprInfixGreater1", mOp.EndRange)) }
+
+  | declExpr GREATER
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression ">")
+       mkSynInfix mOp $1 ">" (arbExpr ("declExprInfixGreater2", mOp.EndRange)) }
 
   | declExpr INFIX_AT_HAT_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4475,7 +4500,12 @@ declExpr:
   | declExpr INFIX_AT_HAT_OP ends_coming_soon_or_recover %prec infix_at_hat_op_binary
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
-       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix", mOp.EndRange)) }
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix1", mOp.EndRange)) }
+
+  | declExpr INFIX_AT_HAT_OP %prec infix_at_hat_op_binary
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix2", mOp.EndRange)) }
 
   | declExpr PERCENT_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4483,7 +4513,12 @@ declExpr:
   | declExpr PERCENT_OP ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
-       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPercent", mOp.EndRange)) }
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPercent1", mOp.EndRange)) }
+
+  | declExpr PERCENT_OP
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPercent2", mOp.EndRange)) }
 
   | declExpr COLON_COLON declExpr
      { let mOp = rhs parseState 2
@@ -4497,7 +4532,15 @@ declExpr:
        let m = unionRanges $1.Range mOp
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "::")
        let identExpr = mkSynOperator mOp "::"
-       let tupExpr = SynExpr.Tuple(false, [$1; (arbExpr ("declExprInfixColonColon", mOp.EndRange))], [mOp], m)
+       let tupExpr = SynExpr.Tuple(false, [$1; (arbExpr ("declExprInfixColonColon1", mOp.EndRange))], [mOp], m)
+       SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, m) }
+
+  | declExpr COLON_COLON
+     { let mOp = rhs parseState 2
+       let m = unionRanges $1.Range mOp
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "::")
+       let identExpr = mkSynOperator mOp "::"
+       let tupExpr = SynExpr.Tuple(false, [$1; (arbExpr ("declExprInfixColonColon2", mOp.EndRange))], [mOp], m)
        SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, m) }
 
   | declExpr PLUS_MINUS_OP declExpr
@@ -4506,7 +4549,12 @@ declExpr:
   | declExpr PLUS_MINUS_OP ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
-       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPlusMinus", mOp.EndRange)) }
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPlusMinus1", mOp.EndRange)) }
+
+  | declExpr PLUS_MINUS_OP
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPlusMinus2", mOp.EndRange)) }
 
   | declExpr MINUS declExpr
      { mkSynInfix (rhs parseState 2) $1 "-" $3 }
@@ -4514,7 +4562,12 @@ declExpr:
   | declExpr MINUS ends_coming_soon_or_recover
       { let mOp = rhs parseState 2
         reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "-")
-        mkSynInfix mOp $1 "-" (arbExpr ("declExprInfixMinus", mOp.EndRange)) }
+        mkSynInfix mOp $1 "-" (arbExpr ("declExprInfixMinus1", mOp.EndRange)) }
+
+  | declExpr MINUS
+      { let mOp = rhs parseState 2
+        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "-")
+        mkSynInfix mOp $1 "-" (arbExpr ("declExprInfixMinus2", mOp.EndRange)) }
 
   | declExpr STAR declExpr
      { mkSynInfix (rhs parseState 2) $1 "*" $3 }
@@ -4522,7 +4575,12 @@ declExpr:
   | declExpr STAR ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "*")
-       mkSynInfix mOp $1 "*" (arbExpr ("declExprInfixStar", mOp.EndRange)) }
+       mkSynInfix mOp $1 "*" (arbExpr ("declExprInfixStar1", mOp.EndRange)) }
+
+  | declExpr STAR
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "*")
+       mkSynInfix mOp $1 "*" (arbExpr ("declExprInfixStar2", mOp.EndRange)) }
 
   | declExpr INFIX_STAR_DIV_MOD_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4530,7 +4588,12 @@ declExpr:
   | declExpr INFIX_STAR_DIV_MOD_OP ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
-       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarDivMod", mOp.EndRange)) }
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarDivMod1", mOp.EndRange)) }
+
+  | declExpr INFIX_STAR_DIV_MOD_OP
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarDivMod2", mOp.EndRange)) }
 
   | declExpr INFIX_STAR_STAR_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4538,7 +4601,12 @@ declExpr:
   | declExpr INFIX_STAR_STAR_OP ends_coming_soon_or_recover
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
-       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarStar", mOp.EndRange)) }
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarStar1", mOp.EndRange)) }
+
+  | declExpr INFIX_STAR_STAR_OP
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarStar2", mOp.EndRange)) }
 
   | declExpr DOT_DOT declExpr
       { let wholem = rhs2 parseState 1 3

--- a/tests/service/data/SyntaxTree/Expression/Binary - Eq 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Eq 03.fs.bsl
@@ -17,7 +17,7 @@ ImplFile
                              SynLongIdent
                                ([op_Equality], [], [Some (OriginalNotation "=")]),
                              None, (3,4--3,5)), Ident a, (3,2--3,5)),
-                       ArbitraryAfterError ("declExprInfixEquals", (3,5--3,5)),
+                       ArbitraryAfterError ("declExprInfixEquals2", (3,5--3,5)),
                        (3,2--3,5)), (3,1--3,2), Some (3,6--3,7), (3,1--3,7)),
                  (3,0--3,7)), (3,0--3,7))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,

--- a/tests/service/data/SyntaxTree/Expression/Binary - Eq 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Eq 04.fs.bsl
@@ -32,7 +32,7 @@ ImplFile
                                     [Some (OriginalNotation "=")]), None,
                                  (3,11--3,12)), Ident b, (3,9--3,12)),
                            ArbitraryAfterError
-                             ("declExprInfixEquals", (3,12--3,12)), (3,9--3,12))],
+                             ("declExprInfixEquals2", (3,12--3,12)), (3,9--3,12))],
                        [(3,7--3,8)], (3,2--3,12)), (3,1--3,2), Some (3,12--3,13),
                     (3,1--3,13)), (3,0--3,13)), (3,0--3,13))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,

--- a/tests/service/data/SyntaxTree/Expression/Binary - Eq 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Eq 05.fs.bsl
@@ -21,7 +21,7 @@ ImplFile
                                     [Some (OriginalNotation "=")]), None,
                                  (3,4--3,5)), Ident a, (3,2--3,5)),
                            ArbitraryAfterError
-                             ("declExprInfixEquals", (3,5--3,5)), (3,2--3,5));
+                             ("declExprInfixEquals2", (3,5--3,5)), (3,2--3,5));
                         App
                           (NonAtomic, false,
                            App
@@ -40,5 +40,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,5)-(3,6) parse error Unexpected symbol ',' in expression
 (3,4)-(3,5) parse error Unexpected token '=' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/Binary - Eq 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Eq 06.fs.bsl
@@ -32,7 +32,7 @@ ImplFile
                                     [Some (OriginalNotation "=")]), None,
                                  (3,11--3,12)), Ident b, (3,9--3,12)),
                            ArbitraryAfterError
-                             ("declExprInfixEquals", (3,12--3,12)), (3,9--3,12));
+                             ("declExprInfixEquals2", (3,12--3,12)), (3,9--3,12));
                         App
                           (NonAtomic, false,
                            App
@@ -51,5 +51,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(3,12)-(3,13) parse error Unexpected symbol ',' in expression
 (3,11)-(3,12) parse error Unexpected token '=' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/Binary - Plus 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Plus 02.fs.bsl
@@ -14,7 +14,7 @@ ImplFile
                        SynLongIdent
                          ([op_Addition], [], [Some (OriginalNotation "+")]),
                        None, (3,2--3,3)), Ident a, (3,0--3,3)),
-                 ArbitraryAfterError ("declExprInfixPlusMinus", (3,3--3,3)),
+                 ArbitraryAfterError ("declExprInfixPlusMinus1", (3,3--3,3)),
                  (3,0--3,3)), (3,0--3,3))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--3,3), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Expression/Binary - Plus 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Plus 03.fs.bsl
@@ -18,7 +18,7 @@ ImplFile
                                ([op_Addition], [], [Some (OriginalNotation "+")]),
                              None, (3,4--3,5)), Ident a, (3,2--3,5)),
                        ArbitraryAfterError
-                         ("declExprInfixPlusMinus", (3,5--3,5)), (3,2--3,5)),
+                         ("declExprInfixPlusMinus2", (3,5--3,5)), (3,2--3,5)),
                     (3,1--3,2), Some (3,6--3,7), (3,1--3,7)), (3,0--3,7)),
               (3,0--3,7))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,

--- a/tests/service/data/SyntaxTree/Expression/Binary - Plus 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Plus 04.fs.bsl
@@ -24,7 +24,7 @@ ImplFile
                                ([op_Addition], [], [Some (OriginalNotation "+")]),
                              None, (3,2--3,3)), Ident a, (3,0--3,3)),
                        ArbitraryAfterError
-                         ("declExprInfixPlusMinus", (3,3--3,3)), (3,0--3,3)),
+                         ("declExprInfixPlusMinus2", (3,3--3,3)), (3,0--3,3)),
                     (3,0--4,2)), Const (Unit, (4,3--4,5)), (3,0--4,5)),
               (3,0--4,5))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
@@ -32,5 +32,4 @@ ImplFile
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
 
-(4,0)-(4,2) parse error Unexpected infix operator in expression
 (3,2)-(3,3) parse error Unexpected token '+' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/Binary - Plus 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Plus 05.fs.bsl
@@ -21,7 +21,7 @@ ImplFile
                            SynLongIdent
                              ([op_Addition], [], [Some (OriginalNotation "+")]),
                            None, (4,6--4,7)), Ident a, (4,4--4,7)),
-                     ArbitraryAfterError ("declExprInfixPlusMinus", (4,7--4,7)),
+                     ArbitraryAfterError ("declExprInfixPlusMinus1", (4,7--4,7)),
                      (4,4--4,7)), (3,4--3,5), Yes (3,0--4,7),
                   { LeadingKeyword = Let (3,0--3,3)
                     InlineKeyword = None

--- a/tests/service/data/SyntaxTree/Expression/Binary 03.fs
+++ b/tests/service/data/SyntaxTree/Expression/Binary 03.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if 1 =
+
+    ()

--- a/tests/service/data/SyntaxTree/Expression/Binary 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary 03.fs.bsl
@@ -1,0 +1,40 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Binary 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (Sequential
+                   (SuppressNeither, true,
+                    IfThenElse
+                      (App
+                         (NonAtomic, false,
+                          App
+                            (NonAtomic, true,
+                             LongIdent
+                               (false,
+                                SynLongIdent
+                                  ([op_Equality], [],
+                                   [Some (OriginalNotation "=")]), None,
+                                (4,9--4,10)), Const (Int32 1, (4,7--4,8)),
+                             (4,7--4,10)),
+                          ArbitraryAfterError
+                            ("declExprInfixEquals2", (4,10--4,10)), (4,7--4,10)),
+                       ArbitraryAfterError ("if1", (4,10--4,10)), None,
+                       Yes (4,4--4,10), true, (4,4--4,10),
+                       { IfKeyword = (4,4--4,6)
+                         IsElif = false
+                         ThenKeyword = (4,10--4,10)
+                         ElseKeyword = None
+                         IfToThenRange = (4,4--4,10) }),
+                    Const (Unit, (6,4--6,6)), (4,4--6,6),
+                    { SeparatorRange = None }), (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(4,9)-(4,10) parse error Unexpected token '=' or incomplete expression
+(4,11)-(6,4) parse error Incomplete structured construct at or before this point in expression
+(4,4)-(4,6) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.

--- a/tests/service/data/SyntaxTree/Expression/Binary 04.fs
+++ b/tests/service/data/SyntaxTree/Expression/Binary 04.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if 1 ==
+
+    ()

--- a/tests/service/data/SyntaxTree/Expression/Binary 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary 04.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Binary 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (Sequential
+                   (SuppressNeither, true,
+                    IfThenElse
+                      (App
+                         (NonAtomic, false,
+                          App
+                            (NonAtomic, true,
+                             LongIdent
+                               (false,
+                                SynLongIdent
+                                  ([op_EqualsEquals], [],
+                                   [Some (OriginalNotation "==")]), None,
+                                (4,9--4,11)), Const (Int32 1, (4,7--4,8)),
+                             (4,7--4,11)),
+                          ArbitraryAfterError ("declExprInfix2", (4,11--4,11)),
+                          (4,7--4,11)),
+                       ArbitraryAfterError ("if1", (4,11--4,11)), None,
+                       Yes (4,4--4,11), true, (4,4--4,11),
+                       { IfKeyword = (4,4--4,6)
+                         IsElif = false
+                         ThenKeyword = (4,11--4,11)
+                         ElseKeyword = None
+                         IfToThenRange = (4,4--4,11) }),
+                    Const (Unit, (6,4--6,6)), (4,4--6,6),
+                    { SeparatorRange = None }), (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
+To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
+(4,9)-(4,11) parse error Unexpected token '==' or incomplete expression
+(4,12)-(6,4) parse error Incomplete structured construct at or before this point in expression
+(4,4)-(4,6) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.


### PR DESCRIPTION
More parser recovery for binary expressions in more complex contexts, like:
```fsharp
if a =

()
```

Or a less simplified example:

<img width="1029" alt="Screenshot 2024-05-17 at 12 07 59" src="https://github.com/dotnet/fsharp/assets/3923587/16b9051d-9ebc-4f52-a725-4007616887e0">
