### PR TITLE
Feature nullness :: apply nullness annotations to usages of 'obj' in Fsharp.Core

### DIFF
--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -483,8 +483,9 @@ let UnifyOverallType (cenv: cenv) (env: TcEnv) m overallTy actualTy =
     match overallTy with
     | MustConvertTo(isMethodArg, reqdTy) when g.langVersion.SupportsFeature LanguageFeature.AdditionalTypeDirectedConversions ->
         let actualTy = tryNormalizeMeasureInType g actualTy
-        let reqdTy = tryNormalizeMeasureInType g reqdTy
-        if AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css m reqdTy actualTy then
+        let reqdTy = tryNormalizeMeasureInType g reqdTy       
+        let reqTyForUnification = reqTyForArgumentNullnessInference g actualTy reqdTy           
+        if AddCxTypeEqualsTypeUndoIfFailed env.DisplayEnv cenv.css m reqTyForUnification actualTy then
             ()
         else
             // try adhoc type-directed conversions

--- a/src/Compiler/Checking/CheckExpressions.fs
+++ b/src/Compiler/Checking/CheckExpressions.fs
@@ -2997,7 +2997,7 @@ let TcRuntimeTypeTest isCast isOperator (cenv: cenv) denv m tgtTy srcTy =
         else
             error(Error(FSComp.SR.tcTypeTestErased(NicePrint.minimalStringOfType denv tgtTy, NicePrint.minimalStringOfType denv (stripTyEqnsWrtErasure EraseAll g tgtTy)), m))
     else
-        for ety in getErasedTypes g tgtTy do
+        for ety in getErasedTypes g tgtTy true do
             if isMeasureTy g ety then
                 warning(Error(FSComp.SR.tcTypeTestLosesMeasures(NicePrint.minimalStringOfType denv ety), m))
             else

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -1081,6 +1081,8 @@ and SolveNullnessSubsumesNullness (csenv: ConstraintSolverEnv) m2 (trace: Option
         SolveNullnessSubsumesNullness csenv m2 trace ty1 ty2 nv1.Solution nullness2
     | _, Nullness.Variable nv2 when nv2.IsSolved -> 
         SolveNullnessSubsumesNullness csenv m2 trace ty1 ty2 nullness1 nv2.Solution
+    | Nullness.Variable _nv1, Nullness.Known NullnessInfo.WithoutNull  -> 
+        CompleteD
     | Nullness.Variable nv1, _ -> 
         trace.Exec (fun () ->   nv1.Set nullness2) (fun () -> nv1.Unset())
         CompleteD
@@ -1414,6 +1416,8 @@ and SolveFunTypeEqn csenv ndeep m2 trace cxsln domainTy1 domainTy2 rangeTy1 rang
     trackErrors {
         // TODO NULLNESS: consider whether flipping the actual and expected in argument position
         // causes other problems, e.g. better/worse diagnostics
+        let g = csenv.g
+        let domainTy2 = reqTyForArgumentNullnessInference g domainTy1 domainTy2
         do! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln domainTy2 domainTy1
         return! SolveTypeEqualsTypeKeepAbbrevsWithCxsln csenv ndeep m2 trace cxsln rangeTy1 rangeTy2
     }

--- a/src/Compiler/Checking/MethodCalls.fs
+++ b/src/Compiler/Checking/MethodCalls.fs
@@ -480,7 +480,7 @@ let MakeCalledArgs amap m (minfo: MethInfo) minst =
         IsOutArg=isOutArg
         ReflArgInfo=reflArgInfo
         NameOpt=nmOpt
-        CalledArgumentType=calledArgTy })
+        CalledArgumentType= changeWithNullReqTyToVariable amap.g calledArgTy})
 
 /// <summary>
 /// Represents the syntactic matching between a caller of a method and the called method.

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -9157,10 +9157,32 @@ let nullnessOfTy g ty =
     |> function
         | TType_app(tcref, _, nullness) ->
             let nullness2 = intrinsicNullnessOfTyconRef g tcref
-            combineNullness nullness nullness2
+            if nullness2 === g.knownWithoutNull then
+                nullness
+            else
+                combineNullness nullness nullness2
         | TType_fun (_, _, nullness) | TType_var (_, nullness) ->
             nullness
         | _ -> g.knownWithoutNull
+
+let changeWithNullReqTyToVariable g reqTy =
+    let sty = stripTyEqns g reqTy
+    match isTyparTy g sty with
+    | false ->
+        match nullnessOfTy g sty with
+        | Nullness.Known NullnessInfo.WithNull -> 
+            reqTy |> replaceNullnessOfTy (NewNullnessVar())
+        | _ -> reqTy
+    | true -> reqTy
+
+/// When calling a null-allowing API, we prefer to infer a without null argument for idiomatic F# code.
+/// That is, unless caller explicitely marks a value (e.g. coming from a function parameter) as WithNull, it should not be infered as such.
+let reqTyForArgumentNullnessInference g actualTy reqTy =
+    // Only change reqd nullness if actualTy is an inference variable
+    match tryDestTyparTy g actualTy with
+    | ValueSome t when t.IsCompilerGenerated ->
+        changeWithNullReqTyToVariable g reqTy       
+    | _ -> reqTy
 
 /// The new logic about whether a type admits the use of 'null' as a value.
 let TypeNullIsExtraValueNew g m ty = 

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -9180,7 +9180,7 @@ let changeWithNullReqTyToVariable g reqTy =
 let reqTyForArgumentNullnessInference g actualTy reqTy =
     // Only change reqd nullness if actualTy is an inference variable
     match tryDestTyparTy g actualTy with
-    | ValueSome t when t.IsCompilerGenerated ->
+    | ValueSome t when t.IsCompilerGenerated && not(t.Constraints |> List.exists(function | TyparConstraint.SupportsNull _ -> true | _ -> false))->
         changeWithNullReqTyToVariable g reqTy       
     | _ -> reqTy
 

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -649,6 +649,10 @@ val tryDestForallTy: TcGlobals -> TType -> Typars * TType
 
 val nullnessOfTy: TcGlobals -> TType -> Nullness
 
+val changeWithNullReqTyToVariable: TcGlobals -> reqTy:TType -> TType
+
+val reqTyForArgumentNullnessInference: TcGlobals -> actualTy:TType -> reqTy:TType -> TType
+
 val isFunTy: TcGlobals -> TType -> bool
 
 val isForallTy: TcGlobals -> TType -> bool

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -649,9 +649,9 @@ val tryDestForallTy: TcGlobals -> TType -> Typars * TType
 
 val nullnessOfTy: TcGlobals -> TType -> Nullness
 
-val changeWithNullReqTyToVariable: TcGlobals -> reqTy:TType -> TType
+val changeWithNullReqTyToVariable: TcGlobals -> reqTy: TType -> TType
 
-val reqTyForArgumentNullnessInference: TcGlobals -> actualTy:TType -> reqTy:TType -> TType
+val reqTyForArgumentNullnessInference: TcGlobals -> actualTy: TType -> reqTy: TType -> TType
 
 val isFunTy: TcGlobals -> TType -> bool
 

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -927,7 +927,7 @@ val anonInfoEquiv: AnonRecdTypeInfo -> AnonRecdTypeInfo -> bool
 val isErasedType: TcGlobals -> TType -> bool
 
 // Return all components (units-of-measure, and types) of this type that would be erased
-val getErasedTypes: TcGlobals -> TType -> TType list
+val getErasedTypes: TcGlobals -> TType -> checkForNullness:bool -> TType list
 
 //-------------------------------------------------------------------------
 // Unit operations

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -927,7 +927,7 @@ val anonInfoEquiv: AnonRecdTypeInfo -> AnonRecdTypeInfo -> bool
 val isErasedType: TcGlobals -> TType -> bool
 
 // Return all components (units-of-measure, and types) of this type that would be erased
-val getErasedTypes: TcGlobals -> TType -> checkForNullness:bool -> TType list
+val getErasedTypes: TcGlobals -> TType -> checkForNullness: bool -> TType list
 
 //-------------------------------------------------------------------------
 // Unit operations

--- a/src/FSharp.Core/Linq.fs
+++ b/src/FSharp.Core/Linq.fs
@@ -55,15 +55,15 @@ module LeafExpressionConverter =
         tyargs.[0], tyargs.[1]
 
     let StringConcat =
-       methodhandleof (fun (x:obj, y:obj) -> String.Concat (x, y))
+       methodhandleof (fun (x:objnull, y:objnull) -> String.Concat (x, y))
        |> System.Reflection.MethodInfo.GetMethodFromHandle
        :?> MethodInfo
 
-    let SubstHelperRaw (q:Expr, x:Var array, y:obj array) : Expr =
+    let SubstHelperRaw (q:Expr, x:Var array, y:objnull array) : Expr =
         let d = Map.ofArray (Array.zip x y)
         q.Substitute(fun v -> v |> d.TryFind |> Option.map (fun x -> Expr.Value (x, v.Type)))
 
-    let SubstHelper<'T> (q:Expr, x:Var array, y:obj array) : Expr<'T> =
+    let SubstHelper<'T> (q:Expr, x:Var array, y:objnull array) : Expr<'T> =
         SubstHelperRaw(q, x, y) |> Expr.Cast
 
     let showAll =
@@ -393,12 +393,12 @@ module LeafExpressionConverter =
     //let (|ArrayAssignQ|_|) = (|SpecificCallToMethod|_|) (methodhandleof (fun -> LanguagePrimitives.IntrinsicFunctions.SetArray : int array -> int -> int -> unit))
     //let (|ArrayTypeQ|_|) (ty:System.Type) = if ty.IsArray && ty.GetArrayRank() = 1 then Some (ty.GetElementType()) else None
     let substHelperMeth =
-        methodhandleof (fun (x:Expr, y:Var array, z:obj array) -> SubstHelper<obj> (x, y, z))
+        methodhandleof (fun (x:Expr, y:Var array, z:objnull array) -> SubstHelper<obj> (x, y, z))
         |> System.Reflection.MethodInfo.GetMethodFromHandle
         :?> MethodInfo
 
     let substHelperRawMeth =
-        methodhandleof (fun (x:Expr, y:Var array, z:obj array) -> SubstHelperRaw (x, y, z))
+        methodhandleof (fun (x:Expr, y:Var array, z:objnull array) -> SubstHelperRaw (x, y, z))
         |> System.Reflection.MethodInfo.GetMethodFromHandle
         :?> MethodInfo
 
@@ -895,7 +895,7 @@ module LeafExpressionConverter =
     // provides no other way to evaluate the expression.
     //
     // REVIEW: It is possible it is just better to interpret the expression in many common cases, e.g. property-gets, values etc.
-    let EvaluateQuotation (e: Microsoft.FSharp.Quotations.Expr) : obj =
+    let EvaluateQuotation (e: Microsoft.FSharp.Quotations.Expr) : objnull =
 #if FX_NO_QUOTATIONS_COMPILE
        raise (new NotSupportedException())
 #else

--- a/src/FSharp.Core/Linq.fsi
+++ b/src/FSharp.Core/Linq.fsi
@@ -71,21 +71,21 @@ module LeafExpressionConverter =
     /// </summary>
     ///
     /// <example-tbd></example-tbd>
-    val EvaluateQuotation: Expr -> obj
+    val EvaluateQuotation: Expr -> objnull
 
     /// <summary>
     /// A runtime helper used to evaluate nested quotation literals.
     /// </summary>
     ///
     /// <example-tbd></example-tbd>
-    val SubstHelper: Expr * Var array * obj array -> Expr<'T>
+    val SubstHelper: Expr * Var array * objnull array -> Expr<'T>
 
     /// <summary>
     /// A runtime helper used to evaluate nested quotation literals.
     /// </summary>
     ///
     /// <example-tbd></example-tbd>
-    val SubstHelperRaw: Expr * Var array * obj array -> Expr
+    val SubstHelperRaw: Expr * Var array * objnull array -> Expr
 
     val internal (|SpecificCallToMethod|_|):
         System.RuntimeMethodHandle -> (Expr -> (Expr option * Reflection.MethodInfo * Expr list) option)

--- a/src/FSharp.Core/Query.fs
+++ b/src/FSharp.Core/Query.fs
@@ -372,7 +372,7 @@ module Query =
 
     let CallGenericStaticMethod (methHandle:System.RuntimeMethodHandle) =
         let methInfo = methHandle |> System.Reflection.MethodInfo.GetMethodFromHandle :?> MethodInfo
-        fun (tyargs: Type list, args: obj list) ->
+        fun (tyargs: Type list, args: objnull list) ->
             let methInfo = if methInfo.IsGenericMethod then methInfo.MakeGenericMethod(Array.ofList tyargs) else methInfo
             try
                methInfo.Invoke(null, Array.ofList args)
@@ -381,7 +381,7 @@ module Query =
 
     let CallGenericInstanceMethod (methHandle:System.RuntimeMethodHandle) =
         let methInfo = methHandle |> System.Reflection.MethodInfo.GetMethodFromHandle :?> MethodInfo
-        fun (objExpr:obj, tyargs: Type list, args: obj list) ->
+        fun (objExpr:obj, tyargs: Type list, args: objnull list) ->
             let methInfo = if methInfo.IsGenericMethod then methInfo.MakeGenericMethod(Array.ofList tyargs) else methInfo
             try
                methInfo.Invoke(objExpr, Array.ofList args)
@@ -467,7 +467,7 @@ module Query =
             else
                 ME ([srcItemTy], [src; key])
 
-        let Call (isIQ, srcItemTy, src:obj, key: Expr) =
+        let Call (isIQ, srcItemTy, src:objnull, key: Expr) =
             let key = key |> LeafExpressionConverter.EvaluateQuotation
             let C = if isIQ then CQ else CE
             C ([srcItemTy], [src; box key])
@@ -496,7 +496,7 @@ module Query =
             else
                 ME ([srcItemTy; keyElemTy], [src; valSelector])
 
-        let Call (isIQ, srcItemTy: Type, _keyItemTy: Type, src:obj, keyElemTy: Type, v: Var, res: Expr) =
+        let Call (isIQ, srcItemTy: Type, _keyItemTy: Type, src:objnull, keyElemTy: Type, v: Var, res: Expr) =
             if isIQ then
                 let selector = FuncExprToLinqFunc2Expression (srcItemTy, keyElemTy, v, res)
                 CQ ([srcItemTy; keyElemTy], [src; box selector])
@@ -505,7 +505,7 @@ module Query =
                 CE ([srcItemTy; keyElemTy], [src; selector])
         Make, Call
 
-    let (MakeMinBy: bool * Expr * Var * Expr -> Expr), (CallMinBy : bool * Type * Type * obj * Type * Var * Expr -> obj) =
+    let (MakeMinBy: bool * Expr * Var * Expr -> Expr), (CallMinBy : bool * Type * Type * objnull * Type * Var * Expr -> obj) =
         let FQ = methodhandleof (fun (x, y: Expression<Func<_, _>>) -> System.Linq.Queryable.Min(x, y))
         let FE = methodhandleof (fun (x, y: Func<_, 'Result>) -> Enumerable.Min(x, y))
         MakeOrCallMinByOrMaxBy FQ FE
@@ -539,7 +539,7 @@ module Query =
             else
                 ME ([srcItemTy], [src; predicate])
 
-        let Call (isIQ, srcItemTy: Type, src:obj, v: Var, res: Expr) =
+        let Call (isIQ, srcItemTy: Type, src:objnull, v: Var, res: Expr) =
             if isIQ then
                 let selector = FuncExprToLinqFunc2Expression (srcItemTy, boolTy, v, res)
                 CQ ([srcItemTy], [src; box selector])
@@ -612,7 +612,7 @@ module Query =
                     let selector = Expr.Lambda (v, res)
                     ME (qb, [srcItemTy; qTy; resTyNoNullable], [src; selector])
 
-        let Call (qb:obj, isIQ, srcItemTy: Type, resTyNoNullable: Type, src:obj, resTy: Type, v: Var, res: Expr) =
+        let Call (qb:obj, isIQ, srcItemTy: Type, resTyNoNullable: Type, src:objnull, resTy: Type, v: Var, res: Expr) =
             if isIQ then
                 let selector = FuncExprToLinqFunc2Expression (srcItemTy, resTy, v, res)
                 let caller =

--- a/src/FSharp.Core/async.fs
+++ b/src/FSharp.Core/async.fs
@@ -1076,7 +1076,7 @@ module AsyncPrimitives =
 
     /// Create an instance of an arbitrary delegate type delegating to the given F# function
     type FuncDelegate<'T>(f) =
-        member _.Invoke(sender: obj, a: 'T) : unit =
+        member _.Invoke(sender: objnull, a: 'T) : unit =
             ignore sender
             f a
 
@@ -1309,7 +1309,7 @@ module AsyncPrimitives =
         | None -> ()
 
     [<Sealed; AutoSerializable(false)>]
-    type AsyncIAsyncResult<'T>(callback: System.AsyncCallback, state: obj) =
+    type AsyncIAsyncResult<'T>(callback: System.AsyncCallback, state: objnull) =
         // This gets set to false if the result is not available by the
         // time the IAsyncResult is returned to the caller of Begin
         let mutable completedSynchronously = true
@@ -2035,7 +2035,7 @@ type Async =
                             // Register the result.
                             resultCell.RegisterResult(res, reuseThread = true) |> unfake)
 
-            let (iar: IAsyncResult) = beginAction (callback, (null: obj))
+            let (iar: IAsyncResult) = beginAction (callback, (null: objnull))
 
             if iar.CompletedSynchronously then
                 // Ensure cancellation is not possible beyond this point
@@ -2067,7 +2067,7 @@ type Async =
     static member AsBeginEnd<'Arg, 'T>
         (computation: ('Arg -> Async<'T>))
         // The 'Begin' member
-        : ('Arg * System.AsyncCallback * obj -> System.IAsyncResult) *
+        : ('Arg * System.AsyncCallback * objnull -> System.IAsyncResult) *
           (System.IAsyncResult -> 'T) *
           (System.IAsyncResult -> unit)
         =
@@ -2334,7 +2334,7 @@ module WebExtensions =
                 Async.FromContinuations(fun (cont, econt, ccont) ->
                     let userToken = obj ()
 
-                    let rec delegate' (_: obj) (args: #ComponentModel.AsyncCompletedEventArgs) =
+                    let rec delegate' (_: objnull) (args: #ComponentModel.AsyncCompletedEventArgs) =
                         // ensure we handle the completed event from correct download call
                         if userToken = args.UserState then
                             event.RemoveHandler handle

--- a/src/FSharp.Core/async.fsi
+++ b/src/FSharp.Core/async.fsi
@@ -860,7 +860,7 @@ namespace Microsoft.FSharp.Control
         /// <category index="5">Legacy .NET Async Interoperability</category>
         ///
         /// <example-tbd></example-tbd>
-        static member FromBeginEnd : beginAction:(System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
+        static member FromBeginEnd : beginAction:(System.AsyncCallback * objnull -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>
         ///  Creates an asynchronous computation in terms of a Begin/End pair of actions in 
@@ -885,7 +885,7 @@ namespace Microsoft.FSharp.Control
         /// <category index="5">Legacy .NET Async Interoperability</category>
         ///
         /// <example-tbd></example-tbd>
-        static member FromBeginEnd : arg:'Arg1 * beginAction:('Arg1 * System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
+        static member FromBeginEnd : arg:'Arg1 * beginAction:('Arg1 * System.AsyncCallback * objnull -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>
         /// Creates an asynchronous computation in terms of a Begin/End pair of actions in 
@@ -909,7 +909,7 @@ namespace Microsoft.FSharp.Control
         /// <category index="5">Legacy .NET Async Interoperability</category>
         ///
         /// <example-tbd></example-tbd>
-        static member FromBeginEnd : arg1:'Arg1 * arg2:'Arg2 * beginAction:('Arg1 * 'Arg2 * System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
+        static member FromBeginEnd : arg1:'Arg1 * arg2:'Arg2 * beginAction:('Arg1 * 'Arg2 * System.AsyncCallback * objnull -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>Creates an asynchronous computation in terms of a Begin/End pair of actions in 
         /// the style used in .NET 2.0 APIs.</summary>
@@ -933,7 +933,7 @@ namespace Microsoft.FSharp.Control
         /// <category index="5">Legacy .NET Async Interoperability</category>
         ///
         /// <example-tbd></example-tbd>
-        static member FromBeginEnd : arg1:'Arg1 * arg2:'Arg2 * arg3:'Arg3 * beginAction:('Arg1 * 'Arg2 * 'Arg3 * System.AsyncCallback * obj -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
+        static member FromBeginEnd : arg1:'Arg1 * arg2:'Arg2 * arg3:'Arg3 * beginAction:('Arg1 * 'Arg2 * 'Arg3 * System.AsyncCallback * objnull -> System.IAsyncResult) * endAction:(System.IAsyncResult -> 'T) * ?cancelAction : (unit -> unit) -> Async<'T>
 
         /// <summary>Creates three functions that can be used to implement the .NET 1.0 Asynchronous 
         /// Programming Model (APM) for a given asynchronous computation.</summary>
@@ -948,7 +948,7 @@ namespace Microsoft.FSharp.Control
         /// <example-tbd></example-tbd>
         static member AsBeginEnd : computation:('Arg -> Async<'T>) -> 
                                      // The 'Begin' member
-                                     ('Arg * System.AsyncCallback * obj -> System.IAsyncResult) * 
+                                     ('Arg * System.AsyncCallback * objnull -> System.IAsyncResult) * 
                                      // The 'End' member
                                      (System.IAsyncResult -> 'T) * 
                                      // The 'Cancel' member

--- a/src/FSharp.Core/event.fs
+++ b/src/FSharp.Core/event.fs
@@ -31,7 +31,7 @@ module private Atomic =
 type DelegateEvent<'Delegate when 'Delegate :> System.Delegate>() =
     let mutable multicast: System.Delegate = null
 
-    member x.Trigger(args: obj array) =
+    member x.Trigger(args: objnull array) =
         match multicast with
         | null -> ()
         | d -> d.DynamicInvoke(args) |> ignore
@@ -54,30 +54,30 @@ type EventDelegee<'Args>(observer: System.IObserver<'Args>) =
                 assert false
                 null // should not be called, one-argument case don't use makeTuple function
 
-    member x.Invoke(_sender: obj, args: 'Args) =
+    member x.Invoke(_sender: objnull, args: 'Args) =
         observer.OnNext args
 
-    member x.Invoke(_sender: obj, a, b) =
+    member x.Invoke(_sender: objnull, a, b) =
         let args = makeTuple ([| a; b |]) :?> 'Args
         observer.OnNext args
 
-    member x.Invoke(_sender: obj, a, b, c) =
+    member x.Invoke(_sender: objnull, a, b, c) =
         let args = makeTuple ([| a; b; c |]) :?> 'Args
         observer.OnNext args
 
-    member x.Invoke(_sender: obj, a, b, c, d) =
+    member x.Invoke(_sender: objnull, a, b, c, d) =
         let args = makeTuple ([| a; b; c; d |]) :?> 'Args
         observer.OnNext args
 
-    member x.Invoke(_sender: obj, a, b, c, d, e) =
+    member x.Invoke(_sender: objnull, a, b, c, d, e) =
         let args = makeTuple ([| a; b; c; d; e |]) :?> 'Args
         observer.OnNext args
 
-    member x.Invoke(_sender: obj, a, b, c, d, e, f) =
+    member x.Invoke(_sender: objnull, a, b, c, d, e, f) =
         let args = makeTuple ([| a; b; c; d; e; f |]) :?> 'Args
         observer.OnNext args
 
-type EventWrapper<'Delegate, 'Args> = delegate of 'Delegate * obj * 'Args -> unit
+type EventWrapper<'Delegate, 'Args> = delegate of 'Delegate * objnull * 'Args -> unit
 
 [<CompiledName("FSharpEvent`2")>]
 type Event<'Delegate, 'Args
@@ -122,7 +122,7 @@ type Event<'Delegate, 'Args
         else
             mi
 
-    member x.Trigger(sender: obj, args: 'Args) =
+    member x.Trigger(sender: objnull, args: 'Args) =
         // Copy multicast value into local variable to avoid changing during member call.
         let multicast = multicast
 

--- a/src/FSharp.Core/event.fsi
+++ b/src/FSharp.Core/event.fsi
@@ -23,7 +23,7 @@ type DelegateEvent<'Delegate when 'Delegate :> System.Delegate> =
     /// <param name="args">The parameters for the event.</param>
     ///
     /// <example-tbd></example-tbd>
-    member Trigger: args: obj array -> unit
+    member Trigger: args: objnull array -> unit
 
     /// <summary>Publishes the event as a first class event value.</summary>
     ///
@@ -49,7 +49,7 @@ type Event<'Delegate, 'Args
     /// <param name="args">The parameters for the event.</param>
     ///
     /// <example-tbd></example-tbd>
-    member Trigger: sender: obj * args: 'Args -> unit
+    member Trigger: sender: objnull * args: 'Args -> unit
 
     /// <summary>Publishes the event as a first class event value.</summary>
     ///

--- a/src/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/FSharp.Core/fslib-extra-pervasives.fs
@@ -496,4 +496,5 @@ type ITypeProvider2 =
     abstract GetStaticParametersForMethod: methodWithoutArguments: MethodBase -> ParameterInfo array
 
     abstract ApplyStaticArgumentsForMethod:
-        methodWithoutArguments: MethodBase * methodNameWithArguments: string * staticArguments: objnull array -> MethodBase
+        methodWithoutArguments: MethodBase * methodNameWithArguments: string * staticArguments: objnull array ->
+            MethodBase

--- a/src/FSharp.Core/fslib-extra-pervasives.fs
+++ b/src/FSharp.Core/fslib-extra-pervasives.fs
@@ -483,7 +483,7 @@ type ITypeProvider =
     abstract GetStaticParameters: typeWithoutArguments: Type -> ParameterInfo array
 
     abstract ApplyStaticArguments:
-        typeWithoutArguments: Type * typePathWithArguments: string array * staticArguments: obj array -> Type
+        typeWithoutArguments: Type * typePathWithArguments: string array * staticArguments: objnull array -> Type
 
     abstract GetInvokerExpression: syntheticMethodBase: MethodBase * parameters: Expr array -> Expr
 
@@ -496,4 +496,4 @@ type ITypeProvider2 =
     abstract GetStaticParametersForMethod: methodWithoutArguments: MethodBase -> ParameterInfo array
 
     abstract ApplyStaticArgumentsForMethod:
-        methodWithoutArguments: MethodBase * methodNameWithArguments: string * staticArguments: obj array -> MethodBase
+        methodWithoutArguments: MethodBase * methodNameWithArguments: string * staticArguments: objnull array -> MethodBase

--- a/src/FSharp.Core/fslib-extra-pervasives.fsi
+++ b/src/FSharp.Core/fslib-extra-pervasives.fsi
@@ -542,7 +542,7 @@ namespace Microsoft.FSharp.Core.CompilerServices
         /// <param name="staticArguments">the static parameters, indexed by name</param>
         ///
         /// <returns></returns>
-        abstract ApplyStaticArguments : typeWithoutArguments:Type * typePathWithArguments:string array * staticArguments:obj array -> Type 
+        abstract ApplyStaticArguments : typeWithoutArguments:Type * typePathWithArguments:string array * staticArguments:objnull array -> Type 
 
         /// <summary>
         /// Called by the compiler to ask for an Expression tree to replace the given MethodBase with.
@@ -586,4 +586,4 @@ namespace Microsoft.FSharp.Core.CompilerServices
         /// <param name="staticArguments">the values of the static parameters, indexed by name</param>
         ///
         /// <returns>The provided method definition corresponding to the given static parameter values</returns>
-        abstract ApplyStaticArgumentsForMethod : methodWithoutArguments:MethodBase * methodNameWithArguments:string * staticArguments:obj array -> MethodBase
+        abstract ApplyStaticArgumentsForMethod : methodWithoutArguments:MethodBase * methodNameWithArguments:string * staticArguments:objnull array -> MethodBase

--- a/src/FSharp.Core/local.fsi
+++ b/src/FSharp.Core/local.fsi
@@ -6,8 +6,8 @@ open Microsoft.FSharp.Core
 
 [<AutoOpen>]
 module internal DetailedExceptions =
-    val inline invalidArgFmt: arg: string -> format: string -> paramArray: obj array -> 'T
-    val inline invalidOpFmt: format: string -> paramArray: obj array -> 'T
+    val inline invalidArgFmt: arg: string -> format: string -> paramArray: objnull array -> 'T
+    val inline invalidOpFmt: format: string -> paramArray: objnull array -> 'T
     val invalidArgDifferentListLength: arg1: string -> arg2: string -> diff: int -> 'T
 
     val invalidArg3ListsDifferent:

--- a/src/FSharp.Core/map.fs
+++ b/src/FSharp.Core/map.fs
@@ -958,7 +958,7 @@ type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonCond
         member m.Count = m.Count
 
     interface System.IComparable with
-        member m.CompareTo(obj: obj) =
+        member m.CompareTo(obj: objnull) =
             match obj with
             | :? Map<'Key, 'Value> as m2 ->
                 Seq.compareWith

--- a/src/FSharp.Core/map.fsi
+++ b/src/FSharp.Core/map.fsi
@@ -215,7 +215,7 @@ type Map<[<EqualityConditionalOn>] 'Key, [<EqualityConditionalOn; ComparisonCond
     interface System.Collections.IEnumerable
     interface IReadOnlyCollection<KeyValuePair<'Key, 'Value>>
     interface IReadOnlyDictionary<'Key, 'Value>
-    override Equals: obj -> bool
+    override Equals: objnull -> bool
 
 /// <summary>Contains operations for working with values of type <see cref="T:Microsoft.FSharp.Collections.FSharpMap`2"/>.</summary>
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/src/FSharp.Core/math/z.fs
+++ b/src/FSharp.Core/math/z.fs
@@ -28,10 +28,10 @@ module NumericLiterals =
 
     module NumericLiteralI =
 
-        let tab64 = new System.Collections.Generic.Dictionary<int64, obj>()
-        let tabParse = new System.Collections.Generic.Dictionary<string, obj>()
+        let tab64 = new System.Collections.Generic.Dictionary<int64, objnull>()
+        let tabParse = new System.Collections.Generic.Dictionary<string, objnull>()
 
-        let FromInt64Dynamic (value: int64) : obj =
+        let FromInt64Dynamic (value: int64) : objnull =
             lock tab64 (fun () ->
                 let mutable res = Unchecked.defaultof<_>
                 let ok = tab64.TryGetValue(value, &res)
@@ -82,7 +82,7 @@ module NumericLiterals =
                     tabParse.[s] <- res
                     res)
 
-        let FromStringDynamic (text: string) : obj =
+        let FromStringDynamic (text: string) : objnull =
             getParse text
 
         let FromString (text: string) : 'T =

--- a/src/FSharp.Core/math/z.fsi
+++ b/src/FSharp.Core/math/z.fsi
@@ -43,7 +43,7 @@ module NumericLiterals =
         val FromString: text: string -> 'T
 
         /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
-        val FromInt64Dynamic: value: int64 -> obj
+        val FromInt64Dynamic: value: int64 -> objnull
 
         /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
-        val FromStringDynamic: text: string -> obj
+        val FromStringDynamic: text: string -> objnull

--- a/src/FSharp.Core/prim-types-prelude.fs
+++ b/src/FSharp.Core/prim-types-prelude.fs
@@ -6,6 +6,11 @@ namespace Microsoft.FSharp.Core
     // Basic type abbreviations
 
     type obj = System.Object
+#if BUILDING_WITH_LKG || NO_NULLCHECKING_LIB_SUPPORT
+    type objnull = obj
+#else
+    type objnull = obj | null
+#endif
     type exn = System.Exception
     type nativeint = System.IntPtr
     type unativeint = System.UIntPtr

--- a/src/FSharp.Core/prim-types-prelude.fsi
+++ b/src/FSharp.Core/prim-types-prelude.fsi
@@ -18,6 +18,16 @@ namespace Microsoft.FSharp.Core
     /// <category>Basic Types</category>
     type obj = System.Object
 
+    /// <summary>An abbreviation for the CLI type <see cref="T:System.Object"/> or null.
+    /// With the 'nullable reference types' feature, this is an alias to 'obj | null'.</summary>
+    ///
+    /// <category>Basic Types</category>
+#if BUILDING_WITH_LKG || NO_NULLCHECKING_LIB_SUPPORT
+    type objnull = obj
+#else
+    type objnull = obj | null
+#endif
+
     /// <summary>An abbreviation for the CLI type <see cref="T:System.Exception"/>.</summary>
     ///
     /// <category>Basic Types</category>

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -1759,7 +1759,7 @@ namespace Microsoft.FSharp.Core
                     | null, null -> true
                     | null, _ -> false
                     | _, null -> false
-                    | (:? (objnull array)      as arr1), (:? (obj array)      as arr2) -> GenericEqualityObjArray    er iec arr1 arr2
+                    | (:? (objnull array)      as arr1), (:? (objnull array)      as arr2) -> GenericEqualityObjArray    er iec arr1 arr2
                     | (:? (byte array)     as arr1), (:? (byte array)     as arr2) -> GenericEqualityByteArray          arr1 arr2
                     | (:? (int32 array)    as arr1), (:? (int32 array)    as arr2) -> GenericEqualityInt32Array         arr1 arr2
                     | (:? (int64 array)    as arr1), (:? (int64 array)    as arr2) -> GenericEqualityInt64Array         arr1 arr2

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -25,11 +25,11 @@ namespace Microsoft.FSharp.Core
     type Unit() =
         override _.GetHashCode() = 0
 
-        override _.Equals(obj:obj) = 
+        override _.Equals(obj:objnull) = 
             match obj with null -> true | :? Unit -> true | _ -> false
 
         interface System.IComparable with 
-            member _.CompareTo(_obj:obj) = 0
+            member _.CompareTo(_obj:objnull) = 0
         
     and unit = Unit
 
@@ -505,8 +505,8 @@ namespace Microsoft.FSharp.Core
     type outref<'T> = byref<'T, ByRefKinds.Out>
 
     module internal BasicInlinedOperations =  
-        let inline unboxPrim<'T>(x:obj) = (# "unbox.any !0" type ('T) x : 'T #)
-        let inline box     (x:'T) = (# "box !0" type ('T) x : obj #)
+        let inline unboxPrim<'T>(x:objnull) = (# "unbox.any !0" type ('T) x : 'T #)
+        let inline box     (x:'T) = (# "box !0" type ('T) x : objnull #)
         let inline convPrim<'T1, 'T2>(x: 'T1) : 'T2 = unboxPrim<'T2> (box x) 
         let inline not     (b:bool) = (# "ceq" b false : bool #)
         let inline (=)     (x:int)   (y:int)    = (# "ceq" x y : bool #) 
@@ -541,7 +541,7 @@ namespace Microsoft.FSharp.Core
         let set (arr: 'T array) (n:int) (x:'T) =  (# "stelem.any !0" type ('T) arr n x #)
 
 
-        let inline objEq (xobj:obj) (yobj:obj) = (# "ceq" xobj yobj : bool #)
+        let inline objEq (xobj:objnull) (yobj:objnull) = (# "ceq" xobj yobj : bool #)
         let inline int64Eq (x:int64) (y:int64) = (# "ceq" x y : bool #) 
         let inline int32Eq (x:int32) (y:int32) = (# "ceq" x y : bool #) 
         let inline floatEq (x:float) (y:float) = (# "ceq" x y : bool #) 
@@ -566,11 +566,11 @@ namespace Microsoft.FSharp.Core
             (# "sizeof !0" type('T) : int #) 
 
         let inline unsafeDefault<'T> : 'T = (# "ilzero !0" type ('T) : 'T #)
-        let inline isinstPrim<'T>(x:obj) = (# "isinst !0" type ('T) x : obj #)
+        let inline isinstPrim<'T>(x:objnull) = (# "isinst !0" type ('T) x : objnull #)
         let inline castclassPrim<'T>(x:obj) = (# "castclass !0" type ('T) x : 'T #)
         let inline notnullPrim<'T when 'T : not struct>(x:'T) = (# "ldnull cgt.un" x : bool #)
 
-        let inline iscastPrim<'T when 'T : not struct>(x:obj) = (# "isinst !0" type ('T) x : 'T #)
+        let inline iscastPrim<'T when 'T : not struct>(x:objnull) = (# "isinst !0" type ('T) x : 'T #)
 
         let inline mask (n:int) (m:int) = (# "and" n m : int #)
 
@@ -713,7 +713,7 @@ namespace Microsoft.FSharp.Core
             //  IL_0006:  brtrue.s   IL_000e
 
             // worst case: nothing known about source or destination
-            let UnboxGeneric<'T>(source: obj) = 
+            let UnboxGeneric<'T>(source: objnull) = 
                 if notnullPrim(source) or TypeInfo<'T>.TypeInfo <> TypeNullnessSemantics_NullNotLiked then 
                     unboxPrim<'T>(source)
                 else
@@ -721,19 +721,19 @@ namespace Microsoft.FSharp.Core
                     raise (System.NullReferenceException()) 
 
             // better: source is NOT TypeNullnessSemantics_NullNotLiked 
-            let inline UnboxFast<'T>(source: obj) = 
+            let inline UnboxFast<'T>(source: objnull) = 
                 // assert not(TypeInfo<'T>.TypeInfo = TypeNullnessSemantics_NullNotLiked)
                 unboxPrim<'T>(source)
 
 
             // worst case: nothing known about source or destination
-            let TypeTestGeneric<'T>(source: obj) = 
+            let TypeTestGeneric<'T>(source: objnull) = 
                 if notnullPrim(isinstPrim<'T>(source)) then true
                 elif notnullPrim(source) then false
                 else (TypeInfo<'T>.TypeInfo = TypeNullnessSemantics_NullTrueValue)
 
             // quick entry: source is NOT TypeNullnessSemantics_NullTrueValue 
-            let inline TypeTestFast<'T>(source: obj) = 
+            let inline TypeTestFast<'T>(source: objnull) = 
                 //assert not(TypeInfo<'T>.TypeInfo = TypeNullnessSemantics_NullTrueValue)
                 notnullPrim(isinstPrim<'T>(source)) 
 
@@ -933,7 +933,7 @@ namespace Microsoft.FSharp.Core
              
             let inline HashCombine nr x y = (x <<< 1) + y + 631 * nr
 
-            let GenericHashObjArray (iec : IEqualityComparer) (x: obj array) : int =
+            let GenericHashObjArray (iec : IEqualityComparer) (x: objnull array) : int =
                   let len = x.Length 
                   let mutable i = len - 1 
                   if i > defaultHashNodes then i <- defaultHashNodes // limit the hash
@@ -999,7 +999,7 @@ namespace Microsoft.FSharp.Core
             // Arrays are structurally hashed through a separate technique.
             //
             // "iec" is either fsEqualityComparerUnlimitedHashingER, fsEqualityComparerUnlimitedHashingPER or a CountLimitedHasherPER.
-            let rec GenericHashParamObj (iec : IEqualityComparer) (x: obj) : int =
+            let rec GenericHashParamObj (iec : IEqualityComparer) (x: objnull) : int =
                   match x with 
                   | null -> 0 
                   | (:? System.Array as a) -> 
@@ -1063,7 +1063,7 @@ namespace Microsoft.FSharp.Core
                     
             /// Implements generic comparison between two objects. This corresponds to the pseudo-code in the F#
             /// specification.  The treatment of NaNs is governed by "comp".
-            let rec GenericCompare (comp:GenericComparer) (xobj:obj, yobj:obj) = 
+            let rec GenericCompare (comp:GenericComparer) (xobj:objnull, yobj:objnull) = 
                   match xobj,yobj with 
                    | null,null -> 0
                    | null,_ -> -1

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -1759,7 +1759,7 @@ namespace Microsoft.FSharp.Core
                     | null, null -> true
                     | null, _ -> false
                     | _, null -> false
-                    | (:? (objnull array)      as arr1), (:? (objnull array)      as arr2) -> GenericEqualityObjArray    er iec arr1 arr2
+                    | (:? (objnull array)  as arr1), (:? (objnull array)  as arr2) -> GenericEqualityObjArray    er iec arr1 arr2
                     | (:? (byte array)     as arr1), (:? (byte array)     as arr2) -> GenericEqualityByteArray          arr1 arr2
                     | (:? (int32 array)    as arr1), (:? (int32 array)    as arr2) -> GenericEqualityInt32Array         arr1 arr2
                     | (:? (int64 array)    as arr1), (:? (int64 array)    as arr2) -> GenericEqualityInt64Array         arr1 arr2

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -1195,7 +1195,7 @@ namespace Microsoft.FSharp.Core
                     check 0
 
             /// optimized case: Core implementation of structural comparison on object arrays.
-            and GenericComparisonObjArrayWithComparer (comp:GenericComparer) (x:obj array) (y:obj array) : int =
+            and GenericComparisonObjArrayWithComparer (comp:GenericComparer) (x:objnull array) (y:objnull array) : int =
                 let lenx = x.Length 
                 let leny = y.Length 
                 let c = intOrder lenx leny 
@@ -1226,7 +1226,7 @@ namespace Microsoft.FSharp.Core
 
             type GenericComparer with
                 interface IComparer with
-                    override c.Compare(x:obj,y:obj) = GenericCompare c (x,y)
+                    override c.Compare(x:objnull,y:objnull) = GenericCompare c (x,y)
 
             /// The unique object for comparing values in PER mode (where local exceptions are thrown when NaNs are compared)
             let fsComparerPER = GenericComparer(true)  
@@ -1562,7 +1562,7 @@ namespace Microsoft.FSharp.Core
             //
             // If "er" is true the "iec" is fsEqualityComparerUnlimitedHashingER
             // If "er" is false the "iec" is fsEqualityComparerUnlimitedHashingPER
-            let rec GenericEqualityObj (er:bool) (iec:IEqualityComparer) ((xobj:obj),(yobj:obj)) : bool = 
+            let rec GenericEqualityObj (er:bool) (iec:IEqualityComparer) ((xobj:objnull),(yobj:objnull)) : bool = 
                 (*if objEq xobj yobj then true else  *)
                 match xobj,yobj with 
                  | null,null -> true
@@ -1651,7 +1651,7 @@ namespace Microsoft.FSharp.Core
                     check 0
 
             /// optimized case: Core implementation of structural equality on object arrays.
-            and GenericEqualityObjArray er iec (x:obj array) (y:obj array) : bool =
+            and GenericEqualityObjArray er iec (x:objnull array) (y:objnull array) : bool =
                 let lenx = x.Length 
                 let leny = y.Length 
                 let c = (lenx = leny )
@@ -1754,12 +1754,12 @@ namespace Microsoft.FSharp.Core
                 checkType 0 [| rootType |]
 
             let arrayEqualityComparer<'T> er comparer =
-                let arrayEquals (er: bool) (iec: IEqualityComparer) (xobj: obj) (yobj: obj) : bool = 
+                let arrayEquals (er: bool) (iec: IEqualityComparer) (xobj: objnull) (yobj: objnull) : bool = 
                     match xobj, yobj with 
                     | null, null -> true
                     | null, _ -> false
                     | _, null -> false
-                    | (:? (obj array)      as arr1), (:? (obj array)      as arr2) -> GenericEqualityObjArray    er iec arr1 arr2
+                    | (:? (objnull array)      as arr1), (:? (obj array)      as arr2) -> GenericEqualityObjArray    er iec arr1 arr2
                     | (:? (byte array)     as arr1), (:? (byte array)     as arr2) -> GenericEqualityByteArray          arr1 arr2
                     | (:? (int32 array)    as arr1), (:? (int32 array)    as arr2) -> GenericEqualityInt32Array         arr1 arr2
                     | (:? (int64 array)    as arr1), (:? (int64 array)    as arr2) -> GenericEqualityInt64Array         arr1 arr2
@@ -1769,10 +1769,10 @@ namespace Microsoft.FSharp.Core
                     | (:? Array            as arr1), (:? Array            as arr2) -> GenericEqualityArbArray    er iec arr1 arr2
                     | _ -> raise (Exception "invalid logic - expected array")
 
-                let getHashCode (iec, xobj: obj) =
+                let getHashCode (iec, xobj: objnull) =
                     match xobj with 
                     | null -> 0 
-                    | :? (obj array)      as oa -> GenericHashObjArray iec oa 
+                    | :? (objnull array)      as oa -> GenericHashObjArray iec oa 
                     | :? (byte array)     as ba -> GenericHashByteArray ba 
                     | :? (int array)      as ia -> GenericHashInt32Array ia 
                     | :? (int64 array)    as ia -> GenericHashInt64Array ia 
@@ -1958,9 +1958,9 @@ namespace Microsoft.FSharp.Core
             type CountLimitedHasherPER with
                 
                 interface IEqualityComparer with
-                    override iec.Equals(x:obj,y:obj) =
+                    override iec.Equals(x:objnull,y:objnull) =
                         GenericEqualityObj false iec (x,y)
-                    override iec.GetHashCode(x:obj) =
+                    override iec.GetHashCode(x:objnull) =
                         iec.nodeCount <- iec.nodeCount - 1
                         if iec.nodeCount > 0 then
                             GenericHashParamObj iec  x
@@ -1971,14 +1971,14 @@ namespace Microsoft.FSharp.Core
             type UnlimitedHasherER with
                 
                 interface IEqualityComparer with
-                    override iec.Equals(x:obj,y:obj) = GenericEqualityObj true iec (x,y)
-                    override iec.GetHashCode(x:obj) = GenericHashParamObj iec  x
+                    override iec.Equals(x:objnull,y:objnull) = GenericEqualityObj true iec (x,y)
+                    override iec.GetHashCode(x:objnull) = GenericHashParamObj iec  x
                    
             /// Fill in the implementation of UnlimitedHasherPER
             type UnlimitedHasherPER with
                 interface IEqualityComparer with
-                    override iec.Equals(x:obj,y:obj) = GenericEqualityObj false iec (x,y)
-                    override iec.GetHashCode(x:obj) = GenericHashParamObj iec x
+                    override iec.Equals(x:objnull,y:objnull) = GenericEqualityObj false iec (x,y)
+                    override iec.GetHashCode(x:objnull) = GenericHashParamObj iec x
 
             /// Intrinsic for calls to depth-unlimited structural hashing that were not optimized by static conditionals.
             //
@@ -4352,13 +4352,13 @@ namespace Microsoft.FSharp.Core
         let seq (sequence: seq<'T>) = sequence 
 
         [<CompiledName("Unbox")>]
-        let inline unbox (value: obj) = UnboxGeneric(value)
+        let inline unbox (value: objnull) = UnboxGeneric(value)
 
         [<CompiledName("Box")>]
-        let inline box (value: 'T) = (# "box !0" type ('T) value : obj #)
+        let inline box (value: 'T) = (# "box !0" type ('T) value : objnull #)
 
         [<CompiledName("TryUnbox")>]
-        let inline tryUnbox (value:obj) = 
+        let inline tryUnbox (value:objnull) = 
             match value with 
             | :? 'T as v -> Some v
             | _ -> None
@@ -5469,7 +5469,7 @@ namespace Microsoft.FSharp.Core
         module Unchecked =
 
             [<CompiledName("Unbox")>]
-            let inline unbox<'T> (v:obj) = unboxPrim<'T> v
+            let inline unbox<'T> (v:objnull) = unboxPrim<'T> v
 
             [<CompiledName("DefaultOf")>]
             let inline defaultof<'T> = unsafeDefault<'T>
@@ -7296,7 +7296,7 @@ namespace Microsoft.FSharp.Control
         inherit IObservable<'Args>
 
     [<CompiledName("FSharpHandler`1")>]
-    type Handler<'Args> =  delegate of sender:obj * args:'Args -> unit 
+    type Handler<'Args> =  delegate of sender:objnull * args:'Args -> unit 
 
     type IEvent<'Args> = IEvent<Handler<'Args>, 'Args>
 

--- a/src/FSharp.Core/prim-types.fsi
+++ b/src/FSharp.Core/prim-types.fsi
@@ -1763,19 +1763,19 @@ namespace Microsoft.FSharp.Core
 
             /// <summary>A compiler intrinsic that implements the ':?>' operator</summary>
             [<CompilerMessage("This function is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val UnboxGeneric<'T> : source: obj -> 'T
+            val UnboxGeneric<'T> : source: objnull -> 'T
 
             /// <summary>A compiler intrinsic that implements the ':?>' operator</summary>
             [<CompilerMessage("This function is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val inline UnboxFast<'T> : source: obj -> 'T
+            val inline UnboxFast<'T> : source: objnull -> 'T
 
             /// <summary>A compiler intrinsic that implements the ':?' operator</summary>
             [<CompilerMessage("This function is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val TypeTestGeneric<'T> : source: obj -> bool
+            val TypeTestGeneric<'T> : source: objnull -> bool
 
             /// <summary>A compiler intrinsic that implements the ':?' operator</summary>
             [<CompilerMessage("This function is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
-            val inline TypeTestFast<'T> : source: obj -> bool 
+            val inline TypeTestFast<'T> : source: objnull -> bool 
 
             /// <summary>Primitive used by pattern match compilation</summary>
             //[<CompilerMessage("This function is for use by compiled F# code and should not be used directly", 1204, IsHidden=true)>]
@@ -3407,7 +3407,7 @@ namespace Microsoft.FSharp.Core
         /// </example>
         /// 
         [<CompiledName("Unbox")>]
-        val inline unbox: value: obj -> 'T
+        val inline unbox: value: objnull -> 'T
 
         /// <summary>Boxes a strongly typed value.</summary>
         ///
@@ -3425,7 +3425,7 @@ namespace Microsoft.FSharp.Core
         /// </example>
         /// 
         [<CompiledName("Box")>]
-        val inline box: value: 'T -> obj
+        val inline box: value: 'T -> objnull
 
         /// <summary>Try to unbox a strongly typed value.</summary>
         ///
@@ -3443,7 +3443,7 @@ namespace Microsoft.FSharp.Core
         /// </example>
         /// 
         [<CompiledName("TryUnbox")>]
-        val inline tryUnbox: value: obj -> 'T option
+        val inline tryUnbox: value: objnull -> 'T option
 
         /// <summary>Determines whether the given value is null.</summary>
         ///
@@ -5723,7 +5723,7 @@ namespace Microsoft.FSharp.Core
             /// <example-tbd></example-tbd>
             /// 
             [<CompiledName("Unbox")>]
-            val inline unbox<'T> : value: obj -> 'T
+            val inline unbox<'T> : value: objnull -> 'T
 
             /// <summary>Generate a default value for any type. This is null for reference types, 
             /// For structs, this is struct value where all fields have the default value. 
@@ -6203,7 +6203,7 @@ namespace Microsoft.FSharp.Control
     ///
     /// <category index="3">Events and Observables</category>
     [<CompiledName("FSharpHandler`1")>]
-    type Handler<'T> =  delegate of sender:obj * args:'T -> unit 
+    type Handler<'T> =  delegate of sender:objnull * args:'T -> unit 
 
     /// <summary>First-class listening points (i.e. objects that permit you to register a callback
     /// activated when the event is triggered). </summary>

--- a/src/FSharp.Core/printf.fsi
+++ b/src/FSharp.Core/printf.fsi
@@ -31,14 +31,14 @@ type PrintfFormat<'Printer, 'State, 'Residue, 'Result> =
     /// <param name="captureTys">The types of expressions for %A expression gaps in interpolated string.</param>
     /// <returns>The PrintfFormat containing the formatted result.</returns>
     new:
-        value: string * captures: obj array * captureTys: Type array ->
+        value: string * captures: objnull array * captureTys: Type array ->
             PrintfFormat<'Printer, 'State, 'Residue, 'Result>
 
     /// <summary>The raw text of the format string.</summary>
     member Value: string
 
     /// <summary>The captures associated with an interpolated string.</summary>
-    member Captures: obj array
+    member Captures: objnull array
 
     /// <summary>The capture types associated with an interpolated string.</summary>
     member CaptureTypes: System.Type array
@@ -71,7 +71,7 @@ type PrintfFormat<'Printer, 'State, 'Residue, 'Result, 'Tuple> =
     ///
     /// <returns>The created format string.</returns>
     new:
-        value: string * captures: obj array * captureTys: Type array ->
+        value: string * captures: objnull array * captureTys: Type array ->
             PrintfFormat<'Printer, 'State, 'Residue, 'Result, 'Tuple>
 
 /// <summary>Type of a formatting expression.</summary>

--- a/src/FSharp.Core/quotations.fs
+++ b/src/FSharp.Core/quotations.fs
@@ -140,13 +140,13 @@ type Var(name: string, typ: Type, ?isMutable: bool) =
     override _.GetHashCode() =
         base.GetHashCode()
 
-    override v.Equals(obj: obj) =
+    override v.Equals(obj: objnull) =
         match obj with
         | :? Var as v2 -> System.Object.ReferenceEquals(v, v2)
         | _ -> false
 
     interface System.IComparable with
-        member v.CompareTo(obj: obj) =
+        member v.CompareTo(obj: objnull) =
             match obj with
             | :? Var as v2 ->
                 if System.Object.ReferenceEquals(v, v2) then
@@ -223,15 +223,15 @@ and [<StructuralEquality; NoComparison>] ExprConstInfo =
     | ForIntegerRangeLoopOp
     | WhileLoopOp
     // Arbitrary spliced values - not serialized
-    | ValueOp of obj * Type * string option
-    | WithValueOp of obj * Type
+    | ValueOp of objnull * Type * string option
+    | WithValueOp of objnull * Type
     | DefaultValueOp of Type
 
 and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(term: Tree, attribs: Expr list) =
     member x.Tree = term
     member x.CustomAttributes = attribs
 
-    override x.Equals obj =
+    override x.Equals (obj:objnull) =
         match obj with
         | :? Expr as y ->
             let rec eq t1 t2 =
@@ -2655,7 +2655,7 @@ type Expr with
     static member Value(value: 'T) =
         mkValue (box value, typeof<'T>)
 
-    static member Value(value: obj, expressionType: Type) =
+    static member Value(value: objnull, expressionType: Type) =
         checkNonNull "expressionType" expressionType
         mkValue (value, expressionType)
 
@@ -2663,7 +2663,7 @@ type Expr with
         checkNonNull "name" name
         mkValueWithName (box value, typeof<'T>, name)
 
-    static member ValueWithName(value: obj, expressionType: Type, name: string) =
+    static member ValueWithName(value: objnull, expressionType: Type, name: string) =
         checkNonNull "expressionType" expressionType
         checkNonNull "name" name
         mkValueWithName (value, expressionType, name)
@@ -2672,7 +2672,7 @@ type Expr with
         let raw = mkValueWithDefn (box value, typeof<'T>, definition)
         new Expr<'T>(raw.Tree, raw.CustomAttributes)
 
-    static member WithValue(value: obj, expressionType: Type, definition: Expr) =
+    static member WithValue(value: objnull, expressionType: Type, definition: Expr) =
         checkNonNull "expressionType" expressionType
         mkValueWithDefn (value, expressionType, definition)
 
@@ -2917,7 +2917,7 @@ module DerivedPatterns =
 module ExprShape =
     open Patterns
 
-    let RebuildShapeCombination (shape: obj, arguments) =
+    let RebuildShapeCombination (shape: objnull, arguments) =
         // preserve the attributes
         let op, attrs = unbox<ExprConstInfo * Expr list> (shape)
 

--- a/src/FSharp.Core/quotations.fs
+++ b/src/FSharp.Core/quotations.fs
@@ -231,7 +231,7 @@ and [<CompiledName("FSharpExpr"); StructuredFormatDisplay("{DebugText}")>] Expr(
     member x.Tree = term
     member x.CustomAttributes = attribs
 
-    override x.Equals (obj:objnull) =
+    override x.Equals(obj: objnull) =
         match obj with
         | :? Expr as y ->
             let rec eq t1 t2 =

--- a/src/FSharp.Core/quotations.fsi
+++ b/src/FSharp.Core/quotations.fsi
@@ -187,7 +187,7 @@ type Expr =
     /// </example>
     member CustomAttributes: Expr list
 
-    override Equals: obj: obj -> bool
+    override Equals: obj: objnull -> bool
 
     /// <summary>Builds an expression that represents getting the address of a value.</summary>
     ///
@@ -1047,7 +1047,7 @@ type Expr =
     /// </code>
     /// Evaluates to a quotation with the same structure as <c>&lt;@ 1 @&gt;</c>.
     /// </example>
-    static member Value: value: obj * expressionType: Type -> Expr
+    static member Value: value: objnull * expressionType: Type -> Expr
 
     /// <summary>Builds an expression that represents a constant value </summary>
     ///
@@ -1096,7 +1096,7 @@ type Expr =
     /// </code>
     /// Evaluates to a quotation with the same structure as <c>&lt;@ 1 @&gt;</c> and associated information that the name of the value is <c>"name"</c>.
     /// </example>
-    static member ValueWithName: value: obj * expressionType: Type * name: string -> Expr
+    static member ValueWithName: value: objnull * expressionType: Type * name: string -> Expr
 
     /// <summary>Builds an expression that represents a value and its associated reflected definition as a quotation</summary>
     ///
@@ -1131,7 +1131,7 @@ type Expr =
     /// </code>
     /// Evaluates to a quotation that displays as <c>WithValue (1, Call (None, op_Subtraction, [Value (2), Value (1)]))</c>.
     /// </example>
-    static member WithValue: value: obj * expressionType: Type * definition: Expr -> Expr
+    static member WithValue: value: objnull * expressionType: Type * definition: Expr -> Expr
 
     /// <summary>Builds an expression that represents a variable</summary>
     ///
@@ -1709,7 +1709,7 @@ module Patterns =
     ///
     /// <example-tbd></example-tbd>
     [<CompiledName("ValuePattern")>]
-    val (|Value|_|): input: Expr -> (obj * Type) option
+    val (|Value|_|): input: Expr -> (objnull * Type) option
 
     /// <summary>An active pattern to recognize expressions that represent a constant value</summary>
     ///
@@ -1719,7 +1719,7 @@ module Patterns =
     ///
     /// <example-tbd></example-tbd>
     [<CompiledName("ValueWithNamePattern")>]
-    val (|ValueWithName|_|): input: Expr -> (obj * Type * string) option
+    val (|ValueWithName|_|): input: Expr -> (objnull * Type * string) option
 
     /// <summary>An active pattern to recognize expressions that are a value with an associated definition</summary>
     ///
@@ -1729,7 +1729,7 @@ module Patterns =
     ///
     /// <example-tbd></example-tbd>
     [<CompiledName("WithValuePattern")>]
-    val (|WithValue|_|): input: Expr -> (obj * Type * Expr) option
+    val (|WithValue|_|): input: Expr -> (objnull * Type * Expr) option
 
     /// <summary>An active pattern to recognize expressions that represent a variable</summary>
     ///
@@ -2269,7 +2269,7 @@ module ExprShape =
     ///
     /// <example-tbd></example-tbd>
     [<CompiledName("ShapePattern")>]
-    val (|ShapeVar|ShapeLambda|ShapeCombination|): input: Expr -> Choice<Var, (Var * Expr), (obj * Expr list)>
+    val (|ShapeVar|ShapeLambda|ShapeCombination|): input: Expr -> Choice<Var, (Var * Expr), (objnull * Expr list)>
 
     /// <summary>Re-build combination expressions. The first parameter should be an object
     /// returned by the <c>ShapeCombination</c> case of the active pattern in this module.</summary>
@@ -2280,4 +2280,4 @@ module ExprShape =
     /// <returns>The rebuilt expression.</returns>
     ///
     /// <example-tbd></example-tbd>
-    val RebuildShapeCombination: shape: obj * arguments: Expr list -> Expr
+    val RebuildShapeCombination: shape: objnull * arguments: Expr list -> Expr

--- a/src/FSharp.Core/reflect.fs
+++ b/src/FSharp.Core/reflect.fs
@@ -47,7 +47,7 @@ module internal Impl =
            else
                Type.op_Equality (ty1, ty2)
 
-    let func = typedefof<(obj -> obj)>
+    let func = typedefof<(objnull -> objnull)>
 
     let isOptionType typ =
         equivHeadTypes typ (typeof<int option>)
@@ -87,7 +87,7 @@ module internal Impl =
             Expression.Property(Expression.Convert(param, prop.DeclaringType), prop)
 
         let expr =
-            Expression.Lambda<Func<obj, obj>>(Expression.Convert(propExpr, typeof<obj>), param)
+            Expression.Lambda<Func<obj, objnull>>(Expression.Convert(propExpr, typeof<obj>), param)
 
         expr.Compile()
 
@@ -96,7 +96,7 @@ module internal Impl =
         let typedParam = Expression.Variable typ
 
         let expr =
-            Expression.Lambda<Func<obj, obj array>>(
+            Expression.Lambda<Func<obj, objnull array>>(
                 Expression.Block(
                     [ typedParam ],
                     Expression.Assign(typedParam, Expression.Convert(param, typ)),
@@ -115,10 +115,10 @@ module internal Impl =
 
     let compileRecordConstructorFunc (ctorInfo: ConstructorInfo) =
         let ctorParams = ctorInfo.GetParameters()
-        let paramArray = Expression.Parameter(typeof<obj array>, "paramArray")
+        let paramArray = Expression.Parameter(typeof<objnull array>, "paramArray")
 
         let expr =
-            Expression.Lambda<Func<obj array, obj>>(
+            Expression.Lambda<Func<objnull array, obj>>(
                 Expression.Convert(
                     Expression.New(
                         ctorInfo,
@@ -139,10 +139,10 @@ module internal Impl =
 
     let compileUnionCaseConstructorFunc (methodInfo: MethodInfo) =
         let methodParams = methodInfo.GetParameters()
-        let paramArray = Expression.Parameter(typeof<obj array>, "param")
+        let paramArray = Expression.Parameter(typeof<objnull array>, "param")
 
         let expr =
-            Expression.Lambda<Func<obj array, obj>>(
+            Expression.Lambda<Func<objnull array, objnull>>(
                 Expression.Convert(
                     Expression.Call(
                         methodInfo,
@@ -169,7 +169,7 @@ module internal Impl =
             | Choice1Of2 info -> Expression.Call(info, Expression.Convert(param, info.DeclaringType)) :> Expression
             | Choice2Of2 info -> Expression.Property(Expression.Convert(param, info.DeclaringType), info) :> _
 
-        let expr = Expression.Lambda<Func<obj, int>>(tag, param)
+        let expr = Expression.Lambda<Func<objnull, int>>(tag, param)
         expr.Compile()
 
     let compileTupleConstructor tupleEncField getTupleConstructorMethod typ =
@@ -192,10 +192,10 @@ module internal Impl =
                 ]
             )
 
-        let elements = Expression.Parameter(typeof<obj array>, "elements")
+        let elements = Expression.Parameter(typeof<objnull array>, "elements")
 
         let expr =
-            Expression.Lambda<Func<obj array, obj>>(
+            Expression.Lambda<Func<objnull array, obj>>(
                 Expression.Convert(constituentTuple typ elements 0, typeof<obj>),
                 elements
             )
@@ -246,7 +246,7 @@ module internal Impl =
                 genericArgs.Length
 
         let expr =
-            Expression.Lambda<Func<obj, obj array>>(
+            Expression.Lambda<Func<obj, objnull array>>(
                 Expression.Block(
                     [ outputArray ],
                     [
@@ -516,7 +516,7 @@ module internal Impl =
     let getUnionCaseRecordReader (typ: Type, tag: int, bindingFlags) =
         let props = fieldsPropsOfUnionCase (typ, tag, bindingFlags)
 
-        (fun (obj: obj) ->
+        (fun (obj: objnull) ->
             props
             |> Array.map (fun prop -> prop.GetValue(obj, bindingFlags, null, null, null)))
 
@@ -526,9 +526,9 @@ module internal Impl =
         let caseTyp = if isNull caseTyp then typ else caseTyp
         compileRecordOrUnionCaseReaderFunc(caseTyp, props).Invoke
 
-    let getUnionTagReader (typ: Type, bindingFlags) : (obj -> int) =
+    let getUnionTagReader (typ: Type, bindingFlags) : (objnull -> int) =
         if isOptionType typ then
-            (fun (obj: obj) ->
+            (fun (obj: objnull) ->
                 match obj with
                 | null -> 0
                 | _ -> 1)
@@ -536,19 +536,19 @@ module internal Impl =
             let tagMap = getUnionTypeTagNameMap (typ, bindingFlags)
 
             if tagMap.Length <= 1 then
-                (fun (_obj: obj) -> 0)
+                (fun (_obj: objnull) -> 0)
             else
                 match getInstancePropertyReader (typ, "Tag", bindingFlags) with
-                | Some reader -> (fun (obj: obj) -> reader obj :?> int)
+                | Some reader -> (fun (obj: objnull) -> reader obj :?> int)
                 | None ->
                     let m2b =
                         typ.GetMethod("GetTag", BindingFlags.Static ||| bindingFlags, null, [| typ |], null)
 
-                    (fun (obj: obj) -> m2b.Invoke(null, [| obj |]) :?> int)
+                    (fun (obj: objnull) -> m2b.Invoke(null, [| obj |]) :?> int)
 
-    let getUnionTagReaderCompiled (typ: Type, bindingFlags) : (obj -> int) =
+    let getUnionTagReaderCompiled (typ: Type, bindingFlags) : (objnull -> int) =
         if isOptionType typ then
-            (fun (obj: obj) ->
+            (fun (obj: objnull) ->
                 match obj with
                 | null -> 0
                 | _ -> 1)
@@ -556,7 +556,7 @@ module internal Impl =
             let tagMap = getUnionTypeTagNameMap (typ, bindingFlags)
 
             if tagMap.Length <= 1 then
-                (fun (_obj: obj) -> 0)
+                (fun (_obj: objnull) -> 0)
             else
                 match getInstancePropertyInfo (typ, "Tag", bindingFlags) with
                 | null ->
@@ -831,7 +831,7 @@ module internal Impl =
     let getTupleCtor (typ: Type) =
         let ctor = getTupleConstructorMethod typ
 
-        (fun (args: obj array) ->
+        (fun (args: objnull array) ->
             ctor.Invoke(BindingFlags.InvokeMethod ||| BindingFlags.Instance ||| BindingFlags.Public, null, args, null))
 
     let getTupleElementAccessors (typ: Type) =
@@ -872,7 +872,7 @@ module internal Impl =
             let tyBenc = etys.[tupleEncField]
             let maker2 = getTupleConstructor tyBenc
 
-            (fun (args: obj array) ->
+            (fun (args: objnull array) ->
                 let encVal = maker2 args.[tupleEncField..]
                 maker1 (Array.append args.[0 .. tupleEncField - 1] [| encVal |]))
 
@@ -991,7 +991,7 @@ module internal Impl =
     let getRecordConstructor (typ: Type, bindingFlags) =
         let ctor = getRecordConstructorMethod (typ, bindingFlags)
 
-        (fun (args: obj array) ->
+        (fun (args: objnull array) ->
             ctor.Invoke(BindingFlags.InvokeMethod ||| BindingFlags.Instance ||| bindingFlags, null, args, null))
 
     let getRecordConstructorCompiled (typ: Type, bindingFlags) =
@@ -1104,7 +1104,7 @@ type UnionCaseInfo(typ: System.Type, tag: int) =
     override x.GetHashCode() =
         typ.GetHashCode() + tag
 
-    override _.Equals(obj: obj) =
+    override _.Equals(obj: objnull) =
         match obj with
         | :? UnionCaseInfo as uci -> uci.DeclaringType = typ && uci.Tag = tag
         | _ -> false
@@ -1260,11 +1260,11 @@ type FSharpValue =
 
         getRecordReader (typ, bindingFlags) record
 
-    static member PreComputeRecordFieldReader(info: PropertyInfo) : obj -> obj =
+    static member PreComputeRecordFieldReader(info: PropertyInfo) : obj -> objnull =
         checkNonNull "info" info
         compilePropGetterFunc(info).Invoke
 
-    static member PreComputeRecordReader(recordType: Type, ?bindingFlags) : (obj -> obj array) =
+    static member PreComputeRecordReader(recordType: Type, ?bindingFlags) : (obj -> objnull array) =
         let bindingFlags = defaultArg bindingFlags BindingFlags.Public
         checkRecordType ("recordType", recordType, bindingFlags)
         getRecordReaderCompiled (recordType, bindingFlags)
@@ -1279,7 +1279,7 @@ type FSharpValue =
         checkRecordType ("recordType", recordType, bindingFlags)
         getRecordConstructorMethod (recordType, bindingFlags)
 
-    static member MakeFunction(functionType: Type, implementation: (obj -> obj)) =
+    static member MakeFunction(functionType: Type, implementation: (objnull -> objnull)) =
         checkNonNull "functionType" functionType
 
         if not (isFunctionType functionType) then
@@ -1291,10 +1291,10 @@ type FSharpValue =
         let dynCloMakerTy = typedefof<DynamicFunction<obj, obj>>
         let saverTy = dynCloMakerTy.MakeGenericType [| domain; range |]
         let o = Activator.CreateInstance saverTy
-        let (f: (obj -> obj) -> obj) = downcast o
+        let (f: (objnull -> objnull) -> obj) = downcast o
         f implementation
 
-    static member MakeTuple(tupleElements: obj array, tupleType: Type) =
+    static member MakeTuple(tupleElements: objnull array, tupleType: Type) =
         checkNonNull "tupleElements" tupleElements
         checkTupleType ("tupleType", tupleType)
         getTupleConstructor tupleType tupleElements
@@ -1327,7 +1327,7 @@ type FSharpValue =
 
         fields.[index]
 
-    static member PreComputeTupleReader(tupleType: Type) : (obj -> obj array) =
+    static member PreComputeTupleReader(tupleType: Type) : (obj -> objnull array) =
         checkTupleType ("tupleType", tupleType)
         (compileTupleReader tupleEncField getTupleElementAccessors tupleType).Invoke
 
@@ -1345,7 +1345,7 @@ type FSharpValue =
         checkTupleType ("tupleType", tupleType)
         getTupleConstructorInfo tupleType
 
-    static member MakeUnion(unionCase: UnionCaseInfo, args: obj array, ?bindingFlags) =
+    static member MakeUnion(unionCase: UnionCaseInfo, args: objnull array, ?bindingFlags) =
         let bindingFlags = defaultArg bindingFlags BindingFlags.Public
         checkNonNull "unionCase" unionCase
         getUnionCaseConstructor (unionCase.DeclaringType, unionCase.Tag, bindingFlags) args
@@ -1360,10 +1360,10 @@ type FSharpValue =
         checkNonNull "unionCase" unionCase
         getUnionCaseConstructorMethod (unionCase.DeclaringType, unionCase.Tag, bindingFlags)
 
-    static member GetUnionFields(value: obj, unionType: Type, ?bindingFlags) =
+    static member GetUnionFields(value: objnull, unionType: Type, ?bindingFlags) =
         let bindingFlags = defaultArg bindingFlags BindingFlags.Public
 
-        let ensureType (typ: Type, obj: obj) =
+        let ensureType (typ: Type, obj: objnull) =
             match typ with
             | null ->
                 match obj with
@@ -1381,7 +1381,7 @@ type FSharpValue =
         let flds = getUnionCaseRecordReader (unionType, tag, bindingFlags) value
         UnionCaseInfo(unionType, tag), flds
 
-    static member PreComputeUnionTagReader(unionType: Type, ?bindingFlags) : (obj -> int) =
+    static member PreComputeUnionTagReader(unionType: Type, ?bindingFlags) : (objnull -> int) =
         let bindingFlags = defaultArg bindingFlags BindingFlags.Public
         checkNonNull "unionType" unionType
         let unionType = getTypeOfReprType (unionType, bindingFlags)
@@ -1395,7 +1395,7 @@ type FSharpValue =
         checkUnionType (unionType, bindingFlags)
         getUnionTagMemberInfo (unionType, bindingFlags)
 
-    static member PreComputeUnionReader(unionCase: UnionCaseInfo, ?bindingFlags) : (obj -> obj array) =
+    static member PreComputeUnionReader(unionCase: UnionCaseInfo, ?bindingFlags) : (objnull -> objnull array) =
         let bindingFlags = defaultArg bindingFlags BindingFlags.Public
         checkNonNull "unionCase" unionCase
         let typ = unionCase.DeclaringType
@@ -1450,7 +1450,7 @@ module FSharpReflectionExtensions =
             (
                 recordType: Type,
                 ?allowAccessToPrivateRepresentation
-            ) : (obj -> obj array) =
+            ) : (obj -> objnull array) =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.PreComputeRecordReader(recordType, bindingFlags)
 
@@ -1462,7 +1462,7 @@ module FSharpReflectionExtensions =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.PreComputeRecordConstructorInfo(recordType, bindingFlags)
 
-        static member MakeUnion(unionCase: UnionCaseInfo, args: obj array, ?allowAccessToPrivateRepresentation) =
+        static member MakeUnion(unionCase: UnionCaseInfo, args: objnull array, ?allowAccessToPrivateRepresentation) =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.MakeUnion(unionCase, args, bindingFlags)
 
@@ -1478,11 +1478,11 @@ module FSharpReflectionExtensions =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.PreComputeUnionTagMemberInfo(unionType, bindingFlags)
 
-        static member GetUnionFields(value: obj, unionType: Type, ?allowAccessToPrivateRepresentation) =
+        static member GetUnionFields(value: objnull, unionType: Type, ?allowAccessToPrivateRepresentation) =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.GetUnionFields(value, unionType, bindingFlags)
 
-        static member PreComputeUnionTagReader(unionType: Type, ?allowAccessToPrivateRepresentation) : (obj -> int) =
+        static member PreComputeUnionTagReader(unionType: Type, ?allowAccessToPrivateRepresentation) : (objnull -> int) =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.PreComputeUnionTagReader(unionType, bindingFlags)
 
@@ -1490,7 +1490,7 @@ module FSharpReflectionExtensions =
             (
                 unionCase: UnionCaseInfo,
                 ?allowAccessToPrivateRepresentation
-            ) : (obj -> obj array) =
+            ) : (objnull -> objnull array) =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.PreComputeUnionReader(unionCase, bindingFlags)
 

--- a/src/FSharp.Core/reflect.fs
+++ b/src/FSharp.Core/reflect.fs
@@ -1482,7 +1482,11 @@ module FSharpReflectionExtensions =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.GetUnionFields(value, unionType, bindingFlags)
 
-        static member PreComputeUnionTagReader(unionType: Type, ?allowAccessToPrivateRepresentation) : (objnull -> int) =
+        static member PreComputeUnionTagReader
+            (
+                unionType: Type,
+                ?allowAccessToPrivateRepresentation
+            ) : (objnull -> int) =
             let bindingFlags = getBindingFlags allowAccessToPrivateRepresentation
             FSharpValue.PreComputeUnionTagReader(unionType, bindingFlags)
 

--- a/src/FSharp.Core/reflect.fsi
+++ b/src/FSharp.Core/reflect.fsi
@@ -209,7 +209,7 @@ type FSharpValue =
     /// <returns>The field from the record.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member GetRecordField: record: obj * info: PropertyInfo -> obj
+    static member GetRecordField: record: obj * info: PropertyInfo -> objnull
 
     /// <summary>Precompute a function for reading a particular field from a record.
     /// Assumes the given type is a RecordType with a field of the given name.
@@ -226,7 +226,7 @@ type FSharpValue =
     /// <returns>A function to read the specified field from the record.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member PreComputeRecordFieldReader: info: PropertyInfo -> (obj -> obj)
+    static member PreComputeRecordFieldReader: info: PropertyInfo -> (obj -> objnull)
 
     /// <summary>Creates an instance of a record type.</summary>
     ///
@@ -243,7 +243,7 @@ type FSharpValue =
     /// <example-tbd></example-tbd>
     static member MakeRecord:
         [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] recordType: Type *
-        values: obj array *
+        values: objnull array *
         ?bindingFlags: BindingFlags ->
             obj
 
@@ -258,7 +258,7 @@ type FSharpValue =
     /// <returns>The array of fields from the record.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member GetRecordFields: record: obj * ?bindingFlags: BindingFlags -> obj array
+    static member GetRecordFields: record: obj * ?bindingFlags: BindingFlags -> objnull array
 
     /// <summary>Precompute a function for reading all the fields from a record. The fields are returned in the
     /// same order as the fields reported by a call to Microsoft.FSharp.Reflection.Type.GetInfo for
@@ -282,7 +282,7 @@ type FSharpValue =
     static member PreComputeRecordReader:
         [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] recordType: Type *
         ?bindingFlags: BindingFlags ->
-            (obj -> obj array)
+            (obj -> objnull array)
 
     /// <summary>Precompute a function for constructing a record value. </summary>
     ///
@@ -300,7 +300,7 @@ type FSharpValue =
     static member PreComputeRecordConstructor:
         [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] recordType: Type *
         ?bindingFlags: BindingFlags ->
-            (obj array -> obj)
+            (objnull array -> obj)
 
     /// <summary>Get a ConstructorInfo for a record type</summary>
     ///
@@ -324,7 +324,7 @@ type FSharpValue =
     /// <returns>The constructed union case.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member MakeUnion: unionCase: UnionCaseInfo * args: obj array * ?bindingFlags: BindingFlags -> obj
+    static member MakeUnion: unionCase: UnionCaseInfo * args: objnull array * ?bindingFlags: BindingFlags -> objnull
 
     /// <summary>Identify the union case and its fields for an object</summary>
     ///
@@ -343,10 +343,10 @@ type FSharpValue =
     ///
     /// <example-tbd></example-tbd>
     static member GetUnionFields:
-        value: obj *
+        value: objnull *
         [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] unionType: Type *
         ?bindingFlags: BindingFlags ->
-            UnionCaseInfo * obj array
+            UnionCaseInfo * objnull array
 
     /// <summary>Assumes the given type is a union type.
     /// If not, <see cref="T:System.ArgumentException" /> is raised during pre-computation.</summary>
@@ -363,7 +363,7 @@ type FSharpValue =
     /// <example-tbd></example-tbd>
     static member PreComputeUnionTagReader:
         [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] unionType: Type * ?bindingFlags: BindingFlags ->
-            (obj -> int)
+            (objnull -> int)
 
     /// <summary>Precompute a property or static method for reading an integer representing the case tag of a union type.</summary>
     ///
@@ -387,7 +387,7 @@ type FSharpValue =
     /// <returns>A function to for reading the fields of the given union case.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member PreComputeUnionReader: unionCase: UnionCaseInfo * ?bindingFlags: BindingFlags -> (obj -> obj array)
+    static member PreComputeUnionReader: unionCase: UnionCaseInfo * ?bindingFlags: BindingFlags -> (objnull -> objnull array)
 
     /// <summary>Precompute a function for constructing a discriminated union value for a particular union case. </summary>
     ///
@@ -398,7 +398,7 @@ type FSharpValue =
     ///
     /// <example-tbd></example-tbd>
     static member PreComputeUnionConstructor:
-        unionCase: UnionCaseInfo * ?bindingFlags: BindingFlags -> (obj array -> obj)
+        unionCase: UnionCaseInfo * ?bindingFlags: BindingFlags -> (objnull array -> objnull)
 
     /// <summary>A method that constructs objects of the given case</summary>
     ///
@@ -422,7 +422,7 @@ type FSharpValue =
     /// <returns>The fields from the given exception.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member GetExceptionFields: exn: obj * ?bindingFlags: BindingFlags -> obj array
+    static member GetExceptionFields: exn: obj * ?bindingFlags: BindingFlags -> objnull array
 
     /// <summary>Creates an instance of a tuple type</summary>
     ///
@@ -436,7 +436,7 @@ type FSharpValue =
     /// <returns>An instance of the tuple type with the given elements.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member MakeTuple: tupleElements: obj array * tupleType: Type -> obj
+    static member MakeTuple: tupleElements: objnull array * tupleType: Type -> obj
 
     /// <summary>Reads a field from a tuple value.</summary>
     ///
@@ -448,7 +448,7 @@ type FSharpValue =
     /// <returns>The value of the field.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member GetTupleField: tuple: obj * index: int -> obj
+    static member GetTupleField: tuple: obj * index: int -> objnull
 
     /// <summary>Reads all fields from a tuple.</summary>
     ///
@@ -461,7 +461,7 @@ type FSharpValue =
     /// <returns>An array of the fields from the given tuple.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member GetTupleFields: tuple: obj -> obj array
+    static member GetTupleFields: tuple: obj -> objnull array
 
     /// <summary>Precompute a function for reading the values of a particular tuple type</summary>
     ///
@@ -476,7 +476,7 @@ type FSharpValue =
     ///
     /// <example-tbd></example-tbd>
     static member PreComputeTupleReader:
-        [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] tupleType: Type -> (obj -> obj array)
+        [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] tupleType: Type -> (obj -> objnull array)
 
     /// <summary>Gets information that indicates how to read a field of a tuple</summary>
     ///
@@ -503,7 +503,7 @@ type FSharpValue =
     ///
     /// <example-tbd></example-tbd>
     static member PreComputeTupleConstructor:
-        [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] tupleType: Type -> (obj array -> obj)
+        [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] tupleType: Type -> (objnull array -> obj)
 
     /// <summary>Gets a method that constructs objects of the given tuple type.
     /// For small tuples, no additional type will be returned.</summary>
@@ -535,7 +535,7 @@ type FSharpValue =
     /// <example-tbd></example-tbd>
     static member MakeFunction:
         [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] functionType: Type *
-        implementation: (obj -> obj) ->
+        implementation: (objnull -> objnull) ->
             obj
 
 /// <summary>Contains operations associated with constructing and analyzing F# types such as records, unions and tuples</summary>
@@ -745,7 +745,7 @@ module FSharpReflectionExtensions =
         /// <example-tbd></example-tbd>
         static member MakeRecord:
             [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] recordType: Type *
-            values: obj array *
+            values: objnull array *
             ?allowAccessToPrivateRepresentation: bool ->
                 obj
 
@@ -764,7 +764,7 @@ module FSharpReflectionExtensions =
         static member GetRecordFields:
             [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] record: obj *
             ?allowAccessToPrivateRepresentation: bool ->
-                obj array
+                objnull array
 
         /// <summary>Precompute a function for reading all the fields from a record. The fields are returned in the
         /// same order as the fields reported by a call to Microsoft.FSharp.Reflection.Type.GetInfo for
@@ -788,7 +788,7 @@ module FSharpReflectionExtensions =
         static member PreComputeRecordReader:
             [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] recordType: Type *
             ?allowAccessToPrivateRepresentation: bool ->
-                (obj -> obj array)
+                (obj -> objnull array)
 
         /// <summary>Precompute a function for constructing a record value. </summary>
         ///
@@ -806,7 +806,7 @@ module FSharpReflectionExtensions =
         static member PreComputeRecordConstructor:
             [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] recordType: Type *
             ?allowAccessToPrivateRepresentation: bool ->
-                (obj array -> obj)
+                (objnull array -> obj)
 
         /// <summary>Get a ConstructorInfo for a record type</summary>
         ///
@@ -831,7 +831,7 @@ module FSharpReflectionExtensions =
         ///
         /// <example-tbd></example-tbd>
         static member MakeUnion:
-            unionCase: UnionCaseInfo * args: obj array * ?allowAccessToPrivateRepresentation: bool -> obj
+            unionCase: UnionCaseInfo * args: objnull array * ?allowAccessToPrivateRepresentation: bool -> objnull
 
         /// <summary>Identify the union case and its fields for an object</summary>
         ///
@@ -851,10 +851,10 @@ module FSharpReflectionExtensions =
         ///
         /// <example-tbd></example-tbd>
         static member GetUnionFields:
-            value: obj *
+            value: objnull *
             [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] unionType: Type *
             ?allowAccessToPrivateRepresentation: bool ->
-                UnionCaseInfo * obj array
+                UnionCaseInfo * objnull array
 
         /// <summary>Assumes the given type is a union type.
         /// If not, <see cref="T:System.ArgumentException" /> is raised during pre-computation.</summary>
@@ -872,7 +872,7 @@ module FSharpReflectionExtensions =
         static member PreComputeUnionTagReader:
             [<DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)>] unionType: Type *
             ?allowAccessToPrivateRepresentation: bool ->
-                (obj -> int)
+                (objnull -> int)
 
         /// <summary>Precompute a property or static method for reading an integer representing the case tag of a union type.</summary>
         ///
@@ -898,7 +898,7 @@ module FSharpReflectionExtensions =
         ///
         /// <example-tbd></example-tbd>
         static member PreComputeUnionReader:
-            unionCase: UnionCaseInfo * ?allowAccessToPrivateRepresentation: bool -> (obj -> obj array)
+            unionCase: UnionCaseInfo * ?allowAccessToPrivateRepresentation: bool -> (objnull -> objnull array)
 
         /// <summary>Precompute a function for constructing a discriminated union value for a particular union case. </summary>
         ///
@@ -909,7 +909,7 @@ module FSharpReflectionExtensions =
         ///
         /// <example-tbd></example-tbd>
         static member PreComputeUnionConstructor:
-            unionCase: UnionCaseInfo * ?allowAccessToPrivateRepresentation: bool -> (obj array -> obj)
+            unionCase: UnionCaseInfo * ?allowAccessToPrivateRepresentation: bool -> (objnull array -> objnull)
 
         /// <summary>A method that constructs objects of the given case</summary>
         ///
@@ -934,7 +934,7 @@ module FSharpReflectionExtensions =
         /// <returns>The fields from the given exception.</returns>
         ///
         /// <example-tbd></example-tbd>
-        static member GetExceptionFields: exn: obj * ?allowAccessToPrivateRepresentation: bool -> obj array
+        static member GetExceptionFields: exn: obj * ?allowAccessToPrivateRepresentation: bool -> objnull array
 
     type FSharpType with
 

--- a/src/FSharp.Core/reflect.fsi
+++ b/src/FSharp.Core/reflect.fsi
@@ -387,7 +387,8 @@ type FSharpValue =
     /// <returns>A function to for reading the fields of the given union case.</returns>
     ///
     /// <example-tbd></example-tbd>
-    static member PreComputeUnionReader: unionCase: UnionCaseInfo * ?bindingFlags: BindingFlags -> (objnull -> objnull array)
+    static member PreComputeUnionReader:
+        unionCase: UnionCaseInfo * ?bindingFlags: BindingFlags -> (objnull -> objnull array)
 
     /// <summary>Precompute a function for constructing a discriminated union value for a particular union case. </summary>
     ///

--- a/src/FSharp.Core/resumable.fs
+++ b/src/FSharp.Core/resumable.fs
@@ -63,7 +63,7 @@ and ResumptionFunc<'Data> = delegate of byref<ResumableStateMachine<'Data>> -> b
 
 and [<AbstractClass>] ResumptionDynamicInfo<'Data>(initial: ResumptionFunc<'Data>) =
     member val ResumptionFunc: ResumptionFunc<'Data> = initial with get, set
-    member val ResumptionData: obj = null with get, set
+    member val ResumptionData: objnull = null with get, set
     abstract MoveNext: machine: byref<ResumableStateMachine<'Data>> -> unit
     abstract SetStateMachine: machine: byref<ResumableStateMachine<'Data>> * machineState: IAsyncStateMachine -> unit
 

--- a/src/FSharp.Core/resumable.fsi
+++ b/src/FSharp.Core/resumable.fsi
@@ -49,7 +49,7 @@ and
     member ResumptionFunc: ResumptionFunc<'Data> with get, set 
     
     /// Additional data associated with the state machine
-    member ResumptionData: obj with get, set 
+    member ResumptionData: objnull with get, set 
 
     /// Executes the MoveNext implementation of the state machine
     abstract MoveNext: machine: byref<ResumableStateMachine<'Data>> -> unit

--- a/src/FSharp.Core/seqcore.fs
+++ b/src/FSharp.Core/seqcore.fs
@@ -451,7 +451,7 @@ module RuntimeHelpers =
                         // Enumeration has finished. In this case, we do NOT invoke the exception handlers for the .Dispose() call
                         | None -> disposeOriginal()}))
 
-    let CreateEvent (addHandler : 'Delegate -> unit) (removeHandler : 'Delegate -> unit) (createHandler : (obj -> 'Args -> unit) -> 'Delegate ) :IEvent<'Delegate,'Args> =
+    let CreateEvent (addHandler : 'Delegate -> unit) (removeHandler : 'Delegate -> unit) (createHandler : (objnull -> 'Args -> unit) -> 'Delegate ) :IEvent<'Delegate,'Args> =
         { new obj() with
               member x.ToString() = "<published event>"
           interface IEvent<'Delegate,'Args> with

--- a/src/FSharp.Core/seqcore.fsi
+++ b/src/FSharp.Core/seqcore.fsi
@@ -125,7 +125,7 @@ module RuntimeHelpers =
     val CreateEvent:
         addHandler: ('Delegate -> unit) ->
         removeHandler: ('Delegate -> unit) ->
-        createHandler: ((obj -> 'Args -> unit) -> 'Delegate) ->
+        createHandler: ((objnull -> 'Args -> unit) -> 'Delegate) ->
             Microsoft.FSharp.Control.IEvent<'Delegate, 'Args>
 
 /// <summary>The F# compiler emits implementations of this type for compiled sequence expressions.</summary>

--- a/src/FSharp.Core/set.fs
+++ b/src/FSharp.Core/set.fs
@@ -901,7 +901,7 @@ type Set<[<EqualityConditionalOn>] 'T when 'T: comparison>(comparer: IComparer<'
         | _ -> false
 
     interface System.IComparable with
-        member this.CompareTo(that: obj) =
+        member this.CompareTo(that: objnull) =
             SetTree.compare this.Comparer this.Tree ((that :?> Set<'T>).Tree)
 
     interface IStructuralEquatable with

--- a/src/FSharp.Core/set.fsi
+++ b/src/FSharp.Core/set.fsi
@@ -231,7 +231,7 @@ type Set<[<EqualityConditionalOn>] 'T when 'T: comparison> =
     interface System.IComparable
     interface System.Collections.IStructuralEquatable
     interface IReadOnlyCollection<'T>
-    override Equals: obj -> bool
+    override Equals: objnull -> bool
 
 namespace Microsoft.FSharp.Collections
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/ReferenceDU.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/ReferenceDU.fs
@@ -8,7 +8,7 @@ type MyDu =
 
 let giveMeLabel () = JustLabel
 
-let createMaybeString (innerValue) = MaybeString innerValue
+let createMaybeString (innerValue:string|null) = MaybeString innerValue
 
 let processNullableDu (x : (MyDu | null)) : string | null =
     match x with

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/ReferenceDU.fs.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/ReferenceDU.fs.il.net472.bsl
@@ -8,7 +8,7 @@
 .assembly extern netstandard
 {
   .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         
-  .ver 2:0:0:0
+  .ver 2:1:0:0
 }
 .assembly assembly
 {
@@ -58,8 +58,7 @@
                                                                                                                             44 65 62 75 67 54 79 70 65 50 72 6F 78 79 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   
                                                                                                      61 79 28 29 2C 6E 71 7D 00 00 )                   
-      .method assembly specialname rtspecialname 
-              instance void  .ctor() cil managed
+      .method assembly specialname rtspecialname instance void  .ctor() cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -88,8 +87,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(int32 item) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(int32 item) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -106,8 +104,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance int32 
-              get_Item() cil managed
+      .method public hidebysig instance int32 get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -143,8 +140,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(string item) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(string item) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -161,8 +157,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance string 
-              get_Item() cil managed
+      .method public hidebysig instance string get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -194,8 +189,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname 
-              instance void  .ctor(class MyTestModule/MyDu/_JustLabel obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class MyTestModule/MyDu/_JustLabel obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -221,8 +215,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname 
-              instance void  .ctor(class MyTestModule/MyDu/JustInt obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class MyTestModule/MyDu/JustInt obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -239,8 +232,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance int32 
-              get_Item() cil managed
+      .method public hidebysig instance int32 get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -270,8 +262,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname 
-              instance void  .ctor(class MyTestModule/MyDu/MaybeString obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class MyTestModule/MyDu/MaybeString obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -288,8 +279,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance string 
-              get_Item() cil managed
+      .method public hidebysig instance string get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -317,8 +307,7 @@
     .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .method private specialname rtspecialname static 
-            void  .cctor() cil managed
+    .method private specialname rtspecialname static void  .cctor() cil managed
     {
       
       .maxstack  8
@@ -327,8 +316,7 @@
       IL_000a:  ret
     } 
 
-    .method assembly specialname rtspecialname 
-            instance void  .ctor() cil managed
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
     {
       .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                               class [runtime]System.Type) = ( 01 00 E0 07 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -342,8 +330,7 @@
       IL_0006:  ret
     } 
 
-    .method public static class MyTestModule/MyDu 
-            get_JustLabel() cil managed
+    .method public static class MyTestModule/MyDu get_JustLabel() cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -353,8 +340,7 @@
       IL_0005:  ret
     } 
 
-    .method public hidebysig instance bool 
-            get_IsJustLabel() cil managed
+    .method public hidebysig instance bool get_IsJustLabel() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -367,8 +353,7 @@
       IL_0009:  ret
     } 
 
-    .method public static class MyTestModule/MyDu 
-            NewJustInt(int32 item) cil managed
+    .method public static class MyTestModule/MyDu NewJustInt(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 01 00 00 00 00 00 ) 
@@ -379,8 +364,7 @@
       IL_0006:  ret
     } 
 
-    .method public hidebysig instance bool 
-            get_IsJustInt() cil managed
+    .method public hidebysig instance bool get_IsJustInt() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -393,8 +377,7 @@
       IL_0009:  ret
     } 
 
-    .method public static class MyTestModule/MyDu 
-            NewMaybeString(string item) cil managed
+    .method public static class MyTestModule/MyDu NewMaybeString(string item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 02 00 00 00 00 00 ) 
@@ -407,8 +390,7 @@
       IL_0006:  ret
     } 
 
-    .method public hidebysig instance bool 
-            get_IsMaybeString() cil managed
+    .method public hidebysig instance bool get_IsMaybeString() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -421,8 +403,7 @@
       IL_0009:  ret
     } 
 
-    .method public hidebysig instance int32 
-            get_Tag() cil managed
+    .method public hidebysig instance int32 get_Tag() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -446,8 +427,7 @@
       IL_0017:  ret
     } 
 
-    .method assembly hidebysig specialname 
-            instance object  __DebugDisplay() cil managed
+    .method assembly hidebysig specialname instance object  __DebugDisplay() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -461,8 +441,7 @@
       IL_0015:  ret
     } 
 
-    .method public strict virtual instance string 
-            ToString() cil managed
+    .method public strict virtual instance string ToString() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
@@ -512,8 +491,7 @@
     } 
   } 
 
-  .method public static class MyTestModule/MyDu 
-          giveMeLabel() cil managed
+  .method public static class MyTestModule/MyDu giveMeLabel() cil managed
   {
     
     .maxstack  8
@@ -521,8 +499,7 @@
     IL_0005:  ret
   } 
 
-  .method public static class MyTestModule/MyDu 
-          createMaybeString(string innerValue) cil managed
+  .method public static class MyTestModule/MyDu createMaybeString(string innerValue) cil managed
   {
     .param [1]
     .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 02 00 00 ) 
@@ -660,8 +637,7 @@
     IL_0014:  ret
   } 
 
-  .method public hidebysig specialname instance class [runtime]System.Type 
-          get_Type() cil managed
+  .method public hidebysig specialname instance class [runtime]System.Type get_Type() cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -672,8 +648,7 @@
     IL_0006:  ret
   } 
 
-  .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes 
-          get_MemberType() cil managed
+  .method public hidebysig specialname instance valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes get_MemberType() cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -707,8 +682,7 @@
   .field public uint8[] NullableFlags
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-  .method public specialname rtspecialname 
-          instance void  .ctor(uint8 scalarByteValue) cil managed
+  .method public specialname rtspecialname instance void  .ctor(uint8 scalarByteValue) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -727,8 +701,7 @@
     IL_0016:  ret
   } 
 
-  .method public specialname rtspecialname 
-          instance void  .ctor(uint8[] NullableFlags) cil managed
+  .method public specialname rtspecialname instance void  .ctor(uint8[] NullableFlags) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -751,8 +724,7 @@
   .field public uint8 Flag
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-  .method public specialname rtspecialname 
-          instance void  .ctor(uint8 Flag) cil managed
+  .method public specialname rtspecialname instance void  .ctor(uint8 Flag) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/ReferenceDU.fs.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/ReferenceDU.fs.il.netcore.bsl
@@ -58,8 +58,7 @@
                                                                                                                                         44 65 62 75 67 54 79 70 65 50 72 6F 78 79 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = ( 01 00 15 7B 5F 5F 44 65 62 75 67 44 69 73 70 6C   
                                                                                                            61 79 28 29 2C 6E 71 7D 00 00 )                   
-      .method assembly specialname rtspecialname 
-              instance void  .ctor() cil managed
+      .method assembly specialname rtspecialname instance void  .ctor() cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -88,8 +87,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(int32 item) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(int32 item) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -106,8 +104,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance int32 
-              get_Item() cil managed
+      .method public hidebysig instance int32 get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -143,8 +140,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(string item) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(string item) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -161,8 +157,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance string 
-              get_Item() cil managed
+      .method public hidebysig instance string get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -194,8 +189,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname 
-              instance void  .ctor(class MyTestModule/MyDu/_JustLabel obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class MyTestModule/MyDu/_JustLabel obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -221,8 +215,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname 
-              instance void  .ctor(class MyTestModule/MyDu/JustInt obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class MyTestModule/MyDu/JustInt obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -239,8 +232,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance int32 
-              get_Item() cil managed
+      .method public hidebysig instance int32 get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -270,8 +262,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname 
-              instance void  .ctor(class MyTestModule/MyDu/MaybeString obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class MyTestModule/MyDu/MaybeString obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -288,8 +279,7 @@
         IL_000d:  ret
       } 
 
-      .method public hidebysig instance string 
-              get_Item() cil managed
+      .method public hidebysig instance string get_Item() cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -317,8 +307,7 @@
     .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-    .method private specialname rtspecialname static 
-            void  .cctor() cil managed
+    .method private specialname rtspecialname static void  .cctor() cil managed
     {
       
       .maxstack  8
@@ -327,8 +316,7 @@
       IL_000a:  ret
     } 
 
-    .method assembly specialname rtspecialname 
-            instance void  .ctor() cil managed
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
     {
       .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                               class [runtime]System.Type) = ( 01 00 E0 07 00 00 11 4D 79 54 65 73 74 4D 6F 64   
@@ -342,8 +330,7 @@
       IL_0006:  ret
     } 
 
-    .method public static class MyTestModule/MyDu 
-            get_JustLabel() cil managed
+    .method public static class MyTestModule/MyDu get_JustLabel() cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -353,8 +340,7 @@
       IL_0005:  ret
     } 
 
-    .method public hidebysig instance bool 
-            get_IsJustLabel() cil managed
+    .method public hidebysig instance bool get_IsJustLabel() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -367,8 +353,7 @@
       IL_0009:  ret
     } 
 
-    .method public static class MyTestModule/MyDu 
-            NewJustInt(int32 item) cil managed
+    .method public static class MyTestModule/MyDu NewJustInt(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 01 00 00 00 00 00 ) 
@@ -379,8 +364,7 @@
       IL_0006:  ret
     } 
 
-    .method public hidebysig instance bool 
-            get_IsJustInt() cil managed
+    .method public hidebysig instance bool get_IsJustInt() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -393,8 +377,7 @@
       IL_0009:  ret
     } 
 
-    .method public static class MyTestModule/MyDu 
-            NewMaybeString(string item) cil managed
+    .method public static class MyTestModule/MyDu NewMaybeString(string item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 02 00 00 00 00 00 ) 
@@ -407,8 +390,7 @@
       IL_0006:  ret
     } 
 
-    .method public hidebysig instance bool 
-            get_IsMaybeString() cil managed
+    .method public hidebysig instance bool get_IsMaybeString() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -421,8 +403,7 @@
       IL_0009:  ret
     } 
 
-    .method public hidebysig instance int32 
-            get_Tag() cil managed
+    .method public hidebysig instance int32 get_Tag() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -446,8 +427,7 @@
       IL_0017:  ret
     } 
 
-    .method assembly hidebysig specialname 
-            instance object  __DebugDisplay() cil managed
+    .method assembly hidebysig specialname instance object  __DebugDisplay() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -461,8 +441,7 @@
       IL_0015:  ret
     } 
 
-    .method public strict virtual instance string 
-            ToString() cil managed
+    .method public strict virtual instance string ToString() cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
@@ -512,8 +491,7 @@
     } 
   } 
 
-  .method public static class MyTestModule/MyDu 
-          giveMeLabel() cil managed
+  .method public static class MyTestModule/MyDu giveMeLabel() cil managed
   {
     
     .maxstack  8
@@ -521,8 +499,7 @@
     IL_0005:  ret
   } 
 
-  .method public static class MyTestModule/MyDu 
-          createMaybeString(string innerValue) cil managed
+  .method public static class MyTestModule/MyDu createMaybeString(string innerValue) cil managed
   {
     .param [1]
     .custom instance void [runtime]System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 02 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/Language/NullableReferenceTypesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/NullableReferenceTypesTests.fs
@@ -32,9 +32,13 @@ let nonStrictFunc(x:string | null) = strictFunc(x)
 [<Theory>]
 [<InlineData("fileExists(path)")>]
 [<InlineData("fileExists path")>]
+[<InlineData("fileExists null")>]
 [<InlineData("path |> fileExists")>]
+[<InlineData("null |> fileExists")>]
 [<InlineData("System.IO.File.Exists(path)")>]
+[<InlineData("System.IO.File.Exists(null)")>]
 [<InlineData("path |> System.IO.File.Exists")>]
+[<InlineData("null |> System.IO.File.Exists")>]
 [<InlineData("System.String.IsNullOrEmpty(path)")>]
 let ``Calling a nullAllowing API can still infer a withoutNull type``(functionCall) =
     FSharp $"""
@@ -46,6 +50,19 @@ let fileExists (path:string|null) = true
 let myStringReturningFunc (path) = 
     let ex = {functionCall}
     myStrictFunc(path)
+    """
+    |> asLibrary
+    |> typeCheckWithStrictNullness
+    |> shouldSucceed
+
+//[<Fact>]
+// TODO Tomas - as of now, this does not bring the desired result
+let ``Type inference with underscore or null`` () =
+    FSharp $"""
+module MyLib
+
+let myFunc (path: _ | null) =
+    System.IO.File.Exists(path)
     """
     |> asLibrary
     |> typeCheckWithStrictNullness

--- a/tests/FSharp.Compiler.ComponentTests/Language/NullableReferenceTypesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/NullableReferenceTypesTests.fs
@@ -36,7 +36,6 @@ let nonStrictFunc(x:string | null) = strictFunc(x)
 [<InlineData("System.IO.File.Exists(path)")>]
 [<InlineData("path |> System.IO.File.Exists")>]
 [<InlineData("System.String.IsNullOrEmpty(path)")>]
-[<InlineData("(null) = (path)")>]
 let ``Calling a nullAllowing API can still infer a withoutNull type``(functionCall) =
     FSharp $"""
 module MyLib
@@ -71,15 +70,12 @@ let myFunc path : string =
 
 [<Fact>]
 let ``Type inference fsharp func`` () =
-    FSharp $"""
-module MyLib
+    FSharp $"""module MyLib
 
-let myStrictFunc(x: string) = x.GetHashCode()
 let fileExists (path:string|null) = true
-
-let myStringReturningFunc (path) = 
-    let ex = fileExists path
-    myStrictFunc(path)
+let myStringReturningFunc (pathArg) : string = 
+    let ex = pathArg |> fileExists
+    pathArg
     """
     |> asLibrary
     |> typeCheckWithStrictNullness

--- a/tests/FSharp.Compiler.ComponentTests/Language/NullableReferenceTypesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/NullableReferenceTypesTests.fs
@@ -14,7 +14,7 @@ let withNullnessOptions cu =
 let typeCheckWithStrictNullness cu =
     cu
     |> withNullnessOptions
-    |> typecheck
+    |> compile
     
 [<Fact>]
 let ``Cannot pass possibly null value to a strict function``() =

--- a/tests/adhoc/nullness/enabled/positive.fs
+++ b/tests/adhoc/nullness/enabled/positive.fs
@@ -92,10 +92,10 @@ module KonsoleWithNullsModule =
     let WriteLineC2(fmt: C | null, arg1: C | null) = Console.WriteLine(fmt.Value, arg1.Value)
 
 module KonsoleWithNullsModule2 = 
-    let WriteLine x = KonsoleWithNullsModule.WriteLine x
-    let WriteLine2 (fmt, arg1) = KonsoleWithNullsModule.WriteLine2(fmt, arg1)
-    let WriteLineC(s) = KonsoleWithNullsModule.WriteLineC(s)
-    let WriteLineC2(fmt, arg1) = KonsoleWithNullsModule.WriteLineC2(fmt, arg1)
+    let WriteLine (x : string | null) = KonsoleWithNullsModule.WriteLine x
+    let WriteLine2 (fmt: string | null, arg1: string | null) = KonsoleWithNullsModule.WriteLine2(fmt, arg1)
+    let WriteLineC(s: _ | null) = KonsoleWithNullsModule.WriteLineC(s)
+    let WriteLineC2(fmt: _ | null, arg1: _ | null) = KonsoleWithNullsModule.WriteLineC2(fmt, arg1)
 
 type KonsoleNoNulls = 
     static member WriteLine(s: String) = Console.WriteLine(s)

--- a/tests/adhoc/nullness/out.fsi
+++ b/tests/adhoc/nullness/out.fsi
@@ -236,14 +236,18 @@ module KonsoleWithNullsModule =
 
 module KonsoleWithNullsModule2 =
     
-    val WriteLine: x: System.String | null -> unit
+    val WriteLine: x: string | null -> unit
     
-    val WriteLine2:
-      fmt: System.String | null * arg1: System.String | null -> unit
+    val WriteLine2: fmt: string | null * arg1: string | null -> unit
     
-    val WriteLineC: s: C | null -> unit
+    val WriteLineC:
+      s: 'a | null -> unit
+        when 'a: not null and 'a: not struct and 'a :> C | null
     
-    val WriteLineC2: fmt: C | null * arg1: C | null -> unit
+    val WriteLineC2:
+      fmt: 'a | null * arg1: 'b | null -> unit
+        when 'a: not null and 'a: not struct and 'a :> C | null and 'b: not null and
+             'b: not struct and 'b :> C | null
 
 [<Class>]
 type KonsoleNoNulls =

--- a/tests/fsharp/core/printing/output.1000.stdout.bsl
+++ b/tests/fsharp/core/printing/output.1000.stdout.bsl
@@ -1517,7 +1517,7 @@ module Test4343e =
     val dB: D<int> = D(2)
     val dAB: D<int> * D<int> * D<int> list = (D(1), D(2), [D(1); D(2)])
     val dC: D<bool> = D(True)
-    val boxed_dABC: obj list = [D(1); D(2); D(True)]
+    val boxed_dABC: objnull list = [D(1); D(2); D(True)]
 type F1 =
   inherit System.Windows.Forms.Form
   interface System.IDisposable

--- a/tests/fsharp/core/printing/output.200.stdout.bsl
+++ b/tests/fsharp/core/printing/output.200.stdout.bsl
@@ -762,7 +762,7 @@ module Test4343e =
     val dB: D<int> = D(2)
     val dAB: D<int> * D<int> * D<int> list = (D(1), D(2), [D(1); D(2)])
     val dC: D<bool> = D(True)
-    val boxed_dABC: obj list = [D(1); D(2); D(True)]
+    val boxed_dABC: objnull list = [D(1); D(2); D(True)]
 type F1 =
   inherit System.Windows.Forms.Form
   interface System.IDisposable

--- a/tests/fsharp/core/printing/output.47.stdout.bsl
+++ b/tests/fsharp/core/printing/output.47.stdout.bsl
@@ -5062,7 +5062,7 @@ module Test4343e =
     val dB: D<int> = D(2)
     val dAB: D<int> * D<int> * D<int> list = (D(1), D(2), [D(1); D(2)])
     val dC: D<bool> = D(True)
-    val boxed_dABC: obj list = [D(1); D(2); D(True)]
+    val boxed_dABC: objnull list = [D(1); D(2); D(True)]
 type F1 =
   inherit System.Windows.Forms.Form
   interface System.IDisposable

--- a/tests/fsharp/core/printing/output.multiemit.stdout.bsl
+++ b/tests/fsharp/core/printing/output.multiemit.stdout.bsl
@@ -5064,7 +5064,7 @@ module Test4343e =
     val dB: D<int> = D(2)
     val dAB: D<int> * D<int> * D<int> list = (D(1), D(2), [D(1); D(2)])
     val dC: D<bool> = D(True)
-    val boxed_dABC: obj list = [D(1); D(2); D(True)]
+    val boxed_dABC: objnull list = [D(1); D(2); D(True)]
 type F1 =
   inherit System.Windows.Forms.Form
   interface System.IDisposable

--- a/tests/fsharp/core/printing/output.off.stdout.bsl
+++ b/tests/fsharp/core/printing/output.off.stdout.bsl
@@ -548,7 +548,7 @@ module Test4343e =
     val dB: D<int>
     val dAB: D<int> * D<int> * D<int> list
     val dC: D<bool>
-    val boxed_dABC: obj list
+    val boxed_dABC: objnull list
 type F1 =
   inherit System.Windows.Forms.Form
   interface System.IDisposable

--- a/tests/fsharp/core/printing/output.stdout.bsl
+++ b/tests/fsharp/core/printing/output.stdout.bsl
@@ -5064,7 +5064,7 @@ module Test4343e =
     val dB: D<int> = D(2)
     val dAB: D<int> * D<int> * D<int> list = (D(1), D(2), [D(1); D(2)])
     val dC: D<bool> = D(True)
-    val boxed_dABC: obj list = [D(1); D(2); D(True)]
+    val boxed_dABC: objnull list = [D(1); D(2); D(True)]
 type F1 =
   inherit System.Windows.Forms.Form
   interface System.IDisposable

--- a/tests/fsharp/typecheck/sigs/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/neg20.bsl
@@ -147,7 +147,7 @@ neg20.fs(167,13,167,31): typecheck error FS0502: The member or object constructo
 
 neg20.fs(182,14,182,31): typecheck error FS0041: No overloads match for method 'M'.
 
-Known types of arguments: string * obj
+Known types of arguments: string * objnull
 
 Available overloads:
  - static member C2.M: fmt: string * [<System.ParamArray>] args: int array -> string // Argument 'args' doesn't match
@@ -156,12 +156,12 @@ Available overloads:
 neg20.fs(183,29,183,34): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(183,35,183,40): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(183,14,183,41): typecheck error FS0193: Type constraint mismatch. The type 
     'string'    
@@ -172,16 +172,16 @@ is not compatible with type
 neg20.fs(184,28,184,33): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(184,34,184,39): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(188,14,188,31): typecheck error FS0041: No overloads match for method 'M'.
 
-Known types of arguments: string * obj
+Known types of arguments: string * objnull
 
 Available overloads:
  - static member C3.M: fmt: string * [<System.ParamArray>] args: string array -> string // Argument 'args' doesn't match
@@ -190,12 +190,12 @@ Available overloads:
 neg20.fs(189,29,189,34): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(189,35,189,40): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(189,14,189,41): typecheck error FS0193: Type constraint mismatch. The type 
     'string'    
@@ -206,12 +206,12 @@ is not compatible with type
 neg20.fs(190,28,190,33): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(190,34,190,39): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(195,5,195,10): typecheck error FS0842: This attribute is not valid for use on this language element
 

--- a/tests/fsharp/typecheck/sigs/version50/neg20.bsl
+++ b/tests/fsharp/typecheck/sigs/version50/neg20.bsl
@@ -197,7 +197,7 @@ neg20.fs(167,13,167,31): typecheck error FS0502: The member or object constructo
 
 neg20.fs(182,14,182,31): typecheck error FS0041: No overloads match for method 'M'.
 
-Known types of arguments: string * obj
+Known types of arguments: string * objnull
 
 Available overloads:
  - static member C2.M: fmt: string * [<System.ParamArray>] args: int array -> string // Argument 'args' doesn't match
@@ -206,12 +206,12 @@ Available overloads:
 neg20.fs(183,29,183,34): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(183,35,183,40): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(183,14,183,41): typecheck error FS0001: This expression was expected to have type
     'unit'    
@@ -221,16 +221,16 @@ but here has type
 neg20.fs(184,28,184,33): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(184,34,184,39): typecheck error FS0001: This expression was expected to have type
     'int'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(188,14,188,31): typecheck error FS0041: No overloads match for method 'M'.
 
-Known types of arguments: string * obj
+Known types of arguments: string * objnull
 
 Available overloads:
  - static member C3.M: fmt: string * [<System.ParamArray>] args: string array -> string // Argument 'args' doesn't match
@@ -239,12 +239,12 @@ Available overloads:
 neg20.fs(189,29,189,34): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(189,35,189,40): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(189,14,189,41): typecheck error FS0001: This expression was expected to have type
     'unit'    
@@ -254,12 +254,12 @@ but here has type
 neg20.fs(190,28,190,33): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(190,34,190,39): typecheck error FS0001: This expression was expected to have type
     'string'    
 but here has type
-    'obj'    
+    'objnull'    
 
 neg20.fs(195,5,195,10): typecheck error FS0842: This attribute is not valid for use on this language element
 

--- a/tests/service/PatternMatchCompilationTests.fs
+++ b/tests/service/PatternMatchCompilationTests.fs
@@ -367,12 +367,12 @@ match box 1 with
 """
     assertHasSymbolUsages (List.map string ['a'..'j']) checkResults
     dumpDiagnostics checkResults |> shouldEqual [
-        "(5,34--5,35): The type 'obj' does not support the operator '+'"
-        "(5,32--5,33): The type 'obj' does not support the operator '+'"
-        "(7,45--7,46): The type 'obj' does not match the type 'uint64'"
-        "(7,43--7,44): The type 'obj' does not match the type 'uint64'"
-        "(8,43--8,44): The type 'obj' does not match the type 'int8'"
-        "(8,41--8,42): The type 'obj' does not match the type 'int8'"
+        "(5,34--5,35): The type 'objnull' does not support the operator '+'"
+        "(5,32--5,33): The type 'objnull' does not support the operator '+'"
+        "(7,45--7,46): The type 'objnull' does not match the type 'uint64'"
+        "(7,43--7,44): The type 'objnull' does not match the type 'uint64'"
+        "(8,43--8,44): The type 'objnull' does not match the type 'int8'"
+        "(8,41--8,42): The type 'objnull' does not match the type 'int8'"
         "(3,6--3,11): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s)."
     ]
 
@@ -830,7 +830,7 @@ Some x |> eq<obj>
 """
     assertHasSymbolUsages (List.map string ['a'..'z']) checkResults
     dumpDiagnostics checkResults |> shouldEqual [
-        "(11,25--11,26): This expression was expected to have type\u001d    'int'    \u001dbut here has type\u001d    'obj'";
+        "(11,25--11,26): This expression was expected to have type\u001d    'int'    \u001dbut here has type\u001d    'objnull'";
         "(28,6--28,24): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).";
         "(26,6--26,12): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).";
         "(24,6--24,12): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).";
@@ -1039,8 +1039,8 @@ Some "" |> eq<int> // No more type checks after the above line?
 """
     assertHasSymbolUsages (Set.toList validSet) checkResults
     dumpDiagnostics checkResults |> shouldEqual [
-        "(27,2--27,14): This expression was expected to have type\u001d    'obj'    \u001dbut here has type\u001d    'struct ('a * 'b)'";
-        "(52,2--52,13): This expression was expected to have type\u001d    'obj'    \u001dbut here has type\u001d    'AAA'";
+        "(27,2--27,14): This expression was expected to have type\u001d    'objnull'    \u001dbut here has type\u001d    'struct ('a * 'b)'";
+        "(52,2--52,13): This expression was expected to have type\u001d    'objnull'    \u001dbut here has type\u001d    'AAA'";
         "(26,6--26,24): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).";
         "(24,6--24,12): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).";
         "(22,6--22,12): Incomplete pattern matches on this expression. For example, the value '``some-other-subtype``' may indicate a case not covered by the pattern(s).";
@@ -1124,10 +1124,10 @@ Some "" |> eq<int>
 """
     assertHasSymbolUsages (set ['a'..'y'] - set [ 'm'..'r' ] |> Set.map string |> Set.toList) checkResults
     dumpDiagnostics checkResults |> shouldEqual [
-        "(19,2--19,4): This expression was expected to have type\u001d    'obj'    \u001dbut here has type\u001d    'int'";
-        "(21,2--21,7): This expression was expected to have type\u001d    'obj'    \u001dbut here has type\u001d    'bool'";
-        "(23,2--23,6): This expression was expected to have type\u001d    'obj'    \u001dbut here has type\u001d    'bool'";
-        "(28,28--28,29): The type 'obj' does not match the type 'int'";
+        "(19,2--19,4): This expression was expected to have type\u001d    'objnull'    \u001dbut here has type\u001d    'int'";
+        "(21,2--21,7): This expression was expected to have type\u001d    'objnull'    \u001dbut here has type\u001d    'bool'";
+        "(23,2--23,6): This expression was expected to have type\u001d    'objnull'    \u001dbut here has type\u001d    'bool'";
+        "(28,28--28,29): The type 'objnull' does not match the type 'int'";
         "(41,5--41,6): The value or constructor 'm' is not defined.";
         "(42,5--42,6): The value or constructor 'n' is not defined.";
         "(43,5--43,6): The value or constructor 'o' is not defined.";

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -261,7 +261,7 @@ type UsingMSBuild() =
         """
         let expectedTooltip = """
 type Async =
-  static member AsBeginEnd: computation: ('Arg -> Async<'T>) -> ('Arg * AsyncCallback * obj -> IAsyncResult) * (IAsyncResult -> 'T) * (IAsyncResult -> unit)
+  static member AsBeginEnd: computation: ('Arg -> Async<'T>) -> ('Arg * AsyncCallback * objnull -> IAsyncResult) * (IAsyncResult -> 'T) * (IAsyncResult -> unit)
   static member AwaitEvent: event: IEvent<'Del,'T> * ?cancelAction: (unit -> unit) -> Async<'T> (requires delegate and 'Del :> Delegate)
   static member AwaitIAsyncResult: iar: IAsyncResult * ?millisecondsTimeout: int -> Async<bool>
   static member AwaitTask: task: Task<'T> -> Async<'T> + 1 overload
@@ -269,7 +269,7 @@ type Async =
   static member CancelDefaultToken: unit -> unit
   static member Catch: computation: Async<'T> -> Async<Choice<'T,exn>>
   static member Choice: computations: Async<'T option> seq -> Async<'T option>
-  static member FromBeginEnd: beginAction: (AsyncCallback * obj -> IAsyncResult) * endAction: (IAsyncResult -> 'T) * ?cancelAction: (unit -> unit) -> Async<'T> + 3 overloads
+  static member FromBeginEnd: beginAction: (AsyncCallback * objnull -> IAsyncResult) * endAction: (IAsyncResult -> 'T) * ?cancelAction: (unit -> unit) -> Async<'T> + 3 overloads
   static member FromContinuations: callback: (('T -> unit) * (exn -> unit) * (OperationCanceledException -> unit) -> unit) -> Async<'T>
   ...
 Full name: Microsoft.FSharp.Control.Async""".TrimStart().Replace("\r\n", "\n")


### PR DESCRIPTION
Apply nullness annotations to FSharp.Core everywhere where it deals with `obj`.
This is by far the biggest user of potential nulls (reflection, queries, quotations, printing,..).

A separate follow up will be other types, apart from `obj` usages of arrays are the next bigger candidate.


The chosen approach is to use a conditional type alias `objnull`, which becomes part of the F#-visible API surface. It gets erased from IL code, but is kept in signature data and therefore users of FSharp.Core will see it.
The reason is to keep the codebase sane and only have one conditional around `obj | null` and not to have it around every single usage.