### PR TITLE
Revert "Fix AOT"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ extends:
             - script: eng\CIBuild.cmd
                       -configuration $(_BuildConfig)
                       -prepareMachine
-                      -testAllButIntegration
+                      -testAllButIntegrationAndAot
                       -officialSkipTests $(SkipTests)
                       /p:SignType=$(_SignType)
                       /p:DotNetSignType=$(_SignType)

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -61,6 +61,7 @@ param (
     [switch]$testVs,
     [switch]$testAll,
     [switch]$testAllButIntegration,
+    [switch]$testAllButIntegrationAndAot,
     [switch]$testpack,
     [switch]$testAOT,
     [switch]$testBenchmarks,
@@ -104,6 +105,7 @@ function Print-Usage() {
     Write-Host "Test actions"
     Write-Host "  -testAll                      Run all tests"
     Write-Host "  -testAllButIntegration        Run all but integration tests"
+    Write-Host "  -testAllButIntegrationAndAot  Run all but integration and AOT tests"
     Write-Host "  -testCambridge                Run Cambridge tests"
     Write-Host "  -testCompiler                 Run FSharpCompiler unit tests"
     Write-Host "  -testCompilerService          Run FSharpCompilerService unit tests"
@@ -170,9 +172,19 @@ function Process-Arguments() {
         $script:testAOT = $True
     }
 
+    if($testAllButIntegrationAndAot) {
+        $script:testDesktop = $True
+        $script:testCoreClr = $True
+        $script:testFSharpQA = $True
+        $script:testIntegration = $False
+        $script:testVs = $True
+        $script:testAOT = $False
+    }
+
     if ([System.Boolean]::Parse($script:officialSkipTests)) {
         $script:testAll = $False
         $script:testAllButIntegration = $False
+        $script:testAllButIntegrationAndAot = $False
         $script:testCambridge = $False
         $script:testCompiler = $False
         $script:testCompilerService = $False

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -48,6 +48,9 @@
     <DependentProjects Include="$(MSBuildThisFileDirectory)..\Compiler\FSharp.Compiler.Service.fsproj">
         <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
     </DependentProjects>
+    <DependentProjects Include="$(MSBuildThisFileDirectory)..\Compiler\FSharp.Compiler.Service.fsproj">
+        <AdditionalProperties>TargetFrameworks=netstandard2.0</AdditionalProperties>
+    </DependentProjects>
   </ItemGroup>
 
    <ItemGroup>

--- a/tests/AheadOfTime/check.ps1
+++ b/tests/AheadOfTime/check.ps1
@@ -1,12 +1,4 @@
 Write-Host "AheadOfTime: check1.ps1"
 
-# the NUGET_PACKAGES environment variable tells dotnet nuget where the global package is
-# So save the current setting, we'll reset it after the tests are complete
-# Then clear the global cache so that we can grab the FSharp.Core nuget we built earlier
-$savedNUGET_PACKAGES=$env:NUGET_PACKAGES
-$env:NUGET_PACKAGES=Join-Path $PSScriptRoot "../../artifacts/nuget/AOT/"
-dotnet nuget locals global-packages --clear
-
 Equality\check.ps1
 Trimming\check.ps1
-$env:NUGET_PACKAGES=$savedNUGET_PACKAGES


### PR DESCRIPTION
Reverts dotnet/fsharp#17238, it's blocking official builds: https://dev.azure.com/dnceng/internal/_build/results?buildId=2461709&view=logs&j=e3072f97-b3f6-597b-f816-087a04d4fd77&t=07e4547f-998e-543b-6583-a685e0bebde1