### PR TITLE
Bump to macos-12 build image

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -507,7 +507,7 @@ stages:
         # MacOS
         - job: MacOS
           pool:
-            vmImage: macos-11
+            vmImage: macos-12
           variables:
           - name: _SignType
             value: Test
@@ -642,7 +642,7 @@ stages:
         # Plain FCS build Mac
         - job: Plain_Build_MacOS
           pool:
-            vmImage: macos-11
+            vmImage: macos-12
           variables:
           - name: _BuildConfig
             value: Debug


### PR DESCRIPTION
## Description

AzDO will remove macos-11 in about two weeks: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#recent-updates
