### PR TITLE
Use concurrent dictionary in NameMultiMap for CE yield cache

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5564,7 +5564,7 @@ let emptyTcEnv g =
       eCallerMemberName = None 
       eLambdaArgInfos = []
       eIsControlFlow = false
-      eCachedImplicitYieldExpressions = HashMultiMap(HashIdentity.Structural) }
+      eCachedImplicitYieldExpressions = HashMultiMap(HashIdentity.Structural, useConcurrentDictionary = true) }
 
 let CreateInitialTcEnv(g, amap, scopem, assemblyName, ccus) =
     (emptyTcEnv g, ccus) ||> List.collectFold (fun env (ccu, autoOpens, internalsVisible) -> 

--- a/src/Compiler/Utilities/HashMultiMap.fsi
+++ b/src/Compiler/Utilities/HashMultiMap.fsi
@@ -13,14 +13,14 @@ type internal HashMultiMap<'Key, 'Value
 #endif
     > =
     /// Create a new empty mutable HashMultiMap with the given key hash/equality functions.
-    new: comparer: IEqualityComparer<'Key> -> HashMultiMap<'Key, 'Value>
+    new: comparer: IEqualityComparer<'Key> * ?useConcurrentDictionary: bool -> HashMultiMap<'Key, 'Value>
 
     /// Create a new empty mutable HashMultiMap with an internal bucket array of the given approximate size
     /// and with the given key hash/equality functions.
-    new: size: int * comparer: IEqualityComparer<'Key> -> HashMultiMap<'Key, 'Value>
+    new: size: int * comparer: IEqualityComparer<'Key> * ?useConcurrentDictionary: bool -> HashMultiMap<'Key, 'Value>
 
     /// Build a map that contains the bindings of the given IEnumerable.
-    new: entries: seq<'Key * 'Value> * comparer: IEqualityComparer<'Key> -> HashMultiMap<'Key, 'Value>
+    new: entries: seq<'Key * 'Value> * comparer: IEqualityComparer<'Key> * ?useConcurrentDictionary: bool -> HashMultiMap<'Key, 'Value>
 
     /// Make a shallow copy of the collection.
     member Copy: unit -> HashMultiMap<'Key, 'Value>


### PR DESCRIPTION
This might fix https://github.com/ionide/ionide-vscode-fsharp/issues/2035, until we have a better stack, this is our best guess what's happening (the only related change between 8.0.300 - 8.0.400).

Full list of changes between: https://github.com/dotnet/fsharp/compare/release/dev17.10...release/dev17.11

If anyone has better idea, feel free to chime in.