### PR TITLE
Fix reporting IsFromComputationExpression for inappropriate symbols

### DIFF
--- a/src/Compiler/Checking/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/CheckComputationExpressions.fs
@@ -252,7 +252,7 @@ let TcComputationExpression (cenv: cenv) env (overallTy: OverallTy) tpenv (mWhol
         // An unparameterized custom builder, e.g., `query`, `async`.
         | Expr.Val(vref, _, m)
         // A parameterized custom builder, e.g., `builder<…>`, `builder ()`.
-        | Expr.App(funcExpr = Expr.Val(vref, _, m)) ->
+        | Expr.App(funcExpr = Expr.Val(vref, _, m)) when vref.IsConstructor || not (vref.IsMember || vref.IsExtensionMember) ->
             let item = Item.CustomBuilder(vref.DisplayName, vref)
             CallNameResolutionSink cenv.tcSink (m, env.NameEnv, item, emptyTyparInst, ItemOccurence.Use, env.eAccessRights)
             valRefEq cenv.g vref cenv.g.query_value_vref

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -135,3 +135,20 @@ let _pythags = seqbuilder {{
         |> FSharp     
         |> typecheck
         |> shouldSucceed
+
+    [<Fact>]
+    let ``A CE returned from type member succeeds``() =
+        FSharp """
+module ComputationExpressionTests
+type Builder () =
+    member _.Bind(x, f) = f x
+    member _.Return(x) = x
+
+type A =
+    static member Prop = Builder ()
+
+let x = A.Prop { return 0 }
+        """
+        |> compile
+        |> shouldSucceed
+        |> ignore


### PR DESCRIPTION
Upon investigating the syntax highlighting issue for CE code in Rider, I found that FCS reports a separate `SymbolUse` for expressions that are not a constructor invocation of the CE builder type or an associated with it let-binding:

![image](https://github.com/dotnet/fsharp/assets/26364714/96919deb-d029-474d-8894-f140e8a16404)

This behavior seems incorrect because the `Object.Prop` expression does not appear to require highlighting as a CE keyword.

https://github.com/dotnet/fsharp/blob/5c6d8e705a4152ca2711ba57e58850fc561eafea/src/Compiler/Service/FSharpCheckerResults.fs#L236-L242

Also, I did not find any tests confirming that IsFromComputationExpression should be true for such expressions.



This PR suggests reporting `IsFromComputationExpression` only for CE Builder type constructors and let-bindings.

## Checklist

- [x] Test cases added
- [ ] Release notes entry updated