### PR TITLE
Sink: report function domain type

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -9,6 +9,7 @@
 ### Added
 
 * Support for nullable reference types ([PR #15181](https://github.com/dotnet/fsharp/pull/15181))
+* Sink: report function domain type ([PR #17470](https://github.com/dotnet/fsharp/pull/17470))
 
 ### Changed
 


### PR DESCRIPTION
Reports the inferred `function` domain type to the sink. This can be used in features like code completion.