### PR TITLE
Address vsix package creation change

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -152,7 +152,7 @@
     <MicrosoftVisualStudioProjectSystemVersion>$(VisualStudioProjectSystemPackagesVersion)</MicrosoftVisualStudioProjectSystemVersion>
     <MicrosoftVisualStudioProjectSystemManagedVersion>2.3.6152103</MicrosoftVisualStudioProjectSystemManagedVersion>
     <!-- Misc. Visual Studio packages -->
-    <MicrosoftVSSDKBuildToolsVersion>17.1.4054</MicrosoftVSSDKBuildToolsVersion>
+    <MicrosoftVSSDKBuildToolsVersion>17.10.2179</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftVisualStudioRpcContractsVersion>17.7.3-preview</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioValidationVersion>17.6.11</MicrosoftVisualStudioValidationVersion>

--- a/vsintegration/Vsix/Directory.Build.props
+++ b/vsintegration/Vsix/Directory.Build.props
@@ -15,6 +15,7 @@
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <IncludeCopyLocalReferencesInVSIXContainer>false</IncludeCopyLocalReferencesInVSIXContainer>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <IsWebBootstrapper>false</IsWebBootstrapper>


### PR DESCRIPTION
Fixes:   https://github.com/dotnet/fsharp/issues/17279

Recently we updated the microsoft.vssdk.buildtools nuget package that we use in the build, the one we originally referenced was really quite old.

This change caused us to fail some validation steps when inserting into the Visual Studio.  The failure happened because a change in the VSSDK vsix package generation code changed, to include additional unnecessary .dlls in the generated .vsix file.

We had a short term fix that reverted the vssdk bnuget package we use.  Here is the final fix, this uses the latest shipped release vssdk package and sets a property to stop the extra .dlls being shipped in the .vsix.

