### PR TITLE
Skip a flaky test

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedCoreTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedCoreTests.fs
@@ -401,7 +401,7 @@ let ``controlChamenos-FSI`` () =
 [<Fact>]
 let ``controlMailbox-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/controlMailbox" FSC_OPTIMIZED
 
-[<Fact>]
+[<Fact(Skip="Flaky")>]
 let ``controlMailbox-FSI`` () = singleTestBuildAndRun "core/controlMailbox" FSI
 
 [<Fact>]


### PR DESCRIPTION
I have seen this failing multiple times in CI, last occasion [here](https://dev.azure.com/dnceng-public/public/_build/results?buildId=750266&view=ms.vss-test-web.build-test-results-tab&runId=18995152&resultId=101466&paneView=debug).