### PR TITLE
Keep extra parens around unit & tuples in arg pats

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -12,6 +12,7 @@
 * MethodAccessException on equality comparison of a type private to module. ([Issue #17541](https://github.com/dotnet/fsharp/issues/17541), [PR #17548](https://github.com/dotnet/fsharp/pull/17548))
 * Fixed checking failure when `global` namespace is involved with enabled GraphBasedChecking ([PR #17553](https://github.com/dotnet/fsharp/pull/17553))
 * Add missing byte chars notations, enforce limits in decimal notation in byte char & string (Issues [#15867](https://github.com/dotnet/fsharp/issues/15867), [#15868](https://github.com/dotnet/fsharp/issues/15868), [#15869](https://github.com/dotnet/fsharp/issues/15869), [PR #15898](https://github.com/dotnet/fsharp/pull/15898))
+* Parentheses analysis: keep extra parentheses around unit & tuples in method definitions. ([PR #17618](https://github.com/dotnet/fsharp/pull/17618))
 
 ### Added
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -2801,7 +2801,15 @@ module Patterns =
 
                 expectFix code expected
 
-            let bareAtomics = fmtAllAsMemberData bareAtomics
+            let bareAtomics =
+                bareAtomics
+                |> List.map (function
+                    // We can't actually reliably remove the extra parens in argument patterns,
+                    // since they affect compilation.
+                    // See https://github.com/dotnet/fsharp/issues/17611, https://github.com/dotnet/fsharp/issues/16254, etc.
+                    | SynPat.Paren(SynPat.Const "()") as doubleParen, _ -> doubleParen, doubleParen
+                    | pats -> pats)
+                |> fmtAllAsMemberData
 
             let bareNonAtomics =
                 patterns
@@ -2825,7 +2833,15 @@ module Patterns =
                 let expected = $"type T () = member _.M %s{expected} = Unchecked.defaultof<_>"
                 expectFix code expected
 
-            let bareAtomics = fmtAllAsMemberData bareAtomics
+            let bareAtomics =
+                bareAtomics
+                |> List.map (function
+                    // We can't actually reliably remove the extra parens in argument patterns,
+                    // since they affect compilation.
+                    // See https://github.com/dotnet/fsharp/issues/17611, https://github.com/dotnet/fsharp/issues/16254, etc.
+                    | SynPat.Paren(SynPat.Const "()") as doubleParen, _ -> doubleParen, doubleParen
+                    | pats -> pats)
+                |> fmtAllAsMemberData
 
             let bareNonAtomics =
                 patterns
@@ -2959,7 +2975,7 @@ module Patterns =
             ",
             "
             type C = abstract M : unit -> unit
-            let _ = { new C with override _.M () = () }
+            let _ = { new C with override _.M (()) = () }
             "
 
             // See https://github.com/dotnet/fsharp/issues/16254.


### PR DESCRIPTION
## Description

Another followup to #16079, et seq.

There are several scenarios where it is impossible to know whether the parentheses are required, or whether they may affect compilation, by looking only at the syntax. I addressed this for invocations in #17012, but not for definitions.

- Always keep extra parentheses around `()` in argument patterns.

  In the absence of additional type information, `(())` (or `((()))`, etc.) may be compiled differently from `()` when used as an argument pattern in a method definition.

  (See https://github.com/dotnet/fsharp/issues/17611, https://github.com/dotnet/fsharp/issues/16254.)

- Always keep extra parentheses around tuples in argument patterns.

  In the absence of additional type information, `((x, y))` (or `(((x, y)))`, etc.) may be compiled differently from `(x, y)` in argument patterns.

## Checklist

- [x] Test cases added.
- [x] Release notes entry updated.