### PR TITLE
Parser: recover on missing union case fields

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -9,6 +9,7 @@
 ### Added
 
 * Support for nullable reference types ([PR #15181](https://github.com/dotnet/fsharp/pull/15181))
+* Parser: recover on missing union case fields ([#17452](https://github.com/dotnet/fsharp/pull/17452))
 * Sink: report function domain type ([PR #17470](https://github.com/dotnet/fsharp/pull/17470))
 
 ### Changed

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1762,7 +1762,7 @@ featureReuseSameFieldsInStructUnions,"Share underlying fields in a [<Struct>] di
 3860,chkStaticMembersOnObjectExpressions,"Object expressions cannot implement interfaces with static abstract members or declare static members."
 3861,chkTailCallAttrOnNonRec,"The TailCall attribute should only be applied to recursive functions."
 3862,parsStaticMemberImcompleteSyntax,"Incomplete declaration of a static construct. Use 'static let','static do','static member' or 'static val' for declaration."
-3863,parsExpectingField,"Expecting record field"
+3863,parsExpectingRecordField,"Expecting record field"
 3864,tooManyMethodsInDotNetTypeWritingAssembly,"The type '%s' has too many methods. Found: '%d', maximum: '%d'"
 3865,parsOnlySimplePatternsAreAllowedInConstructors,"Only simple patterns are allowed in primary constructors"
 3866,chkStaticAbstractInterfaceMembers,"A static abstract non-virtual interface member should only be called via type parameter (for example: 'T.%s)."
@@ -1775,3 +1775,4 @@ featureParsedHashDirectiveArgumentNonString,"# directives with non-quoted string
 3869,featureParsedHashDirectiveUnexpectedInteger,"Unexpected integer literal '%d'."
 3869,featureParsedHashDirectiveUnexpectedIdentifier,"Unexpected identifier '%s'."
 featureEmptyBodiedComputationExpressions,"Support for computation expressions with empty bodies: builder {{ }}"
+3870,parsExpectingUnionCaseField,"Expecting union case field"

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2471,7 +2471,7 @@ braceFieldDeclList:
      { [] }
 
   | LBRACE rbrace
-     { errorR (Error(FSComp.SR.parsExpectingField(), rhs parseState 2))
+     { errorR (Error(FSComp.SR.parsExpectingRecordField (), rhs parseState 2))
        [] }
 
 anonRecdType:
@@ -2876,6 +2876,7 @@ unionCaseReprElements:
 
   | STAR unionCaseReprElements
      { let mStar = rhs parseState 1
+       errorR (Error(FSComp.SR.parsExpectingUnionCaseField (), rhs parseState 1))
        let fields, mFields = $2
        let ty = SynType.FromParseError mStar.StartRange
        let field = mkSynAnonField (ty, PreXmlDoc.Empty)

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2711,17 +2711,26 @@ attrUnionCaseDecl:
       { fun (xmlDoc, mBar) -> mkSynUnionCase $1 $2 (SynIdent(mkSynId mBar.EndRange "", None)) (SynUnionCaseKind.Fields []) mBar (xmlDoc, mBar) |> Choice2Of2 }
 
   | opt_attributes opt_access unionCaseName OF unionCaseRepr
-      { mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.Fields $5) (rhs2 parseState 1 5) >> Choice2Of2 }
+      { let mId = rhs parseState 3
+        let fields, mFields = $5
+        let mWhole = unionRanges mId mFields
+        mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.Fields fields) mWhole >> Choice2Of2 }
 
   | opt_attributes opt_access unionCaseName unionCaseRepr
       { errorR (Error(FSComp.SR.parsMissingKeyword("of"), rhs2 parseState 3 4))
-        mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.Fields $4) (rhs2 parseState 1 4) >> Choice2Of2 }
+        let mAttributes = rhs parseState 1
+        let fields, mFields = $4
+        let mWhole = unionRanges mAttributes mFields
+        mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.Fields fields) mWhole >> Choice2Of2 }
 
   | opt_attributes opt_access OF unionCaseRepr
-      { let mOf = rhs parseState 3
+      { let mAttributes = rhs parseState 1
+        let mOf = rhs parseState 3
         let mId = mOf.StartRange
+        let fields, mFields = $4
+        let mWhole = unionRanges mAttributes mFields
         errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mOf))
-        mkSynUnionCase $1 $2 (SynIdent(mkSynId mId "", None)) (SynUnionCaseKind.Fields $4) (rhs2 parseState 1 4) >> Choice2Of2 }
+        mkSynUnionCase $1 $2 (SynIdent(mkSynId mId "", None)) (SynUnionCaseKind.Fields fields) mWhole >> Choice2Of2 }
 
   | opt_attributes opt_access OF recover
       { let mOf = rhs parseState 3
@@ -2733,13 +2742,18 @@ attrUnionCaseDecl:
       { mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.Fields []) (rhs2 parseState 1 4) >> Choice2Of2 }
 
   | opt_attributes opt_access unionCaseName COLON topType
-      { if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyWarning(lhs parseState)
-        mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.FullType $5) (rhs2 parseState 1 5) >> Choice2Of2 }
+      { let mAttributes = rhs parseState 1
+        let fullType, _ = $5
+        let mWhole = unionRanges mAttributes fullType.Range
+        if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyWarning(lhs parseState)
+        mkSynUnionCase $1 $2 $3 (SynUnionCaseKind.FullType $5) mWhole >> Choice2Of2 }
 
   | opt_attributes opt_access unionCaseName EQUALS atomicExpr
       { if Option.isSome $2 then errorR(Error(FSComp.SR.parsEnumFieldsCannotHaveVisibilityDeclarations(), rhs parseState 2))
         let mEquals = rhs parseState 4
-        let mDecl = rhs2 parseState 1 5
+        let mAttributes = rhs parseState 1
+        let expr, _ = $5
+        let mDecl = unionRanges mAttributes expr.Range
         (fun (xmlDoc, mBar) ->
             let trivia: SynEnumCaseTrivia = { BarRange = Some mBar; EqualsRange = mEquals }
             let mDecl = unionRangeWithXmlDoc xmlDoc mDecl
@@ -2797,16 +2811,20 @@ firstUnionCaseDeclOfMany:
 
 firstUnionCaseDecl:
   | ident OF unionCaseRepr
-      { let trivia: SynUnionCaseTrivia = { BarRange = None }
+      { let fields, mFields = $3
+        let trivia: SynUnionCaseTrivia = { BarRange = None }
         let xmlDoc = grabXmlDoc (parseState, [], 1)
-        let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
-        Choice2Of2(SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields $3, xmlDoc, None, mDecl, trivia)) }
+        let mId = rhs parseState 1
+        let mDecl = unionRanges mId mFields |> unionRangeWithXmlDoc xmlDoc
+        Choice2Of2(SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields fields, xmlDoc, None, mDecl, trivia)) }
 
-  | unionCaseName COLON topType 
+  | unionCaseName COLON topType
       { if parseState.LexBuffer.ReportLibraryOnlyFeatures then libraryOnlyWarning(lhs parseState)
         let trivia: SynUnionCaseTrivia = { BarRange = None }
         let xmlDoc = grabXmlDoc (parseState, [], 1)
-        let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
+        let mId = rhs parseState 1
+        let fullType, _ = $3
+        let mDecl = unionRanges mId fullType.Range |> unionRangeWithXmlDoc xmlDoc
         Choice2Of2(SynUnionCase([], $1, SynUnionCaseKind.FullType $3, xmlDoc, None, mDecl, trivia)) }
 
   | ident OF recover
@@ -2818,18 +2836,21 @@ firstUnionCaseDecl:
   | OF unionCaseRepr
      { let mOf = rhs parseState 1
        let mId = mOf.StartRange
+       let fields, mFields = $2
        errorR (Error(FSComp.SR.parsMissingUnionCaseName(), mOf))
        let id = SynIdent(mkSynId mId "", None)
        let trivia: SynUnionCaseTrivia = { BarRange = None }
        let xmlDoc = grabXmlDoc (parseState, [], 1)
-       let mDecl = rhs2 parseState 1 2 |> unionRangeWithXmlDoc xmlDoc
-       Choice2Of2(SynUnionCase([], id, SynUnionCaseKind.Fields $2, xmlDoc, None, mDecl, trivia)) }
+       let mDecl = unionRanges mOf mFields |> unionRangeWithXmlDoc xmlDoc
+       Choice2Of2(SynUnionCase([], id, SynUnionCaseKind.Fields fields, xmlDoc, None, mDecl, trivia)) }
 
   | ident EQUALS atomicExpr opt_OBLOCKSEP
-      { let mEquals = rhs parseState 2
+      { let mId = rhs parseState 1
+        let mEquals = rhs parseState 2
         let trivia: SynEnumCaseTrivia = { BarRange = None; EqualsRange = mEquals }
         let xmlDoc = grabXmlDoc (parseState, [], 1)
-        let mDecl = rhs2 parseState 1 3 |> unionRangeWithXmlDoc xmlDoc
+        let expr, _ = $3
+        let mDecl = unionRanges mId expr.Range |> unionRangeWithXmlDoc xmlDoc
         Choice1Of2(SynEnumCase([], SynIdent($1, None), fst $3, xmlDoc, mDecl, trivia)) }
 
   | ident EQUALS recover opt_OBLOCKSEP
@@ -2843,10 +2864,25 @@ firstUnionCaseDecl:
 
 unionCaseReprElements:
   | unionCaseReprElement STAR unionCaseReprElements
-     { $1 :: $3 }
+     { let mField = rhs parseState 1
+       let fields, mFields = $3
+       $1 :: fields, unionRanges mField mFields }
+
+  | unionCaseReprElement STAR recover
+     { let mStar = rhs parseState 2
+       let ty = SynType.FromParseError mStar.EndRange
+       let field = mkSynAnonField (ty, PreXmlDoc.Empty)
+       [$1; field], rhs2 parseState 1 2 }
+
+  | STAR unionCaseReprElements
+     { let mStar = rhs parseState 1
+       let fields, mFields = $2
+       let ty = SynType.FromParseError mStar.StartRange
+       let field = mkSynAnonField (ty, PreXmlDoc.Empty)
+       field :: fields, unionRanges mStar mFields }
 
   | unionCaseReprElement %prec prec_toptuptyptail_prefix
-     { [$1] }
+     { [$1], rhs parseState 1 }
 
 unionCaseReprElement:
   | ident COLON appTypeNullableInParens
@@ -2872,7 +2908,7 @@ unionCaseReprElement:
 unionCaseRepr:
   | braceFieldDeclList
      { errorR(Deprecated(FSComp.SR.parsConsiderUsingSeparateRecordType(), lhs parseState))
-       $1 }
+       $1, rhs parseState 1 }
 
   | unionCaseReprElements
      { $1 }
@@ -2948,7 +2984,8 @@ exconIntro:
       { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF unionCaseRepr
-      { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields $3, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
+      { let fields, _ = $3
+        SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields fields, PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }
 
   | ident OF recover
       { SynUnionCase([], SynIdent($1, None), SynUnionCaseKind.Fields [], PreXmlDoc.Empty, None, lhs parseState, { BarRange = None }) }

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Byl očekáván výraz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Očekává se pole záznamu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Očekává se vzorek.</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Očekává se typ</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Ausdruck wird erwartet</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Datensatzfeld wird erwartet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Muster wird erwartet</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Typ wird erwartet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Se espera una expresión</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Se espera un campo de registro</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Se espera un patrón</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Tipo esperado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated"> Expression attendue</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Champ d’enregistrement attendu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Modèle attendu</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Type attendu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Prevista espressione.</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Previsto campo record</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Criterio previsto</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Previsto tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">式を指定してください</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">レコード フィールドが必要です</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">必要なパターン</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">型が必要です</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">식이 필요함</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">레코드 필드 필요</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">예상되는 패턴</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">예상 형식</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Oczekiwanie na wyrażenie</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Oczekiwanie pola rekordu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Oczekiwano wzorca</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Oczekiwano typu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Esperando uma expressão</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Esperando campo de registro</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Padrão esperado</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Esperando tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">Ожидается выражение</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Ожидается поле записи</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Ожидается шаблон</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Требуется тип</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">İfade bekleniyor</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">Kayıt alanı bekleniyor</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">Desen bekleniyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">Tür bekleniyor</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">应为表达式</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">应为记录字段</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">预期模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">预期类型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -1007,19 +1007,24 @@
         <target state="translated">必須是運算式</target>
         <note />
       </trans-unit>
-      <trans-unit id="parsExpectingField">
-        <source>Expecting record field</source>
-        <target state="translated">必須是記錄欄位</target>
-        <note />
-      </trans-unit>
       <trans-unit id="parsExpectingPattern">
         <source>Expecting pattern</source>
         <target state="translated">必須是模式</target>
         <note />
       </trans-unit>
+      <trans-unit id="parsExpectingRecordField">
+        <source>Expecting record field</source>
+        <target state="new">Expecting record field</target>
+        <note />
+      </trans-unit>
       <trans-unit id="parsExpectingType">
         <source>Expecting type</source>
         <target state="translated">必須是類型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="parsExpectingUnionCaseField">
+        <source>Expecting union case field</source>
+        <target state="new">Expecting union case field</target>
         <note />
       </trans-unit>
       <trans-unit id="parsIncompleteTyparExpr1">

--- a/tests/service/data/SyntaxTree/Type/Union 01.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    | A

--- a/tests/service/data/SyntaxTree/Type/Union 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 01.fs.bsl
@@ -1,0 +1,26 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 01.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None), Fields [],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,7), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,7)), (4,4--4,7)), [], None, (3,5--4,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Union 02.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    | A of int * int

--- a/tests/service/data/SyntaxTree/Type/Union 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 02.fs.bsl
@@ -1,0 +1,41 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 02.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,14), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,17), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,17--4,20), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,20), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,20)), (4,4--4,20)), [], None, (3,5--4,20),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,20))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,20), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Union 03.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 03.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    | A of int *

--- a/tests/service/data/SyntaxTree/Type/Union 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 03.fs.bsl
@@ -1,0 +1,43 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 03.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,14), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None, FromParseError (4,16--4,16),
+                                  false, PreXmlDocEmpty, None, (4,16--4,16),
+                                  { LeadingKeyword = None
+                                    MutableKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,16), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,16)), (4,4--4,16)), [], None, (3,5--4,16),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,16))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,16), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
+To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in union case

--- a/tests/service/data/SyntaxTree/Type/Union 04.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 04.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    | A of int * int *

--- a/tests/service/data/SyntaxTree/Type/Union 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 04.fs.bsl
@@ -1,0 +1,50 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 04.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,14), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,17), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,17--4,20), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None, FromParseError (4,22--4,22),
+                                  false, PreXmlDocEmpty, None, (4,22--4,22),
+                                  { LeadingKeyword = None
+                                    MutableKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,22), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,22)), (4,4--4,22)), [], None, (3,5--4,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,0)-(5,0) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
+To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in union case

--- a/tests/service/data/SyntaxTree/Type/Union 05.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 05.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    | A of int * * int

--- a/tests/service/data/SyntaxTree/Type/Union 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 05.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 05.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,14), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None, FromParseError (4,17--4,17),
+                                  false, PreXmlDocEmpty, None, (4,17--4,17),
+                                  { LeadingKeyword = None
+                                    MutableKeyword = None });
+                               SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,19), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,19--4,22), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,22), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,22)), (4,4--4,22)), [], None, (3,5--4,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Union 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 05.fs.bsl
@@ -44,3 +44,5 @@ ImplFile
           (1,0--4,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
+
+(4,17)-(4,18) parse error Expecting union case field

--- a/tests/service/data/SyntaxTree/Type/Union 06.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 06.fs
@@ -1,0 +1,4 @@
+module Module
+
+type U =
+    | A of * int * int

--- a/tests/service/data/SyntaxTree/Type/Union 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 06.fs.bsl
@@ -1,0 +1,46 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 06.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None, FromParseError (4,11--4,11),
+                                  false, PreXmlDocEmpty, None, (4,11--4,11),
+                                  { LeadingKeyword = None
+                                    MutableKeyword = None });
+                               SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,13), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,13--4,16), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,19), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,19--4,22), { LeadingKeyword = None
+                                                        MutableKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,22), { BarRange = Some (4,4--4,5) })],
+                        (4,4--4,22)), (4,4--4,22)), [], None, (3,5--4,22),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--4,22))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Type/Union 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 06.fs.bsl
@@ -44,3 +44,5 @@ ImplFile
           (1,0--4,22), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
       { ConditionalDirectives = []
         CodeComments = [] }, set []))
+
+(4,11)-(4,12) parse error Expecting union case field

--- a/tests/service/data/SyntaxTree/Type/Union 07.fs
+++ b/tests/service/data/SyntaxTree/Type/Union 07.fs
@@ -1,0 +1,5 @@
+module Module
+
+type U =
+    | A of int *
+    | B

--- a/tests/service/data/SyntaxTree/Type/Union 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Type/Union 07.fs.bsl
@@ -1,0 +1,45 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Type/Union 07.fs", false, QualifiedNameOfFile Module, [], [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Types
+             ([SynTypeDefn
+                 (SynComponentInfo
+                    ([], None, [], [U],
+                     PreXmlDoc ((3,0), FSharp.Compiler.Xml.XmlDocCollector),
+                     false, None, (3,5--3,6)),
+                  Simple
+                    (Union
+                       (None,
+                        [SynUnionCase
+                           ([], SynIdent (A, None),
+                            Fields
+                              [SynField
+                                 ([], false, None,
+                                  LongIdent (SynLongIdent ([int], [], [None])),
+                                  false,
+                                  PreXmlDoc ((4,11), FSharp.Compiler.Xml.XmlDocCollector),
+                                  None, (4,11--4,14), { LeadingKeyword = None
+                                                        MutableKeyword = None });
+                               SynField
+                                 ([], false, None, FromParseError (4,16--4,16),
+                                  false, PreXmlDocEmpty, None, (4,16--4,16),
+                                  { LeadingKeyword = None
+                                    MutableKeyword = None })],
+                            PreXmlDoc ((4,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (4,6--4,16), { BarRange = Some (4,4--4,5) });
+                         SynUnionCase
+                           ([], SynIdent (B, None), Fields [],
+                            PreXmlDoc ((5,4), FSharp.Compiler.Xml.XmlDocCollector),
+                            None, (5,6--5,7), { BarRange = Some (5,4--5,5) })],
+                        (4,4--5,7)), (4,4--5,7)), [], None, (3,5--5,7),
+                  { LeadingKeyword = Type (3,0--3,4)
+                    EqualsRange = Some (3,7--3,8)
+                    WithKeyword = None })], (3,0--5,7))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))
+
+(5,4)-(5,5) parse error Unexpected symbol '|' in union case


### PR DESCRIPTION
Adds recovery for various unfinished union case declarations:

```fsharp
type U =
    | A of int *
```

```fsharp
type U =
    | A of int * int *
```

```fsharp
type U =
    | A of int * * int
```

```fsharp
type U =
    | A of * int * int
```

Also fixes range calculations. Otherwise, recovered nodes would use wrong range that spans past the node end.