### PR TITLE
Support using `Slice` to enable slicing syntax `expr1[expr2..expr3]`

### DIFF
--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -675,6 +675,8 @@ type TcGlobals(
   let v_or_info =                    makeIntrinsicValRef(fslib_MFIntrinsicOperators_nleref,                    "or"                                   , None                 , Some "Or"     , [],         mk_rel_sig v_bool_ty)
   let v_or2_info =                   makeIntrinsicValRef(fslib_MFIntrinsicOperators_nleref,                    CompileOpName "||"                     , None                 , None          , [],         mk_rel_sig v_bool_ty)
   let v_compare_operator_info                = makeIntrinsicValRef(fslib_MFOperators_nleref,                   "compare"                              , None                 , Some "Compare", [vara],     mk_compare_sig varaTy)
+  let v_max_operator_info                    = makeIntrinsicValRef(fslib_MFOperators_nleref,                   "max"                                  , None                 , Some "Max"    , [vara],     ([[varaTy];[varaTy]], varaTy))
+  let v_min_operator_info                    = makeIntrinsicValRef(fslib_MFOperators_nleref,                   "min"                                  , None                 , Some "Min"    , [vara],     ([[varaTy];[varaTy]], varaTy))
   let v_equals_operator_info                 = makeIntrinsicValRef(fslib_MFOperators_nleref,                   CompileOpName "="                      , None                 , None          , [vara],     mk_rel_sig varaTy)
   let v_equals_nullable_operator_info        = makeIntrinsicValRef(fslib_MFNullableOperators_nleref,           CompileOpName "=?"                     , None                 , None          , [vara],     ([[varaTy];[mkNullableTy varaTy]], v_bool_ty))
   let v_nullable_equals_operator_info        = makeIntrinsicValRef(fslib_MFNullableOperators_nleref,           CompileOpName "?="                     , None                 , None          , [vara],     ([[mkNullableTy varaTy];[varaTy]], v_bool_ty))
@@ -1673,6 +1675,8 @@ type TcGlobals(
   member val invalid_op_vref            = ValRefForIntrinsic v_invalid_op_info
   member val failwithf_vref             = ValRefForIntrinsic v_failwithf_info
 
+  member _.max_operator_info           = v_max_operator_info
+  member _.min_operator_info           = v_min_operator_info
   member _.equals_operator_info        = v_equals_operator_info
   member _.not_equals_operator         = v_not_equals_operator_info
   member _.less_than_operator          = v_less_than_operator_info

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -7747,6 +7747,10 @@ let mkCallGenericEqualityWithComparerOuter (g: TcGlobals) m ty comp e1 e2 = mkAp
 
 let mkCallGenericHashWithComparerOuter (g: TcGlobals) m ty comp e1 = mkApps g (typedExprForIntrinsic g m g.generic_hash_withc_outer_info, [[ty]], [comp;e1], m)
 
+let mkCallMaxOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.max_operator_info, [[ty]], [ e1;e2 ], m)
+
+let mkCallMinOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.min_operator_info, [[ty]], [ e1;e2 ], m)
+
 let mkCallEqualsOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.equals_operator_info, [[ty]], [ e1;e2 ], m)
 
 let mkCallNotEqualsOperator (g: TcGlobals) m ty e1 e2 = mkApps g (typedExprForIntrinsic g m g.not_equals_operator, [[ty]], [ e1;e2 ], m)

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -2084,6 +2084,10 @@ val mkCallGenericEqualityWithComparerOuter: TcGlobals -> range -> TType -> Expr 
 
 val mkCallGenericHashWithComparerOuter: TcGlobals -> range -> TType -> Expr -> Expr -> Expr
 
+val mkCallMaxOperator: g: TcGlobals -> m: range -> ty: TType -> e1: Expr -> e2: Expr -> Expr
+
+val mkCallMinOperator: g: TcGlobals -> m: range -> ty: TType -> e1: Expr -> e2: Expr -> Expr
+
 val mkCallEqualsOperator: TcGlobals -> range -> TType -> Expr -> Expr -> Expr
 
 val mkCallNotEqualsOperator: TcGlobals -> range -> TType -> Expr -> Expr -> Expr


### PR DESCRIPTION
## Description

- Add support for using a `Slice` method to enable slicing syntax `expr1[expr2..expr3]`.
  - [x] Language suggestion: https://github.com/fsharp/fslang-suggestions/issues/1317
  - [ ] RFC: TODO
  - [ ] RFC discussion: TODO

## Checklist

- [ ] Test cases added.
- [ ] Release notes entry updated.

## Notes

- It was rather difficult to follow the existing flow of logic in the indexing/slicing typechecking, and it became even harder as I added the new logic, so I refactored it. I hope it's at least a little bit clearer: the main control flow logic is now centralized in the final pattern match.