### PR TITLE
Move test delaying startup code to the test it belongs to

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/CompilationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/CompilationTests.fs
@@ -28,8 +28,7 @@ let compileAValidScenario (scenario: Scenario) (method: Method) =
     let cUnit =
         let files =
             scenario.Files
-            |> Array.map (fun (f: FileInScenario) -> SourceCodeFileKind.Create(f.FileWithAST.File, f.Content))
-            |> Array.toList
+            |> List.map (fun (f: FileInScenario) -> SourceCodeFileKind.Create(f.FileName, f.Content))
 
         match files with
         | [] -> failwith "empty files"
@@ -44,7 +43,7 @@ let compileAValidScenario (scenario: Scenario) (method: Method) =
     |> shouldSucceed
     |> ignore
 
-let scenarios = codebases |> List.map (fun c -> [| box c |]) |> Array.ofList
+let scenarios = scenarios |> List.map (fun c -> [| box c |])
 
 [<Theory>]
 [<MemberData(nameof scenarios)>]

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/DependencyResolutionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/DependencyResolutionTests.fs
@@ -5,15 +5,17 @@ open NUnit.Framework
 open FSharp.Compiler.GraphChecking
 open Scenarios
 
-let scenarios = codebases
-
 [<TestCaseSource(nameof scenarios)>]
 let ``Supported scenario`` (scenario: Scenario) =
-    let files = scenario.Files |> Array.map (fun f -> TestFileWithAST.Map f.FileWithAST) 
+    let files =
+        scenario.Files
+        |> List.map (fun f ->
+            {Idx = f.Index; FileName = f.FileName; ParsedInput = parseSourceCode(f.FileName, f.Content)}) 
+        |> List.toArray
     let filePairs = FilePairMap(files)
     let graph, _trie = DependencyResolution.mkGraph filePairs files
 
     for file in scenario.Files do
         let expectedDeps = file.ExpectedDependencies
-        let actualDeps = set graph.[file.FileWithAST.Idx]
-        Assert.AreEqual(expectedDeps, actualDeps, $"Dependencies don't match for {System.IO.Path.GetFileName file.FileWithAST.File}")
+        let actualDeps = set graph.[file.Index]
+        Assert.AreEqual(expectedDeps, actualDeps, $"Dependencies don't match for {System.IO.Path.GetFileName file.FileName}")

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs
@@ -2,41 +2,36 @@
 
 open TestUtils
 
-type Scenario =
+type FileInScenario =
     {
-        Name: string
-        Files: FileInScenario array
-    }
-
-    override x.ToString() = x.Name
-
-and FileInScenario =
-    {
-        FileWithAST: TestFileWithAST
+        Index: int
+        FileName: string
         ExpectedDependencies: Set<int>
         Content: string
     }
 
+type Scenario =
+    {
+        Name: string
+        Files: FileInScenario list
+    }
+
+    override x.ToString() = x.Name
+
 let private scenario name files =
-    let files = files |> List.toArray |> Array.mapi (fun idx f -> f idx)
+    let files = files |> List.mapi (fun idx f -> f idx)
     { Name = name; Files = files }
 
 let private sourceFile fileName content (dependencies: Set<int>) =
     fun idx ->
-        let fileWithAST =
-            {
-                Idx = idx
-                AST = parseSourceCode (fileName, content)
-                File = fileName
-            }
-
         {
-            FileWithAST = fileWithAST
+            Index = idx
+            FileName = fileName
             ExpectedDependencies = dependencies
             Content = content
         }
 
-let internal codebases =
+let internal scenarios =
     [
         scenario
             "Link via full open statement"


### PR DESCRIPTION
## Description

In `FSharp.Compiler.ComponentTests`, a certain test module executes a lot of parsing steps in static startup code.
This not only leads to a substantial delay in test startup when executing any other single test, but also considerably impedes debugging.

This PR moves the parsing steps to the (single) test that needs them.

> Notes for reviewers:
Looking at the main branch version, you see that [`codebases`](https://github.com/dotnet/fsharp/blob/c8f22cd4d827536cbf1110091d0fb87a9d6c10d0/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs#L39) is initialized during startup. This includes running [`parseSourceCode`](https://github.com/dotnet/fsharp/blob/c8f22cd4d827536cbf1110091d0fb87a9d6c10d0/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/Scenarios.fs#L29C23-L29C39) 84 times and storing the resulting ASTs. The core of this PR is the removal of `parseSourceCode` from startup code to [this](https://github.com/dotnet/fsharp/blob/1290b0a534fb46b2aba00fcebf2128f66c944760/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/DependencyResolutionTests.fs#L13) place in the only test that uses the ASTs. On the way, I also removed the duplicated nested data in `FileInScenario`, renamed `codebases` to `scenarios`, and adapted the [other tests](https://github.com/dotnet/fsharp/blob/1290b0a534fb46b2aba00fcebf2128f66c944760/tests/FSharp.Compiler.ComponentTests/TypeChecks/Graph/CompilationTests.fs#L46) accordingly.
