### PR TITLE
Add dependencies for System libraries that need to be lifted in the source-build / VMR context

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -28,6 +28,10 @@
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
     </Dependency>
+    <Dependency Name="System.Reflection.Metadata" Version="8.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24311.3">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,28 @@
       <Sha>4642f9b75b588565642dd00dabcfedfe67ca106f</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.11.0-preview-24178-03">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
+      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.Build" Version="17.11.0-preview-24178-03">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Framework" Version="17.11.0-preview-24178-03">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.11.0-preview-24178-03">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.11.0-preview-24178-03">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24311.3">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -36,6 +36,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
+    <Dependency Name="System.Threading.Tasks.Dataflow" Version="8.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24311.3">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -32,6 +32,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
+    <Dependency Name="System.Collections.Immutable" Version="8.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24311.3">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,28 +6,6 @@
       <Sha>4642f9b75b588565642dd00dabcfedfe67ca106f</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.11.0-preview-24178-03">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
-      <SourceBuild RepoName="msbuild" ManagedOnly="true" />
-    </Dependency>
-    <Dependency Name="Microsoft.Build" Version="17.11.0-preview-24178-03">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Build.Framework" Version="17.11.0-preview-24178-03">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.11.0-preview-24178-03">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.11.0-preview-24178-03">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>2d02daa886f279e2ee749cad03db4b1b75bb9adb</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24311.3">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,8 +97,7 @@
     <MicrosoftVisualStudioShellPackagesVersion>17.10.40152</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.10.526-pre-g1b474069f5</VisualStudioProjectSystemPackagesVersion>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.10.41</MicrosoftVisualStudioThreadingPackagesVersion>
-    <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
-    <!-- -->
+    <MicrosoftBuildVersion>17.11.0-preview-24178-03</MicrosoftBuildVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesTextVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -91,14 +91,13 @@
     <SystemThreadingTasksDataflow>$(SystemPackageVersionVersion)</SystemThreadingTasksDataflow>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
-    <!-- -->
     <!-- Versions for package groups -->
     <RoslynVersion>4.11.0-2.24264.2</RoslynVersion>
     <VisualStudioEditorPackagesVersion>17.10.191</VisualStudioEditorPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.10.40152</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.10.526-pre-g1b474069f5</VisualStudioProjectSystemPackagesVersion>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.10.41</MicrosoftVisualStudioThreadingPackagesVersion>
-    <MicrosoftBuildVersion>17.11.0-preview-24178-03</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
     <!-- -->
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4477

Source-build lifts the MSBuild package versions to the N-1 (previously produced assets) but fsharp pins the System.Reflection.Metadata (and similar System libs) version which is a transitive dependency to 8.0.0. That results in a package downgrade error. Define a dependency for System.Reflection.Metadata (and other System libs) so that source-build can lift that version as well.