### PR TITLE
Create UseLocalCompiler.Directory.Build.props

### DIFF
--- a/UseLocalCompiler.Directory.Build.props
+++ b/UseLocalCompiler.Directory.Build.props
@@ -15,7 +15,7 @@
     <FSharpPreferNetFrameworkTools>False</FSharpPreferNetFrameworkTools>
     <FSharpPrefer64BitTools>True</FSharpPrefer64BitTools>
 
-    <LocalFSharpBuildBinPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(Configuration)/net8.0</LocalFSharpBuildBinPath>
+    <LocalFSharpBuildBinPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0</LocalFSharpBuildBinPath>
     <FSharpBuildAssemblyFile>$(LocalFSharpBuildBinPath)/FSharp.Build.dll</FSharpBuildAssemblyFile>
     <FSharpTargetsPath>$(LocalFSharpBuildBinPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
     <FSharpPropsShim>$(LocalFSharpBuildBinPath)/Microsoft.FSharp.NetSdk.props</FSharpPropsShim>

--- a/UseLocalCompiler.Directory.Build.props
+++ b/UseLocalCompiler.Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LocalFSharpCompilerConfiguration Condition="'$(LocalFSharpCompilerConfiguration )' != ''">Debug</LocalFSharpCompilerConfiguration>
 
-    <LocalFSharpCompilerPath>$(MSBuildThisFileDirectory)</LocalFSharpCompilerPath>
+    <LocalFSharpCompilerPath  Condition="'$(LocalFSharpCompilerPath  )' != ''">$(MSBuildThisFileDirectory)</LocalFSharpCompilerPath>
     <LocalFSCDllPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0/fsc.dll</LocalFSCDllPath>
 
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>

--- a/UseLocalCompiler.Directory.Build.props
+++ b/UseLocalCompiler.Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LocalFSharpCompilerConfiguration>Debug</LocalFSharpCompilerConfiguration>
+    <LocalFSharpCompilerConfiguration Condition="'$(LocalFSharpCompilerConfiguration )' != ''">Debug</LocalFSharpCompilerConfiguration>
 
     <LocalFSharpCompilerPath>$(MSBuildThisFileDirectory)</LocalFSharpCompilerPath>
     <LocalFSCDllPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0/fsc.dll</LocalFSCDllPath>

--- a/UseLocalCompiler.Directory.Build.props
+++ b/UseLocalCompiler.Directory.Build.props
@@ -1,0 +1,32 @@
+<Project>
+  <PropertyGroup>
+    <LocalFSharpCompilerConfiguration>Debug</LocalFSharpCompilerConfiguration>
+
+    <LocalFSharpCompilerPath>$(MSBuildThisFileDirectory)</LocalFSharpCompilerPath>
+    <LocalFSCDllPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0/fsc.dll</LocalFSCDllPath>
+
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+
+    <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
+
+    <DotnetFscCompilerPath>$(LocalFSCDllPath)</DotnetFscCompilerPath>
+    <Fsc_DotNET_DotnetFscCompilerPath>$(LocalFSCDllPath)</Fsc_DotNET_DotnetFscCompilerPath>
+
+    <FSharpPreferNetFrameworkTools>False</FSharpPreferNetFrameworkTools>
+    <FSharpPrefer64BitTools>True</FSharpPrefer64BitTools>
+
+    <LocalFSharpBuildBinPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(Configuration)/net8.0</LocalFSharpBuildBinPath>
+    <FSharpBuildAssemblyFile>$(LocalFSharpBuildBinPath)/FSharp.Build.dll</FSharpBuildAssemblyFile>
+    <FSharpTargetsPath>$(LocalFSharpBuildBinPath)/Microsoft.FSharp.Targets</FSharpTargetsPath>
+    <FSharpPropsShim>$(LocalFSharpBuildBinPath)/Microsoft.FSharp.NetSdk.props</FSharpPropsShim>
+    <FSharpTargetsShim>$(LocalFSharpBuildBinPath)/Microsoft.FSharp.NetSdk.targets</FSharpTargetsShim>
+    <FSharpOverridesTargetsShim>$(LocalFSharpBuildBinPath)/Microsoft.FSharp.Overrides.NetSdk.targets</FSharpOverridesTargetsShim>
+  </PropertyGroup>
+
+  <UsingTask TaskName="FSharpEmbedResourceText" AssemblyFile="$(FSharpBuildAssemblyFile)" Override="true" />
+  <UsingTask TaskName="FSharpEmbedResXSource" AssemblyFile="$(FSharpBuildAssemblyFile)" Override="true" />
+
+  <ItemGroup>
+    <Reference Include="$(LocalFSharpCompilerPath)/artifacts/bin/FSharp.Core/$(LocalFSharpCompilerConfiguration)/netstandard2.0/FSharp.Core.dll" />
+  </ItemGroup>
+</Project>

--- a/UseLocalCompiler.Directory.Build.props
+++ b/UseLocalCompiler.Directory.Build.props
@@ -1,16 +1,14 @@
 <Project>
   <PropertyGroup>
-    <LocalFSharpCompilerConfiguration Condition="'$(LocalFSharpCompilerConfiguration )' != ''">Debug</LocalFSharpCompilerConfiguration>
+    <LocalFSharpCompilerConfiguration Condition="'$(LocalFSharpCompilerConfiguration)' == ''">Release</LocalFSharpCompilerConfiguration>
 
-    <LocalFSharpCompilerPath  Condition="'$(LocalFSharpCompilerPath  )' != ''">$(MSBuildThisFileDirectory)</LocalFSharpCompilerPath>
-    <LocalFSCDllPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0/fsc.dll</LocalFSCDllPath>
+    <LocalFSharpCompilerPath Condition=" '$(LocalFSharpCompilerPath)' == '' ">$(MSBuildThisFileDirectory)</LocalFSharpCompilerPath>
 
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-
     <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
 
-    <DotnetFscCompilerPath>$(LocalFSCDllPath)</DotnetFscCompilerPath>
-    <Fsc_DotNET_DotnetFscCompilerPath>$(LocalFSCDllPath)</Fsc_DotNET_DotnetFscCompilerPath>
+    <DotnetFscCompilerPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0/fsc.dll</DotnetFscCompilerPath>
+    <Fsc_DotNET_DotnetFscCompilerPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net8.0/fsc.dll</Fsc_DotNET_DotnetFscCompilerPath>
 
     <FSharpPreferNetFrameworkTools>False</FSharpPreferNetFrameworkTools>
     <FSharpPrefer64BitTools>True</FSharpPrefer64BitTools>


### PR DESCRIPTION
Added props file, which will point to locally build compiler (Debug configuration), which can simply be included in contributor's project (via `<Import Project="UseLocalCompiler.Directory.Build.props"/>`) to test changes easier.
