### PR TITLE
Increase Linux and macOS timeouts

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -546,6 +546,7 @@ stages:
         - job: Linux
           pool:
             vmImage: $(UbuntuMachineQueueName)
+          timeoutInMinutes: 120
           variables:
           - name: _SignType
             value: Test
@@ -586,6 +587,7 @@ stages:
         - job: MacOS
           pool:
             vmImage: macos-12
+          timeoutInMinutes: 120
           variables:
           - name: _SignType
             value: Test


### PR DESCRIPTION
120 is default value for windows vms, and until we parallelize compiler tests, we will need to extend the timeout