### PR TITLE
source-build: don't use PublishReadyToRun on Mono-builds.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,13 @@
     <OtherFlags Condition="'$(BuildNoRealsig)' != 'true'">$(OtherFlags) --realsig+</OtherFlags>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Set PublishReadyToRun to speed up the build. -->
+    <EnablePublishReadyToRun>true</EnablePublishReadyToRun>
+    <!-- Crossgen2 is not built with source-built Mono-based .NET SDKs. -->
+    <EnablePublishReadyToRun Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">false</EnablePublishReadyToRun>
+  </PropertyGroup>
+
   <Import Project="$(RepoRoot)/Directory.Build.props.user" Condition="Exists('$(RepoRoot)/Directory.Build.props.user')" />
 
   <PropertyGroup Condition="'$(BUILDING_USING_DOTNET)' == 'true'">

--- a/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRun>$(EnablePublishReadyToRun)</PublishReadyToRun>
     <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/buildtools/fslex/fslex.fsproj
+++ b/buildtools/fslex/fslex.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRun>$(EnablePublishReadyToRun)</PublishReadyToRun>
     <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/buildtools/fsyacc/fsyacc.fsproj
+++ b/buildtools/fsyacc/fsyacc.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRun>$(EnablePublishReadyToRun)</PublishReadyToRun>
     <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -40,7 +40,7 @@
          -bl enables the binlogs for the tools and Proto builds, which make debugging failures here easier
     -->
     <Exec
-      Command="./build.sh --bootstrap --skipBuild -bl $(SourceBuildBootstrapTfmArg)"
+      Command="./build.sh --bootstrap --skipBuild -bl $(SourceBuildBootstrapTfmArg) /p:SourceBuildUseMonoRuntime=$(SourceBuildUseMonoRuntime)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv);DotNetBuildFromSource=true" />
   </Target>

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -279,7 +279,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto /p:ArcadeBuildFromSource=$source_build"
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto /p:ArcadeBuildFromSource=$source_build $properties"
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi

--- a/src/fsc/fscProject/fsc.fsproj
+++ b/src/fsc/fscProject/fsc.fsproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Proto'">
     <TargetFramework>$(FSharpNetCoreProductTargetFramework)</TargetFramework>
-    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRun>$(EnablePublishReadyToRun)</PublishReadyToRun>
     <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/fsi/fsiProject/fsi.fsproj
+++ b/src/fsi/fsiProject/fsi.fsproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Proto'">
     <TargetFramework>$(FSharpNetCoreProductTargetFramework)</TargetFramework>
-    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRun>$(EnablePublishReadyToRun)</PublishReadyToRun>
     <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
   </PropertyGroup>
 


### PR DESCRIPTION
Crossgen2 is not built with Mono-based .NET SDKs.

Fixes https://github.com/dotnet/source-build/issues/4463.

@ViktorHofer @KevinRansom @MichaelSimons ptal

cc @omajid