### PR TITLE
Fix 17561 - FS0243 - Unrecognized option: '--realsig-

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/8.0.400.md
@@ -18,6 +18,7 @@
 * Fix for exponential runtime in CE builders when using nested implicit yields [PR #17096](https://github.com/dotnet/fsharp/pull/17096)
 * Fix several AND operator parser bugs and regressions ([Issue #16447](https://github.com/dotnet/fsharp/issues/16447), [Issue #17134](https://github.com/dotnet/fsharp/issues/17134), [Issue #16309](https://github.com/dotnet/fsharp/issues/16309), [PR #17113](https://github.com/dotnet/fsharp/pull/17113))
 * Treat exceptions as types in a namespace for graph based type checking ([Issue #17262](https://github.com/dotnet/fsharp/issues/17262), [PR #17268](https://github.com/dotnet/fsharp/pull/17268))
+* FS0243 - Unrecognized option: '--realsig-' #17561 ([Issue #17561](https://github.com/dotnet/fsharp/issues/17561), [PR #17268](https://github.com/dotnet/fsharp/pull/17562))
 
 ### Added
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>8</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>400</FSBuildVersion>
+    <FSBuildVersion>401</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->

--- a/src/FSharp.Build/Fsc.fs
+++ b/src/FSharp.Build/Fsc.fs
@@ -56,7 +56,7 @@ type public Fsc() as this =
     let mutable preferredUILang: string MaybeNull = null
     let mutable publicSign: bool = false
     let mutable provideCommandLineArgs: bool = false
-    let mutable realsig: bool = false
+    let mutable realsig: bool option = None
     let mutable references: ITaskItem[] = [||]
     let mutable referencePath: string MaybeNull = null
     let mutable refOnly: bool = false
@@ -196,10 +196,10 @@ type public Fsc() as this =
             builder.AppendSwitch("--optimize-")
 
         // realsig
-        if realsig then
-            builder.AppendSwitch("--realsig+")
-        else
-            builder.AppendSwitch("--realsig-")
+        match realsig with
+        | Some true -> builder.AppendSwitch("--realsig+")
+        | Some false -> builder.AppendSwitch("--realsig-")
+        | None -> ()
 
         // Tailcalls
         if not tailcalls then
@@ -539,8 +539,11 @@ type public Fsc() as this =
 
     // --realsig[+-]
     member _.RealSig
-        with get () = realsig
-        and set (b) = realsig <- b
+        with get () =
+            match realsig with
+            | Some true -> true
+            | _ -> false
+        and set (b) = realsig <- Some b
 
     // -r <string>: Reference an F# or .NET assembly.
     member _.References

--- a/vsintegration/tests/UnitTests/Tests.Build.fs
+++ b/vsintegration/tests/UnitTests/Tests.Build.fs
@@ -79,7 +79,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--codepage:65001" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -95,7 +94,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("-g" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -111,7 +109,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--debug:pdbonly" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -129,7 +126,6 @@ type Build() =
         AssertEqual ("--define:FOO=3" + Environment.NewLine +
                      "--define:BAR=4" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -144,7 +140,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--nowarn:52,109" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -160,7 +155,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -175,7 +169,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--warnaserror-:52,109" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -189,9 +182,7 @@ type Build() =
         tool.VersionFile <- "src/version"
         AssertEqual "src/version" tool.VersionFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--versionfile:src/version" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -208,7 +199,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--doc:foo.xml" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -224,7 +214,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--sig:foo.fsi" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -240,7 +229,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--keyfile:key.txt" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -256,7 +244,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--noframework" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -269,9 +256,7 @@ type Build() =
         tool.Optimize <- false
         AssertEqual false tool.Optimize 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize-" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -285,9 +270,7 @@ type Build() =
         AssertEqual true tool.Tailcalls
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        // REVIEW we don't put the default, is that desired?
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -300,9 +283,7 @@ type Build() =
         tool.OtherFlags <- "--yadda yadda"
         AssertEqual "--yadda yadda" tool.OtherFlags 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -320,7 +301,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("-o:oUt.dll" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -333,9 +313,7 @@ type Build() =
         tool.PdbFile <- "out.pdb"
         AssertEqual "out.pdb" tool.PdbFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--pdb:out.pdb" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -349,9 +327,7 @@ type Build() =
         tool.Platform <- "x64"
         AssertEqual "x64" tool.Platform 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--platform:x64" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -365,9 +341,7 @@ type Build() =
         tool.Platform <- "x86"
         AssertEqual "x86" tool.Platform 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--platform:x86" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -382,9 +356,7 @@ type Build() =
         tool.References <- [| MakeTaskItem dll |]
         AssertEqual 1 tool.References.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "-r:" + dll + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -399,9 +371,7 @@ type Build() =
         tool.ReferencePath <- path
         AssertEqual path tool.ReferencePath 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--lib:c:\\sd\\staging\\tools\\nunit\\,c:\\Foo" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -416,9 +386,7 @@ type Build() =
         tool.ReferencePath <- path
         AssertEqual path tool.ReferencePath 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--lib:c:\\program files,c:\\sd\\staging\\tools\\nunit,c:\\Foo" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -432,9 +400,7 @@ type Build() =
         tool.Resources <- [| MakeTaskItem "Foo.resources" |]
         AssertEqual 1 tool.Resources.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--resource:Foo.resources" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -450,9 +416,7 @@ type Build() =
         tool.Sources <- [| iti; iti |]
         AssertEqual 2 tool.Sources.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -468,9 +432,7 @@ type Build() =
         tool.TargetType <- "Library"
         AssertEqual "Library" tool.TargetType 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--target:library" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -484,9 +446,7 @@ type Build() =
         tool.TargetType <- "Winexe"
         AssertEqual "Winexe" tool.TargetType 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--target:winexe" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -500,9 +460,7 @@ type Build() =
         tool.TargetType <- "Module"
         AssertEqual "Module" tool.TargetType 
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--target:module" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -515,9 +473,7 @@ type Build() =
         let tool = new FSharp.Build.Fsc()
         tool.Utf8Output <- true
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--utf8output" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -530,9 +486,7 @@ type Build() =
         let tool = new FSharp.Build.Fsc()
         tool.Win32ResourceFile <- "foo.res"
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--win32res:foo.res" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -545,9 +499,7 @@ type Build() =
         let tool = new FSharp.Build.Fsc()
         tool.Win32ManifestFile <- "foo.manifest"
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--win32manifest:foo.manifest" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -560,9 +512,7 @@ type Build() =
         let tool = new FSharp.Build.Fsc()
         tool.HighEntropyVA <- true
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva+" + Environment.NewLine +
@@ -574,9 +524,7 @@ type Build() =
         let tool = new FSharp.Build.Fsc()
         tool.SubsystemVersion <- "6.02"
         let cmd = tool.InternalGenerateResponseFileCommands()
-        printfn "cmd=\"%s\"" cmd
         AssertEqual ("--optimize+" + Environment.NewLine +
-                     "--realsig-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--subsystemversion:6.02" + Environment.NewLine +
@@ -631,7 +579,6 @@ type Build() =
             "--sig:foo.fsi" + Environment.NewLine +
             "--keyfile:key.txt" + Environment.NewLine +
             "--optimize+" + Environment.NewLine +
-            "--realsig-" + Environment.NewLine +
             "--pdb:out.pdb" + Environment.NewLine +
             "--platform:anycpu" + Environment.NewLine +
             "--resource:MyRes.resources" + Environment.NewLine +
@@ -675,7 +622,6 @@ type Build() =
             "--sig:foo.fsi" 
             "--keyfile:key.txt"
             "--optimize+"
-            "--realsig-"
             "--pdb:out.pdb"
             "--platform:anycpu"
             "--resource:MyRes.resources"
@@ -719,7 +665,6 @@ type Build() =
 
         let expected =
             "--optimize+" + Environment.NewLine +
-            "--realsig-" + Environment.NewLine +
             "--nowarn:52,109,110,73,85" + Environment.NewLine +
             "--fullpaths" + Environment.NewLine +
             "--flaterrors" + Environment.NewLine +


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f7b331aa-66c9-4b35-95f9-c160a719f193)

Repro:
on a clean machine:
1. Install Visual Studio 2022.11  --- https://visualstudio.microsoft.com/downloads/
2. Install Dotnet Sdk 7.0.410   -- https://dotnet.microsoft.com/en-us/download/dotnet/7.0
3. Create a new F# console project
4. Edit the project file to resemble this:
````
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net7.0</TargetFramework>
    <FSharpPreferNetFrameworkTools>False</FSharpPreferNetFrameworkTools>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="Program.fs" />
  </ItemGroup>

</Project>
````
5. Build the project and observe this error:
![image](https://github.com/user-attachments/assets/62dcabd9-7d3d-42c5-85be-b3dcac01cfd6)

The issue is that the buildtask emits --realsig- even though the projectfile and dependent props and targets do not mention it.
This pr fixes the issue by not emiting a value when realsig has not been specified.

There is no decent work around, other than build from the command line using dotnet build.


