### PR TITLE
Fix UseLocalCompiler.Directory.Build.props to invoke dotnet.exe

### DIFF
--- a/UseLocalCompiler.Directory.Build.props
+++ b/UseLocalCompiler.Directory.Build.props
@@ -8,6 +8,8 @@
 
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableAutoSetFscCompilerPath>true</DisableAutoSetFscCompilerPath>
+    <FscToolPath Condition="'$(FscToolPath)' == ''">$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))</FscToolPath>
+    <FscToolExe Condition="'$(FscToolExe)' == ''">$([System.IO.Path]::GetFileName($(DOTNET_HOST_PATH)))</FscToolExe>
 
     <DotnetFscCompilerPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net9.0/fsc.dll</DotnetFscCompilerPath>
     <Fsc_DotNET_DotnetFscCompilerPath>$(LocalFSharpCompilerPath)/artifacts/bin/fsc/$(LocalFSharpCompilerConfiguration)/net9.0/fsc.dll</Fsc_DotNET_DotnetFscCompilerPath>


### PR DESCRIPTION
Before, the setup was yielding:
![image](https://github.com/user-attachments/assets/ce2e9418-6b11-4e98-8d84-79c4bb03c020)
![image](https://github.com/user-attachments/assets/f5c3730b-8536-4988-9ff9-39e01b7e7c6e)


This makes sure that compilation happens by: dotnet.exe $pathToLocalFsc.dll