### PR TITLE
Skip another flaky transparent compiler test

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -1013,7 +1013,7 @@ printfn "Hello from F#"
         checkFile "As 01" expectTwoWarnings
     }
 
-[<Fact>]
+[<Fact(Skip="Flaky. See https://github.com/dotnet/fsharp/issues/16766")>]
 let ``Transparent Compiler ScriptClosure cache is populated after GetProjectOptionsFromScript`` () =
     async {
         let transparentChecker = FSharpChecker.Create(useTransparentCompiler = true)


### PR DESCRIPTION
Failed [here](https://dev.azure.com/dnceng-public/public/_build/results?buildId=719552&view=ms.vss-test-web.build-test-results-tab&runId=18036952&resultId=100761&paneView=debug).
Related issue: https://github.com/dotnet/fsharp/issues/16766