### PR TITLE
Fix 17572

### DIFF
--- a/src/FSharp.Build/FSharpCommandLineBuilder.fs
+++ b/src/FSharp.Build/FSharpCommandLineBuilder.fs
@@ -89,6 +89,12 @@ type FSharpCommandLineBuilder() =
         if s <> String.Empty then
             args <- s :: args
 
+    member this.AppendOptionalSwitch(switch: string, value: bool option) =
+        match value with
+        | Some true -> this.AppendSwitch($"{switch}+")
+        | Some false -> this.AppendSwitch($"{switch}-")
+        | None -> ()
+
     member _.AppendSwitchUnquotedIfNotNull(switch: string, value: string MaybeNull) =
         assert (switch = "") // we only call this method for "OtherFlags"
         // Unfortunately we still need to mimic what cmd.exe does, but only for "OtherFlags".

--- a/src/FSharp.Build/Fsc.fs
+++ b/src/FSharp.Build/Fsc.fs
@@ -27,7 +27,7 @@ type public Fsc() as this =
     let mutable codePage: string MaybeNull = null
     let mutable commandLineArgs: ITaskItem list = []
     let mutable compilerTools: ITaskItem[] = [||]
-    let mutable compressMetadata = true
+    let mutable compressmetadata: bool option = None
     let mutable debugSymbols = false
     let mutable debugType: string MaybeNull = null
     let mutable defineConstants: ITaskItem[] = [||]
@@ -168,8 +168,7 @@ type public Fsc() as this =
         builder.AppendSwitchIfNotNull("--baseaddress:", baseAddress)
 
         // CompressMetadata
-        if compressMetadata then
-            builder.AppendSwitch("--compressmetadata")
+        builder.AppendOptionalSwitch("--compressmetadata", compressmetadata)
 
         // DefineConstants
         for item in defineConstants do
@@ -197,10 +196,7 @@ type public Fsc() as this =
             builder.AppendSwitch("--optimize-")
 
         // realsig
-        match realsig with
-        | Some true -> builder.AppendSwitch("--realsig+")
-        | Some false -> builder.AppendSwitch("--realsig-")
-        | None -> ()
+        builder.AppendOptionalSwitch("--realsig", realsig)
 
         // Tailcalls
         if not tailcalls then
@@ -385,10 +381,13 @@ type public Fsc() as this =
         with get () = compilerTools
         and set (a) = compilerTools <- a
 
-    // CompressMetadata
+    // compressmetadata[+-]
     member _.CompressMetadata
-        with get () = compressMetadata
-        and set (v) = compressMetadata <- v
+        with get () =
+            match compressmetadata with
+            | Some true -> true
+            | _ -> false
+        and set (v) = compressmetadata <- Some v
 
     // -g: Produce debug file. Disables optimizations if a -O flag is not given.
     member _.DebugSymbols

--- a/vsintegration/tests/UnitTests/Tests.Build.fs
+++ b/vsintegration/tests/UnitTests/Tests.Build.fs
@@ -78,7 +78,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--codepage:65001" + Environment.NewLine +
-                     "--compressmetadata" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -94,7 +93,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("-g" + Environment.NewLine +
-                     "--compressmetadata" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -110,7 +108,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--debug:pdbonly" + Environment.NewLine +
-                     "--compressmetadata" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -126,8 +123,7 @@ type Build() =
         AssertEqual 2 tool.DefineConstants.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--define:FOO=3" + Environment.NewLine +
+        AssertEqual ("--define:FOO=3" + Environment.NewLine +
                      "--define:BAR=4" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
@@ -143,8 +139,7 @@ type Build() =
         AssertEqual "52;109" tool.DisabledWarnings
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--nowarn:52,109" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -159,8 +154,7 @@ type Build() =
         AssertEqual ";" tool.DisabledWarnings
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -174,8 +168,7 @@ type Build() =
         AssertEqual "52;109" tool.WarningsNotAsErrors
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--warnaserror-:52,109" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -190,8 +183,7 @@ type Build() =
         AssertEqual "src/version" tool.VersionFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--versionfile:src/version" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -206,8 +198,7 @@ type Build() =
         AssertEqual "foo.xml" tool.DocumentationFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--doc:foo.xml" + Environment.NewLine +
+        AssertEqual ("--doc:foo.xml" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -222,8 +213,7 @@ type Build() =
         AssertEqual "foo.fsi" tool.GenerateInterfaceFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--sig:foo.fsi" + Environment.NewLine +
+        AssertEqual ("--sig:foo.fsi" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -238,8 +228,7 @@ type Build() =
         AssertEqual "key.txt" tool.KeyFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--keyfile:key.txt" + Environment.NewLine +
+        AssertEqual ("--keyfile:key.txt" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -255,7 +244,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("--noframework" + Environment.NewLine +
-                     "--compressmetadata" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -270,8 +258,7 @@ type Build() =
         AssertEqual false tool.Optimize 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize-" + Environment.NewLine +
+        AssertEqual ("--optimize-" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -286,8 +273,7 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         // REVIEW we don't put the default, is that desired?
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -301,8 +287,7 @@ type Build() =
         AssertEqual "--yadda yadda" tool.OtherFlags 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -319,7 +304,6 @@ type Build() =
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
         AssertEqual ("-o:oUt.dll" + Environment.NewLine +
-                     "--compressmetadata" + Environment.NewLine +
                      "--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -334,8 +318,7 @@ type Build() =
         AssertEqual "out.pdb" tool.PdbFile 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--pdb:out.pdb" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -350,8 +333,7 @@ type Build() =
         AssertEqual "x64" tool.Platform 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--platform:x64" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -366,8 +348,7 @@ type Build() =
         AssertEqual "x86" tool.Platform 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--platform:x86" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -383,8 +364,7 @@ type Build() =
         AssertEqual 1 tool.References.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "-r:" + dll + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -400,8 +380,7 @@ type Build() =
         AssertEqual path tool.ReferencePath 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--lib:c:\\sd\\staging\\tools\\nunit\\,c:\\Foo" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -417,8 +396,7 @@ type Build() =
         AssertEqual path tool.ReferencePath 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--lib:c:\\program files,c:\\sd\\staging\\tools\\nunit,c:\\Foo" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -433,8 +411,7 @@ type Build() =
         AssertEqual 1 tool.Resources.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--resource:Foo.resources" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -451,8 +428,7 @@ type Build() =
         AssertEqual 2 tool.Sources.Length 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva-" + Environment.NewLine +
@@ -469,8 +445,7 @@ type Build() =
         AssertEqual "Library" tool.TargetType 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--target:library" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -485,8 +460,7 @@ type Build() =
         AssertEqual "Winexe" tool.TargetType 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--target:winexe" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -501,8 +475,7 @@ type Build() =
         AssertEqual "Module" tool.TargetType 
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--target:module" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -516,8 +489,7 @@ type Build() =
         tool.Utf8Output <- true
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--utf8output" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -531,8 +503,7 @@ type Build() =
         tool.Win32ResourceFile <- "foo.res"
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--win32res:foo.res" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -546,8 +517,7 @@ type Build() =
         tool.Win32ManifestFile <- "foo.manifest"
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--win32manifest:foo.manifest" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
@@ -561,8 +531,7 @@ type Build() =
         tool.HighEntropyVA <- true
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--highentropyva+" + Environment.NewLine +
@@ -575,8 +544,7 @@ type Build() =
         tool.SubsystemVersion <- "6.02"
         let cmd = tool.InternalGenerateResponseFileCommands()
         printfn "cmd=\"%s\"" cmd
-        AssertEqual ("--compressmetadata" + Environment.NewLine +
-                     "--optimize+" + Environment.NewLine +
+        AssertEqual ("--optimize+" + Environment.NewLine +
                      "--fullpaths" + Environment.NewLine +
                      "--flaterrors" + Environment.NewLine +
                      "--subsystemversion:6.02" + Environment.NewLine +
@@ -625,7 +593,6 @@ type Build() =
             "--debug:full" + Environment.NewLine +
             "--noframework" + Environment.NewLine  +
             "--baseaddress:0xBADF00D" + Environment.NewLine +
-            "--compressmetadata" + Environment.NewLine +
             "--define:FOO=3" + Environment.NewLine +
             "--define:BAR=4" + Environment.NewLine +
             "--doc:foo.xml" + Environment.NewLine +
@@ -669,7 +636,6 @@ type Build() =
             "--debug:full"
             "--noframework"
             "--baseaddress:0xBADF00D"
-            "--compressmetadata"
             "--define:FOO=3"
             "--define:BAR=4"
             "--doc:foo.xml"
@@ -718,7 +684,6 @@ type Build() =
         printfn "cmd=\"%s\"" cmd
 
         let expected =
-            "--compressmetadata" + Environment.NewLine +
             "--optimize+" + Environment.NewLine +
             "--nowarn:52,109,110,73,85" + Environment.NewLine +
             "--fullpaths" + Environment.NewLine +


### PR DESCRIPTION
Fixes: https://github.com/dotnet/fsharp/issues/17572 compressMetadata switch in fsc build task needs to be made optional

Update the fsc BuildTask so that it doesn't add compressMetadata to the fsc command line when it is not mentioned in the project file.  This allows the build task to work better with earlier versions of the compiler.



