### PR TITLE
Remove invalid attributes

### DIFF
--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -58,7 +58,6 @@ type SemanticClassificationType =
     | TypeDef = 35
     | Plaintext = 36
 
-[<RequireQualifiedAccess>]
 [<Struct>]
 type SemanticClassificationItem =
     val Range: range

--- a/src/Compiler/Service/SemanticClassification.fsi
+++ b/src/Compiler/Service/SemanticClassification.fsi
@@ -49,7 +49,6 @@ type SemanticClassificationType =
     | TypeDef = 35
     | Plaintext = 36
 
-[<RequireQualifiedAccess>]
 [<Struct>]
 type SemanticClassificationItem =
     val Range: range

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -15,7 +15,6 @@ open System.Runtime.CompilerServices
 type InterruptibleLazy<'T> private (value, valueFactory: unit -> 'T) =
     let syncObj = obj ()
 
-    [<VolatileField>]
     let mutable valueFactory = valueFactory
 
     let mutable value = value

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -475,7 +475,6 @@ type ProjectRequest = ProjectAction * AsyncReplyChannel<SyntheticProject>
 
 type FuzzingEvent = StartedChecking | FinishedChecking of bool | AbortedChecking of string | ModifiedImplFile | ModifiedSigFile
 
-[<RequireQualifiedAccess>]
 type SignatureFiles = Yes = 1 | No = 2 | Some = 3
 
 let fuzzingTest seed (project: SyntheticProject) = task {

--- a/tests/service/data/TestTP/ProvidedTypes.fs
+++ b/tests/service/data/TestTP/ProvidedTypes.fs
@@ -3220,7 +3220,6 @@ module internal AssemblyReader =
           systemRuntimeScopeRef: ILScopeRef }
         override __.ToString() = "<ILGlobals>"
 
-    [<AutoOpen>]
     [<Struct>]
     type ILTableName(idx: int) =
         member __.Index = idx


### PR DESCRIPTION
## Description

When adding `<LangVersion>preview</LangVersion>`, these attributes give an `error FS0842: This attribute is not valid for use on this language element`.

//cc @edgarfgp 

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**