### PR TITLE
Set ReflectionFree if PublishAot is set, and delay that decision until after the project file has been loaded.

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -49,7 +49,6 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <WarningsAsErrors>3239;$(WarningsAsErrors)</WarningsAsErrors>
     <UseStandardResourceNames Condition=" '$(UseStandardResourceNames)' == '' ">true</UseStandardResourceNames>
     <FsiExec Condition=" '$(FsiExec)' == '' ">true</FsiExec>
-    <ReflectionFree Condition=" '$(ReflectionFree)' == '' ">false</ReflectionFree>
   </PropertyGroup>
 
   <!-- BinaryFormatter is disabled (warning is treated as error) by default in .NET8+, this mirroring the change in SDK (https://github.com/dotnet/sdk/pull/31591) -->

--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -25,6 +25,11 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <DefineCommonCapabilities Condition=" '$(DefineCommonCapabilities)' == '' ">true</DefineCommonCapabilities>
     <SimpleResolution>true</SimpleResolution>
   </PropertyGroup>
+  
+  <PropertyGroup Label="AOT Customization" >
+    <ReflectionFree Condition=" '$(ReflectionFree)' == '' and '$(PublishAot)' == 'true' ">true</ReflectionFree>
+    <ReflectionFree Condition=" '$(ReflectionFree)' == '' ">false</ReflectionFree>
+  </PropertyGroup>
 
   <ItemGroup Condition="'$(_DebugSymbolsProduced)' == 'true' and '$(PdbFile)' != ''">
     <_DebugSymbolsIntermediatePathTemporary Include="$(PdbFile)"/>


### PR DESCRIPTION
## Description

This PR delays the default of ReflectionFree until the .target files, so the user project's PublishAot value can influence the default chosen for ReflectionFree.

Since AOT apps require ReflectionFree to be useful, this seems like a helpful default.

Fixes #17361

## Checklist

- [ ] Test cases added
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/releae-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**