### PR TITLE
Nullness - prevent duplicate warnings coming from speculative method resolution

### DIFF
--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -1101,7 +1101,7 @@ and SolveNullnessSubsumesNullness (csenv: ConstraintSolverEnv) m2 (trace: Option
         | NullnessInfo.WithNull, NullnessInfo.WithoutNull ->             
             CompleteD
         | NullnessInfo.WithoutNull, NullnessInfo.WithNull -> 
-            if csenv.g.checkNullness then               
+            if csenv.g.checkNullness && not csenv.IsSpeculativeForMethodOverloading then               
                  WarnD(ConstraintSolverNullnessWarningWithTypes(csenv.DisplayEnv, ty1, ty2, n1, n2, csenv.m, m2)) 
             else
                 CompleteD

--- a/tests/FSharp.Compiler.ComponentTests/Language/Nullness/NullableReferenceTypesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/Nullness/NullableReferenceTypesTests.fs
@@ -15,6 +15,18 @@ let typeCheckWithStrictNullness cu =
     cu
     |> withNullnessOptions
     |> typecheck
+
+[<Fact>]
+let ``Does not duplicate warnings`` () =
+    FSharp """
+module MyLib
+let getLength (x: string | null) = x.Length
+    """
+    |> asLibrary
+    |> typeCheckWithStrictNullness
+    |> shouldFail
+    |> withDiagnostics [Error 3261, Line 3, Col 36, Line 3, Col 44, "Nullness warning: The types 'string' and 'string | null' do not have compatible nullability."]
+
     
 [<Fact>]
 let ``Cannot pass possibly null value to a strict function``() =


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/17410.

Reason was contraint solver being invoked twice, once for identifying the best candidate for method resolution (speculative mode), and then once more for real.