### PR TITLE
Disable UpdateXlfOnBuild for VMR builds

### DIFF
--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -71,7 +71,7 @@
   <!-- localization -->
   <PropertyGroup>
     <EnableXlfLocalization Condition="'$(EnableXlfLocalization)' == '' AND ('$(Configuration)' == 'Proto' OR '$(MonoPackaging)' == 'true')">false</EnableXlfLocalization>
-    <UpdateXlfOnBuild Condition="'$(CI)' != '1'">true</UpdateXlfOnBuild>
+    <UpdateXlfOnBuild Condition="'$(OfficialBuildId)' == '' and '$(ContinuousIntegrationBuild)' != 'true' and '$(CI)' != '1'">true</UpdateXlfOnBuild>
   </PropertyGroup>
 
   <!-- source build -->

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -70,8 +70,7 @@
 
   <!-- localization -->
   <PropertyGroup>
-    <EnableXlfLocalization Condition="'$(EnableXlfLocalization)' == '' AND ('$(Configuration)' == 'Proto' OR '$(MonoPackaging)' == 'true')">false</EnableXlfLocalization>
-    <UpdateXlfOnBuild Condition="'$(OfficialBuildId)' == '' and '$(ContinuousIntegrationBuild)' != 'true' and '$(CI)' != '1'">true</UpdateXlfOnBuild>
+    <EnableXlfLocalization Condition="'$(EnableXlfLocalization)' == '' AND ('$(Configuration)' == 'Proto' OR '$(MonoPackaging)' == 'true')">false</EnableXlfLocalization>    
   </PropertyGroup>
 
   <!-- source build -->

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -553,8 +553,6 @@ stages:
           - checkout: self
             clean: true
           - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
-            env:
-              SKIP_NETCURRENT_FSC_BUILD: true
             displayName: Build / Test
           - task: PublishTestResults@2
             displayName: Publish Test Results
@@ -597,7 +595,6 @@ stages:
           - script: ./eng/cibuild.sh --configuration $(_BuildConfig) --testcoreclr
             env:
               COMPlus_DefaultStackSize: 1000000
-              SKIP_NETCURRENT_FSC_BUILD: true
             displayName: Build / Test
           - task: PublishTestResults@2
             displayName: Publish Test Results

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -19,7 +19,7 @@
 		 We are still not building the actual product in NetCurrent, so for official builds we remain as ns2.0.
 		 For 'BUILDING_USING_DOTNET' builds, we still want latest BCL annotations, so that contributors can get related warnings locally.
 
-     On CI, OSX has problems with Xliff targets for net9, skipping via SKIP_NETCURRENT_FSC_BUILD until resolved ( The target "UpdateXlf" does not exist in the project.)
+     OSX and Linux has problems with Xliff targets for net9, skipping via SKIP_NETCURRENT_FSC_BUILD until resolved ( The target "UpdateXlf" does not exist in the project.)
 	-->
     <TargetFrameworks Condition=" '$(OfficialBuildId)' == '' AND '$(FSharpNetCoreProductDefaultTargetFramework)' != '' AND '$(Configuration)' != 'Proto' AND '$(SKIP_NETCURRENT_FSC_BUILD)' != 'true' ">$(FSharpNetCoreProductDefaultTargetFramework);$(TargetFrameworks)</TargetFrameworks>
     <DefineConstants Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">$(DefineConstants);FSHARPCORE_USE_PACKAGE</DefineConstants>

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.cs.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.cs.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Další informace o F# najdete na:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Na tomto webu najdete tento kurz v podobě dokumentace:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">K získání dalších informací o použitém programovém kódu F# použijte</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Můžete upravit obsah elementu pole pomocí operátoru přiřazení s šipkou doleva.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Můžete upravit obsah elementu pole pomocí operátoru přiřazení s šipkou doleva.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Rozlišované sjednocení může také představovat hodnotu hrací karty.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Rozlišované sjednocení může také představovat hodnotu hrací karty.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Při vyjadřování dat se běžně používají záznamy i rozlišovaná sjednocení.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Při vyjadřování dat se běžně používají záznamy i rozlišovaná sjednocení.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Rozlišovaná sjednocení podporují i rekurzivní definice.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Rozlišovaná sjednocení podporují i rekurzivní definice.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.de.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.de.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Weitere Informationen zu F# finden Sie unter:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Dieses Tutorial ist auch als Dokumentation verfügbar. Siehe hierzu:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Verwenden Sie Folgendes, um weitere Informationen zur praktischen F#-Programmierung zu erhalten</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Sie können die Inhalte eines Arrayelements mithilfe des Zuweisungsoperators "Pfeil nach links" ändern.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Sie können die Inhalte eines Arrayelements mithilfe des Zuweisungsoperators "Pfeil nach links" ändern.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Eine diskriminierte Union kann auch verwendet werden, um den Rang einer Spielkarte darzustellen.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Eine diskriminierte Union kann auch verwendet werden, um den Rang einer Spielkarte darzustellen.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Beim Darstellen von Daten werden häufig sowohl Datensätze als auch diskriminierte Unions verwendet.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Beim Darstellen von Daten werden häufig sowohl Datensätze als auch diskriminierte Unions verwendet.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Diskriminierte Unions unterstützen auch rekursive Definitionen.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Diskriminierte Unions unterstützen auch rekursive Definitionen.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.es.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.es.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Para obtener más información acerca de F#, vea:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Para ver este tutorial en forma de documentación, vea:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Para obtener más información sobre la programación de F# aplicada, use</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Puede modificar el contenido de un elemento de matriz mediante el operador de asignación de flecha izquierda.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Puede modificar el contenido de un elemento de matriz mediante el operador de asignación de flecha izquierda.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">También se puede usar una unión discriminada para representar el rango de una carta.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">También se puede usar una unión discriminada para representar el rango de una carta.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Es habitual utilizar tanto registros como uniones discriminadas cuando se representan datos.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Es habitual utilizar tanto registros como uniones discriminadas cuando se representan datos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Las uniones discriminadas admiten también definiciones recursivas.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Las uniones discriminadas admiten también definiciones recursivas.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.fr.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.fr.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Pour en savoir plus sur F#, consultez :</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Pour afficher ce didacticiel au format documentation, consultez :</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Pour en savoir plus sur la programmation F# appliquée, utilisez</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Vous pouvez modifier le contenu d'un élément de tableau à l'aide de l'opérateur d'assignation flèche gauche.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Vous pouvez modifier le contenu d'un élément de tableau à l'aide de l'opérateur d'assignation flèche gauche.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Une union discriminée peut également servir à représenter le rang d'une carte à jouer.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Une union discriminée peut également servir à représenter le rang d'une carte à jouer.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Il est fréquent d'utiliser à la fois des enregistrements et des unions discriminées pour représenter des données.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Il est fréquent d'utiliser à la fois des enregistrements et des unions discriminées pour représenter des données.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Les unions discriminées prennent également en charge les définitions récursives.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Les unions discriminées prennent également en charge les définitions récursives.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.it.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.it.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Per altre informazioni su F#, vedere:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Per visualizzare questa esercitazione sotto forma di documentazione, vedere:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Per altre informazioni sulla programmazione F# applicata, usare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">È possibile modificare il contenuto di un elemento di matrice usando l'operatore di assegnazione freccia sinistra.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">È possibile modificare il contenuto di un elemento di matrice usando l'operatore di assegnazione freccia sinistra.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">È possibile usare un'unione discriminata anche per rappresentare il valore di una carta da gioco.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">È possibile usare un'unione discriminata anche per rappresentare il valore di una carta da gioco.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Per la rappresentazione dei dati si usano in genere record e unioni discriminate.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Per la rappresentazione dei dati si usano in genere record e unioni discriminate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Le unioni discriminate supportano anche definizioni ricorsive.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Le unioni discriminate supportano anche definizioni ricorsive.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.ja.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.ja.xlf
@@ -22,14 +22,14 @@
         <target state="translated">F# の詳細については、次のページを参照してください:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">このチュートリアルをドキュメント形式で表示するには、次を参照してください:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">適用された F# プログラミングの詳細については、次を使用します</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">左矢印代入演算子を使用して、配列要素の内容を変更できます。</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">左矢印代入演算子を使用して、配列要素の内容を変更できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">判別共用体はトランプのランクを表すためにも使用できます。</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">判別共用体はトランプのランクを表すためにも使用できます。</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">データを表すときには、レコードと判別共用体の両方を使用するのが一般的です。</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">データを表すときには、レコードと判別共用体の両方を使用するのが一般的です。</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">判別共用体は再帰的な定義もサポートしています。</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">判別共用体は再帰的な定義もサポートしています。</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.ko.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.ko.xlf
@@ -22,14 +22,14 @@
         <target state="translated">F#에 대한 자세한 내용은 다음을 참조하세요:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">이 자습서를 설명서 형식으로 보려면 다음을 참조하세요:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">적용된 F# 프로그래밍에 대해 자세히 알아보려면 다음을 사용하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">왼쪽 화살표 대입 연산자를 사용하여 배열 요소의 내용을 수정할 수 있습니다.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">왼쪽 화살표 대입 연산자를 사용하여 배열 요소의 내용을 수정할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">구분된 공용 구조체를 사용하여 플레잉 카드의 순위를 나타낼 수도 있습니다.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">구분된 공용 구조체를 사용하여 플레잉 카드의 순위를 나타낼 수도 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">일반적으로 레코드와 구분된 공용 구조체를 모두 사용하여 데이터를 나타냅니다.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">일반적으로 레코드와 구분된 공용 구조체를 모두 사용하여 데이터를 나타냅니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">구분된 공용 구조체는 재귀 정의도 지원합니다.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">구분된 공용 구조체는 재귀 정의도 지원합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.pl.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.pl.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Aby uzyskać więcej informacji o języku F#, zobacz:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Aby wyświetlić ten samouczek w formie dokumentacji, zobacz:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Aby dowiedzieć się więcej o programowaniu w języku F# w praktyce, użyj</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Możesz zmodyfikować zawartość elementu tablicy za pomocą operatora przypisania „strzałka w lewo”.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Możesz zmodyfikować zawartość elementu tablicy za pomocą operatora przypisania „strzałka w lewo”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Unii rozłącznej można również użyć do reprezentowania wartości karty do gry.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Unii rozłącznej można również użyć do reprezentowania wartości karty do gry.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Często używa się rekordów i unii rozłącznych w przypadku reprezentowania danych.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Często używa się rekordów i unii rozłącznych w przypadku reprezentowania danych.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Unie rozłączne obsługują również definicje rekursywne.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Unie rozłączne obsługują również definicje rekursywne.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.pt-BR.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.pt-BR.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Para obter mais informações sobre F#, consulte:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Para ver este tutorial em forma de documentação, consulte:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Para saber mais sobre a programação F# aplicada, use</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Você pode modificar o conteúdo de um elemento de matriz usando o operador de atribuição de seta para a esquerda.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Você pode modificar o conteúdo de um elemento de matriz usando o operador de atribuição de seta para a esquerda.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Uma União Discriminada também pode ser usada para representar a classificação de uma carta de baralho.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Uma União Discriminada também pode ser usada para representar a classificação de uma carta de baralho.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">É comum usar Registros e Uniões Discriminadas ao representar dados.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">É comum usar Registros e Uniões Discriminadas ao representar dados.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Uniões Discriminadas também dão suporte a definições recursivas.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Uniões Discriminadas também dão suporte a definições recursivas.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.ru.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.ru.xlf
@@ -22,14 +22,14 @@
         <target state="translated">Дополнительные сведения о F# см. по адресу:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Чтобы просмотреть это руководство в виде документа, см.:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Чтобы получить дополнительные сведения о прикладном программировании на языке F#, воспользуйтесь</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Изменить содержимое элемента массива можно с помощью оператора присваивания в виде стрелки влево.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Изменить содержимое элемента массива можно с помощью оператора присваивания в виде стрелки влево.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Размеченное объединение также может использоваться для представления ранга игральной карты.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Размеченное объединение также может использоваться для представления ранга игральной карты.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Как правило, при представлении данных используются как записи, так и размеченные объединения.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Как правило, при представлении данных используются как записи, так и размеченные объединения.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Размеченные объединения также поддерживают рекурсивные определения.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Размеченные объединения также поддерживают рекурсивные определения.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.tr.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.tr.xlf
@@ -22,14 +22,14 @@
         <target state="translated">F# hakkında daha fazla bilgi için bkz:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">Bu öğreticiyi belge biçiminde görmek için, bkz:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">Uygulamalı F# programlama hakkında daha fazla bilgi edinmek için şunu kullanın</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">Bir dizi öğesinin içeriğini sol ok atama işlecini kullanarak değiştirebilirsiniz.</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">Bir dizi öğesinin içeriğini sol ok atama işlecini kullanarak değiştirebilirsiniz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">Bir iskambil kartının sırasını göstermek için bir Ayırt Edici Birleşim de kullanılabilir.</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">Bir iskambil kartının sırasını göstermek için bir Ayırt Edici Birleşim de kullanılabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">Verileri temsil ederken Kayıtları ve Ayırt Edici Birleşimleri birlikte kullanmak yaygındır.</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">Verileri temsil ederken Kayıtları ve Ayırt Edici Birleşimleri birlikte kullanmak yaygındır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">Ayırt Edici Birleşimler ayrıca özyinelemeli tanımları da destekler.</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">Ayırt Edici Birleşimler ayrıca özyinelemeli tanımları da destekler.</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.zh-Hans.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.zh-Hans.xlf
@@ -22,14 +22,14 @@
         <target state="translated">有关 F# 的详细信息，请参见:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">若要以文档的形式查看此教程，请参阅:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">若要了解有关已应用的 F# 编程的详细信息，请使用</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">可使用左箭头赋值运算符来修改数组元素的内容。</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">可使用左箭头赋值运算符来修改数组元素的内容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">可区分联合还可用来表示纸牌的设置级别。</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">可区分联合还可用来表示纸牌的设置级别。</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">表示数据时同时使用记录和可区分联合是很常见的。</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">表示数据时同时使用记录和可区分联合是很常见的。</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">可区分联合还支持递归定义。</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">可区分联合还支持递归定义。</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.zh-Hant.xlf
+++ b/vsintegration/ProjectTemplates/TutorialProject/Template/xlf/Tutorial.fsx.zh-Hant.xlf
@@ -22,14 +22,14 @@
         <target state="translated">如需有關 F# 的詳細資訊，請參閱:</target>
         <note />
       </trans-unit>
-      <trans-unit id="SeeDocumentaton">
-        <source>To see this tutorial in documentation form, see:</source>
-        <target state="translated">若要參閱文件表單中的此教學課程，請參閱:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="LearnMoreAbout">
         <source>To learn more about applied F# programming, use</source>
         <target state="translated">如需深入了解套用的 F# 程式設計，請使用</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SeeDocumentation">
+        <source>To see this tutorial in documentation form, see:</source>
+        <target state="new">To see this tutorial in documentation form, see:</target>
         <note />
       </trans-unit>
       <trans-unit id="ToInstall-Line1">
@@ -743,8 +743,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line1">
-        <source>You can modify the contents of an an array element by using the left arrow assignment operator.</source>
-        <target state="translated">您可以使用向左鍵指派運算子來修改陣列元素的內容。</target>
+        <source>You can modify the contents of an array element by using the left arrow assignment operator.</source>
+        <target state="needs-review-translation">您可以使用向左鍵指派運算子來修改陣列元素的內容。</target>
         <note />
       </trans-unit>
       <trans-unit id="ArrayAssignment-Line2">
@@ -1008,8 +1008,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardRank">
-        <source>A Disciminated Union can also be used to represent the rank of a playing card.</source>
-        <target state="translated">差異聯集也可用以代表一張撲克牌的順位。</target>
+        <source>A Discriminated Union can also be used to represent the rank of a playing card.</source>
+        <target state="needs-review-translation">差異聯集也可用以代表一張撲克牌的順位。</target>
         <note />
       </trans-unit>
       <trans-unit id="CardRankValue">
@@ -1028,8 +1028,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CardType-Line2">
-        <source>It's common to use both Records and Disciminated Unions when representing data.</source>
-        <target state="translated">代表資料時，通常會使用記錄與差異聯集。</target>
+        <source>It's common to use both Records and Discriminated Unions when representing data.</source>
+        <target state="needs-review-translation">代表資料時，通常會使用記錄與差異聯集。</target>
         <note />
       </trans-unit>
       <trans-unit id="ComputeFullDeck">
@@ -1088,8 +1088,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line1">
-        <source>Disciminated Unions also support recursive definitions.</source>
-        <target state="translated">差異聯集也支援遞迴定義。</target>
+        <source>Discriminated Unions also support recursive definitions.</source>
+        <target state="needs-review-translation">差異聯集也支援遞迴定義。</target>
         <note />
       </trans-unit>
       <trans-unit id="DuRecursiveDef-Line2">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.cs.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Určete, kolik informací je zahrnuto ve výstupu sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">Rozhraní kompatibilní se standardem ECMA-335 pro rozhraní CLI (musí být zadané umístění)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Sestavení se spustit nedá, protože už probíhá jiné sestavení.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">Pracovní adresář neexistuje:\n{0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.de.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Geben Sie an, wie viele Informationen in der Buildausgabe enthalten sein sollen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI-kompatibles Framework (Ort muss angegeben werden)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Ein Buildvorgang kann nicht gestartet werden, da bereits ein Buildvorgang ausgeführt wird.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">Das Arbeitsverzeichnis existiert nicht:\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.es.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Especifique la información que se incluirá en el resultado de la compilación.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">Versión de .NET Framework compatible con ECMA-335 CLI (se debe proporcionar la ubicación)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">No se puede iniciar una compilación porque ya hay otra compilación en curso.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">El directorio de trabajo no existe:\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.fr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Indique les informations incluses dans la sortie de génération</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">Framework compatible ECMA-335 CLI (emplacement doit être fourni)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Impossible de démarrer une build, car une autre build est déjà en cours.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">Le répertoire de travail n'existe pas :\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.it.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Specificare la quantità di informazioni incluse nell'output di compilazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">Framework compatibile con lo standard ECMA-335 CLI (è necessario fornire il percorso)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Non è possibile avviare una compilazione perché ne è già in corso un'altra.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">La directory di lavoro non esiste:\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.ja.xlf
@@ -52,6 +52,11 @@
         <target state="translated">ビルド出力に含まれる情報の量を指定します</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI 互換フレームワーク (場所の指定が必要)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">別のビルドが既に進行中であるため、ビルドを開始できません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">作業ディレクトリが存在しません:\n'{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.ko.xlf
@@ -52,6 +52,11 @@
         <target state="translated">빌드 출력에 포함할 정보의 양을 지정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI 호환 프레임워크(위치를 지정해야 함)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">다른 빌드가 이미 진행 중이므로 빌드를 시작할 수 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">작업 디렉터리가 없습니다.\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.pl.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Określ, ile informacji ma być uwzględnionych w danych wyjściowych kompilacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">Platforma zgodna z ECMA-335 CLI (należy podać lokalizację)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Nie można uruchomić kompilacji, ponieważ trwa już inna kompilacja.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">Katalog roboczy nie istnieje:\n„{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Especificar quantas informações são incluídas na saída da compilação</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">Estrutura compatível com a CLI da ECMA-335 (a localização deve ser fornecida)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Não é possível iniciar uma compilação porque outra já está em andamento.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">O diretório de trabalho não existe\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.ru.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Объем сведений, включаемых в выходные данные сборки</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI-совместимая инфраструктура (следует указать расположение)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Не удается начать сборку, поскольку уже выполняется другая сборка.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">Рабочий каталог не существует:\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.tr.xlf
@@ -52,6 +52,11 @@
         <target state="translated">Derleme çıktısında ne kadar bilgi bulunduğunu belirtin</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI uyumlu Framework (konum sağlanmalıdır)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">Zaten devam eden başka bir yapı olduğu için yapı başlatılamaz.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">Çalışma dizini yok:\n'{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="translated">指定生成输出中包含多少信息</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI 兼容框架(必须提供位置)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">无法启动生成，因为另一个生成已经在进行中。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">工作目录不存在:\n“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/xlf/Microsoft.VisualStudio.Package.Project.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="translated">指定組建輸出中要包含多少資訊</target>
         <note />
       </trans-unit>
+      <trans-unit id="WorkingDirectoryNonexistent">
+        <source>The working directory does not exist:\n'{0}'.</source>
+        <target state="new">The working directory does not exist:\n'{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="cli1">
         <source>ECMA-335 CLI compatible framework (location must be provided)</source>
         <target state="translated">ECMA-335 CLI 相容架構 (必須提供位置)</target>
@@ -713,11 +718,6 @@
       <trans-unit id="CannotBuildWhenBuildInProgress">
         <source>Cannot start a build, because another build is already in progress.</source>
         <target state="translated">無法啟動建置，因為另一個建置已經在進行中。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="WorkingDirectoryNotExists">
-        <source>The working directory does not exist:\n'{0}'.</source>
-        <target state="translated">工作目錄不存在:\n'{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectReferencesDifferentFramework">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Preferovat 32bitovou verzi</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Výstup</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">Žád&amp;ná</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">Potlačit upozo&amp;rnění:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">32-Bit &amp;bevorzugen</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Ausgabe</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Keine</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">Warnungen &amp;unterdrücken:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Preferir 32 bits</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Salida</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">Ning&amp;uno</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">&amp;Suprimir advertencias:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Préférer 32 bits</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Sortie</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Aucune</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">&amp;Supprimer les avertissements :</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Preferisci 32 bit</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Output</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Nessuna</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">Non visualizzare avvi&amp;si:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">32 ビットを優先(&amp;P)</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">出力</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">なし(&amp;N)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">警告の表示なし(&amp;S):</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">32비트 기본 사용(&amp;P)</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">출력</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">없음(&amp;N)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">경고 표시 안 함(&amp;S):</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Preferuj wersję 32-bitową</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Wyjściowe</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Brak</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">&amp;Pomiń ostrzeżenia:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Preferir 32 bits</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Saída</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Nenhuma</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">&amp;Suprimir avisos:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">&amp;Предпочитать 32-разрядн.</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Вывод</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Нет</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">&amp;Отключить предупреждения:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">32 Biti &amp;Tercih Et</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">Çıkış</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">&amp;Hiçbiri</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">&amp;Uyarıları kapat:</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">首选 32 位(&amp;P)</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">输出</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">无(&amp;N)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">禁止显示警告(&amp;S):</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/xlf/BuildPropPage.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">建議使用 32 位元(&amp;P)</target>
         <note />
       </trans-unit>
+      <trans-unit id="lblSuppressWarnings.Text">
+        <source>&amp;Suppress warnings:</source>
+        <target state="new">&amp;Suppress warnings:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="outputLabel.Text">
         <source>Output</source>
         <target state="translated">輸出</target>
@@ -60,11 +65,6 @@
       <trans-unit id="rbWarningNone.Text">
         <source>&amp;None</source>
         <target state="translated">無(&amp;N)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="lblSupressWarnings.Text">
-        <source>&amp;Suppress warnings:</source>
-        <target state="translated">隱藏警告(&amp;S):</target>
         <note />
       </trans-unit>
       <trans-unit id="cboWarningLevel.Items">

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
@@ -913,14 +913,14 @@ Chyba:</target>
         <target state="translated">Vlastnosti odkazu</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Název vzdáleného počítače nesmí být prázdný.  Zadejte prosím název vzdáleně laděného počítače.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Externí program se nedá najít. Zadejte prosím platný spustitelný soubor.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Chyba:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">Adresa URL není platná. Zadejte prosím platnou adresu URL, třeba http://www.microsoft.com/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Chyba:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">„Soubory prostředků musí mít příponu .res. Zadejte prosím platný název souboru prostředků.“</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Zadaný soubor prostředků neexistuje."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Chyba:</target>
         <target state="translated">Vyžaduje:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Název</target>
@@ -1763,11 +1778,6 @@ Opravdu chcete tento soubor upravit?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">Položka prostředku používá typ {0}, který se v tomto projektu nepodporuje.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Jedna nebo více položek prostředků {0} nejdou správně uložit.  Tyto položky budou zahozeny.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Spojený až při kompilaci</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Vložený do souboru .resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Bitové mapy</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Odstranit hodnoty buněk {0}</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Kategorie:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
@@ -913,14 +913,14 @@ Fehler:</target>
         <target state="translated">Verweiseigenschaften</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Der Name des Remotecomputers darf nicht leer sein.  Geben Sie den Namen des Computers für das Remotedebuggen ein.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Das externe Programm wurde nicht gefunden. Geben Sie eine gültige ausführbare Datei ein.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Fehler:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">Die URL ist ungültig. Geben Sie eine gültige URL (beispielsweise "http://www.microsoft.com/") ein.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Fehler:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"Ressourcendateien müssen die Dateierweiterung ".res" besitzen. Geben Sie einen gültigen Ressourcendateinamen ein."</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Die eingegebene Ressourcendatei ist nicht vorhanden."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Fehler:</target>
         <target state="translated">Erforderlich:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Name</target>
@@ -1763,11 +1778,6 @@ Möchten Sie die Datei wirklich bearbeiten?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">Das Ressourcenelement verwendet den Typ "{0}", der in diesem Projekt nicht unterstützt wird.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Die Ressourcenelemente "{0}" konnten nicht ordnungsgemäß gespeichert werden.  Die Elemente werden verworfen.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Zur Kompilierzeit verknüpft</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">In .resx eingebettet</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Bitmaps</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Werte in {0} Zelle(n) löschen</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Kategorien:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
@@ -913,14 +913,14 @@ Error:</target>
         <target state="translated">Propiedades de la referencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">El nombre de la máquina remota no puede estar en blanco.  Especifique el nombre de la máquina para la depuración remota.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">No se encuentra el programa externo. Especifique un archivo ejecutable válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Error:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">La dirección URL no es válida. Escriba una dirección URL válida, como "http://www.microsoft.com/"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Error:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"Los archivos de recursos deben tener una extensión de archivo .res. Escriba un nombre de archivo de recursos válido".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"El archivo de recursos introducido no existe."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Error:</target>
         <target state="translated">Requiere:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Nombre</target>
@@ -1763,11 +1778,6 @@ Do you really want to edit this file?</source>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">El elemento de recurso utiliza el tipo '{0}'; que no se admite en este proyecto.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Los elementos de recurso {0} no se pueden guardar correctamente.  Estos elementos se descartarán.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Vinculado en tiempo de compilación</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Insertado en .resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Mapas de bits</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Eliminar valores en {0} celdas</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Categorías:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
@@ -913,14 +913,14 @@ Erreur :</target>
         <target state="translated">Propriétés de la référence</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Le nom de l'ordinateur distant ne peut pas être vide.  Spécifiez le nom de l'ordinateur à déboguer à distance.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Le programme externe est introuvable. Entrez un fichier exécutable valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Erreur :</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">L'URL n'est pas valide. Entrez une URL valide telle que "http://www.microsoft.com/"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Erreur :</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"Les fichiers de ressources doivent avoir une extension de fichier .res. Entrez un nom de fichier de ressources valide."</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Le fichier de ressources entré n'existe pas."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Erreur :</target>
         <target state="translated">Nécessite :</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Nom</target>
@@ -1763,11 +1778,6 @@ Voulez-vous vraiment modifier ce fichier ?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">L'élément de la ressource utilise le type '{0}' alors que ce type n'est pas pris en charge dans ce projet.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Impossible d'enregistrer correctement les éléments de la ressource {0}.  Ils vont être ignorés.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Lié au moment de la compilation</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Incorporé dans .resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Bitmaps</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Supprimer les valeurs dans {0} cellule(s)</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Catégories :</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -913,14 +913,14 @@ Errore:</target>
         <target state="translated">Proprietà del riferimento</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Il nome del computer remoto non può essere vuoto. Specificare il nome del computer di cui eseguire il debug remoto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Il programma esterno non è stato trovato. Immettere un file eseguibile valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Errore:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">L'URL non è valido. Immettere un URL valido, ad esempio "http://www.microsoft.com/"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Errore:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"Il file di risorse deve avere l'estensione RES. Immettere un nome di file di risorse valido."</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Il file di risorse immesso non esiste."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Errore:</target>
         <target state="translated">Richiede:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Nome</target>
@@ -1763,11 +1778,6 @@ Modificare il file?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">L'elemento risorsa usa il tipo '{0}', che non è supportato in questo progetto.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Non è possibile salvare correttamente gli elementi risorsa {0}. Gli elementi verranno ignorati.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Collegato in fase di compilazione</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Incorporato in .resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Bitmap</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Elimina valori in {0} cella/e</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Categorie:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
@@ -913,14 +913,14 @@ Error:</source>
         <target state="translated">参照プロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">リモート コンピューター名を空白にすることはできません。リモートでデバッグするコンピューターの名前を指定してください。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">外部プログラムが見つかりません。有効な実行可能ファイルを入力してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Error:</source>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">URL が無効です。"http://www.microsoft.com/" のような有効な URL を入力してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Error:</source>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"リソース ファイルには .res 拡張子が必要です。有効なリソース ファイル名を入力してください。"</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"入力されたリソース ファイルは存在しません。</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Error:</source>
         <target state="translated">必要なアクセス許可:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">名前</target>
@@ -1763,11 +1778,6 @@ Do you really want to edit this file?</source>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">リソース アイテムは '{0}' 型を使用していますが、このプロジェクトではサポートされていません。</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">リソース アイテム {0} を正しく保存できません。アイテムは破棄されます。</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">コンパイル時にリンクされました</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">.resx に埋め込まれました</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">ビットマップ</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">{0} 個のセルの値を消去します</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">カテゴリ(&amp;C):</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
@@ -913,14 +913,14 @@ Error:</source>
         <target state="translated">참조 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">원격 컴퓨터 이름은 비워 둘 수 없습니다.  원격으로 디버그할 컴퓨터의 이름을 지정하세요.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">외부 프로그램을 찾을 수 없습니다. 올바른 실행 파일을 입력하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Error:</source>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">URL이 잘못되었습니다. "http://www.microsoft.com/"과 같은 올바른 URL을 입력하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Error:</source>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"리소스 파일의 확장명은 .res여야 합니다. 올바른 리소스 파일 이름을 입력하세요."</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"입력한 리소스 파일이 없습니다."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Error:</source>
         <target state="translated">필요한 권한:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">이름</target>
@@ -1763,11 +1778,6 @@ Do you really want to edit this file?</source>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">리소스 항목이 이 프로젝트에서 지원하지 않는 '{0}' 형식을 사용합니다.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">리소스 항목 {0}을(를) 올바로 저장할 수 없습니다.  이 항목이 삭제됩니다.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">컴파일 시간에 링크됨</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">.resx에 포함됨</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">비트맵</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">{0}개 셀에서 값 삭제</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">범주(&amp;C):</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
@@ -913,14 +913,14 @@ Błąd:</target>
         <target state="translated">Właściwości odwołania</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Nazwa zdalnego komputera nie może być pusta.  Podaj nazwę komputera do zdalnego debugowania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Nie można odnaleźć zewnętrznego programu. Wprowadź prawidłowy plik wykonywalny.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Błąd:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">Adres URL jest nieprawidłowy. Wprowadź poprawny adres URL, np. „http://www.microsoft.com/”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Błąd:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">„Pliki zasobów muszą mieć rozszerzenie res. Wprowadź prawidłową nazwę pliku zasobu”.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Wprowadzony plik zasobu nie istnieje".</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Błąd:</target>
         <target state="translated">Wymagania:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Nazwa</target>
@@ -1763,11 +1778,6 @@ Czy na pewno chcesz edytować ten plik?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">Element zasobu używa typu '{0}', który nie jest obsługiwany w tym projekcie.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Nie można poprawnie zapisać elementów zasobów {0}.  Elementy zostaną odrzucone.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Połączone w czasie kompilacji</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Osadzone w pliku resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Mapy bitowe</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Usuń wartości w komórkach ({0})</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Kategorie:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
@@ -913,14 +913,14 @@ Erro:</target>
         <target state="translated">Propriedades de Referência</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">O nome do computador remoto não pode ficar em branco.  Especifique o nome do computador a ser depurado remotamente.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">O programa externo não foi encontrado. Insira um arquivo executável válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Erro:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">A URL é inválida. Insira uma URL válida como "http://www.microsoft.com/"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Erro:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"Os arquivos de recurso devem ter a extensão .res. Insira um nome de arquivo de recurso válido."</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"O arquivo de recurso inserido não existe."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Erro:</target>
         <target state="translated">Necessita de:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Nome</target>
@@ -1763,11 +1778,6 @@ Deseja realmente editar esse arquivo?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">O item de recurso usa o tipo '{0}', que não tem suporte neste projeto.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Os itens de recurso {0} não podem ser salvos corretamente.  Os itens serão descartados.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Vinculado no tempo de compilação</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Inserido no .resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Bitmaps</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Excluir valores em {0} célula(s)</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Categorias:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
@@ -913,14 +913,14 @@ Error:</source>
         <target state="translated">Свойства ссылки</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Имя удаленного компьютера не может быть пустым.  Укажите имя компьютера для удаленной отладки.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Невозможно найти внешнюю программу. Укажите допустимый исполняемый файл.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Error:</source>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">URL-адрес недопустим. Введите допустимый URL-адрес, например http://www.microsoft.com/.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Error:</source>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"У файлов ресурсов должно быть расширение RES. Укажите допустимое имя файла ресурсов".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Указанный файл ресурсов не существует."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Error:</source>
         <target state="translated">Требуется:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Имя</target>
@@ -1763,11 +1778,6 @@ Do you really want to edit this file?</source>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">Для элемента ресурса используется тип "{0}", который не поддерживается в этом проекте.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Невозможно правильно сохранить элементы ресурса "{0}".  Элементы будут отменены.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Скомпоновано во время компиляции</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">Внедрено в RESX-файл</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Точечные рисунки</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">Удаление значений в нескольких ячейках: {0}</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Категории:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
@@ -913,14 +913,14 @@ Hata:</target>
         <target state="translated">Başvuru Özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Uzak makine adı boş olamaz.  Lütfen uzaktan hata ayıklama işleminin yapılacağı makinenin adını belirtin.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">Dış program bulunamıyor. Lütfen geçerli bir yürütülebilir dosya girin.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Hata:</target>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">URL geçersiz. Lütfen "http://www.microsoft.com/" gibi geçerli bir URL girin</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Hata:</target>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"Kaynak dosyalarının uzantısı .res olmalıdır. Lütfen geçerli bir kaynak dosyası adı girin."</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"Girilen kaynak dosyası yok."</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Hata:</target>
         <target state="translated">Gereksinimler:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">Ad</target>
@@ -1763,11 +1778,6 @@ Bu dosyayı düzenlemek istediğinizden emin misiniz?</target>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">Kaynak öğesi bu projede desteklenmeyen '{0}' türünü kullanıyor.</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">Şu kaynak öğeleri doğru şekilde kaydedilemiyor: {0}.  Öğeler atılacak.</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">Derleme zamanında bağlandı</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">.resx biçiminde eklendi</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">Bit eşlemler</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">{0} hücredeki değerleri sil</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">&amp;Kategoriler:</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
@@ -913,14 +913,14 @@ Error:</source>
         <target state="translated">引用属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">远程计算机名称不能为空。请指定要远程调试的计算机的名称。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">未能找到外部程序。请输入有效的可执行文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Error:</source>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">URL 无效。请输入有效的 URL，如“http://www.microsoft.com/”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Error:</source>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">“资源文件必须具有文件扩展名 .res。请输入有效的资源文件名。”</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"输入的资源文件不存在。"</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Error:</source>
         <target state="translated">要求:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">名称</target>
@@ -1763,11 +1778,6 @@ Do you really want to edit this file?</source>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">资源项使用“{0}”类型，但该类型在此项目中不受支持。</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">无法正确保存资源项 {0}。将弃用此项(或这些项)。</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">在编译时链接</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">嵌入在 .resx 中</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">位图</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">删除 {0} 个单元格中的值</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">类别(&amp;C):</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
@@ -913,14 +913,14 @@ Error:</source>
         <target state="translated">參考屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_ProgramNonexistent">
+        <source>The external program cannot be found. Please enter a valid executable file.</source>
+        <target state="new">The external program cannot be found. Please enter a valid executable file.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">遠端電腦名稱不能為空白。請指定電腦名稱以進行遠端偵錯。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ProgramNotExist">
-        <source>The external program cannot be found. Please enter a valid executable file.</source>
-        <target state="translated">找不到外部程式。請輸入有效的可執行檔。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_NeedExternalProgram">
@@ -941,6 +941,11 @@ Error:</source>
       <trans-unit id="PropPage_InvalidURL">
         <source>The URL is invalid. Please enter a valid URL like "http://www.microsoft.com/"</source>
         <target state="translated">URL 無效。請輸入有效的 URL，例如 "http://www.microsoft.com/"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PropPage_ResourceFileNonexistent">
+        <source>"The resource file entered does not exist."</source>
+        <target state="new">"The resource file entered does not exist."</target>
         <note />
       </trans-unit>
       <trans-unit id="PropPage_WorkingDirError">
@@ -991,11 +996,6 @@ Error:</source>
       <trans-unit id="PropPage_NeedResFile">
         <source>"Resource files must have a .res file extension. Please enter a valid resource file name."</source>
         <target state="translated">"資源檔必須具有 .res 副檔名。請輸入有效的資源檔名稱。"</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PropPage_ResourceFileNotExist">
-        <source>"The resource file entered does not exist."</source>
-        <target state="translated">"輸入的資源檔不存在。"</target>
         <note />
       </trans-unit>
       <trans-unit id="APPDES_Title">
@@ -1610,6 +1610,21 @@ Error:</source>
         <target state="translated">需要:</target>
         <note />
       </trans-unit>
+      <trans-unit id="RES_PersistenceMode_Embedded">
+        <source>Embedded in .resx</source>
+        <target state="new">Embedded in .resx</target>
+        <note>File Persistence Mode</note>
+      </trans-unit>
+      <trans-unit id="RSE_CategoriesLabel">
+        <source>&amp;Categories:</source>
+        <target state="new">&amp;Categories:</target>
+        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
+      </trans-unit>
+      <trans-unit id="RSE_Err_CantSaveResourceDiscard_1Arg">
+        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
+        <target state="new">The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</target>
+        <note>{0} - name list of the resource</note>
+      </trans-unit>
       <trans-unit id="RSE_ResourceNameColumn">
         <source>Name</source>
         <target state="translated">名稱</target>
@@ -1763,11 +1778,6 @@ Do you really want to edit this file?</source>
         <source>The resource item uses the type '{0}', which is not supported in this project.</source>
         <target state="translated">資源項目使用 '{0}' 類型，但此專案不支援該類型。</target>
         <note>{0} - name of the type</note>
-      </trans-unit>
-      <trans-unit id="RSE_Err_CantSaveResouce_1Arg">
-        <source>The resource item(s) {0} cannot be saved correctly.  The item(s) will be discarded.</source>
-        <target state="translated">無法正確儲存資源項目 {0}，將捨棄這些項目。</target>
-        <note>{0} - name list of the resource</note>
       </trans-unit>
       <trans-unit id="RSE_Err_Name">
         <source>'{0}'</source>
@@ -2001,11 +2011,6 @@ CONSIDER: get this from CodeDom</note>
         <target state="translated">於編譯時間連結</target>
         <note>File Persistence Mode</note>
       </trans-unit>
-      <trans-unit id="RES_PersistenceMode_Embeded">
-        <source>Embedded in .resx</source>
-        <target state="translated">內嵌於 .resx</target>
-        <note>File Persistence Mode</note>
-      </trans-unit>
       <trans-unit id="RSE_Filter_Bitmap">
         <source>Bitmaps</source>
         <target state="translated">點陣圖</target>
@@ -2229,11 +2234,6 @@ CONSIDER: get this from CodeDom</note>
         <source>Delete values in {0} cell(s)</source>
         <target state="translated">刪除 {0} 個儲存格中的值</target>
         <note>{0} = number of cells cleared</note>
-      </trans-unit>
-      <trans-unit id="RSE_CategiesLabel">
-        <source>&amp;Categories:</source>
-        <target state="translated">類別(&amp;C):</target>
-        <note>The label in the menu strip for the combobox that holds the categories of resources to display</note>
       </trans-unit>
       <trans-unit id="RSE_PropDesc_Name">
         <source>Name used to identify the resource in code.</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.cs.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Pro zobrazení operací služby vyberte její kontrakt.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Pro zobrazení operací služby vyberte její kontrakt.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.de.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Wählen Sie einen Dienstvertrag aus, um seine Abläufe anzuzeigen.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Wählen Sie einen Dienstvertrag aus, um seine Abläufe anzuzeigen.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.es.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Seleccione un contrato de servicio para ver sus operaciones.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Seleccione un contrato de servicio para ver sus operaciones.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.fr.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Sélectionnez un contrat de service pour afficher ses opérations.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Sélectionnez un contrat de service pour afficher ses opérations.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.it.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Selezionare un contratto di servizio per visualizzarne le operazioni.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Selezionare un contratto di servizio per visualizzarne le operazioni.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.ja.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">サービス コントラクトを選択して操作を表示します。</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">サービス コントラクトを選択して操作を表示します。</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.ko.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">서비스 계약을 선택하여 해당 작업을 확인하세요.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">서비스 계약을 선택하여 해당 작업을 확인하세요.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.pl.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Wybierz kontrakt usługi, aby wyświetlić jego operacje.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Wybierz kontrakt usługi, aby wyświetlić jego operacje.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.pt-BR.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Selecione um contrato de serviço para exibir as operações.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Selecione um contrato de serviço para exibir as operações.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.ru.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">Чтобы просмотреть операции службы, выберете контракт службы.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">Чтобы просмотреть операции службы, выберете контракт службы.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.tr.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">İşlemlerini görüntülemek için bir hizmet sözleşmesi seçin.</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">İşlemlerini görüntülemek için bir hizmet sözleşmesi seçin.</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.zh-Hans.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">选择服务协定可查看其操作。</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">选择服务协定可查看其操作。</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/Resources/xlf/WCF.zh-Hant.xlf
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="AddSvcRefDlg_OPSelectContract">
         <source>Select a service contract to view its operations.</source>
-        <target state="translated">選取要檢視其作業的服務合約。</target>
-        <note>This is the message displayed when user selects non-cotract nodes.</note>
+        <target state="needs-review-translation">選取要檢視其作業的服務合約。</target>
+        <note>This is the message displayed when user selects non-contract nodes.</note>
       </trans-unit>
       <trans-unit id="CSRDlg_Title">
         <source>Service Reference Settings</source>

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.cs.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Transparentní kompilátor (experimentální)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">UPOZORNĚNÍ! Transparentní kompilátor zatím nepodporuje všechny funkce a může způsobit chybové ukončení nebo předat nesprávné výsledky.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Používejte na vlastní nebezpečí!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Zaškrtnutím tohoto políčka také udělíte výslovný souhlas s další telemetrií výkonu</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.de.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Transparenter Compiler (experimentell)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">WARNUNG! Der transparente Compiler unterstützt noch nicht alle Features und kann Abstürze verursachen oder falsche Ergebnisse ausgeben.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Auf eigene Gefahr verwenden!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Wenn Sie diese Option aktivieren, stimmen Sie auch der Erfassung zusätzlicher Leistungstelemetriedaten zu.</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.es.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Compilador transparente (experimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">ADVERTENCIA El compilador transparente aún no admite todas las características y puede provocar bloqueos o proporcionar resultados incorrectos.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Úselo bajo su propio riesgo.</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Al marcar esto, también puede optar por obtener telemetría de rendimiento adicional.</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.fr.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Transparent Compiler (expérience)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">AVERTISSEMENT ! Transparent Compiler ne prend pas encore en charge toutes les fonctionnalités et peut provoquer des blocages ou donner des résultats incorrects.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Utilisez-le à vos propres risques !</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">En cochant cette option, vous acceptez également d’autres données de télémétrie des performances</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.it.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Compilatore Transparent (sperimentale)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">AVVISO Il compilatore Transparent non supporta ancora tutte le funzionalità e può causare arresti anomali o fornire risultati non corretti.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Usalo a tuo rischio e pericolo.</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Selezionando questa opzione si acconsente esplicitamente anche alla telemetria aggiuntiva delle prestazioni</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ja.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Transparent Compiler (試験段階)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">警告Transparent Compiler は、現時点ですべての機能に対応しておらず、クラッシュを引き起こしたり、正しくない結果を出力したりする可能性があります。</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">ご使用は自己責任でお願いいたします。</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">これを確認すると、追加のパフォーマンス テレメトリもオプトインします</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ko.xlf
@@ -207,19 +207,19 @@
         <target state="translated">투명한 컴파일러(실험적)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">경고! 투명 컴파일러는 아직 모든 기능을 지원하지 않으며 충돌을 발생시키거나 잘못된 결과를 제공할 수 있습니다.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">본인 책임하에 사용하세요!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">이를 확인하여 추가 성능 원격 분석을 옵트인합니다.</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pl.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Kompilator przezroczysty (eksperymentalny)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">OSTRZEŻENIE! Kompilator przezroczysty nie obsługuje jeszcze wszystkich funkcji i może powodować awarie lub dawać niepoprawne wyniki.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Używaj na własne ryzyko!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Zaznaczając to pole wyboru, możesz również zdecydować się na dodatkowe dane telemetryczne dotyczące wydajności</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.pt-BR.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Compilador Transparente (experimental)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">AVISO! O Compilador Transparente ainda não é dá suporte para todos os recursos e pode causar falhas ou fornecer resultados incorretos.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Use por sua própria conta e risco!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Ao marcar essa opção, você também aceita a telemetria de desempenho adicional</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.ru.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Прозрачный компилятор (экспериментальная функция)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">Предупреждение! Прозрачный компилятор пока поддерживает не все функции и может вызывать сбои или предоставлять неверные результаты.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Используйте его на свой риск!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Устанавливая этот флажок, вы также соглашались на дополнительную телеметрию производительности</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.tr.xlf
@@ -207,19 +207,19 @@
         <target state="translated">Saydam Derleyiciyi kullan (deneysel)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">UYARI! Saydam Derleyici henüz tüm özellikleri desteklemiyor ve kilitlenmelere neden olabilir veya hatalı sonuçlar verebilir.</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">Kullanım sorumluluğu size aittir!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">Bunu seçerek ek performans telemetrisini de kabul etmiş olursunuz</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hans.xlf
@@ -207,19 +207,19 @@
         <target state="translated">透明编译器(实验性)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">警告!透明编译器尚不支持所有功能，可能会导致崩溃或提供错误结果。</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">自行承担风险!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">选中此项即表示你也选择加入其他性能遥测</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">

--- a/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.UIResources/xlf/Strings.zh-Hant.xlf
@@ -207,19 +207,19 @@
         <target state="translated">透明編譯器 (實驗性)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer1">
+      <trans-unit id="TransparentCompiler_Disclaimer1">
         <source>WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</source>
-        <target state="translated">警告!透明編譯器尚未支援所有功能，而且可能會造成當機或提供不正確的結果。</target>
+        <target state="new">WARNING! Transparent Compiler does not yet support all features and can cause crashes or give incorrect results.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer2">
+      <trans-unit id="TransparentCompiler_Disclaimer2">
         <source>Use at your own risk!</source>
-        <target state="translated">自行承擔使用風險!</target>
+        <target state="new">Use at your own risk!</target>
         <note />
       </trans-unit>
-      <trans-unit id="TransparentCompiler_Discalimer3">
+      <trans-unit id="TransparentCompiler_Disclaimer3">
         <source>By checking this you also opt-in for additional performance telemetry</source>
-        <target state="translated">一旦核取，您也選擇加入其他效能遙測</target>
+        <target state="new">By checking this you also opt-in for additional performance telemetry</target>
         <note />
       </trans-unit>
       <trans-unit id="Transparent_Compiler_Cache_Factor">


### PR DESCRIPTION
This changes the condition set for UpdateXlfOnBuild.

Right now, net9 builds are occasionally failing with "The target "UpdateXlf" does not exist in the project".

However, updating localization files happens locally before contribution (see guidelines), it is not needed as a CI step.
