### PR TITLE
Remove unused values from TcGlobals

### DIFF
--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -310,6 +310,7 @@
     <Compile Include="TypedTree\TypedTree.fs" />
     <Compile Include="TypedTree\TypedTreeBasics.fsi" />
     <Compile Include="TypedTree\TypedTreeBasics.fs" />
+    <Compile Include="TypedTree\TcGlobals.fsi" />
     <Compile Include="TypedTree\TcGlobals.fs" />
     <Compile Include="TypedTree\TypedTreeOps.fsi" />
     <Compile Include="TypedTree\TypedTreeOps.fs" />

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -381,14 +381,12 @@ type TcGlobals(
   let tryMkSysNonGenericTy path n = tryFindSysTyconRef path n |> Option.map mkNonGenericTy
 
   let sys = ["System"]
-  let sysLinq = ["System";"Linq"]
   let sysCollections = ["System";"Collections"]
   let sysGenerics = ["System";"Collections";"Generic"]
   let sysCompilerServices = ["System";"Runtime";"CompilerServices"]
 
   let lazy_tcr = findSysTyconRef sys "Lazy`1"
   let v_fslib_IEvent2_tcr        = mk_MFControl_tcref fslibCcu "IEvent`2"
-  let v_tcref_IQueryable      = findSysTyconRef sysLinq "IQueryable`1"
   let v_tcref_IObservable      = findSysTyconRef sys "IObservable`1"
   let v_tcref_IObserver        = findSysTyconRef sys "IObserver`1"
   let v_fslib_IDelegateEvent_tcr = mk_MFControl_tcref fslibCcu "IDelegateEvent`1"
@@ -789,7 +787,6 @@ type TcGlobals(
   let v_sbyte_operator_info        = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "sbyte"                                , None                 , Some "ToSByte",   [vara],   ([[varaTy]], v_sbyte_ty))
   let v_int16_operator_info        = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "int16"                                , None                 , Some "ToInt16",   [vara],   ([[varaTy]], v_int16_ty))
   let v_uint16_operator_info       = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "uint16"                               , None                 , Some "ToUInt16",  [vara],   ([[varaTy]], v_uint16_ty))
-  let v_int_operator_info          = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "int"                                  , None                 , Some "ToInt",     [vara],   ([[varaTy]], v_int_ty))
   let v_int32_operator_info        = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "int32"                                , None                 , Some "ToInt32",   [vara],   ([[varaTy]], v_int32_ty))
   let v_uint32_operator_info       = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "uint32"                               , None                 , Some "ToUInt32",  [vara],   ([[varaTy]], v_uint32_ty))
   let v_int64_operator_info        = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "int64"                                , None                 , Some "ToInt64",   [vara],   ([[varaTy]], v_int64_ty))
@@ -876,7 +873,6 @@ type TcGlobals(
   let v_lazy_create_info           = makeIntrinsicValRef(fslib_MFLazyExtensions_nleref,                        "Create"                               , Some "Lazy`1"        , None                          , [vara],     ([[v_unit_ty --> varaTy]], mkLazyTy varaTy))
 
   let v_seq_info                   = makeIntrinsicValRef(fslib_MFOperators_nleref,                             "seq"                                  , None                 , Some "CreateSequence"         , [vara],     ([[mkSeqTy varaTy]], mkSeqTy varaTy))
-  let v_refcell_info               = makeIntrinsicValRef(fslib_MFCore_nleref,                                  "ref"                                  , Some "FSharpRef`1"   , None                          , [vara],     ([[mkRefCellTy varaTy]; []], varaTy))
   let v_splice_expr_info           = makeIntrinsicValRef(fslib_MFExtraTopLevelOperators_nleref,                "op_Splice"                            , None                 , None                          , [vara],     ([[mkQuotedExprTy varaTy]], varaTy))
   let v_splice_raw_expr_info       = makeIntrinsicValRef(fslib_MFExtraTopLevelOperators_nleref,                "op_SpliceUntyped"                     , None                 , None                          , [vara],     ([[mkRawQuotedExprTy]], varaTy))
   let v_new_decimal_info           = makeIntrinsicValRef(fslib_MFIntrinsicFunctions_nleref,                    "MakeDecimal"                          , None                 , None                          , [],         ([[v_int_ty]; [v_int_ty]; [v_int_ty]; [v_bool_ty]; [v_byte_ty]], v_decimal_ty))
@@ -897,7 +893,6 @@ type TcGlobals(
   let v_query_source_info          = makeIntrinsicValRef(fslib_MFLinq_nleref,                                  "Source"                               , Some "QueryBuilder"  , None                          , [vara],      ([[mkQueryBuilderTy];[mkSeqTy varaTy ]], mkQuerySourceTy varaTy (mkNonGenericTy v_tcref_System_Collections_IEnumerable)) )
   let v_query_source_as_enum_info  = makeIntrinsicValRef(fslib_MFLinq_nleref,                                  "get_Source"                           , Some "QuerySource`2" , None                          , [vara; vare],      ([[mkQuerySourceTy varaTy vareTy];[]], mkSeqTy varaTy) )
   let v_new_query_source_info     = makeIntrinsicValRef(fslib_MFLinq_nleref,                                  ".ctor"                                 , Some "QuerySource`2" , None                          , [vara; vare],      ([[mkSeqTy varaTy]], mkQuerySourceTy varaTy vareTy) )
-  let v_query_where_value_info     = makeIntrinsicValRef(fslib_MFLinq_nleref,                                  "Where"                                , Some "QueryBuilder"  , None                          , [vara; vare],      ([[mkQueryBuilderTy];[mkQuerySourceTy varaTy vareTy;varaTy --> v_bool_ty]], mkQuerySourceTy varaTy vareTy) )
   let v_query_zero_value_info      = makeIntrinsicValRef(fslib_MFLinq_nleref,                                  "Zero"                                 , Some "QueryBuilder"  , None                          , [vara; vare],      ([[mkQueryBuilderTy];[]], mkQuerySourceTy varaTy vareTy) )
   let v_fail_init_info             = makeIntrinsicValRef(fslib_MFIntrinsicFunctions_nleref,                    "FailInit"                             , None                 , None                          , [],      ([[v_unit_ty]], v_unit_ty))
   let v_fail_static_init_info      = makeIntrinsicValRef(fslib_MFIntrinsicFunctions_nleref,                    "FailStaticInit"                       , None                 , None                          , [],      ([[v_unit_ty]], v_unit_ty))
@@ -1100,8 +1095,6 @@ type TcGlobals(
 
   static member IsInEmbeddableKnownSet name = isInEmbeddableKnownSet name
 
-  member _.embeddedTypeDefs = embeddedILTypeDefs.Values |> Seq.toList
-
   member _.tryRemoveEmbeddedILTypeDefs () = [
       for key in embeddedILTypeDefs.Keys.OrderBy id do
         match (embeddedILTypeDefs.TryRemove(key)) with
@@ -1134,8 +1127,6 @@ type TcGlobals(
 
   member _.emitDebugInfoInQuotations = emitDebugInfoInQuotations
 
-  member _.directoryToResolveRelativePaths = directoryToResolveRelativePaths
-
   member _.pathMap = pathMap
 
   member _.langVersion = langVersion
@@ -1155,10 +1146,6 @@ type TcGlobals(
   member val valueoption_tcr_canon = mk_MFCore_tcref     fslibCcu "ValueOption`1"
 
   member _.list_tcr_canon = v_list_tcr_canon
-
-  member val set_tcr_canon = mk_MFCollections_tcref   fslibCcu "Set`1"
-
-  member val map_tcr_canon = mk_MFCollections_tcref   fslibCcu "Map`2"
 
   member _.lazy_tcr_canon = lazy_tcr
 
@@ -1183,10 +1170,6 @@ type TcGlobals(
   member _.raw_expr_tcr = v_raw_expr_tcr
 
   member _.nativeint_tcr = v_nativeint_tcr
-
-  member _.unativeint_tcr = v_unativeint_tcr
-
-  member _.int_tcr = v_int_tcr
 
   member _.int32_tcr = v_int32_tcr
 
@@ -1213,8 +1196,6 @@ type TcGlobals(
   member _.bool_tcr = v_bool_tcr
 
   member _.unit_tcr_canon = v_unit_tcr_canon
-
-  member _.unit_tcr_nice = v_unit_tcr_nice
 
   member _.exn_tcr = v_exn_tcr
 
@@ -1266,7 +1247,6 @@ type TcGlobals(
 
   member _.MatchFailureException_tcr = v_mfe_tcr
 
-  member _.tcref_IQueryable = v_tcref_IQueryable
 
   member _.tcref_IObservable = v_tcref_IObservable
 
@@ -1355,7 +1335,6 @@ type TcGlobals(
   member _.string_ty_ambivalent = v_string_ty_ambivalent
   member _.system_IFormattable_tcref = v_IFormattable_tcref
   member _.system_FormattableString_tcref = v_FormattableString_tcref
-  member _.system_FormattableStringFactory_tcref = v_FormattableStringFactory_tcref
   member _.system_IFormattable_ty = v_IFormattable_ty
   member _.system_FormattableString_ty = v_FormattableString_ty
   member _.system_FormattableStringFactory_ty = v_FormattableStringFactory_ty
@@ -1381,10 +1360,7 @@ type TcGlobals(
   member val system_Delegate_ty = mkSysNonGenericTy sys "Delegate"
   member val system_MulticastDelegate_ty = mkSysNonGenericTy sys "MulticastDelegate"
   member val system_Enum_ty = mkSysNonGenericTy sys "Enum"
-  member val system_Exception_ty = mkSysNonGenericTy sys "Exception"
-  member val system_String_typ = mkSysNonGenericTy sys "String"
   member val system_String_tcref = findSysTyconRef sys "String"
-  member val system_Int32_ty = mkSysNonGenericTy sys "Int32"
   member _.system_Type_ty = v_system_Type_ty
   member val system_TypedReference_tcref = tryFindSysTyconRef sys "TypedReference"
   member val system_ArgIterator_tcref = tryFindSysTyconRef sys "ArgIterator"
@@ -1405,7 +1381,6 @@ type TcGlobals(
   member val system_Single_tcref = findSysTyconRef sys "Single"
   member val system_Double_tcref = findSysTyconRef sys "Double"
   member val system_RuntimeTypeHandle_ty = mkSysNonGenericTy sys "RuntimeTypeHandle"
-  member _.system_RuntimeMethodHandle_ty = v_system_RuntimeMethodHandle_ty
 
   member val system_MarshalByRefObject_tcref = tryFindSysTyconRef sys "MarshalByRefObject"
   member val system_MarshalByRefObject_ty = tryMkSysNonGenericTy sys "MarshalByRefObject"
@@ -1413,14 +1388,11 @@ type TcGlobals(
   member val system_ExceptionDispatchInfo_ty =
       tryMkSysNonGenericTy ["System"; "Runtime"; "ExceptionServices"] "ExceptionDispatchInfo"
 
-  member _.system_Reflection_MethodInfo_ty = v_system_Reflection_MethodInfo_ty
   member _.mk_IAsyncStateMachine_ty = mkSysNonGenericTy sysCompilerServices "IAsyncStateMachine" 
     
-  member val system_Array_tcref = v_Array_tcref
   member val system_Object_tcref = findSysTyconRef sys "Object"
   member val system_Value_tcref = findSysTyconRef sys "ValueType"
   member val system_Void_tcref = findSysTyconRef sys "Void"
-  member val system_IndexOutOfRangeException_tcref = findSysTyconRef sys "IndexOutOfRangeException"
   member val system_Nullable_tcref = v_nullable_tcr
   member val system_GenericIComparable_tcref = findSysTyconRef sys "IComparable`1"
   member val system_GenericIEquatable_tcref = findSysTyconRef sys "IEquatable`1"
@@ -1438,7 +1410,6 @@ type TcGlobals(
   member val tcref_System_Collections_IEqualityComparer = findSysTyconRef sysCollections "IEqualityComparer"
   member val tcref_System_Collections_Generic_IEqualityComparer = findSysTyconRef sysGenerics "IEqualityComparer`1"
   member val tcref_System_Collections_Generic_Dictionary = findSysTyconRef sysGenerics "Dictionary`2"
-  member val tcref_System_Collections_Generic_IDictionary = findSysTyconRef sysGenerics "IDictionary`2"
 
   member val tcref_System_IComparable = findSysTyconRef sys "IComparable"
   member val tcref_System_IStructuralComparable = findSysTyconRef sysCollections "IStructuralComparable"
@@ -1447,7 +1418,6 @@ type TcGlobals(
 
   member val tcref_LanguagePrimitives = mk_MFCore_tcref fslibCcu "LanguagePrimitives"
 
-  member val tcref_System_Collections_Generic_List = findSysTyconRef sysGenerics "List`1"
   member val tcref_System_Collections_Generic_IList = findSysTyconRef sysGenerics "IList`1"
   member val tcref_System_Collections_Generic_IReadOnlyList = findSysTyconRef sysGenerics "IReadOnlyList`1"
   member val tcref_System_Collections_Generic_ICollection = findSysTyconRef sysGenerics "ICollection`1"
@@ -1462,7 +1432,6 @@ type TcGlobals(
   // Review: Does this need to be an option type?
   member val System_Runtime_CompilerServices_RuntimeFeature_ty = tryFindSysTyconRef sysCompilerServices "RuntimeFeature" |> Option.map mkNonGenericTy
 
-  member val iltyp_TypedReference = tryFindSysILTypeRef "System.TypedReference" |> Option.map mkILNonGenericValueTy
   member val iltyp_StreamingContext = tryFindSysILTypeRef tname_StreamingContext  |> Option.map mkILNonGenericValueTy
   member val iltyp_SerializationInfo = tryFindSysILTypeRef tname_SerializationInfo  |> Option.map mkILNonGenericBoxedTy
   member val iltyp_Missing = findSysILTypeRef tname_Missing |> mkILNonGenericBoxedTy
@@ -1507,7 +1476,6 @@ type TcGlobals(
   member val attrib_OptionalAttribute = tryFindSysAttrib "System.Runtime.InteropServices.OptionalAttribute"
   member val attrib_DefaultParameterValueAttribute = tryFindSysAttrib "System.Runtime.InteropServices.DefaultParameterValueAttribute"
   member val attrib_ThreadStaticAttribute = tryFindSysAttrib "System.ThreadStaticAttribute"
-  member val attrib_SpecialNameAttribute = tryFindSysAttrib "System.Runtime.CompilerServices.SpecialNameAttribute"
   member val attrib_VolatileFieldAttribute = mk_MFCore_attrib "VolatileFieldAttribute"
   member val attrib_NoEagerConstraintApplicationAttribute = mk_MFCompilerServices_attrib "NoEagerConstraintApplicationAttribute"
   member val attrib_ContextStaticAttribute = tryFindSysAttrib "System.ContextStaticAttribute"
@@ -1521,7 +1489,6 @@ type TcGlobals(
   member val attrib_CallerLineNumberAttribute = findSysAttrib "System.Runtime.CompilerServices.CallerLineNumberAttribute"
   member val attrib_CallerFilePathAttribute = findSysAttrib "System.Runtime.CompilerServices.CallerFilePathAttribute"
   member val attrib_CallerMemberNameAttribute = findSysAttrib "System.Runtime.CompilerServices.CallerMemberNameAttribute"
-  member val attrib_ReferenceAssemblyAttribute = findSysAttrib "System.Runtime.CompilerServices.ReferenceAssemblyAttribute"
   member val attrib_SkipLocalsInitAttribute  = findSysAttrib "System.Runtime.CompilerServices.SkipLocalsInitAttribute"
   member val attribs_Unsupported = v_attribs_Unsupported
 
@@ -1587,7 +1554,6 @@ type TcGlobals(
   member _.new_decimal_info = v_new_decimal_info
   member _.seq_info    = v_seq_info
   member val seq_vref    = (ValRefForIntrinsic v_seq_info)
-  member val fsharpref_vref = (ValRefForIntrinsic v_refcell_info)
   member val and_vref    = (ValRefForIntrinsic v_and_info)
   member val and2_vref   = (ValRefForIntrinsic v_and2_info)
   member val addrof_vref = (ValRefForIntrinsic v_addrof_info)
@@ -1645,9 +1611,7 @@ type TcGlobals(
   member _.unchecked_multiply_info    = v_unchecked_multiply_info
   member _.unchecked_division_info    = v_unchecked_division_info
   member _.unchecked_modulus_info     = v_unchecked_modulus_info
-  member _.unchecked_unary_plus_info  = v_unchecked_unary_plus_info
   member _.unchecked_unary_minus_info = v_unchecked_unary_minus_info
-  member _.unchecked_unary_not_info   = v_unchecked_unary_not_info
   member _.unchecked_defaultof_info   = v_unchecked_defaultof_info
 
   member _.checked_addition_info      = v_checked_addition_info
@@ -1671,7 +1635,6 @@ type TcGlobals(
   member _.sbyte_operator_info      = v_sbyte_operator_info
   member _.int16_operator_info      = v_int16_operator_info
   member _.uint16_operator_info     = v_uint16_operator_info
-  member _.int_operator_info        = v_int_operator_info
   member _.int32_operator_info      = v_int32_operator_info
   member _.uint32_operator_info     = v_uint32_operator_info
   member _.int64_operator_info      = v_int64_operator_info
@@ -1713,13 +1676,7 @@ type TcGlobals(
   member _.box_info                   = v_box_info
   member _.isnull_info                = v_isnull_info
   member _.raise_info                 = v_raise_info
-  member _.failwith_info              = v_failwith_info
-  member _.invalid_arg_info           = v_invalid_arg_info
-  member _.null_arg_info              = v_null_arg_info
-  member _.invalid_op_info            = v_invalid_op_info
-  member _.failwithf_info             = v_failwithf_info
   member _.reraise_info               = v_reraise_info
-  member _.methodhandleof_info        = v_methodhandleof_info
   member _.typeof_info                = v_typeof_info
   member _.typedefof_info             = v_typedefof_info
 
@@ -1758,7 +1715,6 @@ type TcGlobals(
   member val seq_append_vref            = ValRefForIntrinsic  v_seq_append_info
   member val seq_generated_vref         = ValRefForIntrinsic  v_seq_generated_info
   member val seq_finally_vref           = ValRefForIntrinsic  v_seq_finally_info
-  member val seq_of_functions_vref      = ValRefForIntrinsic  v_seq_of_functions_info
   member val seq_map_vref               = ValRefForIntrinsic  v_seq_map_info
   member val seq_empty_vref             = ValRefForIntrinsic  v_seq_empty_info
   member val new_format_vref            = ValRefForIntrinsic v_new_format_info
@@ -1775,7 +1731,6 @@ type TcGlobals(
   member val query_yield_vref           = ValRefForIntrinsic v_query_yield_value_info
   member val query_yield_from_vref      = ValRefForIntrinsic v_query_yield_from_value_info
   member val query_select_vref          = ValRefForIntrinsic v_query_select_value_info
-  member val query_where_vref           = ValRefForIntrinsic v_query_where_value_info
   member val query_zero_vref            = ValRefForIntrinsic v_query_zero_value_info
   member val seq_to_list_vref           = ValRefForIntrinsic v_seq_to_list_info
   member val seq_to_array_vref          = ValRefForIntrinsic v_seq_to_array_info
@@ -1801,7 +1756,6 @@ type TcGlobals(
   member _.getstring_info             = v_getstring_info
   member _.unbox_fast_info            = v_unbox_fast_info
   member _.istype_info                = v_istype_info
-  member _.istype_fast_info           = v_istype_fast_info
   member _.lazy_force_info            = v_lazy_force_info
   member _.lazy_create_info           = v_lazy_create_info
   member _.create_instance_info       = v_create_instance_info

--- a/src/Compiler/TypedTree/TcGlobals.fsi
+++ b/src/Compiler/TypedTree/TcGlobals.fsi
@@ -298,8 +298,6 @@ type internal TcGlobals =
 
     member array_length_info: IntrinsicValRef
 
-    member array_map_info: IntrinsicValRef
-
     member array_set_info: IntrinsicValRef
 
     member array_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
@@ -846,8 +844,6 @@ type internal TcGlobals =
     member lift_value_with_defn_info: IntrinsicValRef
 
     member lift_value_with_name_info: IntrinsicValRef
-
-    member list_map_info: IntrinsicValRef
 
     member list_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
 

--- a/src/Compiler/TypedTree/TcGlobals.fsi
+++ b/src/Compiler/TypedTree/TcGlobals.fsi
@@ -1,0 +1,1375 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module internal FSharp.Compiler.TcGlobals
+
+val internal DummyFileNameForRangesWithoutASpecificLocation: string
+
+/// Represents an intrinsic value from FSharp.Core known to the compiler
+[<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
+type internal IntrinsicValRef =
+    | IntrinsicValRef of
+        FSharp.Compiler.TypedTree.NonLocalEntityRef *
+        string *
+        bool *
+        FSharp.Compiler.TypedTree.TType *
+        FSharp.Compiler.TypedTree.ValLinkageFullKey
+
+    /// For debugging
+    override ToString: unit -> string
+
+    /// For debugging
+    [<System.Diagnostics.DebuggerBrowsable(enum<System.Diagnostics.DebuggerBrowsableState> (0))>]
+    member DebugText: string
+
+    member Name: string
+
+val internal ValRefForIntrinsic: IntrinsicValRef -> FSharp.Compiler.TypedTree.ValRef
+
+[<AutoOpen>]
+module internal FSharpLib =
+
+    val Root: string
+
+    val RootPath: string list
+
+    val Core: string
+
+    val CorePath: string list
+
+    val CoreOperatorsCheckedName: string
+
+    val ControlName: string
+
+    val LinqName: string
+
+    val CollectionsName: string
+
+    val LanguagePrimitivesName: string
+
+    val CompilerServicesName: string
+
+    val LinqRuntimeHelpersName: string
+
+    val ExtraTopLevelOperatorsName: string
+
+    val NativeInteropName: string
+
+    val QuotationsName: string
+
+    val ControlPath: string list
+
+    val LinqPath: string list
+
+    val CollectionsPath: string list
+
+    val NativeInteropPath: string array
+
+    val CompilerServicesPath: string array
+
+    val LinqRuntimeHelpersPath: string array
+
+    val QuotationsPath: string array
+
+    val RootPathArray: string array
+
+    val CorePathArray: string array
+
+    val LinqPathArray: string array
+
+    val ControlPathArray: string array
+
+    val CollectionsPathArray: string array
+
+[<NoEquality; NoComparison; StructuredFormatDisplay("{DebugText}")>]
+type internal BuiltinAttribInfo =
+    | AttribInfo of FSharp.Compiler.AbstractIL.IL.ILTypeRef * FSharp.Compiler.TypedTree.TyconRef
+
+    /// For debugging
+    override ToString: unit -> string
+
+    /// For debugging
+    [<System.Diagnostics.DebuggerBrowsable(enum<System.Diagnostics.DebuggerBrowsableState> (0))>]
+    member DebugText: string
+
+    member TyconRef: FSharp.Compiler.TypedTree.TyconRef
+
+    member TypeRef: FSharp.Compiler.AbstractIL.IL.ILTypeRef
+
+[<Literal>]
+val internal tname_InternalsVisibleToAttribute: string = "System.Runtime.CompilerServices.InternalsVisibleToAttribute"
+
+[<Literal>]
+val internal tname_DebuggerHiddenAttribute: string = "System.Diagnostics.DebuggerHiddenAttribute"
+
+[<Literal>]
+val internal tname_DebuggerStepThroughAttribute: string = "System.Diagnostics.DebuggerStepThroughAttribute"
+
+[<Literal>]
+val internal tname_StringBuilder: string = "System.Text.StringBuilder"
+
+[<Literal>]
+val internal tname_FormattableString: string = "System.FormattableString"
+
+[<Literal>]
+val internal tname_SecurityPermissionAttribute: string = "System.Security.Permissions.SecurityPermissionAttribute"
+
+[<Literal>]
+val internal tname_Delegate: string = "System.Delegate"
+
+[<Literal>]
+val internal tname_Enum: string = "System.Enum"
+
+[<Literal>]
+val internal tname_FlagsAttribute: string = "System.FlagsAttribute"
+
+[<Literal>]
+val internal tname_Array: string = "System.Array"
+
+[<Literal>]
+val internal tname_RuntimeArgumentHandle: string = "System.RuntimeArgumentHandle"
+
+[<Literal>]
+val internal tname_IsByRefLikeAttribute: string = "System.Runtime.CompilerServices.IsByRefLikeAttribute"
+
+type internal TcGlobals =
+
+    new:
+        compilingFSharpCore: bool *
+        ilg: FSharp.Compiler.AbstractIL.IL.ILGlobals *
+        fslibCcu: FSharp.Compiler.TypedTree.CcuThunk *
+        directoryToResolveRelativePaths: string *
+        mlCompatibility: bool *
+        isInteractive: bool *
+        checkNullness: bool *
+        useReflectionFreeCodeGen: bool *
+        tryFindSysTypeCcuHelper: (string list -> string -> bool -> FSharp.Compiler.TypedTree.CcuThunk option) *
+        emitDebugInfoInQuotations: bool *
+        noDebugAttributes: bool *
+        pathMap: Internal.Utilities.PathMap *
+        langVersion: FSharp.Compiler.Features.LanguageVersion *
+        realsig: bool ->
+            TcGlobals
+
+    static member IsInEmbeddableKnownSet: name: string -> bool
+
+    member AddFieldGeneratedAttributes:
+        mdef: FSharp.Compiler.AbstractIL.IL.ILFieldDef -> FSharp.Compiler.AbstractIL.IL.ILFieldDef
+
+    member AddFieldNeverAttributes:
+        mdef: FSharp.Compiler.AbstractIL.IL.ILFieldDef -> FSharp.Compiler.AbstractIL.IL.ILFieldDef
+
+    member AddGeneratedAttributes:
+        attrs: FSharp.Compiler.AbstractIL.IL.ILAttributes -> FSharp.Compiler.AbstractIL.IL.ILAttributes
+
+    member AddMethodGeneratedAttributes:
+        mdef: FSharp.Compiler.AbstractIL.IL.ILMethodDef -> FSharp.Compiler.AbstractIL.IL.ILMethodDef
+
+    member AddPropertyGeneratedAttributes:
+        mdef: FSharp.Compiler.AbstractIL.IL.ILPropertyDef -> FSharp.Compiler.AbstractIL.IL.ILPropertyDef
+
+    member AddPropertyNeverAttributes:
+        mdef: FSharp.Compiler.AbstractIL.IL.ILPropertyDef -> FSharp.Compiler.AbstractIL.IL.ILPropertyDef
+
+    member AddValGeneratedAttributes: v: FSharp.Compiler.TypedTree.Val -> (FSharp.Compiler.Text.range -> unit)
+
+    member FindSysAttrib: nm: string -> BuiltinAttribInfo
+
+    member FindSysILTypeRef: nm: string -> FSharp.Compiler.AbstractIL.IL.ILTypeRef
+
+    member isSpliceOperator: FSharp.Compiler.TypedTree.ValRef -> bool
+
+    member FindSysTyconRef: path: string list -> nm: string -> FSharp.Compiler.TypedTree.EntityRef
+
+    member HasTailCallAttrib: attribs: FSharp.Compiler.TypedTree.Attribs -> bool
+
+    /// Find an FSharp.Core LaguagePrimitives dynamic function that corresponds to a trait witness, e.g.
+    /// AdditionDynamic for op_Addition.  Also work out the type instantiation of the dynamic function.
+    member MakeBuiltInWitnessInfo:
+        t: FSharp.Compiler.TypedTree.TraitConstraintInfo -> IntrinsicValRef * FSharp.Compiler.TypedTree.TType list
+
+    member MakeInternalsVisibleToAttribute: simpleAssemName: string -> FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member MkDebuggerTypeProxyAttribute:
+        ty: FSharp.Compiler.AbstractIL.IL.ILType -> FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member TryEmbedILType:
+        tref: FSharp.Compiler.AbstractIL.IL.ILTypeRef *
+        mkEmbeddableType: (unit -> FSharp.Compiler.AbstractIL.IL.ILTypeDef) ->
+            unit
+
+    member TryFindSysAttrib: nm: string -> BuiltinAttribInfo option
+
+    member TryFindSysILTypeRef: nm: string -> FSharp.Compiler.AbstractIL.IL.ILTypeRef option
+
+    member TryFindSysTyconRef: path: string list -> nm: string -> FSharp.Compiler.TypedTree.EntityRef option
+
+    /// Find an FSharp.Core operator that corresponds to a trait witness
+    member TryMakeOperatorAsBuiltInWitnessInfo:
+        isStringTy: (TcGlobals -> FSharp.Compiler.TypedTree.TType -> bool) ->
+        isArrayTy: (TcGlobals -> FSharp.Compiler.TypedTree.TType -> bool) ->
+        t: FSharp.Compiler.TypedTree.TraitConstraintInfo ->
+        argExprs: 'a list ->
+            (IntrinsicValRef * FSharp.Compiler.TypedTree.TType list * 'a list) option
+
+    member decompileType:
+        tcref: FSharp.Compiler.TypedTree.EntityRef ->
+        tinst: FSharp.Compiler.TypedTree.TypeInst ->
+            (FSharp.Compiler.TypedTree.Nullness -> FSharp.Compiler.TypedTree.TType)
+
+    member improveType:
+        tcref: FSharp.Compiler.TypedTree.EntityRef ->
+        tinst: FSharp.Compiler.TypedTree.TType list ->
+            (FSharp.Compiler.TypedTree.Nullness -> FSharp.Compiler.TypedTree.TType)
+
+    /// Memoization table to help minimize the number of ILSourceDocument objects we create
+    member memoize_file: x: int -> FSharp.Compiler.AbstractIL.IL.ILSourceDocument
+
+    member mkDebuggableAttributeV2:
+        jitTracking: bool * jitOptimizerDisabled: bool -> FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member mkDebuggerDisplayAttribute: s: string -> FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member mk_ArrayCollector_ty: seqElemTy: FSharp.Compiler.TypedTree.TType -> FSharp.Compiler.TypedTree.TType
+
+    member mk_GeneratedSequenceBase_ty: seqElemTy: FSharp.Compiler.TypedTree.TType -> FSharp.Compiler.TypedTree.TType
+
+    member mk_IResumableStateMachine_ty: dataTy: FSharp.Compiler.TypedTree.TType -> FSharp.Compiler.TypedTree.TType
+
+    member mk_ListCollector_ty: seqElemTy: FSharp.Compiler.TypedTree.TType -> FSharp.Compiler.TypedTree.TType
+
+    member mk_ResumableStateMachine_ty: dataTy: FSharp.Compiler.TypedTree.TType -> FSharp.Compiler.TypedTree.TType
+
+    member tryRemoveEmbeddedILTypeDefs: unit -> FSharp.Compiler.AbstractIL.IL.ILTypeDef list
+
+    member unionCaseRefEq:
+        x: FSharp.Compiler.TypedTree.UnionCaseRef -> y: FSharp.Compiler.TypedTree.UnionCaseRef -> bool
+
+    member valRefEq: x: FSharp.Compiler.TypedTree.ValRef -> y: FSharp.Compiler.TypedTree.ValRef -> bool
+
+    member CompilerGeneratedAttribute: FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member CompilerGlobalState: FSharp.Compiler.CompilerGlobalState.CompilerGlobalState option
+
+    member DebuggerBrowsableNeverAttribute: FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member DebuggerNonUserCodeAttribute: FSharp.Compiler.AbstractIL.IL.ILAttribute
+
+    member IComparer_ty: FSharp.Compiler.TypedTree.TType
+
+    member IEqualityComparer_ty: FSharp.Compiler.TypedTree.TType
+
+    member ListCollector_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member MatchFailureException_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ResumableCode_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member System_Runtime_CompilerServices_RuntimeFeature_ty: FSharp.Compiler.TypedTree.TType option
+
+    member addrof2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member addrof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member and2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member and_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member array2D_get_info: IntrinsicValRef
+
+    member array2D_get_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member array2D_set_info: IntrinsicValRef
+
+    member array3D_get_info: IntrinsicValRef
+
+    member array3D_get_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member array3D_set_info: IntrinsicValRef
+
+    member array4D_get_info: IntrinsicValRef
+
+    member array4D_get_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member array4D_set_info: IntrinsicValRef
+
+    member array_get_info: IntrinsicValRef
+
+    member array_get_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member array_length_info: IntrinsicValRef
+
+    member array_map_info: IntrinsicValRef
+
+    member array_set_info: IntrinsicValRef
+
+    member array_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
+
+    member attrib_AbstractClassAttribute: BuiltinAttribInfo
+
+    member attrib_AllowNullLiteralAttribute: BuiltinAttribInfo
+
+    member attrib_AttributeUsageAttribute: BuiltinAttribInfo
+
+    member attrib_AutoOpenAttribute: BuiltinAttribInfo
+
+    member attrib_AutoSerializableAttribute: BuiltinAttribInfo
+
+    member attrib_CLIEventAttribute: BuiltinAttribInfo
+
+    member attrib_CLIMutableAttribute: BuiltinAttribInfo
+
+    member attrib_CallerFilePathAttribute: BuiltinAttribInfo
+
+    member attrib_CallerLineNumberAttribute: BuiltinAttribInfo
+
+    member attrib_CallerMemberNameAttribute: BuiltinAttribInfo
+
+    member attrib_ClassAttribute: BuiltinAttribInfo
+
+    member attrib_ComImportAttribute: BuiltinAttribInfo option
+
+    member attrib_ComVisibleAttribute: BuiltinAttribInfo
+
+    member attrib_ComparisonConditionalOnAttribute: BuiltinAttribInfo
+
+    member attrib_CompilationArgumentCountsAttribute: BuiltinAttribInfo
+
+    member attrib_CompilationMappingAttribute: BuiltinAttribInfo
+
+    member attrib_CompilationRepresentationAttribute: BuiltinAttribInfo
+
+    member attrib_CompiledNameAttribute: BuiltinAttribInfo
+
+    member attrib_CompilerFeatureRequiredAttribute: BuiltinAttribInfo
+
+    member attrib_CompilerMessageAttribute: BuiltinAttribInfo
+
+    member attrib_ComponentModelEditorBrowsableAttribute: BuiltinAttribInfo
+
+    member attrib_ConditionalAttribute: BuiltinAttribInfo
+
+    member attrib_ContextStaticAttribute: BuiltinAttribInfo option
+
+    member attrib_CustomComparisonAttribute: BuiltinAttribInfo
+
+    member attrib_CustomEqualityAttribute: BuiltinAttribInfo
+
+    member attrib_CustomOperationAttribute: BuiltinAttribInfo
+
+    member attrib_DebuggerDisplayAttribute: BuiltinAttribInfo
+
+    member attrib_DebuggerTypeProxyAttribute: BuiltinAttribInfo
+
+    member attrib_DefaultAugmentationAttribute: BuiltinAttribInfo
+
+    member attrib_DefaultMemberAttribute: BuiltinAttribInfo
+
+    member attrib_DefaultParameterValueAttribute: BuiltinAttribInfo option
+
+    member attrib_DefaultValueAttribute: BuiltinAttribInfo
+
+    member attrib_DllImportAttribute: BuiltinAttribInfo option
+
+    member attrib_DynamicDependencyAttribute: BuiltinAttribInfo
+
+    member attrib_EntryPointAttribute: BuiltinAttribInfo
+
+    member attrib_EqualityConditionalOnAttribute: BuiltinAttribInfo
+
+    member attrib_ExperimentalAttribute: BuiltinAttribInfo
+
+    member attrib_ExtensionAttribute: BuiltinAttribInfo
+
+    member attrib_FieldOffsetAttribute: BuiltinAttribInfo
+
+    member attrib_FlagsAttribute: BuiltinAttribInfo
+
+    member attrib_GeneralizableValueAttribute: BuiltinAttribInfo
+
+    member attrib_IDispatchConstantAttribute: BuiltinAttribInfo option
+
+    member attrib_IUnknownConstantAttribute: BuiltinAttribInfo option
+
+    member attrib_InAttribute: BuiltinAttribInfo
+
+    member attrib_InlineIfLambdaAttribute: BuiltinAttribInfo
+
+    member attrib_InterfaceAttribute: BuiltinAttribInfo
+
+    member attrib_InternalsVisibleToAttribute: BuiltinAttribInfo
+
+    member attrib_IsReadOnlyAttribute: BuiltinAttribInfo
+
+    member attrib_IsUnmanagedAttribute: BuiltinAttribInfo
+
+    member attrib_LiteralAttribute: BuiltinAttribInfo
+
+    member attrib_MarshalAsAttribute: BuiltinAttribInfo option
+
+    member attrib_MeasureAttribute: BuiltinAttribInfo
+
+    member attrib_MeasureableAttribute: BuiltinAttribInfo
+
+    member attrib_MemberNotNullWhenAttribute: BuiltinAttribInfo
+
+    member attrib_MethodImplAttribute: BuiltinAttribInfo
+
+    member attrib_NoComparisonAttribute: BuiltinAttribInfo
+
+    member attrib_NoCompilerInliningAttribute: BuiltinAttribInfo
+
+    member attrib_NoDynamicInvocationAttribute: BuiltinAttribInfo
+
+    member attrib_NoEagerConstraintApplicationAttribute: BuiltinAttribInfo
+
+    member attrib_NoEqualityAttribute: BuiltinAttribInfo
+
+    member attrib_NonSerializedAttribute: BuiltinAttribInfo option
+
+    member attrib_NullableAttribute: BuiltinAttribInfo
+
+    member attrib_NullableAttribute_opt: BuiltinAttribInfo option
+
+    member attrib_NullableContextAttribute: BuiltinAttribInfo
+
+    member attrib_NullableContextAttribute_opt: BuiltinAttribInfo option
+
+    member attrib_OptionalArgumentAttribute: BuiltinAttribInfo
+
+    member attrib_OptionalAttribute: BuiltinAttribInfo option
+
+    member attrib_OutAttribute: BuiltinAttribInfo
+
+    member attrib_ParamArrayAttribute: BuiltinAttribInfo
+
+    member attrib_PreserveSigAttribute: BuiltinAttribInfo option
+
+    member attrib_ProjectionParameterAttribute: BuiltinAttribInfo
+
+    member attrib_ReferenceEqualityAttribute: BuiltinAttribInfo
+
+    member attrib_ReflectedDefinitionAttribute: BuiltinAttribInfo
+
+    member attrib_RequireQualifiedAccessAttribute: BuiltinAttribInfo
+
+    member attrib_RequiredMemberAttribute: BuiltinAttribInfo
+
+    member attrib_RequiresExplicitTypeArgumentsAttribute: BuiltinAttribInfo
+
+    member attrib_RequiresLocationAttribute: BuiltinAttribInfo
+
+    member attrib_SealedAttribute: BuiltinAttribInfo
+
+    member attrib_SecurityAttribute: BuiltinAttribInfo option
+
+    member attrib_SecurityCriticalAttribute: BuiltinAttribInfo
+
+    member attrib_SecuritySafeCriticalAttribute: BuiltinAttribInfo
+
+    member attrib_SetsRequiredMembersAttribute: BuiltinAttribInfo
+
+    member attrib_SkipLocalsInitAttribute: BuiltinAttribInfo
+
+    member attrib_StructAttribute: BuiltinAttribInfo
+
+    member attrib_StructLayoutAttribute: BuiltinAttribInfo
+
+    member attrib_StructuralComparisonAttribute: BuiltinAttribInfo
+
+    member attrib_StructuralEqualityAttribute: BuiltinAttribInfo
+
+    member attrib_SystemObsolete: BuiltinAttribInfo
+
+    member attrib_ThreadStaticAttribute: BuiltinAttribInfo option
+
+    member attrib_TypeForwardedToAttribute: BuiltinAttribInfo
+
+    member attrib_UnverifiableAttribute: BuiltinAttribInfo
+
+    member attrib_VolatileFieldAttribute: BuiltinAttribInfo
+
+    member attrib_WarnOnWithoutNullArgumentAttribute: BuiltinAttribInfo
+
+    member attribs_Unsupported: FSharp.Compiler.TypedTree.TyconRef list
+
+    member bitwise_and_info: IntrinsicValRef
+
+    member bitwise_and_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member bitwise_or_info: IntrinsicValRef
+
+    member bitwise_or_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member bitwise_shift_left_info: IntrinsicValRef
+
+    member bitwise_shift_left_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member bitwise_shift_right_info: IntrinsicValRef
+
+    member bitwise_shift_right_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member bitwise_unary_not_info: IntrinsicValRef
+
+    member bitwise_unary_not_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member bitwise_xor_info: IntrinsicValRef
+
+    member bitwise_xor_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member bool_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member bool_ty: FSharp.Compiler.TypedTree.TType
+
+    member box_info: IntrinsicValRef
+
+    member byref2_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member byref_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member byrefkind_InOut_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member byrefkind_In_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member byrefkind_Out_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member byte_checked_info: IntrinsicValRef
+
+    member byte_operator_info: IntrinsicValRef
+
+    member byte_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member byte_ty: FSharp.Compiler.TypedTree.TType
+
+    member call_with_witnesses_info: IntrinsicValRef
+
+    member cast_quotation_info: IntrinsicValRef
+
+    member cgh__debugPoint_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member cgh__resumableEntry_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member cgh__resumeAt_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member cgh__stateMachine_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member cgh__useResumableCode_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member char_operator_info: IntrinsicValRef
+
+    member char_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member char_ty: FSharp.Compiler.TypedTree.TType
+
+    member checkNullness: bool
+
+    member check_this_info: IntrinsicValRef
+
+    member checked_addition_info: IntrinsicValRef
+
+    member checked_multiply_info: IntrinsicValRef
+
+    member checked_subtraction_info: IntrinsicValRef
+
+    member checked_unary_minus_info: IntrinsicValRef
+
+    member choice2_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member choice3_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member choice4_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member choice5_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member choice6_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member choice7_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member compare_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member compilingFSharpCore: bool
+
+    member cons_ucref: FSharp.Compiler.TypedTree.UnionCaseRef
+
+    member create_event_info: IntrinsicValRef
+
+    member create_instance_info: IntrinsicValRef
+
+    member date_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member decimal_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member decimal_ty: FSharp.Compiler.TypedTree.TType
+
+    member deserialize_quoted_FSharp_20_plus_info: IntrinsicValRef
+
+    member deserialize_quoted_FSharp_40_plus_info: IntrinsicValRef
+
+    member dispose_info: IntrinsicValRef
+
+    member emitDebugInfoInQuotations: bool
+
+    member enumOfValue_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member enum_DynamicallyAccessedMemberTypes: BuiltinAttribInfo
+
+    member enum_operator_info: IntrinsicValRef
+
+    member enum_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member equals_nullable_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member equals_operator_info: IntrinsicValRef
+
+    member equals_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member exn_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member exn_ty: FSharp.Compiler.TypedTree.TType
+
+    member exponentiation_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member expr_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member fail_init_info: IntrinsicValRef
+
+    member fail_static_init_info: IntrinsicValRef
+
+    member failwith_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member failwithf_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member fastFunc_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member float32_operator_info: IntrinsicValRef
+
+    member float32_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member float32_ty: FSharp.Compiler.TypedTree.TType
+
+    member float_operator_info: IntrinsicValRef
+
+    member float_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member float_ty: FSharp.Compiler.TypedTree.TType
+
+    member format4_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member format_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member fslibCcu: FSharp.Compiler.TypedTree.CcuThunk
+
+    member fslib_IDelegateEvent_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member fslib_IEvent2_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    /// Indicates if we are generating witness arguments for SRTP constraints. Only done if the FSharp.Core
+    /// supports witness arguments.
+    member generateWitnesses: bool
+
+    member generic_compare_withc_tuple2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_compare_withc_tuple3_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_compare_withc_tuple4_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_compare_withc_tuple5_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_comparison_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_comparison_withc_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_comparison_withc_outer_info: IntrinsicValRef
+
+    member generic_equality_er_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equality_er_outer_info: IntrinsicValRef
+
+    member generic_equality_per_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equality_withc_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equality_withc_outer_info: IntrinsicValRef
+
+    member generic_equality_withc_outer_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equals_withc_tuple2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equals_withc_tuple3_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equals_withc_tuple4_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_equals_withc_tuple5_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_hash_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_hash_withc_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_hash_withc_outer_info: IntrinsicValRef
+
+    member generic_hash_withc_tuple2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_hash_withc_tuple3_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_hash_withc_tuple4_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member generic_hash_withc_tuple5_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member get_generic_comparer_info: IntrinsicValRef
+
+    member get_generic_er_equality_comparer_info: IntrinsicValRef
+
+    member get_generic_per_equality_comparer_info: IntrinsicValRef
+
+    member getstring_info: IntrinsicValRef
+
+    member greater_than_operator: IntrinsicValRef
+
+    member greater_than_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member greater_than_or_equals_operator: IntrinsicValRef
+
+    member greater_than_or_equals_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member hash_info: IntrinsicValRef
+
+    member il_arr_tcr_map: FSharp.Compiler.TypedTree.EntityRef array
+
+    member ilg: FSharp.Compiler.AbstractIL.IL.ILGlobals
+
+    member ilsigptr_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member iltyp_AsyncCallback: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_Exception: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_IAsyncResult: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_IComparable: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_Missing: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_ReferenceAssemblyAttributeOpt: FSharp.Compiler.AbstractIL.IL.ILType option
+
+    member iltyp_RuntimeFieldHandle: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_RuntimeMethodHandle: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_RuntimeTypeHandle: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_SerializationInfo: FSharp.Compiler.AbstractIL.IL.ILType option
+
+    member iltyp_StreamingContext: FSharp.Compiler.AbstractIL.IL.ILType option
+
+    member iltyp_UnmanagedType: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member iltyp_ValueType: FSharp.Compiler.AbstractIL.IL.ILType
+
+    member inref_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member int16_checked_info: IntrinsicValRef
+
+    member int16_operator_info: IntrinsicValRef
+
+    member int16_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member int16_ty: FSharp.Compiler.TypedTree.TType
+
+    member int32_checked_info: IntrinsicValRef
+
+    member int32_operator_info: IntrinsicValRef
+
+    member int32_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member int32_ty: FSharp.Compiler.TypedTree.TType
+
+    member int64_checked_info: IntrinsicValRef
+
+    member int64_operator_info: IntrinsicValRef
+
+    member int64_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member int64_ty: FSharp.Compiler.TypedTree.TType
+
+    member int_checked_info: IntrinsicValRef
+
+    member int_ty: FSharp.Compiler.TypedTree.TType
+
+    member invalid_arg_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member invalid_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    /// Indicates if we can use System.Array.Empty when emitting IL for empty array literals
+    member isArrayEmptyAvailable: bool
+
+    /// Are we assuming all code gen is for F# interactive, with no static linking
+    member isInteractive: bool
+
+    member isnull_info: IntrinsicValRef
+
+    member istype_fast_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member istype_info: IntrinsicValRef
+
+    member istype_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member knownFSharpCoreModules: System.Collections.Generic.IDictionary<string, FSharp.Compiler.TypedTree.EntityRef>
+
+    member knownIntrinsics:
+        System.Collections.Concurrent.ConcurrentDictionary<(string * string option * string * int), FSharp.Compiler.TypedTree.ValRef>
+
+    member knownWithNull: FSharp.Compiler.TypedTree.Nullness
+
+    member knownWithoutNull: FSharp.Compiler.TypedTree.Nullness
+
+    member langFeatureNullness: bool
+
+    member langVersion: FSharp.Compiler.Features.LanguageVersion
+
+    member lazy_create_info: IntrinsicValRef
+
+    member lazy_force_info: IntrinsicValRef
+
+    member lazy_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
+
+    member lazy_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
+
+    member less_than_operator: IntrinsicValRef
+
+    member less_than_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member less_than_or_equals_operator: IntrinsicValRef
+
+    member less_than_or_equals_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member lift_value_info: IntrinsicValRef
+
+    member lift_value_with_defn_info: IntrinsicValRef
+
+    member lift_value_with_name_info: IntrinsicValRef
+
+    member list_map_info: IntrinsicValRef
+
+    member list_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
+
+    member list_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
+
+    member measureinverse_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member measureone_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member measureproduct_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member methodhandleof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member mk_Attribute_ty: FSharp.Compiler.TypedTree.TType
+
+    member mk_IAsyncStateMachine_ty: FSharp.Compiler.TypedTree.TType
+
+    member mk_IComparable_ty: FSharp.Compiler.TypedTree.TType
+
+    member mk_IStructuralComparable_ty: FSharp.Compiler.TypedTree.TType
+
+    member mk_IStructuralEquatable_ty: FSharp.Compiler.TypedTree.TType
+
+    member mlCompatibility: bool
+
+    member nameof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member nativeint_checked_info: IntrinsicValRef
+
+    member nativeint_operator_info: IntrinsicValRef
+
+    member nativeint_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member nativeint_ty: FSharp.Compiler.TypedTree.TType
+
+    member nativeptr_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member nativeptr_tobyref_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member new_decimal_info: IntrinsicValRef
+
+    member new_format_info: IntrinsicValRef
+
+    member new_format_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member new_query_source_info: IntrinsicValRef
+
+    member nil_ucref: FSharp.Compiler.TypedTree.UnionCaseRef
+
+    member not_equals_operator: IntrinsicValRef
+
+    member not_equals_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member null_arg_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member nullable_equals_nullable_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member nullable_equals_operator_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member obj_ty_ambivalent: FSharp.Compiler.TypedTree.TType
+
+    member obj_ty_noNulls: FSharp.Compiler.TypedTree.TType
+
+    member obj_ty_withNulls: FSharp.Compiler.TypedTree.TType
+
+    member option_defaultValue_info: IntrinsicValRef
+
+    member option_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
+
+    member option_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
+
+    member option_toNullable_info: IntrinsicValRef
+
+    member or2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member or_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member outref_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pathMap: Internal.Utilities.PathMap
+
+    member pdecimal_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pfloat32_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pfloat_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pint16_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pint64_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pint8_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member pint_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member piperight2_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member piperight3_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member piperight_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member pnativeint_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member puint16_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member puint64_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member puint8_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member puint_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member punativeint_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member query_builder_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member query_for_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_run_enumerable_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_run_value_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_select_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_source_as_enum_info: IntrinsicValRef
+
+    member query_source_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_value_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_yield_from_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_yield_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member query_zero_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member quote_to_linq_lambda_info: IntrinsicValRef
+
+    member raise_info: IntrinsicValRef
+
+    member raise_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_byte_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_char_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_generic_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_int16_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_int32_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_int64_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_nativeint_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_sbyte_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_step_generic_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_step_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_uint16_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_uint32_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_uint64_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member range_unativeint_op_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member raw_expr_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member realsig: bool
+
+    member ref_tuple1_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple2_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple3_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple4_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple5_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple6_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple7_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member ref_tuple8_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member refcell_assign_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member refcell_decr_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member refcell_deref_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member refcell_incr_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member refcell_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
+
+    member refcell_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
+
+    member reference_equality_inner_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member renderNullnessAnnotations: bool
+
+    member reraise_info: IntrinsicValRef
+
+    member reraise_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member sbyte_checked_info: IntrinsicValRef
+
+    member sbyte_operator_info: IntrinsicValRef
+
+    member sbyte_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member sbyte_ty: FSharp.Compiler.TypedTree.TType
+
+    member seq_append_info: IntrinsicValRef
+
+    member seq_append_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_collect_info: IntrinsicValRef
+
+    member seq_collect_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_delay_info: IntrinsicValRef
+
+    member seq_delay_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_empty_info: IntrinsicValRef
+
+    member seq_empty_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_finally_info: IntrinsicValRef
+
+    member seq_finally_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_generated_info: IntrinsicValRef
+
+    member seq_generated_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_info: IntrinsicValRef
+
+    member seq_map_info: IntrinsicValRef
+
+    member seq_map_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_of_functions_info: IntrinsicValRef
+
+    member seq_singleton_info: IntrinsicValRef
+
+    member seq_singleton_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member seq_to_array_info: IntrinsicValRef
+
+    member seq_to_array_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_to_list_info: IntrinsicValRef
+
+    member seq_to_list_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_trywith_info: IntrinsicValRef
+
+    member seq_using_info: IntrinsicValRef
+
+    member seq_using_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member seq_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member sizeof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member splice_expr_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member splice_raw_expr_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member sprintf_info: IntrinsicValRef
+
+    member sprintf_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member string_ty: FSharp.Compiler.TypedTree.TType
+
+    member string_ty_ambivalent: FSharp.Compiler.TypedTree.TType
+
+    member struct_tuple1_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple2_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple3_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple4_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple5_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple6_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple7_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member struct_tuple8_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member suppressed_types: FSharp.Compiler.TypedTree.EntityRef list
+
+    member system_ArgIterator_tcref: FSharp.Compiler.TypedTree.EntityRef option
+
+    member system_Array_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_Bool_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Byte_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Char_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Decimal_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Delegate_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_Double_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Enum_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_ExceptionDispatchInfo_ty: FSharp.Compiler.TypedTree.TType option
+
+    member system_FormattableStringFactory_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_FormattableString_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_FormattableString_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_GenericIComparable_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_GenericIEquatable_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_IDisposable_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_IFormattable_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_IFormattable_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_Int16_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Int32_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Int64_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_IntPtr_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_LinqExpression_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_MarshalByRefObject_tcref: FSharp.Compiler.TypedTree.EntityRef option
+
+    member system_MarshalByRefObject_ty: FSharp.Compiler.TypedTree.TType option
+
+    member system_MulticastDelegate_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_Nullable_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Object_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Object_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_RuntimeArgumentHandle_tcref: FSharp.Compiler.TypedTree.EntityRef option
+
+    member system_RuntimeHelpers_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_RuntimeTypeHandle_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_SByte_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Single_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_String_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Type_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_TypedReference_tcref: FSharp.Compiler.TypedTree.EntityRef option
+
+    member system_UInt16_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_UInt32_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_UInt64_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_UIntPtr_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Value_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member system_Value_ty: FSharp.Compiler.TypedTree.TType
+
+    member system_Void_tcref: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_IObservable: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_IObserver: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_LanguagePrimitives: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Attribute: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_Dictionary: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_ICollection: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_IEnumerable: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_IEnumerator: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_IEqualityComparer: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_IList: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_IReadOnlyCollection: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_Generic_IReadOnlyList: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_IComparer: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_IEnumerable: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_Collections_IEqualityComparer: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_IComparable: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_IDisposable: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_IStructuralComparable: FSharp.Compiler.TypedTree.EntityRef
+
+    member tcref_System_IStructuralEquatable: FSharp.Compiler.TypedTree.EntityRef
+
+    member typedefof_info: IntrinsicValRef
+
+    member typedefof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member typeof_info: IntrinsicValRef
+
+    member typeof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member uint16_checked_info: IntrinsicValRef
+
+    member uint16_operator_info: IntrinsicValRef
+
+    member uint16_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member uint16_ty: FSharp.Compiler.TypedTree.TType
+
+    member uint32_checked_info: IntrinsicValRef
+
+    member uint32_operator_info: IntrinsicValRef
+
+    member uint32_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member uint32_ty: FSharp.Compiler.TypedTree.TType
+
+    member uint64_checked_info: IntrinsicValRef
+
+    member uint64_operator_info: IntrinsicValRef
+
+    member uint64_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+    member uint64_ty: FSharp.Compiler.TypedTree.TType
+
+    member unativeint_checked_info: IntrinsicValRef
+
+    member unativeint_operator_info: IntrinsicValRef
+
+    member unativeint_ty: FSharp.Compiler.TypedTree.TType
+
+    member unbox_fast_info: IntrinsicValRef
+
+    member unbox_fast_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unbox_info: IntrinsicValRef
+
+    member unbox_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_addition_info: IntrinsicValRef
+
+    member unchecked_addition_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_defaultof_info: IntrinsicValRef
+
+    member unchecked_defaultof_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_division_info: IntrinsicValRef
+
+    member unchecked_division_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_modulus_info: IntrinsicValRef
+
+    member unchecked_modulus_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_multiply_info: IntrinsicValRef
+
+    member unchecked_multiply_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_subtraction_info: IntrinsicValRef
+
+    member unchecked_subtraction_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_unary_minus_info: IntrinsicValRef
+
+    member unchecked_unary_minus_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_unary_not_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unchecked_unary_plus_vref: FSharp.Compiler.TypedTree.ValRef
+
+    member unit_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
+
+    member unit_ty: FSharp.Compiler.TypedTree.TType
+
+    member useReflectionFreeCodeGen: bool
+
+    member valueoption_tcr_canon: FSharp.Compiler.TypedTree.EntityRef
+
+    member valueoption_tcr_nice: FSharp.Compiler.TypedTree.EntityRef
+
+    member voidptr_tcr: FSharp.Compiler.TypedTree.EntityRef
+
+#if DEBUG
+// This global is only used during debug output
+val mutable internal global_g: TcGlobals option
+#endif


### PR DESCRIPTION
Remove unused values from TcGlobals and add a TcGlobals.fsi file.  There were quite a few unused values in the TcGlobals file this PR removes them.

TcGlobals is a very widely used bag of values across the compiler.  The .fsi file should help the compiler limit the amount of recompilation when editing the tcglobals.fs file.

No_release notes added, because it's a minor implementation detail.
