### PR TITLE
Investigate.symbols

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -164,7 +164,7 @@
     <MicrosoftVisualStudioProjectSystemManagedVersion>2.3.6152103</MicrosoftVisualStudioProjectSystemManagedVersion>
     <!-- -->
     <!-- Misc. Visual Studio packages -->
-    <MicrosoftVSSDKBuildToolsVersion>17.10.1031-preview2</MicrosoftVSSDKBuildToolsVersion>
+    <MicrosoftVSSDKBuildToolsVersion>17.1.4054</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftVisualStudioRpcContractsVersion>17.10.21</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioValidationVersion>17.8.8</MicrosoftVisualStudioValidationVersion>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/17279

Go back to an older vssdk temporarily.  To ensure that we don't add unnecessary files to our vsix'.