### PR TITLE
Change realSig to be `false` by default

### DIFF
--- a/src/Compiler/Driver/CompilerConfig.fs
+++ b/src/Compiler/Driver/CompilerConfig.fs
@@ -831,7 +831,7 @@ type TcConfigBuilder =
                     DumpGraph = false
                 }
             dumpSignatureData = false
-            realsig = true
+            realsig = false
             strictIndentation = None
         }
 

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -1006,6 +1006,9 @@ Updated automatically, please check diffs in your pull request, changes must be 
     static member CompileLibraryAndVerifyIL((source: string), (f: ILVerifier -> unit)) =
         compileLibraryAndVerifyILWithOptions [||] (SourceCodeFileKind.Create("test.fs", source)) f
 
+    static member CompileLibraryAndVerifyILRealSig((source: string), (f: ILVerifier -> unit)) =
+        compileLibraryAndVerifyILWithOptions [|"--realsig+"|] (SourceCodeFileKind.Create("test.fs", source)) f
+
     static member RunScriptWithOptionsAndReturnResult options (source: string) =
         // Initialize output and input streams
         use inStream = new StringReader("")

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/DelegateAndFuncOptimizations.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/DelegateAndFuncOptimizations.fs
@@ -494,6 +494,8 @@ let ApplyComputedFunction(c: int) =
 
     [<Test>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
+    // See also https://github.com/dotnet/fsharp/issues/17607 for a regression caused by realsig+ becoming default
+    // This test case must keep using direct call to ReduceComputedDelegate, and not a FSharpFunc invocation.
     let ``Reduce Computed Delegate with let rec``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
             """
@@ -506,31 +508,25 @@ let ApplyComputedDelegate(c: int) =
             """,
             (fun verifier -> verifier.VerifyIL [
             """
-  .method public static int32  ApplyComputedDelegate(int32 c) cil managed
-  {
-    
-    .maxstack  4
-    .locals init (class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,int32> V_0,
-             class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_1)
-    IL_0000:  ldsfld     class ReduceComputedDelegate/f@7 ReduceComputedDelegate/f@7::@_instance
-    IL_0005:  stloc.0
-    IL_0006:  ldstr      "hello"
-    IL_000b:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
-    IL_0010:  stloc.1
-    IL_0011:  call       class [netstandard]System.IO.TextWriter [netstandard]System.Console::get_Out()
-    IL_0016:  ldloc.1
-    IL_0017:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.PrintfModule::PrintFormatLineToTextWriter<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [runtime]System.IO.TextWriter,
-                                                                                                                                                         class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
-    IL_001c:  pop
-    IL_001d:  ldloc.0
-    IL_001e:  ldarg.0
-    IL_001f:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,int32>::Invoke(!0)
-    IL_0024:  ldc.i4.3
-    IL_0025:  add
-    IL_0026:  ret
+.method public static int32  ApplyComputedDelegate(int32 c) cil managed
+{
+  
+  .maxstack  4
+  .locals init (class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_0)
+  IL_0000:  ldstr      "hello"
+  IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(string)
+  IL_000a:  stloc.0
+  IL_000b:  call       class [netstandard]System.IO.TextWriter [netstandard]System.Console::get_Out()
+  IL_0010:  ldloc.0
+  IL_0011:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.PrintfModule::PrintFormatLineToTextWriter<class [FSharp.Core]Microsoft.FSharp.Core.Unit>(class [runtime]System.IO.TextWriter,
+                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
+  IL_0016:  pop
+  IL_0017:  ldarg.0
+  IL_0018:  call       int32 ReduceComputedDelegate::f@7(int32)
+  IL_001d:  ldc.i4.3
+  IL_001e:  add
+  IL_001f:  ret
   } 
-
-} 
             """
             ]))
 

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
@@ -13,7 +13,7 @@ module ``Mutation`` =
     [<Test>]
     let ``Mutation 01``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [|"-g"; "--optimize-"|],
+            [|"-g"; "--optimize-";"--realsig+"|],
             """
 module Mutation01
 type Test = struct
@@ -48,7 +48,7 @@ type Test = struct
     [<Test>]
     let ``Mutation 02``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [|"-g"; "--optimize-"|],
+            [|"-g"; "--optimize-";"--realsig+"|],
             """
 module Mutation02
 let x = System.TimeSpan.MinValue
@@ -94,7 +94,7 @@ x.ToString()
     [<Test>]
     let ``Mutation 03``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [|"-g"; "--optimize-"|],
+            [|"-g"; "--optimize-";"--realsig+"|],
             """
 module Mutation03
 let x = System.DateTime.Now
@@ -139,7 +139,7 @@ x.Day
     [<Test>]
     let ``Mutation 04``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [|"-g"; "--optimize-"|],
+            [|"-g"; "--optimize-";"--realsig+"|],
             """
 module Mutation04
 let x = System.Decimal.MaxValue
@@ -185,7 +185,7 @@ x.ToString()
     [<Test>]
     let ``Mutation 05``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [|"-g"; "--optimize-"|],
+            [|"-g"; "--optimize-";"--realsig+"|],
             """
 module Mutation05
 type C() =

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -10,7 +10,7 @@ module ``Static Member`` =
 
     [<Test>]
     let ``Action on Static Member``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember01
 
@@ -74,7 +74,7 @@ type C =
 
     [<Test>]
     let ``Action on Static Member with lambda``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember02
 
@@ -133,7 +133,7 @@ type C =
 
     [<Test>]
     let ``Action on Static Member with closure``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember03
 
@@ -247,7 +247,7 @@ let main _ =
 
     [<Test>]
     let ``Func on Static Member``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember04
 
@@ -313,7 +313,7 @@ type C =
 
     [<Test>]
     let ``Func on Static Member with lambda``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember05
 
@@ -379,7 +379,7 @@ type C =
 
     [<Test>]
     let ``Func on Static Member with closure``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember06
 
@@ -434,7 +434,7 @@ let main _ =
 #if !FX_NO_WINFORMS
     [<Test>]
     let ``EventHandler from Regression/83``() =
-        CompilerAssert.CompileLibraryAndVerifyIL(
+        CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
 module StaticMember07
 

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/TaskGeneratedCode.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/TaskGeneratedCode.fs
@@ -29,7 +29,7 @@ module TaskGeneratedCode =
     [<Test>]
     let ``check MoveNext of simple task debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 
@@ -116,7 +116,7 @@ let testTask() = task { return 1 }
     [<Test>]
     let ``check MoveNext of simple task optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize+"; "/debug:portable"; "/tailcalls+" |],
+            [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
             """
 module Test
 
@@ -190,7 +190,7 @@ let testTask() = task { return 1 }
     [<Test>]
     let ``check MoveNext of simple binding task debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/debug:portable"; "/optimize-"; "/tailcalls-" |],
+            [| "/debug:portable";"--realsig+"; "/optimize-"; "/tailcalls-" |],
             """
 module Test
 open System.Threading.Tasks
@@ -370,7 +370,7 @@ module TaskTryFinallyGeneration =
     [<Test>]
     let ``check MoveNext of task try/finally optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize+"; "/debug:portable"; "/tailcalls+" |],
+            [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
             """
 module Test
 
@@ -479,7 +479,7 @@ let testTask() = task { try 1+1 finally System.Console.WriteLine("finally") }
     [<Test>]
     let ``check MoveNext of task try/finally debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 
@@ -596,7 +596,7 @@ module TaskTryWithGeneration =
     [<Test>]
     let ``check MoveNext of task try/with optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize+"; "/debug:portable"; "/tailcalls+" |],
+            [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
             """
 module Test
 
@@ -709,7 +709,7 @@ let testTask() = task { try 1 with e -> System.Console.WriteLine("finally"); 2 }
     [<Test>]
     let ``check MoveNext of task try/with debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 
@@ -829,7 +829,7 @@ module TaskWhileLoopGeneration =
     [<Test>]
     let ``check MoveNext of task while loop optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize+"; "/debug:portable"; "/tailcalls+" |],
+            [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
             """
 module Test
 
@@ -927,7 +927,7 @@ let testTask() = task { while x > 4 do System.Console.WriteLine("loop") }
     [<Test>]
     let ``check MoveNext of task while loop debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 
@@ -1030,7 +1030,7 @@ module TaskTypeInference =
     [<Test>]
     let ``check initially ambiguous SRTP task code ``() =
         CompilerAssert.CompileExeAndRunWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 
@@ -1050,7 +1050,7 @@ let myTuple : (string -> Task<unit>) * int = (fun (_s: string) -> Task.FromResul
     [<Test>]
     let ``check generic task code ``() =
         CompilerAssert.CompileExeAndRunWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 
@@ -1083,7 +1083,7 @@ printfn "test passed"
     [<Test>]
     let ``check generic task exact code``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
-            [| "/optimize-"; "/debug:portable"; "/tailcalls-" |],
+            [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
             """
 module Test
 

--- a/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
@@ -31,7 +31,7 @@ module QuickInfo =
     let internal GetQuickInfo (code: string) caretPosition =
         asyncMaybe {
             let document =
-                RoslynTestHelpers.CreateSolution(code) |> RoslynTestHelpers.GetSingleDocument
+                RoslynTestHelpers.CreateSolution(code,extraFSharpProjectOtherOptions=[|"--realsig+"|]) |> RoslynTestHelpers.GetSingleDocument
 
             let! _, _, _, tooltip =
                 FSharpAsyncQuickInfoSource.TryGetToolTip(document, caretPosition)

--- a/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
@@ -535,7 +535,7 @@ module Test =
         static let fu$$nc x = ()
 """
 
-        let expectedSignature = "val private func: x: 'a -> unit"
+        let expectedSignature = "val func: x: 'a -> unit"
 
         let tooltip = GetQuickInfoTextFromCode code
 

--- a/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/QuickInfoTests.fs
@@ -31,7 +31,8 @@ module QuickInfo =
     let internal GetQuickInfo (code: string) caretPosition =
         asyncMaybe {
             let document =
-                RoslynTestHelpers.CreateSolution(code,extraFSharpProjectOtherOptions=[|"--realsig+"|]) |> RoslynTestHelpers.GetSingleDocument
+                RoslynTestHelpers.CreateSolution(code, extraFSharpProjectOtherOptions = [| "--realsig+" |])
+                |> RoslynTestHelpers.GetSingleDocument
 
             let! _, _, _, tooltip =
                 FSharpAsyncQuickInfoSource.TryGetToolTip(document, caretPosition)

--- a/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
+++ b/vsintegration/tests/UnitTests/LegacyLanguageService/Tests.LanguageService.QuickInfo.fs
@@ -790,7 +790,7 @@ Full name: Microsoft.FSharp.Control.Async""".TrimStart().Replace("\r\n", "\n")
             type A() = 
                 let fff n = n + 1                
             """
-        this.AssertQuickInfoContainsAtEndOfMarker(code, "let ff", "val private fff: n: int -> int")
+        this.AssertQuickInfoContainsAtEndOfMarker(code, "let ff", "val fff: n: int -> int")
 
     // Regression for 2494
     [<Test>]


### PR DESCRIPTION
This changes the default of realSig to be false until https://github.com/dotnet/fsharp/issues/17607 is resolved.
Once a fix for https://github.com/dotnet/fsharp/issues/17607 is in place, it can change the default back to true.

With current state, compiled code could experience performance degradation at runtime.