### PR TITLE
Do not throw from IsUnionCaseTester and handle a case where symbol is not considered a method/property

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -13,6 +13,7 @@
 * Fixed checking failure when `global` namespace is involved with enabled GraphBasedChecking ([PR #17553](https://github.com/dotnet/fsharp/pull/17553))
 * Add missing byte chars notations, enforce limits in decimal notation in byte char & string (Issues [#15867](https://github.com/dotnet/fsharp/issues/15867), [#15868](https://github.com/dotnet/fsharp/issues/15868), [#15869](https://github.com/dotnet/fsharp/issues/15869), [PR #15898](https://github.com/dotnet/fsharp/pull/15898))
 * Parentheses analysis: keep extra parentheses around unit & tuples in method definitions. ([PR #17618](https://github.com/dotnet/fsharp/pull/17618))
+* Fix IsUnionCaseTester throwing for non-methods/properties [#17301](https://github.com/dotnet/fsharp/pull/17634)
 
 ### Added
 

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -1788,7 +1788,11 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         match d with
         | P p -> p.IsUnionCaseTester
         | M m -> m.IsUnionCaseTester
-        | E _ | C _ | V _ -> false
+        | V v ->
+            v.IsPropertyGetterMethod &&
+            v.LogicalName.StartsWith("get_Is") &&
+            v.IsImplied && v.MemberApparentEntity.IsUnionTycon
+        | E _ | C _ -> false
 
     member _.EventAddMethod =
         checkIsResolved()

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -1788,7 +1788,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
         match d with
         | P p -> p.IsUnionCaseTester
         | M m -> m.IsUnionCaseTester
-        | E _ | C _ | V _ -> invalidOp "the value or member is not a property"
+        | E _ | C _ | V _ -> false
 
     member _.EventAddMethod =
         checkIsResolved()

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -265,7 +265,7 @@ type Foo =
   member Bar: a: int -> int with set"""
 
 [<Fact>]
-let ``IsUnionCaseTester tests`` () =
+let ``get_Is* method has IsUnionCaseTester = true`` () =
     FSharp """
 module Lib
 
@@ -285,14 +285,14 @@ let f = bar.get_IsBar
         let isBarSymbolUse = results.GetSymbolUseAtLocation(12, 21, "let f = bar.get_IsBar", [ "get_IsBar" ]).Value
         match isBarSymbolUse.Symbol with
         | :? FSharpMemberOrFunctionOrValue as mfv ->
-            Assert.False(mfv.IsUnionCaseTester, "IsUnionCaseTester returned true")
-            Assert.False(mfv.IsMethod, "IsMethod returned true")
+            Assert.True(mfv.IsUnionCaseTester, "IsUnionCaseTester returned true")
+            Assert.True(mfv.IsMethod, "IsMethod returned true")
             Assert.False(mfv.IsProperty, "IsProptery returned true")
             Assert.True(mfv.IsPropertyGetterMethod, "IsPropertyGetterMethod returned false")
         | _ -> failwith "Expected FSharpMemberOrFunctionOrValue"
 
 [<Fact>]
-let ``IsUnionCaseTester tests 2`` () =
+let ``IsUnionCaseTester does not throw for non-method non-property`` () =
     FSharp """
 module Lib
 
@@ -307,8 +307,6 @@ let foo = Foo()
         let isBarSymbolUse = results.GetSymbolUseAtLocation(7, 13, "let foo = Foo()", [ "Foo" ]).Value
         match isBarSymbolUse.Symbol with
         | :? FSharpMemberOrFunctionOrValue as mfv ->
-            Assert.False(mfv.IsUnionCaseTester)
-            //Assert.False(mfv.IsMethod)
-            //Assert.False(mfv.IsProperty)
+            Assert.False(mfv.IsUnionCaseTester, "IsUnionCaseTester returned true")
             Assert.True(mfv.IsConstructor)
         | _ -> failwith "Expected FSharpMemberOrFunctionOrValue"

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -282,7 +282,7 @@ let f = bar.get_IsBar
     |> withLangVersionPreview
     |> typecheckResults
     |> fun results ->
-        let isBarSymbolUse = results.GetSymbolUseAtLocation(12, 21, "let f = bar.get_IsBar", [ "get_IsP" ]).Value
+        let isBarSymbolUse = results.GetSymbolUseAtLocation(12, 21, "let f = bar.get_IsBar", [ "get_IsBar" ]).Value
         match isBarSymbolUse.Symbol with
         | :? FSharpMemberOrFunctionOrValue as mfv ->
             Assert.False(mfv.IsUnionCaseTester, "IsUnionCaseTester returned true")

--- a/tests/FSharp.Compiler.Service.Tests/Common.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Common.fs
@@ -5,10 +5,10 @@ open System
 open System.Diagnostics
 open System.IO
 open System.Collections.Generic
+open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.IO
-open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
@@ -473,3 +473,63 @@ let assertRange
     Assert.Equal(Position.mkPos expectedStartLine expectedStartColumn, actualRange.Start)
     Assert.Equal(Position.mkPos expectedEndLine expectedEndColumn, actualRange.End)
 
+[<AutoOpen>]
+module TempDirUtils =
+    let getTempPath dir =
+        Path.Combine(Path.GetTempPath(), dir)
+
+    /// Returns the file name part of a temp file name created with tryCreateTemporaryFileName ()
+    /// and an added process id and thread id to ensure uniqueness between threads.
+    let getTempFileName() =
+        let tempFileName = tryCreateTemporaryFileName ()
+        try
+            let tempFile, tempExt = Path.GetFileNameWithoutExtension tempFileName, Path.GetExtension tempFileName
+            let procId, threadId = Process.GetCurrentProcess().Id, Thread.CurrentThread.ManagedThreadId
+            String.concat "" [tempFile; "_"; string procId; "_"; string threadId; tempExt]  // ext includes dot
+        finally
+            try
+                FileSystem.FileDeleteShim tempFileName
+            with _ -> ()
+
+    /// Given just a file name, returns it with changed extension located in %TEMP%\ExprTests
+    let getTempFilePathChangeExt dir tmp ext =
+        Path.Combine(getTempPath dir, Path.ChangeExtension(tmp, ext))
+
+    /// If it doesn't exists, create a folder 'ExprTests' in local user's %TEMP% folder
+    let createTempDir dirName =
+        let tempPath = getTempPath dirName
+        do
+            if Directory.Exists tempPath then ()
+            else Directory.CreateDirectory tempPath |> ignore
+
+    /// Clean up after a test is run. If you need to inspect the create *.fs files, change this function to do nothing, or just break here.
+    let cleanupTempFiles dirName files =
+        { new IDisposable with
+            member _.Dispose() =
+                for fileName in files do
+                    try
+                        // cleanup: only the source file is written to the temp dir.
+                        FileSystem.FileDeleteShim fileName
+                    with _ -> ()
+
+                try
+                    // remove the dir when empty
+                    let tempPath = getTempPath dirName
+                    if Directory.GetFiles tempPath |> Array.isEmpty then
+                        Directory.Delete tempPath
+                with _ -> () }
+
+    let createProjectOptions dirName fileSources extraArgs =
+        let fileNames = fileSources |> List.map (fun _ -> getTempFileName())
+        let temp2 = getTempFileName()
+        let fileNames = fileNames |> List.map (fun temp1 -> getTempFilePathChangeExt dirName temp1 ".fs")
+        let dllName = getTempFilePathChangeExt dirName temp2 ".dll"
+        let projFileName = getTempFilePathChangeExt dirName temp2 ".fsproj"
+
+        createTempDir dirName
+        for fileSource: string, fileName in List.zip fileSources fileNames do
+             FileSystem.OpenFileForWriteShim(fileName).Write(fileSource)
+        let args = [| yield! extraArgs; yield! mkProjectCommandLineArgs (dllName, []) |]
+        let options = { checker.GetProjectOptionsFromCommandLineArgs (projFileName, args) with SourceFiles = fileNames |> List.toArray }
+
+        cleanupTempFiles dirName (fileNames @ [dllName; projFileName]), options

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -25,6 +25,7 @@
       <Link>FsUnit.fs</Link>
     </Compile>
     <Compile Include="Common.fs" />
+    <Compile Include="GeneratedCodeSymbolsTests.fs" />
     <Compile Include="AssemblyReaderShim.fs" />
     <Compile Include="ModuleReaderCancellationTests.fs" />
     <Compile Include="EditorTests.fs" />

--- a/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
@@ -1,0 +1,136 @@
+module FSharp.Compiler.Service.Tests.GeneratedCodeSymbolsTests
+
+open Xunit
+open System
+open System.Diagnostics
+open System.IO
+open System.Threading
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.IO
+open FSharp.Compiler.Service.Tests.Common
+open FSharp.Compiler.Symbols
+open TestFramework
+
+
+[<AutoOpen>]
+module internal Utils =
+    let getTempPath dir =
+        Path.Combine(Path.GetTempPath(), dir)
+
+    /// Returns the file name part of a temp file name created with tryCreateTemporaryFileName ()
+    /// and an added process id and thread id to ensure uniqueness between threads.
+    let getTempFileName() =
+        let tempFileName = tryCreateTemporaryFileName ()
+        try
+            let tempFile, tempExt = Path.GetFileNameWithoutExtension tempFileName, Path.GetExtension tempFileName
+            let procId, threadId = Process.GetCurrentProcess().Id, Thread.CurrentThread.ManagedThreadId
+            String.concat "" [tempFile; "_"; string procId; "_"; string threadId; tempExt]  // ext includes dot
+        finally
+            try
+                FileSystem.FileDeleteShim tempFileName
+            with _ -> ()
+
+    /// Given just a file name, returns it with changed extension located in %TEMP%\ExprTests
+    let getTempFilePathChangeExt dir tmp ext =
+        Path.Combine(getTempPath dir, Path.ChangeExtension(tmp, ext))
+
+    /// If it doesn't exists, create a folder 'ExprTests' in local user's %TEMP% folder
+    let createTempDir dirName =
+        let tempPath = getTempPath dirName
+        do
+            if Directory.Exists tempPath then ()
+            else Directory.CreateDirectory tempPath |> ignore
+
+    /// Clean up after a test is run. If you need to inspect the create *.fs files, change this function to do nothing, or just break here.
+    let cleanupTempFiles dirName files =
+        { new IDisposable with
+            member _.Dispose() =
+                for fileName in files do
+                    try
+                        // cleanup: only the source file is written to the temp dir.
+                        FileSystem.FileDeleteShim fileName
+                    with _ -> ()
+
+                try
+                    // remove the dir when empty
+                    let tempPath = getTempPath dirName
+                    if Directory.GetFiles tempPath |> Array.isEmpty then
+                        Directory.Delete tempPath
+                with _ -> () }
+
+    let createOptionsAux fileSources extraArgs =
+        let dirName = "GeneratedCodeSymbolsTests"
+        let fileNames = fileSources |> List.map (fun _ -> getTempFileName())
+        let temp2 = getTempFileName()
+        let fileNames = fileNames |> List.map (fun temp1 -> getTempFilePathChangeExt dirName temp1 ".fs")
+        let dllName = getTempFilePathChangeExt dirName temp2 ".dll"
+        let projFileName = getTempFilePathChangeExt dirName temp2 ".fsproj"
+
+        createTempDir dirName
+        for fileSource: string, fileName in List.zip fileSources fileNames do
+             FileSystem.OpenFileForWriteShim(fileName).Write(fileSource)
+        let args = [| yield! extraArgs; yield! mkProjectCommandLineArgs (dllName, []) |]
+        let options = { checker.GetProjectOptionsFromCommandLineArgs (projFileName, args) with SourceFiles = fileNames |> List.toArray }
+
+        cleanupTempFiles dirName (fileNames @ [dllName; projFileName]), options
+
+[<Fact>]
+let ``IsUnionCaseTester in generated file`` () =
+    let source = """
+module Lib
+
+type T () =
+    member x.IsM = 1
+"""
+    let cleanup, options = Utils.createOptionsAux [ source ] [ "--langversion:preview" ]
+    use _holder = cleanup
+    let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=false)
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
+
+    let mfvs =
+        seq {
+            for implFile in wholeProjectResults.AssemblyContents.ImplementationFiles do
+                for decl in implFile.Declarations do
+                    match decl with
+                    | FSharpImplementationFileDeclaration.Entity(e,ds) ->
+                        for d in ds do
+                            match d with
+                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, args, body) ->
+                                yield mfv
+                            | _ -> ()
+                    | _ -> ()
+        }
+
+    Assert.Contains(mfvs, fun x -> x.LogicalName = "get_IsM")
+    let mfv = mfvs |> Seq.filter (fun x -> x.LogicalName = "get_IsM") |> Seq.exactlyOne
+    Assert.False(mfv.IsUnionCaseTester, $"get_IsM has IsUnionCaseTester = {mfv.IsUnionCaseTester}")
+
+[<Fact>]
+let ``IsUnionCaseTester in generated file 2`` () =
+    let source = """
+module Lib
+
+type T = A | B
+"""
+    let cleanup, options = Utils.createOptionsAux [ source ] [ "--langversion:preview" ]
+    use _holder = cleanup
+    let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=false)
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
+
+    let mfvs =
+        seq {
+            for implFile in wholeProjectResults.AssemblyContents.ImplementationFiles do
+                for decl in implFile.Declarations do
+                    match decl with
+                    | FSharpImplementationFileDeclaration.Entity(e,ds) ->
+                        for d in ds do
+                            match d with
+                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, args, body) ->
+                                yield mfv
+                            | _ -> ()
+                    | _ -> ()
+        }
+
+    Assert.Contains(mfvs, fun x -> x.LogicalName = "get_IsA")
+    let mfv = mfvs |> Seq.filter (fun x -> x.LogicalName = "get_IsA") |> Seq.exactlyOne
+    Assert.True(mfv.IsUnionCaseTester, $"get_IsA has IsUnionCaseTester = {mfv.IsUnionCaseTester}")

--- a/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
@@ -9,7 +9,7 @@ open FSharp.Compiler.Symbols
 let dirName = "GeneratedCodeSymbolsTests"
 
 [<Fact>]
-let ``IsUnionCaseTester in generated file`` () =
+let ``IsUnionCaseTester for Is* member in a class`` () =
     let source = """
 module Lib
 
@@ -40,7 +40,7 @@ type T () =
     Assert.False(mfv.IsUnionCaseTester, $"get_IsM has IsUnionCaseTester = {mfv.IsUnionCaseTester}")
 
 [<Fact>]
-let ``IsUnionCaseTester in generated file 2`` () =
+let ``IsUnionCaseTester for Is* generated property in DU`` () =
     let source = """
 module Lib
 
@@ -68,3 +68,37 @@ type T = A | B
     Assert.Contains(mfvs, fun x -> x.LogicalName = "get_IsA")
     let mfv = mfvs |> Seq.filter (fun x -> x.LogicalName = "get_IsA") |> Seq.exactlyOne
     Assert.True(mfv.IsUnionCaseTester, $"get_IsA has IsUnionCaseTester = {mfv.IsUnionCaseTester}")
+
+[<Fact>]
+let ``IsUnionCaseTester for Is* user property in DU`` () =
+    let source = """
+module Lib
+
+type T =
+    | A
+    | B
+    member x.IsC
+        with get () = false
+"""
+    let cleanup, options = createProjectOptions dirName [ source ] [ "--langversion:preview" ]
+    use _holder = cleanup
+    let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=false)
+    let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
+
+    let mfvs =
+        seq {
+            for implFile in wholeProjectResults.AssemblyContents.ImplementationFiles do
+                for decl in implFile.Declarations do
+                    match decl with
+                    | FSharpImplementationFileDeclaration.Entity(e,ds) ->
+                        for d in ds do
+                            match d with
+                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, args, body) ->
+                                yield mfv
+                            | _ -> ()
+                    | _ -> ()
+        }
+
+    Assert.Contains(mfvs, fun x -> x.LogicalName = "get_IsC")
+    let mfv = mfvs |> Seq.filter (fun x -> x.LogicalName = "get_IsC") |> Seq.exactlyOne
+    Assert.False(mfv.IsUnionCaseTester, $"get_IsC has IsUnionCaseTester = {mfv.IsUnionCaseTester}")

--- a/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
@@ -1,78 +1,12 @@
 module FSharp.Compiler.Service.Tests.GeneratedCodeSymbolsTests
 
 open Xunit
-open System
-open System.Diagnostics
-open System.IO
-open System.Threading
 open FSharp.Compiler.CodeAnalysis
-open FSharp.Compiler.IO
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Symbols
-open TestFramework
 
-
-[<AutoOpen>]
-module internal Utils =
-    let getTempPath dir =
-        Path.Combine(Path.GetTempPath(), dir)
-
-    /// Returns the file name part of a temp file name created with tryCreateTemporaryFileName ()
-    /// and an added process id and thread id to ensure uniqueness between threads.
-    let getTempFileName() =
-        let tempFileName = tryCreateTemporaryFileName ()
-        try
-            let tempFile, tempExt = Path.GetFileNameWithoutExtension tempFileName, Path.GetExtension tempFileName
-            let procId, threadId = Process.GetCurrentProcess().Id, Thread.CurrentThread.ManagedThreadId
-            String.concat "" [tempFile; "_"; string procId; "_"; string threadId; tempExt]  // ext includes dot
-        finally
-            try
-                FileSystem.FileDeleteShim tempFileName
-            with _ -> ()
-
-    /// Given just a file name, returns it with changed extension located in %TEMP%\ExprTests
-    let getTempFilePathChangeExt dir tmp ext =
-        Path.Combine(getTempPath dir, Path.ChangeExtension(tmp, ext))
-
-    /// If it doesn't exists, create a folder 'ExprTests' in local user's %TEMP% folder
-    let createTempDir dirName =
-        let tempPath = getTempPath dirName
-        do
-            if Directory.Exists tempPath then ()
-            else Directory.CreateDirectory tempPath |> ignore
-
-    /// Clean up after a test is run. If you need to inspect the create *.fs files, change this function to do nothing, or just break here.
-    let cleanupTempFiles dirName files =
-        { new IDisposable with
-            member _.Dispose() =
-                for fileName in files do
-                    try
-                        // cleanup: only the source file is written to the temp dir.
-                        FileSystem.FileDeleteShim fileName
-                    with _ -> ()
-
-                try
-                    // remove the dir when empty
-                    let tempPath = getTempPath dirName
-                    if Directory.GetFiles tempPath |> Array.isEmpty then
-                        Directory.Delete tempPath
-                with _ -> () }
-
-    let createOptionsAux fileSources extraArgs =
-        let dirName = "GeneratedCodeSymbolsTests"
-        let fileNames = fileSources |> List.map (fun _ -> getTempFileName())
-        let temp2 = getTempFileName()
-        let fileNames = fileNames |> List.map (fun temp1 -> getTempFilePathChangeExt dirName temp1 ".fs")
-        let dllName = getTempFilePathChangeExt dirName temp2 ".dll"
-        let projFileName = getTempFilePathChangeExt dirName temp2 ".fsproj"
-
-        createTempDir dirName
-        for fileSource: string, fileName in List.zip fileSources fileNames do
-             FileSystem.OpenFileForWriteShim(fileName).Write(fileSource)
-        let args = [| yield! extraArgs; yield! mkProjectCommandLineArgs (dllName, []) |]
-        let options = { checker.GetProjectOptionsFromCommandLineArgs (projFileName, args) with SourceFiles = fileNames |> List.toArray }
-
-        cleanupTempFiles dirName (fileNames @ [dllName; projFileName]), options
+[<Literal>]
+let dirName = "GeneratedCodeSymbolsTests"
 
 [<Fact>]
 let ``IsUnionCaseTester in generated file`` () =
@@ -82,7 +16,7 @@ module Lib
 type T () =
     member x.IsM = 1
 """
-    let cleanup, options = Utils.createOptionsAux [ source ] [ "--langversion:preview" ]
+    let cleanup, options = createProjectOptions dirName [ source ] [ "--langversion:preview" ]
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=false)
     let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
@@ -112,7 +46,7 @@ module Lib
 
 type T = A | B
 """
-    let cleanup, options = Utils.createOptionsAux [ source ] [ "--langversion:preview" ]
+    let cleanup, options = createProjectOptions dirName [ source ] [ "--langversion:preview" ]
     use _holder = cleanup
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=false)
     let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #17301

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/release-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**