### PR TITLE
fixes #17541 - Equals visibility for DU's

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -8,6 +8,7 @@
 * Fix `function` implicit conversion. ([Issue #7401](https://github.com/dotnet/fsharp/issues/7401), [PR #17487](https://github.com/dotnet/fsharp/pull/17487))
 * Compiler fails to recognise namespace in FQN with enabled GraphBasedChecking. ([Issue #17508](https://github.com/dotnet/fsharp/issues/17508), [PR #17510](https://github.com/dotnet/fsharp/pull/17510))
 * Fix missing message for type error (FS0001). ([Issue #17373](https://github.com/dotnet/fsharp/issues/17373), [PR #17516](https://github.com/dotnet/fsharp/pull/17516))
+* MethodAccessException on equality comparison of a type private to module. ([Issue #17541](https://github.com/dotnet/fsharp/issues/17541), [PR #17548](https://github.com/dotnet/fsharp/pull/17548))
 
 ### Added
 

--- a/src/Compiler/Checking/AugmentWithHashCompare.fs
+++ b/src/Compiler/Checking/AugmentWithHashCompare.fs
@@ -1322,7 +1322,7 @@ let MakeValsForCompareWithComparerAugmentation g (tcref: TyconRef) =
 let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
     let m = tcref.Range
     let _, ty = mkMinimalTy g tcref
-    let vis = tcref.TypeReprAccessibility
+    let vis = tcref.Accessibility
     let tps = tcref.Typars m
 
     let objEqualsVal =
@@ -1333,7 +1333,7 @@ let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
             g
             tcref
             ty
-            tcref.Accessibility
+            vis
             (if tcref.Deref.IsFSharpException then
                  None
              else
@@ -1347,16 +1347,13 @@ let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
 
 let MakeValsForEqualityWithComparerAugmentation g (tcref: TyconRef) =
     let _, ty = mkMinimalTy g tcref
-    let vis =
-        // Equality method for union types match the union type visibility rather than the TypeReprAccessibility
-        if tcref.IsUnionTycon then tcref.Accessibility
-        else tcref.TypeReprAccessibility
+    let vis = tcref.Accessibility
     let tps = tcref.Typars tcref.Range
 
     let objGetHashCodeVal =
         mkValSpec g tcref ty vis (Some(mkGetHashCodeSlotSig g)) "GetHashCode" (tps +-> (mkHashTy g ty)) unitArg false
 
-    let withcGetHashCodeVal =
+    let withGetHashCodeVal =
         mkValSpec
             g
             tcref
@@ -1368,27 +1365,27 @@ let MakeValsForEqualityWithComparerAugmentation g (tcref: TyconRef) =
             unaryArg
             false
 
-    let withcEqualsVal =
+    let withEqualsVal =
         mkValSpec g tcref ty vis (Some(mkIStructuralEquatableEqualsSlotSig g)) "Equals" (tps +-> (mkEqualsWithComparerTy g ty)) tupArg false
 
-    let withcEqualsValExact =
+    let withEqualsExactWithComparer =
+        let vis = TAccess (updateSyntaxAccessForCompPath (vis.CompilationPaths) SyntaxAccess.Public)
         mkValSpec
             g 
             tcref 
             ty
-            tcref.Accessibility
+            vis
             // This doesn't implement any interface.
             None 
             "Equals" 
             (tps +-> (mkEqualsWithComparerTyExact g ty)) 
             tupArg 
             false
-
     {
         GetHashCode = objGetHashCodeVal
-        GetHashCodeWithComparer = withcGetHashCodeVal
-        EqualsWithComparer = withcEqualsVal
-        EqualsExactWithComparer = withcEqualsValExact
+        GetHashCodeWithComparer = withGetHashCodeVal
+        EqualsWithComparer = withEqualsVal
+        EqualsExactWithComparer = withEqualsExactWithComparer
     }    
 
 let MakeBindingsForCompareAugmentation g (tycon: Tycon) =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/TypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/TypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
@@ -769,9 +769,7 @@ let main _ =
         |> shouldSucceed
         |> verifyIL [
             """
-            .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>
-                  '|IsEqual|IsNonEqual|'<(class [Potato]Potato.Lib/IPotato`1<!!T>) T>(!!T x,
-                                                                                      !!T y) cil managed
+            .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> '|IsEqual|IsNonEqual|'<(class [Potato]Potato.Lib/IPotato`1<!!T>) T>(!!T x, !!T y) cil managed
             {
 
             .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
@@ -871,8 +871,7 @@ let main args =
       IL_0002:  newobj     instance void Foo/StructUnion::.ctor(int32)
       IL_0007:  ret
     }""";(*This is a 'maker method' New{CaseName} used for cases which do have fields associated with them, + the _tag gets initialized*)"""
-            NewCase3(string _field1_3,
-                     string _field2_3) cil managed
+            NewCase3(string _field1_3, string _field2_3) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 02 00 00 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
@@ -283,9 +283,7 @@ type C() =
           .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname
-                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)  get_X() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -313,9 +311,7 @@ type C() =
           .get instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname
-                instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)  get_X() cil managed
         {
           .param [0]
           .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -452,9 +448,7 @@ type C<'T>() =
     abstract X<'U> : unit -> inref<'U>
             """
 
-        let verifyMethod = """.method public hidebysig abstract virtual
-                instance !!U& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                X<U>() cil managed
+        let verifyMethod = """.method public hidebysig abstract virtual instance !!U& modreq([runtime]System.Runtime.InteropServices.InAttribute)  X<U>() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -481,9 +475,7 @@ type C =
           .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname abstract virtual
-                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname abstract virtual instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)  get_X() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CCtorDUWithMember/CCtorDUWithMember.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CCtorDUWithMember/CCtorDUWithMember.fs
@@ -144,3 +144,59 @@ type ILArrayShape =
             ]
         |> shouldSucceed
 
+    [<InlineData(true, "public")>]          // RealSig
+    [<InlineData(false, "assembly")>]       // Regular
+    [<Theory>]
+    let ``private DU in module`` (realSig, expected) =
+        FSharp """
+module RealInternalSignature
+module Module =
+    type private DU = ABC | YYZ
+
+    let publicFunction () : bool =
+        ABC = YYZ
+
+Module.publicFunction () |> printfn "%b"
+"""
+        |> asExe
+        |> withRealInternalSignature realSig
+        |> compileAndRun
+        |> withILContains [
+            $$"""
+      .method {{expected}} hidebysig instance bool Equals(class RealInternalSignature/Module/DU obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      {
+        .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        
+        .maxstack  4
+        .locals init (int32 V_0,
+                 int32 V_1)
+        IL_0000:  ldarg.0
+        IL_0001:  brfalse.s  IL_001b
+
+        IL_0003:  ldarg.1
+        IL_0004:  brfalse.s  IL_0019
+
+        IL_0006:  ldarg.0
+        IL_0007:  ldfld      int32 RealInternalSignature/Module/DU::_tag
+        IL_000c:  stloc.0
+        IL_000d:  ldarg.1
+        IL_000e:  ldfld      int32 RealInternalSignature/Module/DU::_tag
+        IL_0013:  stloc.1
+        IL_0014:  ldloc.0
+        IL_0015:  ldloc.1
+        IL_0016:  ceq
+        IL_0018:  ret
+
+        IL_0019:  ldc.i4.0
+        IL_001a:  ret
+
+        IL_001b:  ldarg.1
+        IL_001c:  ldnull
+        IL_001d:  cgt.un
+        IL_001f:  ldc.i4.0
+        IL_0020:  ceq
+        IL_0022:  ret
+      } 
+"""
+            ]
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.net472.bsl
@@ -128,9 +128,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -235,9 +233,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -259,9 +255,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -285,9 +279,7 @@
         IL_0019:  ret
       } 
 
-      .method public specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method public specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         
         .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.netcore.bsl
@@ -128,9 +128,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -235,9 +233,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -259,9 +255,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -285,9 +279,7 @@
         IL_0019:  ret
       } 
 
-      .method public specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method public specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         
         .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.net472.bsl
@@ -67,9 +67,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion 
-              NewSomeUnion(int32 item1,
-                           int32 item2) cil managed
+      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion NewSomeUnion(int32 item1, int32 item2) cil managed
       {
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -222,9 +220,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -335,9 +331,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -361,9 +355,7 @@
         IL_0022:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.netcore.bsl
@@ -67,9 +67,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion 
-              NewSomeUnion(int32 item1,
-                           int32 item2) cil managed
+      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion NewSomeUnion(int32 item1, int32 item2) cil managed
       {
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -222,9 +220,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -335,9 +331,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -361,9 +355,7 @@
         IL_0022:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.net472.bsl
@@ -87,9 +87,7 @@
         IL_0006:  ret
       } 
 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 39 45 71 75 61 6C 73 31 38 2B   
@@ -191,9 +189,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -298,9 +294,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -322,9 +316,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -560,9 +552,7 @@
   .field private class [runtime]System.Type Type@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-  .method public specialname rtspecialname 
-          instance void  .ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType,
-                               class [runtime]System.Type Type) cil managed
+  .method public specialname rtspecialname instance void  .ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType, class [runtime]System.Type Type) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.netcore.bsl
@@ -87,9 +87,7 @@
         IL_0006:  ret
       } 
 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 39 45 71 75 61 6C 73 31 38 2B   
@@ -191,9 +189,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -298,9 +294,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -322,9 +316,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -36,7 +36,8 @@ module ILChecker =
         let strings = @"""((\\[^\n]|[^""\n])*)"""
         let verbatimStrings = @"@(""[^""]*"")+"
         let methodSingleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(\s*\{)"
-        let methodMultiLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
+        let methodDoubleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
+        let methodTripleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
         let normalizeNewLines (text: string) = text.Replace("\r\n", "\n").Replace("\r\n", "\r")
         let resourceMultiLine = @"(?<resource>\.mresource\s+.*)(?<block>\s*\{[^}]*\})"
 
@@ -52,8 +53,9 @@ module ILChecker =
 
         let unifyMethodLine (text:string) =
             let text1 = Regex.Replace(text, $"{methodSingleLine}", (fun me -> $"{me.Groups[1].Value}\n{me.Groups[2].Value}"), RegexOptions.Multiline)
-            let text2 = Regex.Replace(text1, $"{methodMultiLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value}\n{me.Groups[3].Value}"), RegexOptions.Multiline)
-            text2
+            let text2 = Regex.Replace(text1, $"{methodDoubleLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value}\n{me.Groups[3].Value}"), RegexOptions.Multiline)
+            let text3 = Regex.Replace(text2, $"{methodTripleLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value} {me.Groups[3].Value}\n{me.Groups[4].Value}"), RegexOptions.Multiline)
+            text3
 
         let replace input (pattern, replacement: string) = Regex.Replace(input, pattern, replacement, RegexOptions.Singleline)
 

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
@@ -203,8 +203,7 @@ module Nested =
         IL_0001:  throw
       } 
 
-      .method public specialname rtspecialname 
-              instance void  .ctor(int32 x) cil managed
+      .method public specialname rtspecialname instance void  .ctor(int32 x) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 1D 52 65 66 65 72 65 6E 63 65   
@@ -1216,9 +1215,7 @@ type Person(name : string, age : int) =
             extends [runtime]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
-    .method public specialname rtspecialname
-               instance void  .ctor(string name,
-                                    int32 age) cil managed
+    .method public specialname rtspecialname instance void  .ctor(string name, int32 age) cil managed
     {
 
       .maxstack  8


### PR DESCRIPTION
This PR:
- [x] Fixes: https://github.com/dotnet/fsharp/issues/17541
- [x] Adds a regression for it
- [x] Adds additional IL generation testing.
- [x] Some tests were not evaluating interesting IL, so updates that
- [x] Improves the IL comparison slightly by merging more multi-line method signatures.