### PR TITLE
Parameterize configuration in Microsoft.FSharp.Compiler.nuspec

### DIFF
--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -25,6 +25,7 @@
     <NuspecProperty Include="fSharpCompilerServicePackageVersion=$(FSharpCompilerServicePackageVersion)" />
     <NuspecProperty Include="artifactsPackagesDir=$(ArtifactsPackagesDir)" />
     <NuspecProperty Include="fSharpNetCoreProductTargetFramework=$(FSharpNetCoreProductTargetFramework)" />
+    <NuspecProperty Include="configuration=$(Configuration)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -26,33 +26,33 @@
             this approach gives a very small deployment. Which is kind of necessary.
         -->
         <!-- assemblies -->
-        <file src="fsc\Release\$fSharpNetCoreProductTargetFramework$\fsc.dll"                      target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="fsi\Release\$fSharpNetCoreProductTargetFramework$\fsi.dll"                      target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Core\Release\netstandard2.0\FSharp.Core.dll"                             target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Core\Release\netstandard2.0\FSharp.Core.xml"                             target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Compiler.Service\Release\netstandard2.0\FSharp.Compiler.Service.dll"     target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Build\Release\netstandard2.0\FSharp.Build.dll"                           target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.DependencyManager.Nuget\Release\netstandard2.0\FSharp.DependencyManager.Nuget.dll"
+        <file src="fsc\$configuration$\$fSharpNetCoreProductTargetFramework$\fsc.dll"                      target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="fsi\$configuration$\$fSharpNetCoreProductTargetFramework$\fsi.dll"                      target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="FSharp.Core\$configuration$\netstandard2.0\FSharp.Core.dll"                             target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="FSharp.Core\$configuration$\netstandard2.0\FSharp.Core.xml"                             target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="FSharp.Compiler.Service\$configuration$\netstandard2.0\FSharp.Compiler.Service.dll"     target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\FSharp.Build.dll"                           target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="FSharp.DependencyManager.Nuget\$configuration$\netstandard2.0\FSharp.DependencyManager.Nuget.dll"
                                                                                                              target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Compiler.Interactive.Settings\Release\netstandard2.0\FSharp.Compiler.Interactive.Settings.dll"
+        <file src="FSharp.Compiler.Interactive.Settings\$configuration$\netstandard2.0\FSharp.Compiler.Interactive.Settings.dll"
                                                                                                              target="lib\$fSharpNetCoreProductTargetFramework$" />
         <!-- additional files -->
-        <file src="FSharp.Compiler.Service\Release\netstandard2.0\default.win32manifest"                     target="contentFiles\any\any" />
-        <file src="FSharp.Build\Release\netstandard2.0\Microsoft.FSharp.Targets"                             target="contentFiles\any\any" />
-        <file src="FSharp.Build\Release\netstandard2.0\Microsoft.Portable.FSharp.Targets"                    target="contentFiles\any\any" />
-        <file src="FSharp.Build\Release\netstandard2.0\Microsoft.FSharp.NetSdk.props"                        target="contentFiles\any\any" />
-        <file src="FSharp.Build\Release\netstandard2.0\Microsoft.FSharp.NetSdk.targets"                      target="contentFiles\any\any" />
-        <file src="FSharp.Build\Release\netstandard2.0\Microsoft.FSharp.Overrides.NetSdk.targets"            target="contentFiles\any\any" />
+        <file src="FSharp.Compiler.Service\$configuration$\netstandard2.0\default.win32manifest"                     target="contentFiles\any\any" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.Targets"                             target="contentFiles\any\any" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Microsoft.Portable.FSharp.Targets"                    target="contentFiles\any\any" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.NetSdk.props"                        target="contentFiles\any\any" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.NetSdk.targets"                      target="contentFiles\any\any" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Microsoft.FSharp.Overrides.NetSdk.targets"            target="contentFiles\any\any" />
 
         <!-- resources -->
-        <file src="FSharp.Core\Release\netstandard2.0\**\FSharp.Core.resources.dll"
+        <file src="FSharp.Core\$configuration$\netstandard2.0\**\FSharp.Core.resources.dll"
                                                                                                              target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Compiler.Service\Release\netstandard2.0\**\FSharp.Compiler.Service.resources.dll"
+        <file src="FSharp.Compiler.Service\$configuration$\netstandard2.0\**\FSharp.Compiler.Service.resources.dll"
                                                                                                              target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Compiler.Interactive.Settings\Release\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"
+        <file src="FSharp.Compiler.Interactive.Settings\$configuration$\netstandard2.0\**\FSharp.Compiler.Interactive.Settings.resources.dll"
                                                                                                              target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.Build\Release\netstandard2.0\**\FSharp.Build.resources.dll"                        target="lib\$fSharpNetCoreProductTargetFramework$" />
-        <file src="FSharp.DependencyManager.Nuget\Release\netstandard2.0\**\FSharp.DependencyManager.Nuget.resources.dll"
+        <file src="FSharp.Build\$configuration$\netstandard2.0\**\FSharp.Build.resources.dll"                        target="lib\$fSharpNetCoreProductTargetFramework$" />
+        <file src="FSharp.DependencyManager.Nuget\$configuration$\netstandard2.0\**\FSharp.DependencyManager.Nuget.resources.dll"
                                                                                                              target="lib\$fSharpNetCoreProductTargetFramework$" />
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"                           target="contentFiles\Shipping" />
@@ -61,7 +61,7 @@
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"    target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Release" />
 
-        <file src="FSharp.Build\Release\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"                                         target="contentFiles\Shipping" />
-        <file src="FSharp.Build\Release\netstandard2.0\Release\Microsoft.FSharp.Core.NetSdk.props"                                          target="contentFiles\Release" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"                                         target="contentFiles\Shipping" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\Release\Microsoft.FSharp.Core.NetSdk.props"                                          target="contentFiles\Release" />
     </files>
 </package>


### PR DESCRIPTION

Fix: #https://github.com/dotnet/fsharp/issues/17312

Microsoft.FSharp.Compiler.nuspec did not paramaterize the files it places in the nuget file.  So you had to have done a release build for it to correctly build with the pack switch.

This fixes that, by using $configuration$ and setting that in the project file.