### PR TITLE
Account for `VolatileAttribute`  when checking attribute targets

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -791,3 +791,59 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
         |> withLangVersionPreview
         |> verifyCompile
         |> shouldSucceed
+        
+    // SOURCE= E_VolatileField.fs	# E_VolatileField.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_VolatileField.fs"|])>]
+    let ``E_VolatileField 9.0`` compilation =
+        compilation
+        |> withLangVersion90
+        |> verifyCompile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 823, Line 3, Col 3, Line 4, Col 16, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 823, Line 6, Col 3, Line 7, Col 14, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 879, Line 6, Col 3, Line 7, Col 14, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 823, Line 9, Col 3, Line 10, Col 9, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 879, Line 9, Col 3, Line 10, Col 9, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 823, Line 26, Col 17, Line 26, Col 18, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 879, Line 13, Col 5, Line 14, Col 19, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 879, Line 16, Col 5, Line 17, Col 20, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 879, Line 19, Col 5, Line 20, Col 11, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 879, Line 22, Col 5, Line 23, Col 13, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+        ]
+    
+    // SOURCE=E_AllowNullLiteral.fs	# E_AllowNullLiteral.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_VolatileField.fs"|])>]
+    let ``E_VolatileField preview`` compilation =
+        compilation
+        |> withLangVersionPreview
+        |> verifyCompile
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 823, Line 3, Col 3, Line 4, Col 16, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 823, Line 6, Col 3, Line 7, Col 14, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 879, Line 6, Col 3, Line 7, Col 14, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 823, Line 9, Col 3, Line 10, Col 9, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 879, Line 9, Col 3, Line 10, Col 9, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 823, Line 26, Col 17, Line 26, Col 18, "The 'VolatileField' attribute may only be used on 'let' bindings in classes")
+            (Error 879, Line 13, Col 5, Line 14, Col 19, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 879, Line 16, Col 5, Line 17, Col 20, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 879, Line 19, Col 5, Line 20, Col 11, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+            (Error 879, Line 22, Col 5, Line 23, Col 13, "Volatile fields must be marked 'mutable' and cannot be thread-static")
+        ]
+        
+    // SOURCE= VolatileField01.fs	# VolatileField01.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"VolatileField01.fs"|])>]
+    let ``VolatileField01 9.0`` compilation =
+        compilation
+        |> withLangVersion90
+        |> verifyCompile
+        |> shouldSucceed
+    
+    // SOURCE=AllowNullLiteral01.fs	# AllowNullLiteral01.fs
+    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"VolatileField01.fs"|])>]
+    let ``VolatileField01 preview`` compilation =
+        compilation
+        |> withLangVersionPreview
+        |> verifyCompile
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -812,7 +812,7 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
             (Error 879, Line 22, Col 5, Line 23, Col 13, "Volatile fields must be marked 'mutable' and cannot be thread-static")
         ]
     
-    // SOURCE=E_AllowNullLiteral.fs	# E_AllowNullLiteral.fs
+    // SOURCE=E_VolatileField.fs	# E_VolatileField.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_VolatileField.fs"|])>]
     let ``E_VolatileField preview`` compilation =
         compilation
@@ -840,7 +840,7 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
         |> verifyCompile
         |> shouldSucceed
     
-    // SOURCE=AllowNullLiteral01.fs	# AllowNullLiteral01.fs
+    // SOURCE=VolatileField01.fs	# VolatileField01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"VolatileField01.fs"|])>]
     let ``VolatileField01 preview`` compilation =
         compilation

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/E_VolatileField.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/E_VolatileField.fs
@@ -1,0 +1,31 @@
+module VolatileFieldSanityChecks = begin
+
+  [<VolatileField>]
+  let mutable x = 1
+
+  [<VolatileField>]
+  let rec f x = 1
+
+  [<VolatileField>]
+  let x2 = 1
+
+  type C() = 
+    [<VolatileField>]
+    static let sx2 = 1   // expect an error - not mutable
+
+    [<VolatileField>]
+    static let f x2 = 1   // expect an error - not mutable
+
+    [<VolatileField>]
+    let x2 = 1   // expect an error - not mutable
+
+    [<VolatileField>]
+    let f x2 = 1   // expect an error - not mutable
+
+    [<VolatileField>]
+    val mutable x : int // expect an error - not supported
+
+    member x.P = 1
+
+end
+           

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/VolatileField01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/VolatileField01.fs
@@ -1,0 +1,3 @@
+type InterruptibleLazy (value) =
+    [<VolatileField>]
+    let mutable valueFactory = value

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/VolatileField01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/VolatileField01.fs
@@ -1,3 +1,12 @@
 type InterruptibleLazy (value) =
     [<VolatileField>]
     let mutable valueFactory = value
+
+    [<VolatileField>]
+    static let mutable valueFactory2 = Unchecked.defaultof<_>
+
+    [<VolatileField>]
+    let mutable add1 = fun x -> x + 1
+
+    [<VolatileField>]
+    static let mutable add2 = fun x -> x + 1

--- a/tests/fsharp/typecheck/sigs/neg16.bsl
+++ b/tests/fsharp/typecheck/sigs/neg16.bsl
@@ -73,8 +73,6 @@ neg16.fs(90,7,90,22): typecheck error FS0025: Incomplete pattern matches on this
 
 neg16.fs(96,3,97,16): typecheck error FS0823: The 'VolatileField' attribute may only be used on 'let' bindings in classes
 
-neg16.fs(99,5,99,18): typecheck error FS0842: This attribute is not valid for use on this language element
-
 neg16.fs(99,3,100,14): typecheck error FS0823: The 'VolatileField' attribute may only be used on 'let' bindings in classes
 
 neg16.fs(99,3,100,14): typecheck error FS0879: Volatile fields must be marked 'mutable' and cannot be thread-static


### PR DESCRIPTION
## Description

Account for `VolatileAttribute` when checking attribute targets on let binding classes

Fixes # (issue, if applicable)

## Checklist

- [x] Test cases added
- [ ] Release notes entry updated