### PR TITLE
These don't belong here

### DIFF
--- a/src/Compiler/Interactive/fsihelp.fs
+++ b/src/Compiler/Interactive/fsihelp.fs
@@ -1,9 +1,5 @@
 module FSharp.Compiler.Interactive.FsiHelp
 
-[<assembly: System.Runtime.InteropServices.ComVisible(false)>]
-[<assembly: System.CLSCompliant(true)>]
-do ()
-
 open System
 open System.Collections.Generic
 open System.IO


### PR DESCRIPTION
A recent PR added a couple of unnecessary assemblylevel attributes, in a file they shouldn't be in.

This PR removes them.