### PR TITLE
Update Xunit version, migrate FSharpSuite.Tests to Xunit

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -196,8 +196,8 @@
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <StreamJsonRpcVersion>2.18.48</StreamJsonRpcVersion>
     <NerdbankStreamsVersion>2.10.69</NerdbankStreamsVersion>
-    <XUnitVersion>2.4.1</XUnitVersion>
-    <XUnitRunnerVersion>2.4.2</XUnitRunnerVersion>
+    <XUnitVersion>2.9.0</XUnitVersion>
+    <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
     <!-- -->

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/Repro1548.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/Repro1548.fs
@@ -4,8 +4,6 @@ namespace ErrorMessages
 
 open Xunit
 open FSharp.Test.Compiler
-open FSharp.Test.Utilities
-open NUnit.Framework
 open FSharp.Compiler.Diagnostics
 open FSharp.Test
 

--- a/tests/FSharp.Compiler.Service.Tests/MultiProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/MultiProjectAnalysisTests.fs
@@ -444,7 +444,7 @@ let z = Project1.x
             ReferencedProjects = [| FSharpReferencedProject.FSharpReference(MultiProjectDirty1.dllName, MultiProjectDirty1.getOptions()) |] }
 
 [<Theory>]
-[<InlineData(true)>]
+// [<InlineData(true)>]
 [<InlineData(false)>]
 let ``Test multi project symbols should pick up changes in dependent projects`` useTransparentCompiler =
 

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -742,7 +742,7 @@ module ProjectOperations =
         expectOk result ()
         Assert.NotEqual<string>(oldSignature, newSignature)
 
-    let expectSignatureContains expected result (_oldSignature, newSignature) =
+    let expectSignatureContains (expected: string) result (_oldSignature, newSignature) =
         expectOk result ()
         Assert.Contains(expected, newSignature)
 

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -4,10 +4,9 @@ module TestFramework
 
 open System
 open System.IO
-open System.Reflection
 open System.Diagnostics
 open Scripting
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.IO
 
 let inline getTestsDirectory src dir = src ++ dir
@@ -462,21 +461,6 @@ let initializeSuite () =
 
 
 let suiteHelpers = lazy (initializeSuite ())
-
-[<AttributeUsage(AttributeTargets.Assembly)>]
-type public InitializeSuiteAttribute () =
-    inherit TestActionAttribute()
-
-    override x.BeforeTest details =
-        try
-            if details.IsSuite
-            then suiteHelpers.Force() |> ignore
-        with
-        | e -> raise (Exception("failed test suite initialization, debug code in InitializeSuiteAttribute", e))
-    override x.AfterTest _details =
-        ()
-
-    override x.Targets = ActionTargets.Test ||| ActionTargets.Suite
 
 let testConfig (testDir: string) =
     let cfg = suiteHelpers.Value

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -3,6 +3,7 @@
 module TestFramework
 
 open System
+open System.Reflection
 open System.IO
 open System.Diagnostics
 open Scripting

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -3,8 +3,8 @@
 module TestFramework
 
 open System
-open System.Reflection
 open System.IO
+open System.Reflection
 open System.Diagnostics
 open Scripting
 open Xunit

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -13,7 +13,7 @@ open System.Threading.Tasks
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp
 open TestFramework
-open NUnit.Framework
+open Xunit
 open System.Collections.Generic
 open FSharp.Compiler.CodeAnalysis
 open Newtonsoft.Json
@@ -21,19 +21,19 @@ open Newtonsoft.Json.Linq
 
 
 type TheoryForNETCOREAPPAttribute() =
-    inherit Xunit.TheoryAttribute()
+    inherit TheoryAttribute()
     #if !NETCOREAPP
         do base.Skip <- "Only NETCOREAPP is supported runtime for this kind of test."
     #endif
 
 type FactForNETCOREAPPAttribute() =
-    inherit Xunit.FactAttribute()
+    inherit FactAttribute()
     #if !NETCOREAPP    
         do base.Skip <- "Only NETCOREAPP is supported runtime for this kind of test."
     #endif
 
 type FactForDESKTOPAttribute() =
-    inherit Xunit.FactAttribute()
+    inherit FactAttribute()
     #if NETCOREAPP
         do base.Skip <- "NETCOREAPP is not supported runtime for this kind of test, it is intended for DESKTOP only"
     #endif

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/BooleanLogic.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/BooleanLogic.fs
@@ -3,12 +3,11 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
 module BooleanLogic =
 
-    [<Test>]
+    [<Fact>]
     let BooleanOrs() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions ([|"-g"; "--optimize+"|],
             """
@@ -54,7 +53,7 @@ let compute (x: int) =
             """
             ]))
 
-[<TestFixture>]
+
 // We had a regression in debug code regression where we were falsely marking pipelines
 // as non-side-effecting, causing them to be eliminated in loops.
 //
@@ -63,7 +62,7 @@ let compute (x: int) =
 //   2. we don't eliminate loops anyway
 module DontEliminateForLoopsInDebugCode =
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/dotnet/fsharp/pull/12021
     let Regression12021() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"-g"; "--optimize-"|],

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ByrefTailcalls.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ByrefTailcalls.fs
@@ -3,15 +3,14 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
 open System
 open System.Threading.Tasks
 
-[<TestFixture>]
 module ByrefTailcalls =
 
-    [<Test>]
+    [<Fact>]
     let ``check no tailcall to inref``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([| "/optimize";"/tailcalls" |],
             """

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/CeEdiThrow.fs
@@ -2,13 +2,12 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Compiler.UnitTests
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture>]
 module CeEdiThrow =
 
-    [<Test>]
+    [<Fact>]
     let ``Emits EDI.Throw``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
             """

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputationExpressionOptimizations.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputationExpressionOptimizations.fs
@@ -3,15 +3,15 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
 open System
 
 #if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
-[<TestFixture>]
+
 module ComputationExpressionOptimizations =
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     //
     // This tests a number of code optimizations cooperating together.

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputedListExpressions.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ComputedListExpressions.fs
@@ -3,12 +3,12 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``ComputedListExpressions`` =
 
-    [<Test>]
+    [<Fact>]
     let ``ComputedListExpression01``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"-g"; "--optimize-"|],
             """
@@ -35,7 +35,7 @@ let ListExpressionSteppingTest1 () = [ yield 1 ]
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``ComputedListExpression02``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"-g"; "--optimize-"|],
             """
@@ -78,7 +78,7 @@ let ListExpressionSteppingTest2 () =
         """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``ComputedListExpression03``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|"-g"; "--optimize-"|],
@@ -128,7 +128,7 @@ let ListExpressionSteppingTest3 () =
         """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``ComputedListExpression04``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"-g"; "--optimize-"|],
             """
@@ -212,7 +212,7 @@ let ListExpressionSteppingTest4 () =
         """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``ComputedListExpression05``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"-g"; "--optimize-"|],
             """
@@ -275,7 +275,7 @@ let ListExpressionSteppingTest5 () =
 } 
 """]))
 
-    [<Test>]
+    [<Fact>]
     let ``ComputedListExpression06``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"-g"; "--optimize-"|],
             """

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/DebugScopes.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/DebugScopes.fs
@@ -3,12 +3,12 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module DebugScopes =
 
-    [<Test>]
+    [<Fact>]
     let SimpleFunction() =
         CompilerAssert.CompileLibraryAndVerifyDebugInfoWithOptions(
             [|"--debug:portable"; "--optimize-"; "--optimize-"|],
@@ -20,7 +20,7 @@ let f x =
     2
             """)
 
-    [<Test>]
+    [<Fact>]
     let SimpleShadowingFunction() =
         CompilerAssert.CompileLibraryAndVerifyDebugInfoWithOptions(
             [|"--debug:portable"; "--optimize-"; "--optimize-"|],
@@ -34,7 +34,7 @@ let f x =
     2
             """)
 
-    [<Test>]
+    [<Fact>]
     let ComplexShadowingFunction() =
         CompilerAssert.CompileLibraryAndVerifyDebugInfoWithOptions(
             [|"--debug:portable"; "--optimize-"; "--optimize-"|],

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/DelegateAndFuncOptimizations.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/DelegateAndFuncOptimizations.fs
@@ -3,13 +3,13 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
 #if !DEBUG // sensitive to debug-level code coming across from debug FSharp.Core
-[<TestFixture>]
+
 module DelegateAndFuncOptimizations =
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     let ``Reduce function via InlineIfLambda``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
@@ -153,7 +153,7 @@ type C =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     let ``Reduce delegate invoke via InlineIfLambda``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
@@ -301,7 +301,7 @@ type C =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     let ``Reduce computed function invoke``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
@@ -341,7 +341,7 @@ let ApplyComputedFunction(c: int) =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     let ``Reduce Computed Delegate``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
@@ -381,7 +381,7 @@ let ApplyComputedDelegate(c: int) =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     let ``Reduce Computed Function with irreducible match``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
@@ -433,7 +433,7 @@ let ApplyComputedFunction(c: int) =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     let ``Immediately apply computed function in sequential``() =
         CompilerAssert.CompileLibraryAndVerifyIL(
@@ -492,7 +492,7 @@ let ApplyComputedFunction(c: int) =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     // See https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1034-lambda-optimizations.md
     // See also https://github.com/dotnet/fsharp/issues/17607 for a regression caused by realsig+ becoming default
     // This test case must keep using direct call to ReduceComputedDelegate, and not a FSharpFunc invocation.

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/DeterministicTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/DeterministicTests.fs
@@ -5,10 +5,10 @@ namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 open System.IO
 open FSharp.Test
 open FSharp.Test.Compiler
-open NUnit.Framework
+open Xunit
 
 
-[<TestFixture>]
+
 module DeterministicTests =
 
     let commonOptions = ["--refonly";"--deterministic";"--nooptimizationdata"]
@@ -61,7 +61,7 @@ let test() =
         mvid1 , mvid2
 
 
-    [<Test>]
+    [<Fact>]
     let ``Simple assembly should be deterministic``() =  
         File.WriteAllText(inputPath, basicCodeSnippet)
 
@@ -71,55 +71,55 @@ let test() =
             |> compileGuid
 
         // Two identical compilations should produce the same MVID
-        Assert.AreEqual(getMvid(), getMvid())
+        Assert.Equal(getMvid(), getMvid())
 
-    [<Test>]
+    [<Fact>]
     let ``Simple assembly with different platform should not be deterministic``() = 
         let mvid1 = getMvid basicCodeSnippet ["--deterministic"]
         let mvid2 = getMvid basicCodeSnippet ["--deterministic";"--platform:Itanium"]
         // No two platforms should produce the same MVID
-        Assert.AreNotEqual(mvid1, mvid2)
+        Assert.NotEqual(mvid1, mvid2)
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly should be deterministic``() =
         let mvid1, mvid2 = calculateRefAssMvids basicCodeSnippet basicCodeSnippet
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly with different platform should not be deterministic``() =
         let mvid1 = getMvid basicCodeSnippet ["--refonly";"--deterministic"]
         let mvid2 = getMvid basicCodeSnippet ["--refonly";"--deterministic";"--platform:Itanium"]
 
         // No two platforms should produce the same MVID
-        Assert.AreNotEqual(mvid1, mvid2)
+        Assert.NotEqual(mvid1, mvid2)
 
-    [<Test>]
+    [<Fact>]
     let ``False-positive reference assemblies test, different assemblies' mvid should not match`` () =
         let src2 = basicCodeSnippet.Replace("test()","test2()")
         let mvid1, mvid2 = calculateRefAssMvids basicCodeSnippet src2
-        Assert.AreNotEqual(mvid1, mvid2)
+        Assert.NotEqual(mvid1, mvid2)
 
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function name is different with the same function name length`` () =
         let privCode1 = basicCodeSnippet.Replace("privTest()","privTest1()")
         let privCode2 = basicCodeSnippet.Replace("privTest()","privTest2()")
         let mvid1, mvid2 = calculateRefAssMvids privCode1 privCode2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
     
     
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function name is different with the different function name length`` () =
         let src2 = basicCodeSnippet.Replace("privTest()","privTest11()")
         let mvid1, mvid2 = calculateRefAssMvids basicCodeSnippet src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
     
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function body is different`` () =
         let src2 = basicCodeSnippet.Replace("""Console.WriteLine("Private Hello World!")""","""Console.Write("Private Hello World!")""")
         let mvid1, mvid2 = calculateRefAssMvids basicCodeSnippet src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
         
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function return type is different`` () =
 
         let src2 =
@@ -135,9 +135,9 @@ let test() =
     Console.WriteLine()
             """
         let mvid1, mvid2 = calculateRefAssMvids basicCodeSnippet src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
      
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function parameter count is different`` () =
         let src =
             """
@@ -166,9 +166,9 @@ let test() =
             """
 
         let mvid1, mvid2 = calculateRefAssMvids src src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
 
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function parameter count is different and private function is unused`` () =
         let src =
             """
@@ -194,9 +194,9 @@ let test() =
             """
 
         let mvid1, mvid2 = calculateRefAssMvids src src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
      
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when only private function parameter types are different`` () =
         let src =
             """
@@ -225,9 +225,9 @@ let test() =
             """
        
         let mvid1, mvid2 = calculateRefAssMvids src src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
         
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when private function is missing in one of them`` () =
         let src =
             """
@@ -253,9 +253,9 @@ let test() =
             """
 
         let mvid1, mvid2 = calculateRefAssMvids src src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
 
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be deterministic when inner function is removed`` () =
         let src =
             """
@@ -282,9 +282,9 @@ let test() =
             """
        
         let mvid1, mvid2 = calculateRefAssMvids src src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
 
-    [<Test>] 
+    [<Fact>] 
     let ``Reference assemblies should be same when contents of quoted expression change`` () =
         let src =
             """
@@ -301,26 +301,26 @@ let foo () = <@ 2 + 3 @>
             """
 
         let mvid1, mvid2 = calculateRefAssMvids src src2
-        Assert.AreEqual(mvid1, mvid2)
+        Assert.Equal(mvid1, mvid2)
 
-    [<Test>]
+    [<Fact>]
     let ``Reference assemblies must change when a must-inline function changes body`` () =
         let codeBefore = """module ReferenceAssembly
 let inline myFunc x y = x + y"""
         let codeAfter = codeBefore.Replace("+","-")
         let mvid1, mvid2 = calculateRefAssMvids codeBefore codeAfter
-        Assert.AreNotEqual(mvid1,mvid2)
+        Assert.NotEqual(mvid1,mvid2)
 
-    [<Test>]
+    [<Fact>]
     let ``Reference assemblies must not change when a must-inline function does not change`` () =
         let codeBefore = """module ReferenceAssembly
 let inline myFunc x y = x - y"""       
         let mvid1, mvid2 = calculateRefAssMvids codeBefore codeBefore
-        Assert.AreEqual(mvid1,mvid2)
+        Assert.Equal(mvid1,mvid2)
 
-
-    [<TestCase(ivtSnippet, false)>] // If IVT provided -> MVID must reflect internal binding
-    [<TestCase("", true )>] // No IVT => internal binding can be ignored for mvid purposes
+    [<Theory>]
+    [<InlineData(ivtSnippet, false)>] // If IVT provided -> MVID must reflect internal binding
+    [<InlineData("", true )>] // No IVT => internal binding can be ignored for mvid purposes
     let ``Reference assemblies MVID when having internal binding``(additionalSnippet:string, shouldBeStable:bool) =
         let codeAfter = 
             basicCodeSnippet
@@ -330,6 +330,6 @@ let inline myFunc x y = x - y"""
         let mvid1, mvid2 = calculateRefAssMvids basicCodeSnippet codeAfter
 
         if shouldBeStable then
-            Assert.AreEqual(mvid1,mvid2)
+            Assert.Equal(mvid1,mvid2)
         else
-            Assert.AreNotEqual(mvid1,mvid2)
+            Assert.NotEqual(mvid1,mvid2)

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/Mutation.fs
@@ -4,13 +4,13 @@ namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Compiler.UnitTests
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Mutation`` =
     // Regression test for FSHARP1.0:1206
 
-    [<Test>]
+    [<Fact>]
     let ``Mutation 01``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|"-g"; "--optimize-";"--realsig+"|],
@@ -45,7 +45,7 @@ type Test = struct
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Mutation 02``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|"-g"; "--optimize-";"--realsig+"|],
@@ -91,7 +91,7 @@ x.ToString()
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Mutation 03``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|"-g"; "--optimize-";"--realsig+"|],
@@ -136,7 +136,7 @@ x.Day
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Mutation 04``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|"-g"; "--optimize-";"--realsig+"|],
@@ -182,7 +182,7 @@ x.ToString()
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Mutation 05``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|"-g"; "--optimize-";"--realsig+"|],

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
@@ -3,16 +3,16 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test.Compiler
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.IO
 
-[<TestFixture>]
+
 module ReferenceAssemblyTests =
 
     let referenceAssemblyAttributeExpectedIL =
         """.custom instance void [runtime]System.Runtime.CompilerServices.ReferenceAssemblyAttribute::.ctor() = ( 01 00 00 00 )"""
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly should have expected IL``() =
         let src =
             """
@@ -46,7 +46,7 @@ let test() =
         ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly should have expected IL without a private function``() =
         let src =
             """
@@ -84,7 +84,7 @@ let test() =
         ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly should have expected IL with anonymous record``() =
         let src =
             """
@@ -111,7 +111,7 @@ let test(_x: {| a: int32 |}) =
         ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly with nested module should have expected IL``() =
         let src =
             """
@@ -153,7 +153,7 @@ module Nested =
         ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Simple reference assembly with nested module with type should have expected IL``() =
         let src =
             """
@@ -496,7 +496,7 @@ module Nested =
 #endif
         ] |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``--refout should produce both normal and reference assemblies``() =
         // TODO: We probably want a built-in test framework functionality which will be taking care of comparing/verifying refout.
         let refoutDllPath = FileSystem.GetTempPathShim() + "Test.ref.dll"
@@ -558,7 +558,7 @@ let test() =
     }"""
         ]
 
-    [<Test>]
+    [<Fact>]
     let ``Internal DU type doesn't generate any properties/methods without IVT`` () =
         FSharp """
 module ReferenceAssembly
@@ -591,7 +591,7 @@ extends [runtime]System.Object
 
   } """]
 
-    [<Test>]
+    [<Fact>]
     let ``Types with internal-only properties and methods don't generate anything without IVT`` () =
         FSharp """
 module ReferenceAssembly
@@ -628,7 +628,7 @@ extends [runtime]System.Object
 
   }"""]
 
-    [<Test>]
+    [<Fact>]
     let ``Cli events are emitted even for CliEvent members which are not last in a file`` () = 
         FSharp """
 module LibraryWithTwoClassesAndTwoEvents
@@ -726,7 +726,7 @@ type MyClass2() =
     .removeon instance void LibraryWithTwoClassesAndTwoEvents/MyClass2::remove_EventFromSecondType(class [runtime]System.EventHandler`1<class [runtime]System.EventArgs>)
 """ ]
 
-    [<Test>]
+    [<Fact>]
     let ``Properties are emitted for CliMutable records`` () = 
         FSharp """
 namespace ReferenceAssembly
@@ -738,7 +738,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MyRecord = { MyId: int }"""
             referenceAssemblyAttributeExpectedIL
             "      .property instance int32 MyId()"]
 
-    [<Test>] 
+    [<Fact>] 
     let ``Properties are emitted even for CliMutable records which are not last in a file`` () = 
         FSharp """
 namespace ReferenceAssembly
@@ -753,7 +753,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { MySecondId: strin
             "      .property instance int32 MyId()"
             "      .property instance string MySecondId()"]
 
-    [<Test>] // Regression https://github.com/dotnet/fsharp/issues/14088 .
+    [<Fact>] // Regression https://github.com/dotnet/fsharp/issues/14088 .
     // Generated IL was assigning properties to the last record in file instead of where they are supposed to be
     let ``Properties are emitted for equal records in the same file`` () = 
         FSharp """
@@ -904,7 +904,7 @@ type [<CLIMutable;NoComparison;NoEquality>] MySecondRecord = { Name: string }
 
         ]
 
-    [<Test>]
+    [<Fact>]
     let ``Properties, getters, setters are emitted for internal properties`` () =
         FSharp """
 module ReferenceAssembly
@@ -1013,7 +1013,7 @@ type MySecondaryAttribute() =
   } """
         ]
     
-    [<Test>]
+    [<Fact>]
     let ``Internal and private fields are emitted for structs`` () =
         FSharp """
 module ReferenceAssembly
@@ -1042,7 +1042,7 @@ type AStruct =
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.DefaultValueAttribute::.ctor() = ( 01 00 00 00 ) 
   }"""
         ]
-    [<Test>]
+    [<Fact>]
     let ``Only public properties are emitted on non-IVT assemblies`` () =
         FSharp """
 module ReferenceAssembly
@@ -1117,7 +1117,7 @@ type MType() =
     } 
   } """
         ]
-    [<Test>]
+    [<Fact>]
     let ``Only public events are emitted for non-IVT assembly`` () =
         FSharp """
 module ReferenceAssembly
@@ -1149,7 +1149,7 @@ type MType() =
   } """
         ]
 
-    [<Test>]
+    [<Fact>]
     let ``Internal constructor is emitted for attribute`` () =
         FSharp """
 module ReferenceAssembly
@@ -1278,7 +1278,7 @@ type Person(name : string, age : int) =
   }"""
         ]
 
-    [<Test>]
+    [<Fact>]
     let ``Internal constructor is emitted for attribute (with fsi)`` () =
         let fsSig =
             Fsi """
@@ -1377,7 +1377,7 @@ extends [runtime]System.Object
 
 } """ ]
 
-    [<Test>]
+    [<Fact>]
     let ``Build .exe with --refonly ensure it produces a main in the ref assembly`` () =
         FSharp """module ReferenceAssembly
 open System
@@ -1407,7 +1407,7 @@ Console.WriteLine("Hello World!")"""
         ]
         |> ignore
 #if NETCOREAPP
-    [<Test>]
+    [<Fact>]
 #endif
     let ``Refassembly_emits_static_abstracts_implementations_the_same_way_it_does_for_instance_with_empty_signature`` () =
 
@@ -1473,7 +1473,7 @@ type CompilerGoesBoom<'a>() =
 
 
 #if NETCOREAPP
-    [<Test>]
+    [<Fact>]
 #endif
     let ``Refassembly_emits_static_abstracts_implementations_the_same_way_it_does_for_instance_with_signature`` () =
         let signature = """namespace Foobar

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticLinkTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticLinkTests.fs
@@ -6,12 +6,12 @@ open System.IO
 open System.Reflection
 open FSharp.Test
 open FSharp.Test.Utilities
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module StaticLinkTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Static link simple library``() =
         let module1 =
             let source =
@@ -35,7 +35,7 @@ printfn "%A" y
                 deps
                 |> List.iter (fun dep -> try File.Delete dep with | _ -> ())))
 
-    [<Test>]
+    [<Fact>]
     let ``Simple exe should fail to execute if dependency was not found and is not statically linked``() =
         let module1 =
             let source =
@@ -60,7 +60,7 @@ printfn "%A" y
                     deps
                     |> List.iter (fun dep -> try File.Delete dep with | _ -> ())))) |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Simple exe should execute if dependency was found and is not statically linked``() =
         let module1 =
             let source =
@@ -81,7 +81,7 @@ printfn "%A" y
 
         CompilerAssert.Execute module2
 
-    [<Test>]
+    [<Fact>]
     let ``Static link quotes in multiple modules``() =
         let module1 =
             let source =
@@ -154,7 +154,7 @@ else failwith "Test Failed"
 
         CompilerAssert.Execute(module2, ignoreWarnings=true)
 
-    [<Test>]
+    [<Fact>]
     let ``Static link quotes in multiple modules - optimized``() =
         let module1 =
             let source =
@@ -227,7 +227,7 @@ else failwith "Test Failed"
 
         CompilerAssert.Execute(module2, ignoreWarnings=true)
 
-    [<Test>]
+    [<Fact>]
     let ``Standalone linking``() =
         let source =
             """
@@ -240,7 +240,7 @@ let _ = exit 0
         let module1 = Compilation.Create(source, Exe, [|"--standalone"|])
         CompilerAssert.Execute(module1, newProcess=true)
 
-    [<Test>]
+    [<Fact>]
     let ``Standalone linking - optimized``() =
         let source =
             """

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -3,12 +3,12 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Static Member`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Action on Static Member``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
@@ -72,7 +72,7 @@ type C =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Action on Static Member with lambda``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
@@ -131,7 +131,7 @@ type C =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Action on Static Member with closure``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
@@ -245,7 +245,7 @@ let main _ =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Func on Static Member``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
@@ -311,7 +311,7 @@ type C =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Func on Static Member with lambda``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
@@ -377,7 +377,7 @@ type C =
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Func on Static Member with closure``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """
@@ -432,7 +432,7 @@ let main _ =
             ]))
 
 #if !FX_NO_WINFORMS
-    [<Test>]
+    [<Fact>]
     let ``EventHandler from Regression/83``() =
         CompilerAssert.CompileLibraryAndVerifyILRealSig(
             """

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/TaskGeneratedCode.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/TaskGeneratedCode.fs
@@ -3,7 +3,7 @@
 namespace FSharp.Compiler.UnitTests.CodeGen.EmittedIL
 
 open FSharp.Test
-open NUnit.Framework
+open Xunit
 
 open System
 open System.Threading.Tasks
@@ -12,7 +12,7 @@ open System.Threading.Tasks
 // The code generated changes slightly in debug mode
 #if !DEBUG 
 // Check the exact code produced for tasks
-[<TestFixture>]
+
 module TaskGeneratedCode =
 
     // This tests the exact optimized code generated for the MoveNext for a trivial task - we expect 'MoveNext' to be there
@@ -26,7 +26,7 @@ module TaskGeneratedCode =
     //   IL_000e:  ldc.i4.1
     //   IL_000f:  stfld      int32 Test/testTask@4::Result
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of simple task debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -113,7 +113,7 @@ let testTask() = task { return 1 }
     //   IL_000e:  ldc.i4.1
     //   IL_000f:  stfld      int32 Test/testTask@4::Result
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of simple task optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
@@ -187,7 +187,7 @@ let testTask() = task { return 1 }
             ]))
 
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of simple binding task debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/debug:portable";"--realsig+"; "/optimize-"; "/tailcalls-" |],
@@ -367,7 +367,7 @@ let testTask(t: Task<int>) = task { let! res = t in return res+1 }
 
 module TaskTryFinallyGeneration =
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of task try/finally optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
@@ -476,7 +476,7 @@ let testTask() = task { try 1+1 finally System.Console.WriteLine("finally") }
             ]))
 
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of task try/finally debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -593,7 +593,7 @@ let testTask() = task { try 1+1 finally System.Console.WriteLine("finally") }
 
 module TaskTryWithGeneration =
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of task try/with optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
@@ -706,7 +706,7 @@ let testTask() = task { try 1 with e -> System.Console.WriteLine("finally"); 2 }
             ]))
 
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of task try/with debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -826,7 +826,7 @@ let testTask() = task { try 1 with e -> System.Console.WriteLine("with"); 2 }
 
 module TaskWhileLoopGeneration =
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of task while loop optimized``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize+"; "/debug:portable";"--realsig+"; "/tailcalls+" |],
@@ -924,7 +924,7 @@ let testTask() = task { while x > 4 do System.Console.WriteLine("loop") }
             ]))
 
 
-    [<Test>]
+    [<Fact>]
     let ``check MoveNext of task while loop debug``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -1027,7 +1027,7 @@ let testTask() = task { while x > 4 do System.Console.WriteLine("loop") }
 module TaskTypeInference =
     // This tests the compilation of a case that hits corner cases in SRTP constraint processing.
     // See https://github.com/dotnet/fsharp/issues/12188
-    [<Test>]
+    [<Fact>]
     let ``check initially ambiguous SRTP task code ``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -1047,7 +1047,7 @@ let myTuple : (string -> Task<unit>) * int = (fun (_s: string) -> Task.FromResul
             """)
 
     // Test task code in generic position
-    [<Test>]
+    [<Fact>]
     let ``check generic task code ``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -1080,7 +1080,7 @@ printfn "test passed"
 
 #if !DEBUG 
 
-    [<Test>]
+    [<Fact>]
     let ``check generic task exact code``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [| "/optimize-"; "/debug:portable";"--realsig+"; "/tailcalls-" |],
@@ -1382,9 +1382,9 @@ type Generic1InGeneric1<'T>() =
 
 
 #if NETCOREAPP
-[<TestFixture>]
+
 module ``Check stack traces`` = 
-    [<Test>]
+    [<Fact>]
     let ``check stack trace of async exception from task``() =
         let t() =
             task {
@@ -1412,7 +1412,7 @@ module ``Check stack traces`` =
 
 
 // Test that the SRTP Bind on a ValueTask is still generic in the bind type
-[<TestFixture>]
+
 module ``Check return attributes`` = 
     let incr (x:int) : [<Experimental("a")>] (int -> int) = (fun a -> a + x)
 
@@ -1420,7 +1420,7 @@ module ``Check return attributes`` =
     // If the function is curried its inferred arity should be no more than 
     // the declared arguments (the F# rule that infers additional arguments 
     // should not kick in).
-    [<Test>]
+    [<Fact>]
     let ``check return attribute of curried function``() =
         match <@ incr 3 4 @> with
         | Quotations.Patterns.Application (Quotations.Patterns.Call(None, mi, [Quotations.DerivedPatterns.Int32 3]), Quotations.DerivedPatterns.Int32 4) ->

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/BasicConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/BasicConstants.fs
@@ -2,14 +2,12 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
-open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
 module ``Basic Grammar Element Constants`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Basic constants compile `` () =
         CompilerAssert.Pass 
             """
@@ -53,7 +51,7 @@ let boolConst2 = false
 let unitConst = ()
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Long with underscores``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -66,7 +64,7 @@ printfn "%A" socialSecurityNumber
 printfn "%A" creditCardNumber
             """
 
-    [<Test>]
+    [<Fact>]
     let ``float 32 with underscores``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -75,7 +73,7 @@ if pi <> 3.1415F  then failwith "Wrong parsing"
 printfn "%A" pi
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with underscores hexBytes``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -85,7 +83,7 @@ printfn "%A" hexBytes
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``int with underscore hexWords``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -94,7 +92,7 @@ if hexWords <> 0xCAFEBABE then failwith "Wrong parsing"
 printfn "%A" hexWords
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Long with underscores maxLong``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -103,7 +101,7 @@ if maxLong <> 0x7fffffffffffffffL then failwith "Wrong parsing"
 printfn "%A" maxLong
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with underscore nybbles``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -112,7 +110,7 @@ if nybbles <> 0b00100101 then failwith "Wrong parsing"
 printfn "%A" nybbles
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with underscores bytes``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -121,7 +119,7 @@ if bytes <> 0b11010010011010011001010010010010 then failwith "Wrong parsing"
 printfn "%A" bytes
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with single underscore literal``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -130,7 +128,7 @@ if x2 <> 52 then failwith "Wrong parsing"
 printfn "%A" x2
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with multiple underscores literal``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -139,7 +137,7 @@ if x4 <> 52 then failwith "Wrong parsing"
 printfn "%A" x4
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with single underscore Hex literal``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -149,7 +147,7 @@ if x7 <> 0x52 then
 printfn "%A" x7
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with single underscore after leading zero literal``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -158,7 +156,7 @@ if x9 <> 052 then failwith "Wrong parsing"
 printfn "%A" x9
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with single underscore after literal with leading zero ``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -167,7 +165,7 @@ if x10 <> 052 then failwith "Wrong parsing"
 printfn "%A" x10
             """
 
-    [<Test>]
+    [<Fact>]
     let ``int with single underscore after octo literal ``() = 
         CompilerAssert.CompileExeAndRun
             """
@@ -175,7 +173,7 @@ let x14 = 0o5_2
 if x14 <> 0o52 then failwith "Wrong parsing"
 printfn "%A" x14
             """
-    [<Test>]
+    [<Fact>]
     let ``dotless float``() = 
         CompilerAssert.CompileExeWithOptions([|"--langversion:5.0"|],
             """
@@ -183,35 +181,35 @@ let x = 42f
 printfn "%A" x
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``dotted float``() = 
         CompilerAssert.CompileExe("""
 let x = 42.f
 printfn "%A" x
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``dotted floats should be equal to dotless floats``() = 
         CompilerAssert.CompileExeAndRunWithOptions([|"--langversion:5.0"|],
             """
 if 1.0f <> 1f then failwith "1.0f <> 1f"
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``exponent dotted floats should be equal to dotted floats``() =
         CompilerAssert.CompileExeAndRun
             """
 if 1.0e1f <> 10.f then failwith "1.0e1f <> 10.f"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``exponent dotless floats should be equal to dotted floats``() = 
         CompilerAssert.CompileExeAndRun
             """
 if 1e1f <> 10.f then failwith "1e1f <> 10.f" 
             """
 
-    [<Test>]
+    [<Fact>]
     let ``exponent dotted floats should be equal to dotless floats``() = 
         CompilerAssert.CompileExeAndRunWithOptions(
             [|"--langversion:5.0"|],
@@ -219,7 +217,7 @@ if 1e1f <> 10.f then failwith "1e1f <> 10.f"
 if 1.0e1f <> 10f then failwith "1.0e1f <> 10f" 
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``exponent dotless floats should be equal to dotless floats``() = 
         CompilerAssert.CompileExeAndRunWithOptions(
             [|"--langversion:5.0"|],

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/CharConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/CharConstants.fs
@@ -2,20 +2,21 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Char Constants`` =
 
-    [<TestCase('\a', 7 )>] // alert
-    [<TestCase('\b', 8 )>] // backspace
-    [<TestCase('\t', 9 )>] // horizontal tab
-    [<TestCase('\n', 10)>] // new line
-    [<TestCase('\v', 11)>] // vertical tab
-    [<TestCase('\f', 12)>] // form feed
-    [<TestCase('\r', 13)>] // return
-    [<TestCase('\"', 34)>] // double quote
-    [<TestCase('\'', 39)>] // single quote
-    [<TestCase('\\', 92)>] // backslash
+    [<Theory>]
+    [<InlineData('\a', 7 )>] // alert
+    [<InlineData('\b', 8 )>] // backspace
+    [<InlineData('\t', 9 )>] // horizontal tab
+    [<InlineData('\n', 10)>] // new line
+    [<InlineData('\v', 11)>] // vertical tab
+    [<InlineData('\f', 12)>] // form feed
+    [<InlineData('\r', 13)>] // return
+    [<InlineData('\"', 34)>] // double quote
+    [<InlineData('\'', 39)>] // single quote
+    [<InlineData('\\', 92)>] // backslash
     let ``Escape characters`` character value =
         Assert.areEqual character (char value)

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/DecimalConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/DecimalConstants.fs
@@ -2,19 +2,19 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Decimal Constants`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Product of decimal constants``() =
         let oneOfOneMiDec = 1.0E-6M
         let oneMiDec      = 1.0E+6M
 
         Assert.areEqual 1.0M (oneOfOneMiDec * oneMiDec)
 
-    [<Test>]
+    [<Fact>]
     let ``Sum of decimal constants``() =
         let x = 
             1.0E0M 
@@ -38,13 +38,13 @@ module ``Decimal Constants`` =
 
         Assert.areEqual 987654321.123456789M x
 
-    [<Test>]
+    [<Fact>]
     let ``Sum of decimal literals with leading zero in exponential``() =
         let x = 1.0E00M + 2.0E01M + 3.E02M + 1.E-01M + 2.0E-02M
 
         Assert.areEqual 321.12M x
 
-    [<Test>]
+    [<Fact>]
     let ``Non-representable small values are rounded to zero``() =
         // This test involves rounding of decimals. The F# design is to follow the BCL.
         // This means that the behavior is not deterministic, e.g. Mono and NetFx4 round; NetFx2 gives an error

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/IntegerConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/IntegerConstants.fs
@@ -2,12 +2,12 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Integer Constants`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Operations with negative one``() =
         // Verify the ability to specify negative numbers
         // (And not get confused wrt subtraction.)
@@ -19,7 +19,7 @@ module ``Integer Constants`` =
         Assert.areEqual  1 (x * x)
         Assert.areEqual  1 (x / x)
 
-    [<Test>]
+    [<Fact>]
     let ``Operations with negative integers``() =
         // Verify the ability to specify negative numbers
         // (And not get confused wrt subtraction.)
@@ -32,7 +32,7 @@ module ``Integer Constants`` =
         Assert.areEqual -2       fiveMinusSeven 
         Assert.areEqual (-1 * 7) negativeSeven  
 
-    [<Test>]
+    [<Fact>]
     let ``Functions with negative integers``() =
         // Verify the ability to specify negative numbers
         // (And not get confused wrt subtraction.)

--- a/tests/fsharp/Compiler/Conformance/DataExpressions/ComputationExpressions.fs
+++ b/tests/fsharp/Compiler/Conformance/DataExpressions/ComputationExpressions.fs
@@ -2,12 +2,11 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Compiler
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
 module ``ComputationExpressions`` =
     let tmp = 1
 
@@ -197,7 +196,7 @@ let check msg actual expected = if actual <> expected then failwithf "FAILED %s,
         let libLineAdjust = lib |> Seq.filter (fun c -> c = '\n') |> Seq.length
         CompilerAssert.TypeCheckWithErrorsAndOptionsAndAdjust [| "/langversion:4.7" |] libLineAdjust (lib + source) errors
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative`` () =
         ApplicativeLibTest includeAll """
 
@@ -214,7 +213,7 @@ check "fewljvwerjl1" ceResult.Value 3
 check "fewljvwerj12" (tracer.GetTrace ()) [|TraceOp.ApplicativeBind2Return|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeCustomOp`` () =
         ApplicativeLibTest includeAll """
 
@@ -232,7 +231,7 @@ check "fewljvwerjlvwe1" ceResult.Value 3
 check "fewljvwerjvwe12" (tracer.GetTrace ()) [|TraceOp.ApplicativeBind2Return; TraceOp.Log "hello!";TraceOp.ApplicativeBindReturn|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeCustomOp Minimal`` () =
         ApplicativeLibTest includeMinimal """
 
@@ -250,7 +249,7 @@ check "fewljvwerjlvwe1" ceResult.Value 3
 check "fewljvwerjvwe12" (tracer.GetTrace ()) [|TraceOp.MergeSources; TraceOp.ApplicativeBindReturn; TraceOp.Log "hello!";TraceOp.ApplicativeBindReturn|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeCustomOpTwice`` () =
         ApplicativeLibTest includeAll """
 
@@ -269,7 +268,7 @@ check "fewljvwerjlvwe1" ceResult.Value 3
 check "fewljvwerjvwe12" (tracer.GetTrace ()) [|TraceOp.ApplicativeBind2Return; TraceOp.Log "hello!";TraceOp.Log "goodbye!";TraceOp.ApplicativeBindReturn|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Disable`` () =
         ApplicativeLibErrorTestFeatureDisabled includeAll 
             """
@@ -284,7 +283,7 @@ let ceResult : Trace<int> =
             """
             [| FSharpDiagnosticSeverity.Error, 3344, (6, 9, 8, 35), "This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature." |]
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceMultiBindingMonoid`` () =
         ApplicativeLibTest includeAll """
 
@@ -302,7 +301,7 @@ check "fewljvwerjl5" ceResult.Value [3; 5]
 check "fewljvwerj16" (tracer.GetTrace ()) [|TraceOp.Delay; TraceOp.MonadicBind2; TraceOp.ApplicativeYield; TraceOp.Delay; TraceOp.ApplicativeYield; TraceOp.ApplicativeCombine|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceMultiBindingMonadic`` () =
         ApplicativeLibTest includeAll """
 
@@ -325,7 +324,7 @@ check "gwrhjkrwpoiwer1" ceResult.Value 3
 check "gwrhjkrwpoiwer2" (tracer.GetTrace ())  [|TraceOp.MonadicBind; TraceOp.MonadicBind2; TraceOp.MonadicReturn|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceMultiBindingMonadicCustomOp A`` () =
         ApplicativeLibTest includeAll """
 
@@ -340,7 +339,7 @@ let ceResult : Trace<int> =
 check "gwrhjkrwpoiwer1t4" ceResult.Value 3
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceMultiBindingMonadicCustomOp B`` () =
         ApplicativeLibTest includeAll """
 let tracer = TraceMultiBindingMonadicCustomOp()
@@ -356,7 +355,7 @@ check "gwrhjkrwpoiwer1t45" ceResult.Value 3
 check "gwrhjkrwpoiwer2t36" (tracer.GetTrace ())  [|TraceOp.MonadicBind2; TraceOp.MonadicReturn; TraceOp.Log "(3, true)"; TraceOp.MonadicBind; TraceOp.MonadicReturn |]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceMultiBindingMonadic TwoBind`` () =
         ApplicativeLibTest includeAll """
 
@@ -381,7 +380,7 @@ check "gwrhjkrwpoiwer38" ceResult.Value 3
 check "gwrhjkrwpoiwer39" (tracer.GetTrace ())  [|TraceOp.MonadicBind; TraceOp.MonadicBind2; TraceOp.MonadicBind2; TraceOp.MonadicReturn|]
             """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeWithDelayAndRun`` () =
         ApplicativeLibTest includeAll """
 
@@ -398,7 +397,7 @@ check "vlkjrrlwevlk23" ceResult.Value 3
 check "vlkjrrlwevlk24" (tracer.GetTrace ())  [|TraceOp.Delay; TraceOp.ApplicativeBind2Return; TraceOp.Run|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeWithDelay`` () =
         ApplicativeLibTest includeAll """
 
@@ -415,7 +414,7 @@ check "vlkjrrlwevlk23" ceResult.Value 3
 check "vlkjrrlwevlk24" (tracer.GetTrace ())  [|TraceOp.Delay; TraceOp.ApplicativeBind2Return|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeWithDelay Minimal`` () =
         ApplicativeLibTest includeMinimal """
 
@@ -432,7 +431,7 @@ check "vlkjrrlwevlk23" ceResult.Value 3
 check "vlkjrrlwevlk24" (tracer.GetTrace ())  [|TraceOp.Delay; TraceOp.MergeSources; TraceOp.ApplicativeBindReturn|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicativeWithRun`` () =
         ApplicativeLibTest includeAll """
 
@@ -450,7 +449,7 @@ check "vwerweberlk4" (tracer.GetTrace ())  [|TraceOp.ApplicativeBind2Return; Tra
         """
 
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Size 3`` () =
         ApplicativeLibTest includeAll """
 
@@ -468,7 +467,7 @@ check "fewljvwerjl7" ceResult.Value 3
 check "fewljvwerj18" (tracer.GetTrace ()) [|TraceOp.MergeSources3; TraceOp.ApplicativeBindReturn|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Size 3 minimal`` () =
         ApplicativeLibTest includeMinimal """
 
@@ -485,7 +484,7 @@ let ceResult =
 check "fewljvwerjl7" ceResult.Value 3
 check "fewljvwerj18" (tracer.GetTrace ()) [|TraceOp.MergeSources; TraceOp.MergeSources; TraceOp.ApplicativeBindReturn|]
         """
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Size 4`` () =
         ApplicativeLibTest includeAll """
 
@@ -504,7 +503,7 @@ check "fewljvwerjl191" ceResult.Value 3
 check "fewljvwerj1192" (tracer.GetTrace ()) [|TraceOp.MergeSources4; TraceOp.ApplicativeBindReturn|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Size 5`` () =
         ApplicativeLibTest includeAll """
 
@@ -524,7 +523,7 @@ check "fewljvwerjl193" ceResult.Value 16
 check "fewljvwerj1194" (tracer.GetTrace ()) [|TraceOp.MergeSources; TraceOp.MergeSources4; TraceOp.ApplicativeBindReturn|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Size 6`` () =
         ApplicativeLibTest includeAll """
 
@@ -545,7 +544,7 @@ check "fewljvwerjl195" ceResult.Value 25
 check "fewljvwerj1196" (tracer.GetTrace ()) [|TraceOp.MergeSources3; TraceOp.MergeSources4; TraceOp.ApplicativeBindReturn|]
         """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative Size 10`` () =
         ApplicativeLibTest includeAll """
 
@@ -571,7 +570,7 @@ check "fewljvwerj1198" (tracer.GetTrace ()) [|TraceOp.MergeSources4; TraceOp.Mer
     """
 
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang Negative TraceApplicative missing MergeSources`` () =
         ApplicativeLibErrorTest includeAll """
 let tracer = TraceApplicativeNoMergeSources()
@@ -585,7 +584,7 @@ let _ =
     """
             [|(FSharpDiagnosticSeverity.Error, 3343, (6, 9, 6, 25), "The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a 'Bind2' method or appropriate 'MergeSources' and 'Bind' methods")|]
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang Negative TraceApplicative missing Bind and BindReturn`` () =
         ApplicativeLibErrorTest includeAll """
 let tracer = TraceApplicativeNoBindReturn()
@@ -600,7 +599,7 @@ let _ =
             [|(FSharpDiagnosticSeverity.Error, 708, (6, 9, 6, 25), "This control construct may only be used if the computation expression builder defines a 'Bind' method")|]
 
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang Negative TraceApplicative with bad construct`` () =
         ApplicativeLibErrorTest includeAll """
 
@@ -615,7 +614,7 @@ let _ =
     """
             [| FSharpDiagnosticSeverity.Error, 708, (7, 9, 7, 25), "This control construct may only be used if the computation expression builder defines a 'Bind' method" |]
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative with do-bang`` () =
         ApplicativeLibErrorTest includeAll """
 let tracer = TraceApplicative()
@@ -632,7 +631,7 @@ let _ =
               (FSharpDiagnosticSeverity.Error, 604, (5, 12, 5, 13), "Unmatched '{'");
               (FSharpDiagnosticSeverity.Error, 10, (8, 9, 8, 13), "Unexpected keyword 'and!' in implementation file")|]
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang Negative TraceApplicative let between let! and and!`` () =
         ApplicativeLibErrorTest includeAll """
 let tracer = TraceApplicative()
@@ -648,7 +647,7 @@ let _ =
             [| (FSharpDiagnosticSeverity.Error, 10, (8, 9, 8, 13), "Unexpected keyword 'and!' in expression") |]
 
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang Negative TraceApplicative no return`` () =
         ApplicativeLibErrorTest includeAll """
 let tracer = TraceApplicative()
@@ -661,7 +660,7 @@ let _ =
     """
             [|(FSharpDiagnosticSeverity.Error, 10, (8, 5, 8, 6), "Unexpected symbol '}' in expression")|]
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative conditional return`` () =
         ApplicativeLibTest includeAll """
 let tracer = TraceApplicative()
@@ -678,7 +677,7 @@ let ceResult =
 check "grwerjkrwejgk" ceResult.Value 2
     """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative match return`` () =
         ApplicativeLibTest includeAll """
 let tracer = TraceApplicative()
@@ -694,7 +693,7 @@ let ceResult =
 check "grwerjkrwejgk42" ceResult.Value 2
     """
 
-    [<Test>]
+    [<Fact>]
     let ``AndBang TraceApplicative incomplete match return`` () =
         ApplicativeLibTest includeAll """
 #nowarn "25"
@@ -787,7 +786,7 @@ let check msg actual expected = if actual <> expected then failwithf "FAILED %s,
     let OverloadLibTest inclInternalExt inclExternalExt source =
         CompilerAssert.CompileExeAndRunWithOptions([|  |], (Source (overloadLib inclInternalExt inclExternalExt + source)))
 
-    [<Test>]
+    [<Fact>]
     let ``OverloadLib accepts overloaded methods`` () =
         OverloadLibTest false false """
 let mem = new System.IO.MemoryStream("Stream"B)
@@ -804,7 +803,7 @@ let ceResult =
 check "TmFtZVxyXG5FbWF1" ceResult "Name\r\nEmail\r\nsswo\r\nBYTES\r\nStream\r\nDescription\r\nof\r\ncontent\r\n"B
     """
 
-    [<Test>]
+    [<Fact>]
     let ``OverloadLib accepts overloaded internal extension methods`` () =
         OverloadLibTest true false """
 let mem = new System.IO.MemoryStream("Stream"B)
@@ -821,7 +820,7 @@ let ceResult =
 check "TmFtZVxyXG5FbWF2" ceResult "Name\r\nEmail\r\nsswo\r\nBYTES\r\nStream\r\nDescription\r\nof\r\ncontent\r\n"B
     """
 
-    [<Test>]
+    [<Fact>]
     let ``OverloadLib accepts overloaded internal and external extensions`` () =
         OverloadLibTest true true """
 let mem = new System.IO.MemoryStream("Stream"B)

--- a/tests/fsharp/Compiler/Language/AnonRecordTests.fs
+++ b/tests/fsharp/Compiler/Language/AnonRecordTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module AnonRecordsTests =
 
-    [<Test>]
+    [<Fact>]
     let NotStructConstraintPass() =
         CompilerAssert.Pass
             """
@@ -17,7 +17,7 @@ type RefClass<'a when 'a : not struct>() = class end
 let rAnon = RefClass<{| R: int |}>()
             """
 
-    [<Test>]
+    [<Fact>]
     let StructConstraintPass() =
         CompilerAssert.Pass
             """
@@ -25,7 +25,7 @@ type StructClass<'a when 'a : struct>() = class end
 let sAnon = StructClass<struct {| S: int |}>()
             """
 
-    [<Test>]
+    [<Fact>]
     let NotStructConstraintFail() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -37,7 +37,7 @@ let rAnon = RefClass<struct {| R: int |}>()
             (3, 13, 3, 42)
             "A generic construct requires that the type 'struct {| R: int |}' have reference semantics, but it does not, i.e. it is a struct"
 
-    [<Test>]
+    [<Fact>]
     let StructConstraintFail() =
         CompilerAssert.TypeCheckSingleError
             """

--- a/tests/fsharp/Compiler/Language/ComparisonOptimizationTest.fs
+++ b/tests/fsharp/Compiler/Language/ComparisonOptimizationTest.fs
@@ -1,13 +1,12 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
 open System
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture>]
 module ComparisonOptimizationTests =
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_int() =
         let script = 
             """
@@ -36,7 +35,7 @@ let f (x: int) (y: int) = compare x y
             )
         )
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_uint() =
         let script = 
             """
@@ -65,7 +64,7 @@ let f (x: uint) (y: uint) = compare x y
             )
         )
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_int64() =
         let script = 
             """
@@ -94,7 +93,7 @@ let f (x: int64) (y: int64) = compare x y
             )
         )
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_uint64() =
         let script = 
             """
@@ -124,7 +123,7 @@ let f (x: uint64) (y: uint64) = compare x y
         )
 
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_int16() =
         let script = 
             """
@@ -153,7 +152,7 @@ let f (x: int16) (y: int16) = compare x y
             )
         )
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_uint16() =
         let script = 
             """
@@ -182,7 +181,7 @@ let f (x: uint16) (y: uint16) = compare x y
             )
         )
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_byte() =
         let script = 
             """
@@ -212,7 +211,7 @@ let f (x: byte) (y: byte) = compare x y
         )
 
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_sbyte() =
         let script = 
             """
@@ -242,7 +241,7 @@ let f (x: sbyte) (y: sbyte) = compare x y
         )
 
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_char() =
         let script = 
             """
@@ -271,7 +270,7 @@ let f (x: char) (y: char) = compare x y
             )
         )
 
-    [<Test>]
+    [<Fact>]
     let Script_Compare_bool() =
         let script = 
             """
@@ -307,7 +306,7 @@ let f (x: bool) (y: bool) = compare x y
         let areSameSign (x: int) (y: int) =
             Math.Sign(x) |> Assert.areEqual (Math.Sign(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_equivalence_with_CompareTo() =
         let rnd = Random()
         for i in 0 .. 1000 do
@@ -318,7 +317,7 @@ let f (x: bool) (y: bool) = compare x y
 
 
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_int32() =
         let values = [0; 1; -1; Int32.MinValue; Int32.MaxValue; Int32.MinValue+1; Int32.MaxValue-1]
 
@@ -326,7 +325,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_uint32() =
         let values = [0u; 1u; UInt32.MaxValue; UInt32.MaxValue-1u]
 
@@ -334,7 +333,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_int64() =
         let values = [0L; 1L; -1L; Int64.MinValue; Int64.MaxValue; Int64.MinValue+1L; Int64.MaxValue-1L]
 
@@ -342,7 +341,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_uint64() =
         let values = [0UL; 1UL; UInt64.MaxValue; UInt64.MaxValue-1UL]
 
@@ -350,7 +349,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_int16() =
         let values = [0s; 1s; -1s; Int16.MinValue; Int16.MaxValue; Int16.MinValue+1s; Int16.MaxValue-1s]
 
@@ -358,7 +357,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_uint16() =
         let values = [0us; 1us; UInt16.MaxValue; UInt16.MaxValue-1us]
 
@@ -367,7 +366,7 @@ let f (x: bool) (y: bool) = compare x y
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_sbyte() =
         let values = [0y; 1y; -1y; SByte.MinValue; SByte.MaxValue; SByte.MinValue+1y; SByte.MaxValue-1y]
 
@@ -375,7 +374,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_byte() =
         let values = [0uy; 1uy; Byte.MaxValue; Byte.MaxValue-1uy]
 
@@ -383,7 +382,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_char() =
         let values = [Char.MinValue; Char.MinValue+char 1 ; Char.MaxValue; Char.MaxValue+char -1]
 
@@ -391,7 +390,7 @@ let f (x: bool) (y: bool) = compare x y
         for y in values do
             compare x y |> Assert.areSameSign (x.CompareTo(y))
 
-    [<Test>]
+    [<Fact>]
     let Check_limit_case_equivalence_with_CompareTo_bool() =
         let values = [false; true]
 

--- a/tests/fsharp/Compiler/Language/CompilerDirectiveTests.fs
+++ b/tests/fsharp/Compiler/Language/CompilerDirectiveTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module ``Test Compiler Directives`` =
 
-    [<Test>]
+    [<Fact>]
     let ``compiler #r "" is invalid``() =
         let source = """
 #r ""
@@ -20,7 +20,7 @@ module ``Test Compiler Directives`` =
                 FSharpDiagnosticSeverity.Warning, 213, (2,1,2,6), "'' is not a valid assembly name"
             |])
 
-    [<Test>]
+    [<Fact>]
     let ``compiler #r "   " is invalid``() =
         let source = """
 #r "    "

--- a/tests/fsharp/Compiler/Language/ComputationExpressionTests.fs
+++ b/tests/fsharp/Compiler/Language/ComputationExpressionTests.fs
@@ -1,10 +1,10 @@
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module ComputationExpressionTests =
 
     let ``complex CE with source member and applicatives`` ceUsage =
@@ -159,7 +159,7 @@ let asyncResult = AsyncResultBuilder()
 
 %s"""     ceUsage
 
-    [<Test>]
+    [<Fact>]
     let ``do-bang can be used with nested CE expressions``() =
         let code = ``complex CE with source member and applicatives`` """
 asyncResult {
@@ -175,7 +175,7 @@ asyncResult {
 """
         CompilerAssert.Pass code
 
-    [<Test>]
+    [<Fact>]
     let ``match-bang should apply source transformations to its inputs`` () =
         let code = ``complex CE with source member and applicatives`` """
 asyncResult {

--- a/tests/fsharp/Compiler/Language/CustomCollectionTests.fs
+++ b/tests/fsharp/Compiler/Language/CustomCollectionTests.fs
@@ -1,12 +1,12 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module CustomCollectionTests =
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with Item and GetReverseIndex should support reverse index mutation``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -23,7 +23,7 @@ a[^"2"] <- "-1"
 if a["2"] <> "2 -1" then failwithf "expected 2 -1 but got %A" a["2"]
              """)
 
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with GetSlice and GetReverseIndex should support reverse index set slicing``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -41,7 +41,7 @@ a[^"2"..^"1"] <- "-1"
 if a["2".."1"] <> "2 1 -1" then failwithf "expected 2 1 -1 but got %A" a["2".."1"]           
             """)
  
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with Item and GetReverseIndex should support reverse index indexing``() =
         CompilerAssert.CompileExeAndRunWithOptions([| "--langversion:preview" |],
             """
@@ -56,7 +56,7 @@ let a = foo()
 if a[^2] <> 12 then failwith "expected 12"
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with Item and GetReverseIndex should support n-rank reverse index mutation``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -74,7 +74,7 @@ a[^"1",^"2"] <- "3"
 if a[""] <> "0 1 1 2 3" then failwithf "expected 0 1 1 2 3 but got %A" a[""]
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with Item and GetReverseIndex should support n-rank reverse index indexing``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -90,7 +90,7 @@ let a = foo()
 if a[^2,^1] <> 24 then failwithf "expected 23 but got %A" a[^2,^1]
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with Item and no GetReverseIndex should not support reverse index indexing``() =
         CompilerAssert.TypeCheckSingleErrorWithOptions
             [| "--langversion:preview" |]
@@ -109,7 +109,7 @@ if a.[^2] <> 12 then failwith "expected 12"
             (9,7,9,9)
             "The type 'foo' does not define the field, constructor or member 'GetReverseIndex'."
 
-    [<Test>]
+    [<Fact>]
     let ``Custom collection with GetSlice and GetReverseIndex should support reverse index slicing``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -129,7 +129,7 @@ let a = foo()
 if a[^2..1] <> 13 then failwith "expected 13"
             """)
  
-    [<Test>]
+    [<Fact>]
     let ``Custom collection without GetReverseIndex should not support reverse index slicing``() =
         CompilerAssert.TypeCheckSingleErrorWithOptions [| "--langversion:preview" |]
             """

--- a/tests/fsharp/Compiler/Language/DefaultInterfaceMemberTests.fs
+++ b/tests/fsharp/Compiler/Language/DefaultInterfaceMemberTests.fs
@@ -2,20 +2,20 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open FSharp.Compiler.Diagnostics
 
 #if NETCOREAPP
 
-[<TestFixture>]
+
 module DefaultInterfaceMemberConsumptionTests_LanguageVersion_4_6 =
 
     [<Literal>]
     let targetVersion = "5.0"
 
-    [<Test>]
+    [<Fact>]
     let ``IL - Errors with lang version not supported`` () =
         let ilSource =
             """
@@ -55,7 +55,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 20), "No implementation was given for 'ITest.DefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# with explicit implementation - Runs`` () =
         let csharpSource =
             """
@@ -134,7 +134,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "FSharp-Method1-FSharp-Method2-FSharp-Method3-FSharp-Method4")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -180,7 +180,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple - Errors with lang version not supported - 2`` () =
         let csharpSource =
             """
@@ -225,7 +225,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 20), "No implementation was given for 'ITest.DefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple - Errors with lang version not supported - 3`` () =
         let csharpSource =
             """
@@ -270,7 +270,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with internal DIM - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -316,7 +316,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (9, 15, 9, 20), "No implementation was given for 'ITest.DefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with internal DIM - Errors with not accessible`` () =
         let csharpSource =
             """
@@ -363,7 +363,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 855, (11, 19, 11, 32), "No abstract or interface member was found that corresponds to this override")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static operator method - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -414,7 +414,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 3350, (14, 9, 14, 10), "Feature 'default interface member consumption' is not available in F# 4.6. Please use language version " + targetVersion + " or greater.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static method - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -464,7 +464,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 3350, (14, 5, 14, 27), "Feature 'default interface member consumption' is not available in F# 4.6. Please use language version " + targetVersion + " or greater.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static property - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -501,7 +501,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 3350, (8, 5, 8, 22), "Feature 'default interface member consumption' is not available in F# 4.6. Please use language version " + targetVersion + " or greater.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static field - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -538,7 +538,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 3350, (8, 5, 8, 19), "Feature 'default interface member consumption' is not available in F# 4.6. Please use language version " + targetVersion + " or greater.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static method using SRTP - Errors with lang version not supported`` () =
         let csharpSource =
             """
@@ -579,7 +579,7 @@ let f1 () =
             (FSharpDiagnosticSeverity.Error, 3350, (9, 5, 9, 15), "Feature 'default interface member consumption' is not available in F# 4.6. Please use language version " + targetVersion + " or greater.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance - Errors with lang version not supported and should not see the error for specific implementation`` () =
         let csharpSource =
             """
@@ -633,7 +633,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 17), "No implementation was given for 'IA.M() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance - Errors with lang version not supported and should not see the error for specific implementation - 2`` () =
         let csharpSource =
             """
@@ -685,7 +685,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (10, 15, 10, 17), "No implementation was given for 'IA.M() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with protected DIM - Runs`` () =
         let csharpSource =
             """
@@ -763,7 +763,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "Explicit-Explicit")
 
-    [<Test>]
+    [<Fact>]
     let ``C# with overloading and generics - Runs`` () =
         let csharpSource =
             """
@@ -863,7 +863,7 @@ let main _ =
         CompilerAssert.ExecutionHasOutput(fsCmpl, "InTestInTest2123456789111STRING-STRINGABC222FSharpABC333CSharp")
 
 
-    [<Test>]
+    [<Fact>]
     let ``C# with overloading and generics - Errors with lang version`` () =
         let csharpSource =
             """
@@ -943,13 +943,13 @@ type Test2 () =
 
 #else
 
-[<TestFixture>]
+
 module DefaultInterfaceMemberConsumptionTests_LanguageVersion_4_6_net472 =
 
     [<Literal>]
     let targetVersion = "5.0"
 
-    [<Test>]
+    [<Fact>]
     let ``IL - Errors with lang version and target runtime not supported`` () =
         let ilSource =
             """
@@ -990,7 +990,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 20), "No implementation was given for 'ITest.DefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``IL - Errors with target runtime not supported when implemented`` () =
         let ilSource =
             """
@@ -1031,7 +1031,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 3351, (8, 15, 8, 20), "Feature 'default interface member consumption' is not supported by target runtime.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static method - Errors with lang version and target runtime not supported`` () =
         let csharpSource =
             """
@@ -1086,10 +1086,10 @@ let f () =
 
 #if NETCOREAPP
 
-[<TestFixture>]
+
 module DefaultInterfaceMemberConsumptionTests =
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple - Errors with un-implemented non-DIM`` () =
         let csharpSource =
             """
@@ -1131,7 +1131,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 20), "No implementation was given for 'ITest.NonDefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static operator method - Runs`` () =
         let csharpSource =
             """
@@ -1180,7 +1180,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "I1.+1")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple - Runs`` () =
         let csharpSource =
             """
@@ -1230,7 +1230,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "DefaultMethod-NonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with protected DIM - Runs`` () =
         let csharpSource =
             """
@@ -1304,7 +1304,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "ProtectedProtected-ProtectedOverrideProtectedOverride")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with protected DIM using object expression - Runs`` () =
         let csharpSource =
             """
@@ -1367,7 +1367,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "ObjExprProtectedObjExprProtected-ObjExprProtected2ObjExprProtected2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with protected DIM - Errors due to protected level`` () =
         let csharpSource =
             """
@@ -1445,7 +1445,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 491, (31, 5, 31, 16), "The member or object constructor 'M1' is not accessible. Private members may only be accessed from within the declaring type. Protected members may only be accessed from an extending type and cannot be accessed from inner lambda expressions.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with protected DIM - Errors due to protected level - 2`` () =
         let csharpSource =
             """
@@ -1527,7 +1527,7 @@ type Test2 () =
             (FSharpDiagnosticSeverity.Error, 629, (30, 13, 30, 31), "Method 'M1' is not accessible from this code location")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with internal DIM - Runs`` () =
         let csharpSource =
             """
@@ -1575,7 +1575,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "NonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with internal DIM - Errors with missing method`` () =
         let csharpSource =
             """
@@ -1627,7 +1627,7 @@ let f () =
    NonDefaultMethod")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with internal DIM - Errors with not accessible`` () =
         let csharpSource =
             """
@@ -1676,7 +1676,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 855, (11, 19, 11, 32), "No abstract or interface member was found that corresponds to this override")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with internal DIM but with IVT - Runs`` () =
         let csharpSource =
             """
@@ -1731,7 +1731,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "IVT-NonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with one DIM for F# object expression - Runs`` () =
         let csharpSource =
             """
@@ -1770,7 +1770,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "DefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with one DIM and one non-DIM for F# object expression - Runs`` () =
         let csharpSource =
             """
@@ -1813,7 +1813,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "DefaultMethod-ObjExpr")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with one DIM and one non-DIM for F# object expression - Errors with lack of implementation`` () =
         let csharpSource =
             """
@@ -1854,7 +1854,7 @@ let test = { new ITest }
             (FSharpDiagnosticSeverity.Error, 366, (7, 12, 7, 25), "No implementation was given for 'ITest.NonDefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with override - Runs`` () =
         let csharpSource =
             """
@@ -1907,7 +1907,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "OverrideDefaultMethod-NonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with override for object expression - Runs`` () =
         let csharpSource =
             """
@@ -1955,7 +1955,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "ObjExprOverrideDefaultMethod-ObjExprNonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# from hierarchical interfaces - Runs`` () =
         let csharpSource =
             """
@@ -2015,7 +2015,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "FromITest2-Method1-FromITest2-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces - Errors with lack of explicit shared interface type`` () =
         let csharpSource =
             """
@@ -2097,7 +2097,7 @@ Note that all interface members must be implemented and listed under an appropri
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces - Errors with no most specific implementation`` () =
         let csharpSource =
             """
@@ -2173,7 +2173,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces but combined in one C# interface - Errors with no most specific implementation`` () =
         let csharpSource =
             """
@@ -2251,7 +2251,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces but combined in one F# interface - Errors with no most specific implementation`` () =
         let csharpSource =
             """
@@ -2329,7 +2329,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces but re-abstracted in one and then combined in one F# interface - Errors with no most specific implementation`` () =
         let csharpSource =
             """
@@ -2401,7 +2401,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces but all re-abstracted and then combined in one F# interface - Errors with need to implement members`` () =
         let csharpSource =
             """
@@ -2467,7 +2467,7 @@ type Test () =
 Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces then combined in one F# interface and then implemented - Runs`` () =
         let csharpSource =
             """
@@ -2549,7 +2549,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "FSharpICombinedTest-Method1-FSharpICombinedTest-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces but all re-abstracted and then combined in one F# interface and then implemented - Runs`` () =
         let csharpSource =
             """
@@ -2619,7 +2619,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "FSharpICombinedTest-Method1-FSharpICombinedTest-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces then using explicit interfaces and then implemented - Runs`` () =
         let csharpSource =
             """
@@ -2698,7 +2698,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "FSharpExplicitTest-Method1-FSharpExplicitTest-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces but all re-abstracted and then combined in one F# interface and then implemented one method - Errors with no most specific implementation`` () =
         let csharpSource =
             """
@@ -2763,7 +2763,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (14, 15, 14, 28), "No implementation was given for 'ITest1.Method1() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond hierarchical interfaces then combined in one C# interface and then implemented - Runs`` () =
         let csharpSource =
             """
@@ -2849,7 +2849,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "CSharpICombinedTest-Method1-CSharpICombinedTest-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond complex hierarchical interfaces then combined in one C# interface and then implemented - Runs`` () =
         let csharpSource =
             """
@@ -2974,7 +2974,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "CSharpIFinalCombinedTest-Method1-CSharpIFinalCombinedTest-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond complex hierarchical interfaces then combined in one C# interface and then implemented - Runs - 2`` () =
         let csharpSource =
             """
@@ -3085,7 +3085,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "CSharpIFinalCombinedTest-Method1-")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond complex hierarchical interfaces then combined in one C# interface and then implemented - Runs - 3`` () =
         let csharpSource =
             """
@@ -3197,7 +3197,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "CSharpIFinalCombinedTest-Method1-CSharpIFinalCombinedTest-Method2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# multi-diamond complex hierarchical interfaces with hiding methods then explicitly implemented - Runs`` () =
         let csharpSource =
             """
@@ -3313,7 +3313,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "IBase-IB1-IA1-IC1-")
 
-    [<Test>]
+    [<Fact>]
     let ``C# multi-diamond complex hierarchical interfaces then explicitly implemented - Runs`` () =
         let csharpSource =
             """
@@ -3419,7 +3419,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "123XYZ")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond complex hierarchical interfaces then explicitly implemented - Runs`` () =
         let csharpSource =
             """
@@ -3522,7 +3522,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "-")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond complex hierarchical interfaces then combined in one C# interface and then implemented - Errors with no impl`` () =
         let csharpSource =
             """
@@ -3623,7 +3623,7 @@ type Test2 () =
             (FSharpDiagnosticSeverity.Error, 366, (10, 15, 10, 32), "No implementation was given for 'ITest1.Method2() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with property - Runs`` () =
         let csharpSource =
             """
@@ -3668,7 +3668,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "A-NonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with property and override - Runs`` () =
         let csharpSource =
             """
@@ -3715,7 +3715,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "OverrideA-NonDefaultMethod")
 
-    [<Test>]
+    [<Fact>]
     let ``C# with same methods names that hide with overloading - Runs`` () =
         let csharpSource =
             """
@@ -3778,7 +3778,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "")
 
-    [<Test>]
+    [<Fact>]
     let ``C# with multiple separate interfaces - Runs`` () =
         let csharpSource =
             """
@@ -3845,7 +3845,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "IA.MA-IB1.IB.MB-IB1.IB.MB")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance - Errors with no specific implementation`` () =
         let csharpSource =
             """
@@ -3899,7 +3899,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 17), "No implementation was given for 'IA.M() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance - Errors with no specific implementation - 2`` () =
         let csharpSource =
             """
@@ -3951,7 +3951,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (10, 15, 10, 17), "No implementation was given for 'IA.M() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance - Runs`` () =
         let csharpSource =
             """
@@ -4013,7 +4013,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "MMM")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance with overloading - Runs`` () =
         let csharpSource =
             """
@@ -4103,7 +4103,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "M123456floatfs_single")
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance with overloading - Errors with missing overload method`` () =
         let csharpSource =
             """
@@ -4183,7 +4183,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (12, 15, 12, 17), "No implementation was given for 'IA.M(x: float32) : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# with overloading and generics - Runs`` () =
         let csharpSource =
             """
@@ -4278,7 +4278,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "InTestInTest123456789111STRING-STRINGABC222FSharpABC333CSharpM<U>(U, T)M<U>(U, T)")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond inheritance with overloading and generics and properties - Runs`` () =
         let csharpSource =
             """
@@ -4373,7 +4373,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "Test.String-Test.Prop2")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond inheritance with overloading and generics and properties - Errors with no specific implementation`` () =
         let csharpSource =
             """
@@ -4463,7 +4463,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (12, 15, 12, 25), "No implementation was given for 'IA.set_Prop2(value: string) : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple diamond inheritance using object expression - Errors with no specific implementation`` () =
         let csharpSource =
             """
@@ -4516,7 +4516,7 @@ let test =
             (FSharpDiagnosticSeverity.Error, 366, (8, 7, 8, 21), "No implementation was given for 'IA.M() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond inheritance with no most specific problem - Runs`` () =
         let csharpSource =
             """
@@ -4573,7 +4573,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "IB.IA.M")
 
-    [<Test>]
+    [<Fact>]
     let ``C# diamond inheritance with no most specific problem - Runs - 2`` () =
         let csharpSource =
             """
@@ -4629,7 +4629,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "IB.IA.M")
 
-    [<Test>]
+    [<Fact>]
     let ``C# with interface statics - Runs`` () =
         let csharpSource =
             """
@@ -4693,7 +4693,7 @@ f ()
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "1011")
 
-    [<Test>]
+    [<Fact>]
     let ``C# interface statics and F# SRTP (statically resolved type parameters) - Runs`` () =
         let csharpSource =
             """
@@ -4753,7 +4753,7 @@ f3 ()
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "359")
 
-    [<Test>]
+    [<Fact>]
     let ``C# interface statics - Errors with method not defined on C# class`` () =
         let csharpSource =
             """
@@ -4800,7 +4800,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 39, (6, 17, 6, 29), "The type 'CSharpClass' does not define the field, constructor or member 'StaticMethod'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# interface statics - Errors with method not defined on F# class`` () =
         let csharpSource =
             """
@@ -4850,7 +4850,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 39, (11, 17, 11, 29), "The type 'FSharpClass' does not define the field, constructor or member 'StaticMethod'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# interface statics - Errors with method not defined on C# class using SRTP`` () =
         let csharpSource =
             """
@@ -4900,7 +4900,7 @@ let f () =
             (FSharpDiagnosticSeverity.Error, 1, (9, 5, 9, 15), "The type 'CSharpClass' does not support the operator 'StaticMethod'")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# interface statics - Errors with method not defined on F# class using SRTP`` () =
         let csharpSource =
             """
@@ -4955,13 +4955,13 @@ let f () =
 
 #else
 
-[<TestFixture>]
+
 module DefaultInterfaceMemberConsumptionTests_net472 =
 
     [<Literal>]
     let targetVersion = "5.0"
 
-    [<Test>]
+    [<Fact>]
     let ``IL - Errors with target runtime not supported`` () =
         let ilSource =
             """
@@ -5002,7 +5002,7 @@ type Test () =
             (FSharpDiagnosticSeverity.Error, 366, (8, 15, 8, 20), "No implementation was given for 'ITest.DefaultMethod() : unit'. Note that all interface members must be implemented and listed under an appropriate 'interface' declaration, e.g. 'interface ... with member ...'.")
         |])
 
-    [<Test>]
+    [<Fact>]
     let ``C# simple with static method - Errors with target runtime not supported`` () =
         let csharpSource =
             """

--- a/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
+++ b/tests/fsharp/Compiler/Language/FixedIndexSliceTests.fs
@@ -1,13 +1,13 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module FixedIndexSliceTests =
     
-    [<Test>]
+    [<Fact>]
     let ``Fixed index 3d slicing should not be available in 47``() =
         CompilerAssert.TypeCheckWithErrorsAndOptions [| "--langversion:4.7"|]
             """
@@ -30,7 +30,7 @@ arr3.[*, 1, 1]
                 FSharpDiagnosticSeverity.Error, 39, (10,1,10,15), "The type '[,,]<_>' does not define the field, constructor or member 'GetSlice'."
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Fixed index 4d slicing should not be available in 47``() =
         CompilerAssert.TypeCheckWithErrorsAndOptions [| "--langversion:4.7"|]
             """
@@ -67,7 +67,7 @@ arr4.[*, 1, 1, 1]
                 FSharpDiagnosticSeverity.Error, 39, (17,1,17,18), "The type '[,,,]<_>' does not define the field, constructor or member 'GetSlice'."
             |]
             
-    [<Test>]
+    [<Fact>]
     let ``Fixed index 3d set slicing should not be available in 47``() =
         CompilerAssert.TypeCheckWithErrorsAndOptions [| "--langversion:4.7"|]
             """
@@ -92,7 +92,7 @@ arr3.[*, 1, 1] <- arr1
                 FSharpDiagnosticSeverity.Error, 39, (12,1,12,15), "The type '[,,]<_>' does not define the field, constructor or member 'SetSlice'."
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Fixed index 4d set slicing should not be available in 47``() =
         CompilerAssert.TypeCheckWithErrorsAndOptions [| "--langversion:4.7"|]
             """

--- a/tests/fsharp/Compiler/Language/HatDesugaringTests.fs
+++ b/tests/fsharp/Compiler/Language/HatDesugaringTests.fs
@@ -1,13 +1,13 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture; SetUICulture("en-US"); SetCulture("en-US")>]
+[<UseCulture("en-US")>]
 module HatDesugaringTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Hat operator should be overloadable in infix context``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -21,7 +21,7 @@ if 1 ^ 2 <> 3 then failwithf "expected result to be 3 but got %i" (1 ^ 2)
 Console.WriteLine()
             """)
     
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing should work with overloaded infix hat``() =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| "--langversion:preview" |],
@@ -35,7 +35,7 @@ if result <> [1;2] then failwithf "expected result to be [1;2] but got %A" resul
 Console.WriteLine()
             """)
 
-    [<Test>]
+    [<Fact>]
     let ``At operator should not be usable in prefix context``() =
         CompilerAssert.ParseWithErrors
            ("""
@@ -47,7 +47,7 @@ let x = @1
                 FSharpDiagnosticSeverity.Error, 1208, (4,9,4,10), "Invalid prefix operator"
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Hat operator should not be overloadable as prefix operator``() = 
         CompilerAssert.ParseWithErrors
             """
@@ -60,7 +60,7 @@ let (~^) (x: int) (y:int) = x + y
                 FSharpDiagnosticSeverity.Error, 1208, (5,6,5,8), "Invalid operator definition. Prefix operator definitions must use a valid prefix operator name.";
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing should not work with at symbol in 1st slice index``() =
         CompilerAssert.ParseWithErrors
            ("""
@@ -74,7 +74,7 @@ Console.WriteLine(list[@1..])
                 FSharpDiagnosticSeverity.Error, 1208, (6,24,6,25), "Invalid prefix operator"
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing should not work with at symbol in 2nd slice index``() =
         CompilerAssert.ParseWithErrors
            ("""
@@ -88,7 +88,7 @@ Console.WriteLine(list[..@1])
                 FSharpDiagnosticSeverity.Error, 1208, (6,24,6,27), "Invalid prefix operator"
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing should not work with at symbol in both slice index``() =
         CompilerAssert.ParseWithErrors
            ("""
@@ -103,7 +103,7 @@ Console.WriteLine(list[@1..@1])
                 FSharpDiagnosticSeverity.Error, 1208, (6,28,6,29), "Invalid prefix operator"
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse indexing should not work with at symbol``() =
         CompilerAssert.ParseWithErrors
            ("""

--- a/tests/fsharp/Compiler/Language/HatDesugaringTests.fs
+++ b/tests/fsharp/Compiler/Language/HatDesugaringTests.fs
@@ -4,7 +4,6 @@ open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<UseCulture("en-US")>]
 module HatDesugaringTests =
 
     [<Fact>]

--- a/tests/fsharp/Compiler/Language/InitOnlyPropertyConsumptionTests.fs
+++ b/tests/fsharp/Compiler/Language/InitOnlyPropertyConsumptionTests.fs
@@ -2,17 +2,17 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Compiler
 open FSharp.Test.Utilities
 
 #if NETCOREAPP
 
-[<TestFixture>]
+
 module InitOnlyPropertyConsumptionTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Should be able to set an init-only property from a C# record`` () =
         let csharpSource =
             """

--- a/tests/fsharp/Compiler/Language/InterfaceTests.fs
+++ b/tests/fsharp/Compiler/Language/InterfaceTests.fs
@@ -3,14 +3,13 @@
 namespace FSharp.Compiler.UnitTests
 
 open FSharp.Compiler.Diagnostics
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 
-[<TestFixture>]
 module InterfaceTests =
 
-    [<Test>]
+    [<Fact>]
     let ShouldnWork() =
         CompilerAssert.Pass """
 type IGet<'T> =
@@ -162,7 +161,7 @@ assertion (fun (x:float) -> x * 3.0) (fun v ->
         ``Many Instantiations of the same interface - SetUp`` + ``Many Instantiations of the same interface - Asserts``
 
 
-    [<Test>]
+    [<Fact>]
     let MultipleTypedInterfacesFSharp50() =
 
 #if NETSTANDARD
@@ -188,7 +187,7 @@ assertion (fun (x:float) -> x * 3.0) (fun v ->
 
         CompilerAssert.Compile fsCmpl
 
-    [<Test>]
+    [<Fact>]
     let MultipleTypedInterfacesFSharp47() =
         CompilerAssert.TypeCheckWithErrorsAndOptions
             [|
@@ -202,7 +201,7 @@ assertion (fun (x:float) -> x * 3.0) (fun v ->
                 (FSharpDiagnosticSeverity.Error, 3350, (24, 6, 24, 20), "Feature 'interfaces with multiple generic instantiation' is not available in F# 4.7. Please use language version 5.0 or greater.")
             |]
 
-    [<Test>]
+    [<Fact>]
     let MultipleTypedInterfacesFSharp50VerifyIl() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions(
             [|

--- a/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
+++ b/tests/fsharp/Compiler/Language/OpenTypeDeclarationTests.fs
@@ -3,12 +3,12 @@
 namespace FSharp.Compiler.UnitTests
 
 open FSharp.Compiler.Diagnostics
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open FSharp.Test.Compiler
 
-[<TestFixture>]
+
 module OpenTypeDeclarationTests =
 
     [<Literal>]
@@ -34,7 +34,7 @@ type NotAllowedToOpen() =
 
 """
 
-    [<Test>]
+    [<Fact>]
     let ``OpenSystemMathOnce - langversion:4.6`` () =
         Fsx (baseModule + """
 module OpenSystemMathOnce =
@@ -50,7 +50,7 @@ module OpenSystemMathOnce =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenSystemMathOnce - langversion:5.0`` () =
         Fsx (baseModule + """
 module OpenSystemMathOnce =
@@ -62,7 +62,7 @@ module OpenSystemMathOnce =
          |> shouldSucceed
          |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenSystemMathTwice - langversion:4.6`` () =
         Fsx (baseModule + """
 module OpenSystemMathTwice = 
@@ -83,7 +83,7 @@ module OpenSystemMathTwice =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenSystemMathTwice - langversion:50`` () =
         Fsx (baseModule + """
 module OpenSystemMathOnce =
@@ -95,7 +95,7 @@ module OpenSystemMathOnce =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenMyMathOnce - langversion:4.6`` () =
         Fsx (baseModule + """
 module OpenMyMathOnce = 
@@ -113,7 +113,7 @@ module OpenMyMathOnce =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenMyMathOnce - langversion:5.0`` () =
         Fsx (baseModule + """
 module OpenMyMathOnce = 
@@ -126,7 +126,7 @@ module OpenMyMathOnce =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``DontOpenAutoMath - langversion:4.6`` () =
         Fsx (baseModule + """
 module DontOpenAutoMath = 
@@ -142,7 +142,7 @@ module DontOpenAutoMath =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``DontOpenAutoMath - langversion:5.0`` () =
         Fsx (baseModule + """
 module DontOpenAutoMath = 
@@ -154,7 +154,7 @@ module DontOpenAutoMath =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenAutoMath - langversion:4.6`` () =
         Fsx (baseModule + """
 module OpenAutoMath = 
@@ -173,7 +173,7 @@ module OpenAutoMath =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenAutoMath - langversion:5.0`` () =
         Fsx (baseModule + """
 module OpenAutoMath = 
@@ -187,7 +187,7 @@ module OpenAutoMath =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``OpenAccessibleFields - langversion:5.0`` () =
         Fsx (baseModule + """
 module OpenAFieldFromMath =
@@ -199,7 +199,7 @@ module OpenAFieldFromMath =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type and use nested types as unqualified`` () =
         let csharp =
             CSharp """
@@ -241,7 +241,7 @@ module Test =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open a type where the type declaration uses a type abbreviation as a qualifier to a real nested type`` () =
         let csharp =
             CSharp """
@@ -279,7 +279,7 @@ open type Abbrev.NestedTest"""
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open a type where the type declaration uses a type abbreviation`` () =
         let csharp =
             CSharp """
@@ -317,7 +317,7 @@ open type Abbrev"""
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open a nested type as qualified`` () =
         let csharp =
             CSharp """
@@ -350,7 +350,7 @@ module Test =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic type and use nested types as unqualified`` () =
         let csharp =
             CSharp """
@@ -421,7 +421,7 @@ module Test2 =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic type and use nested types as unqualified 2`` () =
          FSharp """
 namespace FSharpTest
@@ -435,7 +435,7 @@ module Test =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic type and use nested types as unqualified 3`` () =
         let csharp =
             CSharp """
@@ -540,7 +540,7 @@ module Test4 =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic type and use nested types as unqualified 4`` () =
         let csharp =
             CSharp """
@@ -639,7 +639,7 @@ module Test3 =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open unit of measure - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -659,7 +659,7 @@ open type kg
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type with unit of measure`` () =
         FSharp """
 namespace FSharpTest
@@ -682,7 +682,7 @@ open type vec3<kg>
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open custom type with unit of measure`` () =
         FSharp """
 namespace FSharpTest
@@ -714,7 +714,7 @@ module Test =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open custom type with unit of measure and more type params`` () =
         FSharp """
 namespace FSharpTest
@@ -755,7 +755,7 @@ module Test =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open custom type with unit of measure should error with measure mismatch`` () =
         FSharp """
 namespace FSharpTest
@@ -787,7 +787,7 @@ module Test =
         |> withErrorCode 1
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open tuple - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -802,7 +802,7 @@ open type (int * int)
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open struct tuple - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -817,7 +817,7 @@ open type struct (int * int)
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open function - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -832,7 +832,7 @@ open type (int -> int)
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open anon type - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -847,7 +847,7 @@ open type {| x: int |}
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open struct anon type - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -862,7 +862,7 @@ open type struct {| x: int |}
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open direct tuple - Errors`` () =
         // Note: `Tuple` is technically a named type but it gets decompiled into F#'s representation of a tuple in its type system.
         //       This test is to verify that behavior.
@@ -881,7 +881,7 @@ open type Tuple<int, int>
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open direct value tuple - Errors`` () =
         // Note: `ValueTuple` is technically a named type but it gets decompiled into F#'s representation of a struct tuple in its type system.
         //       This test is to verify that behavior.
@@ -900,7 +900,7 @@ open type ValueTuple<int, int>
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open direct function - Errors`` () =
         // Note: `FSharpFunc` is technically a named type but it gets decompiled into F#'s representation of a function in its type system.
         //       This test is to verify that behavior.
@@ -917,7 +917,7 @@ open type FSharpFunc<int, int>
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open enum should have access to its cases`` () =
         FSharp """
 namespace FSharpTest
@@ -938,7 +938,7 @@ module Test =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open C# enum should have access to its cases`` () =
         let csharp = 
             CSharp """
@@ -967,7 +967,7 @@ module Test =
         |> compile
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open union should have access to union cases`` () =
         FSharp """
 namespace FSharpTest
@@ -993,7 +993,7 @@ module Test2 =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic union should have access to union cases with the enclosing type instantiations`` () =
         FSharp """
 namespace FSharpTest
@@ -1019,7 +1019,7 @@ module Test2 =
         |> withErrorCode 1
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic union should have access to pattern union cases with the enclosing type instantiations - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -1041,7 +1041,7 @@ module Test2 =
         |> withErrorCode 1
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open record should have access to construct record via labels`` () =
         FSharp """
 namespace FSharpTest
@@ -1065,7 +1065,7 @@ module Test2 =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic record should have access to construct record via labels with enclosing type instantiations`` () =
         FSharp """
 namespace FSharpTest
@@ -1095,7 +1095,7 @@ module Test3 =
         |> withErrorCode 1
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open generic record should have access to pattern record via labels with enclosing type instantiations - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -1124,7 +1124,7 @@ module Test3 =
         |> withErrorCode 1
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type should have no access to constructor - Errors`` () =
         FSharp """
 namespace FSharpTest
@@ -1148,7 +1148,7 @@ module Test2 =
         |> withErrorCode 39
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type should combine both extension and intrinsic method groups`` () =
         FSharp """
 namespace FSharpTest
@@ -1177,7 +1177,7 @@ module Test2 =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type should combine both extension and intrinsic method groups but error if extensions are added after opening the type`` () =
         FSharp """
 namespace FSharpTest
@@ -1206,7 +1206,7 @@ module Test2 =
         |> withErrorCodes [1;1]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Using the 'open' declaration on a possible type identifier - Error`` () =
         let csharp =
             CSharp """
@@ -1241,7 +1241,7 @@ module Test =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type declaration on a namespace - Error`` () =
         FSharp """
 namespace FSharpTest
@@ -1255,7 +1255,7 @@ open type System"""
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type declaration on a module - Error`` () =
         FSharp """
 namespace FSharpTest
@@ -1269,7 +1269,7 @@ open type FSharp.Core.Option"""
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Open type declaration on a byref - Error`` () =
         FSharp """
 namespace FSharpTest
@@ -1287,7 +1287,7 @@ open type outref<int>"""
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Type extensions with static members are able to be accessed in an unqualified manner`` () =
         let fsharpSource =
             """
@@ -1324,7 +1324,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "MPM2ExtP2Ext")
 
-    [<Test>]
+    [<Fact>]
     let ``Type extensions with static members are able to be accessed in an unqualified manner with no shadowing on identical names`` () =
         let fsharpSource =
             """
@@ -1359,7 +1359,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "MP")
 
-    [<Test>]
+    [<Fact>]
     let ``Type extensions with static members are able to be accessed in an unqualified manner with the nuance of favoring extension properties over extension methods of identical names`` () =
         let fsharpSource =
             """
@@ -1397,7 +1397,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "MExtP")
 
-    [<Test>]
+    [<Fact>]
     let ``Type extensions with static members are able to be accessed in an unqualified manner with no shadowing on identical method/property names`` () =
         let fsharpSource =
             """
@@ -1427,7 +1427,7 @@ let main _ =
 
         CompilerAssert.ExecutionHasOutput(fsCmpl, "M")
 
-    [<Test>]
+    [<Fact>]
     let ``Opened types do no allow unqualified access to their inherited type's members - Error`` () =
         Fsx """
 open type System.Math
@@ -1442,7 +1442,7 @@ let x = Equals(2.0, 3.0)
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opened types do no allow unqualified access to C#-style extension methods - Error`` () =
         FSharp """
 open System.Runtime.CompilerServices
@@ -1472,7 +1472,7 @@ let main _ =
             ]
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opened types do allow unqualified access to C#-style extension methods if type has no [<Extension>] attribute`` () =
         FSharp """
 open System.Runtime.CompilerServices
@@ -1495,7 +1495,7 @@ let main _ =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opened types do allow unqualified access to members with no [<Extension>] attribute`` () =
         FSharp """
 open System.Runtime.CompilerServices
@@ -1518,7 +1518,7 @@ let main _ =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opened types with C# style extension members are available for normal extension method lookup`` () =
         FSharp """
 open System.Runtime.CompilerServices
@@ -1543,7 +1543,7 @@ let main _ =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opened types with operators`` () =
         FSharp """
 type A() =
@@ -1562,7 +1562,7 @@ let main _ =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``An assembly with an event and field with the same name, favor the field`` () =
         let ilSource =
             """
@@ -1689,7 +1689,7 @@ let x2: int = X
 
         CompilerAssert.Compile(fsCmpl)
 
-    [<Test>]
+    [<Fact>]
     let ``An assembly with an event and field with the same name, favor the field - reversed`` () =
         let ilSource =
             """
@@ -1815,7 +1815,7 @@ let x2: int = X
 
         CompilerAssert.Compile(fsCmpl)
 
-    [<Test>]
+    [<Fact>]
     let ``An assembly with a property, event, and field with the same name`` () =
         let ilSource =
             """
@@ -1965,7 +1965,7 @@ let x2: string = X
 
         CompilerAssert.Compile(fsCmpl)
 
-    [<Test>]
+    [<Fact>]
     let ``An assembly with a method, property, event, and field with the same name`` () =
         let ilSource =
             """
@@ -2126,7 +2126,7 @@ let x2: float32 = X()
 
 #if NETCOREAPP
 
-    [<Test>]
+    [<Fact>]
     let ``Opening an interface with a static method`` () =
         let csharpSource =
             """
@@ -2165,7 +2165,7 @@ let main _ =
 
         CompilerAssert.Compile(fsCmpl)
 
-    [<Test>]
+    [<Fact>]
     let ``Opening an interface with an internal static method`` () =
         let csharpSource =
             """
@@ -2207,7 +2207,7 @@ let main _ =
 
         CompilerAssert.Compile(fsCmpl)
 
-    [<Test>]
+    [<Fact>]
     let ``Opening an interface with an internal static method - Error`` () =
         let csharpSource =
             """
@@ -2252,7 +2252,7 @@ let main _ =
 
 #if !NETCOREAPP
 
-    [<Test>]
+    [<Fact>]
     let ``Opening type providers with abbreviation result in unqualified access to types and members`` () =
         let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
@@ -2294,7 +2294,7 @@ if StaticProperty1 <> "You got a static property" then
         compileAndRun test
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opening type providers result in unqualified access to types and members`` () =
         let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
@@ -2334,7 +2334,7 @@ if StaticProperty1 <> "You got a static property" then
         compileAndRun test
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opening type providers with nested result in unqualified access to types and members`` () =
         let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
@@ -2367,7 +2367,7 @@ if StaticProperty1 <> "You got a static property" then
         compileAndRun test
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opening generative type providers in unqualified access to types and members`` () =
         let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 
@@ -2401,7 +2401,7 @@ let _ : TheNestedGeneratedType = Unchecked.defaultof<_>
         compileAndRun test
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Opening generative type providers directly in unqualified access to types and members - Errors`` () =
         let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
 

--- a/tests/fsharp/Compiler/Language/OptionalInteropTests.fs
+++ b/tests/fsharp/Compiler/Language/OptionalInteropTests.fs
@@ -3,16 +3,17 @@
 namespace FSharp.Compiler.UnitTests
 
 open System.Collections.Immutable
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open Microsoft.CodeAnalysis
 
-[<TestFixture>]
+
 module OptionalInteropTests =
 
-    [<TestCase("5.0")>]
-    [<TestCase("preview")>]
+    [<Theory>]
+    [<InlineData("5.0")>]
+    [<InlineData("preview")>]
     let ``C# method with an optional parameter and called with an option type should compile`` langVersion =
         let csSrc =
             """

--- a/tests/fsharp/Compiler/Language/SlicingQuotationTests.fs
+++ b/tests/fsharp/Compiler/Language/SlicingQuotationTests.fs
@@ -1,12 +1,12 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module SlicingQuotationTests =
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing quotation on array with range return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -35,7 +35,7 @@ test()
             []
 
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing quotation on array2d with ranges return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -63,7 +63,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing quotation on array2d with fixed index return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -91,7 +91,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse indexing quotation on array2d return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -119,7 +119,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Reverse slicing quotation on list with range return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -149,7 +149,7 @@ test()
 
 
 
-    [<Test>]
+    [<Fact>]
     let ``Regular slicing quotation on array with star return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -177,7 +177,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Regular slicing quotation on array with range return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -206,7 +206,7 @@ test()
             []
 
 
-    [<Test>]
+    [<Fact>]
     let ``Regular slicing quotation on array2d with ranges return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -234,7 +234,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Regular slicing quotation on array2d with fixed index return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -262,7 +262,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Regular indexing quotation on array2d return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -290,7 +290,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Regular slicing quotation on list with star return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """
@@ -318,7 +318,7 @@ test()
             """
             []
 
-    [<Test>]
+    [<Fact>]
     let ``Regular slicing quotation on list with range return expected expression``() =
         CompilerAssert.RunScriptWithOptions [| "--langversion:preview" |]
             """

--- a/tests/fsharp/Compiler/Language/SpanOptimizationTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanOptimizationTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
 #if NETCOREAPP
-[<TestFixture>]
+
 module SpanOptimizationTests =
 
-    [<Test>]
+    [<Fact>]
     let SpanForInDo() =
         let source =
             """
@@ -62,7 +62,7 @@ let test () =
   }"""
                                 ]))
 
-    [<Test>]
+    [<Fact>]
     let ReadOnlySpanForInDo() =
         let source =
             """
@@ -114,7 +114,7 @@ let test () =
   }"""
                             ]))
 
-    [<Test>]
+    [<Fact>]
     let ExplicitSpanTypeForInDo() =
 
         let source =
@@ -203,7 +203,7 @@ module Test =
 """
                         ]))
 
-    [<Test>]
+    [<Fact>]
     let SpanForInBoundsDo() =
         let source =
             """
@@ -254,7 +254,7 @@ let test () =
   }"""
                             ]))
 
-    [<Test>]
+    [<Fact>]
     let ReadOnlySpanForInBoundsDo() =
         let source =
             """

--- a/tests/fsharp/Compiler/Language/SpanTests.fs
+++ b/tests/fsharp/Compiler/Language/SpanTests.fs
@@ -4,14 +4,14 @@ namespace FSharp.Compiler.UnitTests
 
 open System
 open FSharp.Compiler.Diagnostics
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
 #if NETCOREAPP
-[<TestFixture>]
+
 module SpanTests =
 
-    [<Test>]
+    [<Fact>]
     let Script_SpanForInDo() =
         let script = 
             """
@@ -30,7 +30,7 @@ test ()
             """
         
         CompilerAssert.RunScript script []
-    [<Test>]
+    [<Fact>]
     let Script_SpanForInBoundsDo() =
         let script = 
             """
@@ -50,7 +50,7 @@ test ()
         
         CompilerAssert.RunScript script []
 
-    [<Test>]
+    [<Fact>]
     let Script_EmptySpanForInBoundsDo() =
         let script = 
             """
@@ -70,7 +70,7 @@ test ()
         
         CompilerAssert.RunScript script []
 
-    [<Test>]
+    [<Fact>]
     let Script_ReadOnlySpanForInDo() =
         let script = 
             """
@@ -90,7 +90,7 @@ test ()
     
         CompilerAssert.RunScript script []
 
-    [<Test>]
+    [<Fact>]
     let Script_ReadOnlySpanForInBoundsDo() =
         let script = 
             """
@@ -111,7 +111,7 @@ test ()
         CompilerAssert.RunScript script []
 
 
-    [<Test>]
+    [<Fact>]
     let ``Invalid usage of type abbreviated span should fail to compile``() =
         CompilerAssert.TypeCheckWithErrors """
 open System
@@ -148,7 +148,7 @@ let test () =
                 FSharpDiagnosticSeverity.Error, 412, (19, 27, 19, 29), "A type instantiation involves a byref type. This is not permitted by the rules of Common IL."
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``Type abbreviation that boxes a span should fail to compile``() =
         CompilerAssert.TypeCheckWithErrors """
 open System
@@ -161,7 +161,7 @@ let f (x: TA) = ()
                 FSharpDiagnosticSeverity.Error, 3300, (6, 8, 6, 9), "The parameter 'x' has an invalid type 'TA'. This is not permitted by the rules of Common IL."
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``A custom IsByRefLikeAttribute can define a ref struct``() =
         CompilerAssert.TypeCheckWithErrors """
 namespace System.Runtime.CompilerServices

--- a/tests/fsharp/Compiler/Language/StaticNameResolutionTests.fs
+++ b/tests/fsharp/Compiler/Language/StaticNameResolutionTests.fs
@@ -3,15 +3,15 @@
 namespace FSharp.Compiler.UnitTests
 
 open System.Collections.Immutable
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open Microsoft.CodeAnalysis
 
-[<TestFixture>]
+
 module StaticNameResolutionTests =
 
-    [<Test>]
+    [<Fact>]
     let ``C# nested type is accessible even when extension method is present with same name``() =
         let csSrc =
             """

--- a/tests/fsharp/Compiler/Language/StringConcatOptimizationTests.fs
+++ b/tests/fsharp/Compiler/Language/StringConcatOptimizationTests.fs
@@ -3,15 +3,15 @@
 namespace FSharp.Compiler.UnitTests
 
 open System
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
 #if !NETCOREAPP
-[<TestFixture>]
+
 module StringConcatOptimizationTests =
 
     // helper methods in this test only run on the full framework
-    [<Test>]
+    [<Fact>]
     let Optimizations () =
         let baseSource = """
 module Test

--- a/tests/fsharp/Compiler/Language/StringInterpolation.fs
+++ b/tests/fsharp/Compiler/Language/StringInterpolation.fs
@@ -2,11 +2,10 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.Diagnostics
 open FSharp.Test
 
-[<TestFixture>]
 module StringInterpolationTests =
 
     let SimpleCheckTest text =
@@ -18,7 +17,7 @@ let check msg a b =
 
 """ + text))
 
-    [<Test>]
+    [<Fact>]
     let ``Basic string interpolation`` () =
         SimpleCheckTest
             """
@@ -43,7 +42,7 @@ check "basic-string-interp9" $"{1}
 2"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Neighbouring specifiers for string interpolation`` () =
         SimpleCheckTest
             """
@@ -100,7 +99,7 @@ check "nbr-interp7c" $"this is %d{1}%d{2} %d{3}"  "this is 12 3"
 check "nbr-interp7c" $"this is %d{1}%d{2}"  "this is 12"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Basic string interpolation verbatim strings`` () =
         SimpleCheckTest
             """
@@ -130,7 +129,7 @@ check "basic-string-interp-verbatim6b" $@"this i\s {1}"  "this i\s 1"
 
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Basic string interpolation triple quote strings`` () =
         SimpleCheckTest
             "
@@ -157,7 +156,7 @@ is {1+1}\"\"\"
 is 2\"\"\"
             "
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using atomic expression forms`` () =
         SimpleCheckTest
             """
@@ -180,7 +179,7 @@ check "vcewwei8" $"abc{4%3}def" "abc1def"
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using nested control flow expressions`` () =
         SimpleCheckTest
             """
@@ -247,7 +246,7 @@ check "vcewweh17" $"abc{while false do ()}def" "abcdef"
 
 
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using nested string`` () =
         SimpleCheckTest
             "
@@ -263,7 +262,7 @@ do
 
 "
 
-    [<Test>]
+    [<Fact>]
     let ``Triple quote string interpolation using nested string`` () =
         SimpleCheckTest
             "
@@ -283,7 +282,7 @@ for(i=0;i<100;++i) {
 }\"\"\"
 "
 
-    [<Test>]
+    [<Fact>]
     let ``Mixed quote string interpolation using nested string`` () =
         SimpleCheckTest
             "
@@ -311,7 +310,7 @@ check \"vcewweh22n2\"
     END;\"\"\"
 "
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation to FormattableString`` () =
         SimpleCheckTest
             """
@@ -340,7 +339,7 @@ check "fwejwflpej17" (fmt_de $"abc {30000,-10:N2} def {40000:N2} hij") "abc 30.0
 
             """
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation to IFormattable`` () =
         SimpleCheckTest
             """
@@ -369,7 +368,7 @@ check "fwejwflpej17" (fmt_de $"abc {30000,-10:N2} def {40000:N2} hij") "abc 30.0
 
             """
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation to PrintFormat`` () =
         SimpleCheckTest
             """
@@ -389,7 +388,7 @@ check "fwejwflpej4" (sb.ToString()) "0abcabc1"
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using .NET Formats`` () =
         SimpleCheckTest
             """
@@ -404,7 +403,7 @@ check "vcewweh225u" $"abc %5d{1}" "abc     1"
 check "vcewweh225u" $"abc %-5d{1}" "abc 1    "
             """
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation of null`` () =
         SimpleCheckTest
             """
@@ -415,7 +414,7 @@ check "vcewweh221q3" $"abc %s{null}" "abc "
 check "vcewweh221q4" $"abc %s{null} def" "abc  def"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation of basic types`` () =
         SimpleCheckTest
             """
@@ -450,7 +449,7 @@ check "vcewweh221q1l" $"%d{1un}" "1"
 
 check "vcewweh221q1" $"%f{1.0}" "1.000000"
             """
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using escaped braces`` () =
         SimpleCheckTest
             """
@@ -463,7 +462,7 @@ check "vcewweh228d" "{{" "{{"
 check "vcewweh229f" "}}" "}}"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using verbatim strings`` () =
         SimpleCheckTest
             """
@@ -477,7 +476,7 @@ check "vcewweh229f" "}}" "}}"
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using record data`` () =
         SimpleCheckTest
             """
@@ -507,7 +506,7 @@ check "vcewweh21" $"abc{{X=1; Y=2}}def" "abc{X=1; Y=2}def"
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using printf formats`` () =
         SimpleCheckTest
             """
@@ -538,13 +537,13 @@ check "vcewweh22g" $"x = %A{s}" "x = \"sixsix\""
 check "vcewweh20" $"x = %A{1}" "x = 1"
 
             """
-    [<Test>]
+    [<Fact>]
     let ``%B fails for langVersion 5.0`` () =
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
             """printf "%B" 10"""
             [|(FSharpDiagnosticSeverity.Error, 3350, (1, 8, 1, 12),
                    "Feature 'binary formatting for integers' is not available in F# 5.0. Please use language version 6.0 or greater.")|]
-    [<Test>]
+    [<Fact>]
     let ``%B succeeds for langVersion preview`` () =
         CompilerAssert.CompileExeAndRunWithOptions(
             [| |],
@@ -554,7 +553,7 @@ let check msg a b =
 check "vcewweh22a" $"x = %B{19}" "x = 10011"
         """)
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using list and array data`` () =
         SimpleCheckTest
             """
@@ -581,7 +580,7 @@ check "vcewweh22k" $"x = %0A{[|0..100|]} " "x = [|0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``Quotations of interpolation`` () =
         SimpleCheckTest
             """
@@ -590,14 +589,14 @@ check "vcewweh1"
     "Call (None, PrintFormatToString,      [NewObject (PrintfFormat`5, Value (this %P() is 2),                  NewArray (Object, Call (None, Box, [Value (1)])),                  Value (<null>))])"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Quotations in interpolation`` () =
         SimpleCheckTest
             """
 check "check-quotation1" $"this {<@ 1 @>} is 2" "this Value (1) is 2"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Object expression in interpolation`` () =
         SimpleCheckTest
             """
@@ -606,7 +605,7 @@ check "check-object-expression-in-interpolation1"
     "this AA is 2"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Exception handling in interpolation`` () =
         SimpleCheckTest
             """
@@ -615,7 +614,7 @@ check "check-object-expression-in-interpolation1"
     "this AA is 2"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation using anonymous records`` () =
         SimpleCheckTest
             """
@@ -625,7 +624,7 @@ check "vcewweh23" $"abc{({| A=1 |})}def" "abc{ A = 1 }def"
             """
 
 
-    [<Test>]
+    [<Fact>]
     let ``Basic string interpolation (4.7)`` () =
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:4.7" |]
             """
@@ -635,7 +634,7 @@ let x = $"one"
                    "Feature 'string interpolation' is not available in F# 4.7. Please use language version 5.0 or greater.")|]
 
 
-    [<Test>]
+    [<Fact>]
     let ``Basic string interpolation negative`` () =
         let code =    """
 let x1 = $"one %d{System.String.Empty}" // mismatched types
@@ -712,7 +711,7 @@ let xd = $"%A{  }" // empty expression
                "Invalid interpolated string. This interpolated string expression fill is empty, an expression was expected.")
             |]
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation FormattableString negative`` () =
         let code =    """
 
@@ -731,7 +730,7 @@ let x3 : FormattableString = $"one %10s{String.Empty}" // no %10s in Formattable
                "Invalid interpolated string. Interpolated strings used as type IFormattable or type FormattableString may not use '%' specifiers, only .NET-style interpolands such as '{expr}', '{expr,3}' or '{expr:N5}' may be used.")|]
 
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation negative nested in single`` () =
         let code =    """
 
@@ -767,7 +766,7 @@ let s9 = @$"123{456}789{$@"012"}345"
               (FSharpDiagnosticSeverity.Error, 3373, (12, 25, 12, 28),
                "Invalid interpolated string. Single quote or verbatim string literals may not be used in interpolated expressions in single quote or verbatim strings. Consider using an explicit 'let' binding for the interpolation expression or use a triple quote string as the outer string literal.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation negative nested in triple`` () =
         let code =    "
 
@@ -794,7 +793,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
               (FSharpDiagnosticSeverity.Error, 3374, (9, 62, 9, 66),
                "Invalid interpolated string. Triple quote string literals may not be used in interpolated expressions. Consider using an explicit 'let' binding for the interpolation expression.")|]
   
-    [<Test>]
+    [<Fact>]
     let ``String interpolation negative incomplete string`` () =
         let code =    """let x1 = $"one %d{System.String.Empty}"""
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -804,7 +803,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
               (FSharpDiagnosticSeverity.Error, 3379, (1, 38, 1, 39),
                "Incomplete interpolated string begun at or before here")|]
   
-    [<Test>]
+    [<Fact>]
     let ``String interpolation negative incomplete string fill`` () =
         let code =    """let x1 = $"one %d{System.String.Empty"""
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -814,7 +813,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
               (FSharpDiagnosticSeverity.Error, 3378, (1, 18, 1, 19),
                "Incomplete interpolated string expression fill begun at or before here")|]
   
-    [<Test>]
+    [<Fact>]
     let ``String interpolation negative incomplete verbatim string`` () =
         let code =    """let x1 = @$"one %d{System.String.Empty} """
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -824,7 +823,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
               (FSharpDiagnosticSeverity.Error, 3380, (1, 39, 1, 40),
                "Incomplete interpolated verbatim string begun at or before here")|]
   
-    [<Test>]
+    [<Fact>]
     let ``String interpolation negative incomplete triple quote string`` () =
         let code = "let x1 = $\"\"\"one"
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -838,7 +837,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
               (FSharpDiagnosticSeverity.Error, 3381, (1, 10, 1, 14),
                "Incomplete interpolated triple-quote string begun at or before here")|]
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation extra right brace single quote`` () =
         let code = "let x1 = $\"}\""
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -846,7 +845,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
             [|(FSharpDiagnosticSeverity.Error, 3383, (1, 10, 1, 14),
                "A '}' character must be escaped (by doubling) in an interpolated string.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation extra right brace verbatim`` () =
         let code = "let x1 = @$\"}\""
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -854,7 +853,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
             [|(FSharpDiagnosticSeverity.Error, 3383, (1, 10, 1, 15),
                "A '}' character must be escaped (by doubling) in an interpolated string.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation extra right brace triple`` () =
         let code = "let x1 = $\"\"\"}\"\"\""
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -862,7 +861,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
             [|(FSharpDiagnosticSeverity.Error, 3383, (1, 10, 1, 18),
                "A '}' character must be escaped (by doubling) in an interpolated string.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``String interpolation extra right brace single quote with hole`` () =
         let code = "let x1 = $\"{0}}\""
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0" |]
@@ -870,7 +869,7 @@ let TripleInterpolatedInVerbatimInterpolated = $\"123{456}789{$\"\"\"012\"\"\"}3
             [|(FSharpDiagnosticSeverity.Error, 3383, (1, 14, 1, 17),
                "A '}' character must be escaped (by doubling) in an interpolated string.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``String continuation character gives right ranges`` () =
         let code = "let x1 = \"hello \\\n     world\", foo"
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| |]

--- a/tests/fsharp/Compiler/Language/StructActivePatternTests.fs
+++ b/tests/fsharp/Compiler/Language/StructActivePatternTests.fs
@@ -2,11 +2,10 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.Diagnostics
 open FSharp.Test
 
-[<TestFixture>]
 module StructActivePatternTests =
 
     let private pass = CompilerAssert.PassWithOptions [||]
@@ -19,15 +18,15 @@ let fail msg =
     failwith msg
 """ + src))
 
-    [<Test>]
+    [<Fact>]
     let ``Partial active pattern returns Option`1`` () =
         pass "let (|Foo|_|) x = None"
 
-    [<Test>]
+    [<Fact>]
     let ``Partial struct active pattern returns ValueOption`1`` () =
         pass "[<return:Struct>] let (|P1|_|) x = ValueNone"
 
-    [<Test>]
+    [<Fact>]
     let ``StructAttribute can be placed at the active pattern return type annotation`` () =
         pass
             """
@@ -35,7 +34,7 @@ let (|P1|_|) x: [<Struct>] _ = ValueNone
 let (|P2|_|) x: [<return:Struct>] _ = ValueNone
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Partial struct active pattern results can be retrieved`` () =
         run """
 [<Struct>]
@@ -88,7 +87,7 @@ match t4 with
 | _ -> fail "nested"
             """
 
-    [<Test>]
+    [<Fact>]
     let ``[<return:>] attribute is rotated to the return value``() = 
         run
             """
@@ -122,7 +121,7 @@ match ret_attrs, binding_attrs with
 | "MyAttribute", "" -> ()
 | _ -> fail $"ret_attrs = {ret_attrs}, binding_attrs = {binding_attrs} method = {method}"
             """
-    [<Test>]
+    [<Fact>]
     let ``Implicitly-targeted attribute on let binding do not target return``() = 
         run
             """
@@ -160,7 +159,7 @@ match ret_attrs, binding_attrs with
 
 // negative tests
 
-    [<Test>]
+    [<Fact>]
     let ``Struct active pattern (-langversion:5.0)`` () =
         CompilerAssert.TypeCheckWithErrorsAndOptions  [| "--langversion:5.0"|]
             """
@@ -170,7 +169,7 @@ let (|Foo|_|) x = ValueNone
             [|(FSharpDiagnosticSeverity.Error, 3350, (2, 1, 3, 16),
                "Feature 'struct representation for active patterns' is not available in F# 5.0. Please use language version 6.0 or greater.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``StructAttribute must explicitly target active pattern return value`` () =
         fail
             """
@@ -182,7 +181,7 @@ let (|Foo|_|) x = ValueNone
               (FSharpDiagnosticSeverity.Error, 3350, (2, 1, 3, 16),
                "Feature 'Boolean-returning and return-type-directed partial active patterns' is not available in F# 8.0. Please use language version 9.0 or greater.")|]
 
-    [<Test>]
+    [<Fact>]
     let ``StructAttribute not allowed on other bindings than partial active pattern definitions`` () =
         fail 
             """

--- a/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
+++ b/tests/fsharp/Compiler/Language/TypeAttributeTests.fs
@@ -1,20 +1,20 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module TypeAttributeTests = 
 
-    [<Test>]
+    [<Fact>]
     let ``Attribute can be applied to type definition``() = 
         CompilerAssert.Pass
             """
 [<Struct>]
 type Point = {x:int; y:int}
             """
-    [<Test>]
+    [<Fact>]
     let ``Attribute cannot be applied to optional type extension``() = 
         CompilerAssert.TypeCheckSingleError
             """
@@ -29,7 +29,7 @@ type String with
             (4, 1, 4, 15)
             "Attributes cannot be applied to type extensions."
 
-    [<Test>]
+    [<Fact>]
     let ``Attribute cannot be applied to intrinsic type extension``() = 
         CompilerAssert.TypeCheckSingleError
             """

--- a/tests/fsharp/Compiler/Language/TypeDirectedConversionTests.fs
+++ b/tests/fsharp/Compiler/Language/TypeDirectedConversionTests.fs
@@ -2,13 +2,12 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
 module TypeDirectedConversionTests =
-    [<Test>]
+    [<Fact>]
     let ``int32 converts to float in method call parameter``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -33,7 +32,7 @@ let test() = Thing.Do(100)
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``int32 converts to System.Nullable<float> in method call parameter``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -59,7 +58,7 @@ let test() = Thing.Do(100)
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``int32 converts to float in method call property setter``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -91,7 +90,7 @@ let test() = Thing(Do = 100)
             ]))
 
     
-    [<Test>]
+    [<Fact>]
     let ``int32 converts to System.Nullable<float> in method call property setter``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -123,7 +122,7 @@ let test() = Thing(Do = 100)
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``int converts to System.Nullable<int> in method call property setter``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -154,7 +153,7 @@ let test() = Thing(Do = 100)
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``int converts to System.Nullable<int> in method call parameter``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -179,7 +178,7 @@ let test() = Thing.Do(100)
             """
             ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Passing an incompatible argument for System.Nullable<'T> method call parameter produces accurate error``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -199,7 +198,7 @@ is not compatible with type
     'System.Nullable<float>'    
 """       
 
-    [<Test>]
+    [<Fact>]
     let ``Assigning a 'T value to a System.Nullable<'T> binding succeeds``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -212,7 +211,7 @@ let test(): System.Nullable<int> = 1
             (4, 36, 4, 37)
             """This expression uses the implicit conversion 'System.Nullable.op_Implicit(value: int) : System.Nullable<int>' to convert type 'int' to type 'System.Nullable<int>'. See https://aka.ms/fsharp-implicit-convs. This warning may be disabled using '#nowarn "3391"."""
     
-    [<Test>]
+    [<Fact>]
     let ``Assigning an int32 to a System.Nullable<float> binding fails``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -228,7 +227,7 @@ let test(): System.Nullable<float> = 1
 but here has type
     'int'    """
 
-    [<Test>]
+    [<Fact>]
     let ``Overloading on System.Nullable and Result both work without error``() =
         CompilerAssert.Pass
             """
@@ -244,7 +243,7 @@ let test() =
 """     
     
 
-    [<Test>]
+    [<Fact>]
     let ``Overloading on System.Nullable and Result produces a builtin conversion warning when Nullable is picked``() =
         CompilerAssert.TypeCheckSingleErrorWithOptions
             [| "--warnon:3389" |]
@@ -263,7 +262,7 @@ let test() =
             (9, 9, 9, 10)
             """This expression uses a built-in implicit conversion to convert type 'int' to type 'System.Nullable<int>'. See https://aka.ms/fsharp-implicit-convs."""
     
-    [<Test>]
+    [<Fact>]
     let ``Overloading on System.Nullable<int>, System.Nullable<'T> and int all work without error``() =
         CompilerAssert.RunScript
             """
@@ -283,7 +282,7 @@ let test() =
 test()
         """ []
 
-    [<Test>]
+    [<Fact>]
     let ``Picking overload for typar does not favor any form of System.Nullable nor produce ambiguity warnings``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -303,7 +302,8 @@ let test(x: 'T) =
          (11, 5, 11, 11)
          """This construct causes code to be less generic than indicated by the type annotations. The type variable 'T has been constrained to be type 'int'."""
 
-    [<Test(Description="https://github.com/dotnet/fsharp/issues/13731")>]
+    [<Fact>]
+    // https://github.com/dotnet/fsharp/issues/13731
     let ``Picking overload for typar fails when incompatible types are part of the candidate set``() =
         CompilerAssert.TypeCheckWithErrors
             """
@@ -352,7 +352,7 @@ Candidates:
  - static member M2.A: n: int -> unit""")   
          |]
     
-    [<Test>]
+    [<Fact>]
     let ``Ambiguous overload for typar does not pick System.Nullable<'T>``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -378,7 +378,7 @@ Candidates:
  - static member M.A: n: float -> unit
  - static member M.A: n: int -> unit"""
     
-    [<Test>]
+    [<Fact>]
     let ``Passing an argument in nested method call property setter works``() =
         CompilerAssert.CompileLibraryAndVerifyILWithOptions([|"--optimize-"|],
             """
@@ -422,7 +422,7 @@ let test() =
             """
         ]))
 
-    [<Test>]
+    [<Fact>]
     let ``Test retrieving an argument provided in a nested method call property setter works``() =
         CompilerAssert.RunScript
             """
@@ -441,7 +441,7 @@ let test() =
 if not (test().OtherArgs.Value.Name = "test") then failwith "Unexpected value was returned after setting Name"
         """ []
 
-    [<Test>]
+    [<Fact>]
     let ``Prefer nullable conversion only candidate when multiple candidates require conversions``() =
         CompilerAssert.RunScript
             """
@@ -454,7 +454,7 @@ let test() = M.A(System.DateTime.UtcNow, 1)
 if test() <> 1 then failwith "Incorrect overload picked" 
         """ []
 
-    [<Test>]
+    [<Fact>]
     let ``Prefer nullable conversion over numeric conversion``() =
         CompilerAssert.RunScript
             """
@@ -467,7 +467,7 @@ let test() = M.A(0)
 if test() <> 2 then failwith "Incorrect overload picked"
         """ []
 
-    [<Test>]
+    [<Fact>]
     let ``Prefer nullable conversion over op_Implicit conversion``() =
         
         CompilerAssert.RunScript
@@ -482,7 +482,8 @@ if test() <> 2 then failwith "Incorrect overload picked"
         """ []
 
 
-    [<Test(Description="https://github.com/dotnet/fsharp/issues/14318")>]
+    [<Fact>]
+    // https://github.com/dotnet/fsharp/issues/14318
     let ``Picking overload for TDC candidate set fails as ambiguous while one candidate requires more conversions``() =
         CompilerAssert.TypeCheckSingleError
             """

--- a/tests/fsharp/Compiler/Language/UIntTests.fs
+++ b/tests/fsharp/Compiler/Language/UIntTests.fs
@@ -1,9 +1,9 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture>]
+
 module UIntTests =
     let ``uint type abbreviation works`` () =
         let src = "let x = uint 12"

--- a/tests/fsharp/Compiler/Language/WitnessTests.fs
+++ b/tests/fsharp/Compiler/Language/WitnessTests.fs
@@ -2,7 +2,7 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open FSharp.Test.Compiler
@@ -10,10 +10,10 @@ open TestFramework
 
 #if !NETCOREAPP
 
-[<TestFixture>]
+
 module WitnessTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Witness expressions are created as a result of compiling the type provider tests`` () =
         let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
         Fsx (sprintf """

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/CollectionTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/CollectionTests.fs
@@ -13,9 +13,7 @@ module ``Array2D Tests`` =
         // bug in array2D functions would cause iter to blow up
 
         let a = Array2D.createBased 1 5 10 10 0.0
-        let testDelegate = fun _ -> a |> Array2D.iter (printf "%f")
-
-        Assert.doesNotThrow testDelegate
+        a |> Array2D.iter (printf "%f")
 
     [<Fact>]
     let ``Iteri should not throw on non-zero based 2D arrays``() =
@@ -23,6 +21,4 @@ module ``Array2D Tests`` =
         // bug in array2D functions would cause iteri to blow up
 
         let a = Array2D.createBased 1 5 10 10 0.0
-        let testDelegate = fun _ -> a |> Array2D.iteri (fun _ _ x -> printf "%f" x)
-
-        Assert.doesNotThrow testDelegate
+        a |> Array2D.iteri (fun _ _ x -> printf "%f" x)

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/CollectionTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/CollectionTests.fs
@@ -2,27 +2,27 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Array2D Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Iter should not throw on non-zero based 2D arrays``() =
         // Regression for FSHARP1.0: 5919
         // bug in array2D functions would cause iter to blow up
 
         let a = Array2D.createBased 1 5 10 10 0.0
-        let testDelegate = TestDelegate (fun _ -> a |> Array2D.iter (printf "%f"))
+        let testDelegate = fun _ -> a |> Array2D.iter (printf "%f")
 
-        Assert.DoesNotThrow testDelegate
+        Assert.doesNotThrow testDelegate
 
-    [<Test>]
+    [<Fact>]
     let ``Iteri should not throw on non-zero based 2D arrays``() =
         // Regression for FSHARP1.0: 5919
         // bug in array2D functions would cause iteri to blow up
 
         let a = Array2D.createBased 1 5 10 10 0.0
-        let testDelegate = TestDelegate (fun _ -> a |> Array2D.iteri (fun _ _ x -> printf "%f" x))
+        let testDelegate = fun _ -> a |> Array2D.iteri (fun _ _ x -> printf "%f" x)
 
-        Assert.DoesNotThrow testDelegate
+        Assert.doesNotThrow testDelegate

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/IEnumerableTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/IEnumerableTests.fs
@@ -2,9 +2,9 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``IEnumerable Tests`` =
 
     // Regression test for FSHARP1.0:4726
@@ -34,7 +34,7 @@ module ``IEnumerable Tests`` =
         end
     end
 
-    [<Test>]
+    [<Fact>]
     let ``Dispose``() =
         let _ = Seq.cast (new C()) |> Seq.map (fun x -> use o = x; 
                                                         o) |> Seq.length

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/ListTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/ListTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module ``List Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``List hd should not exist``() =
         // Regression test for FSharp1.0:5641
         // Title: List.hd/tl --> List.head/tail
@@ -25,7 +25,7 @@ List.hd [1] |> ignore
 
         
         
-    [<Test>]
+    [<Fact>]
     let ``List tl should not exist``() =
         // Regression test for FSharp1.0:5641
         // Title: List.hd/tl --> List.head/tail
@@ -39,19 +39,19 @@ List.tl [1] |> ignore
             (2, 6, 2, 8)
             "The value, constructor, namespace or type 'tl' is not defined."
 
-    [<Test>]
+    [<Fact>]
     let ``List head of empty list``() =
-        let testDelegate = TestDelegate (fun _ -> (List.head [] |> ignore))
+        let testDelegate = fun _ -> (List.head [] |> ignore)
 
         Assert.Throws<System.ArgumentException> testDelegate |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``List tail of empty list``() =
-        let testDelegate = TestDelegate (fun _ -> (List.tail [] |> ignore))
+        let testDelegate = fun _ -> (List.tail [] |> ignore)
 
         Assert.Throws<System.ArgumentException> testDelegate |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``List head and tail``() =
         Assert.areEqual 1 (List.head [1 .. 10])
         Assert.areEqual "a" (List.head ["a"])

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/MapTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/MapTests.fs
@@ -12,6 +12,4 @@ module ``Map Tests`` =
         // Dev11:19569 - this used to throw an ArgumentException saying Object didn't implement IComparable
     
         let m = Map.ofArray [| 1, obj() |]
-        let testDelegate = fun _ -> (m = m) |> ignore
-    
-        Assert.doesNotThrow testDelegate
+        (m = m) |> ignore

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/MapTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/MapTests.fs
@@ -2,16 +2,16 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Map Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Equality should be implemented on map``() =
         // Dev11:19569 - this used to throw an ArgumentException saying Object didn't implement IComparable
     
         let m = Map.ofArray [| 1, obj() |]
-        let testDelegate = TestDelegate (fun _ -> (m = m) |> ignore)
+        let testDelegate = fun _ -> (m = m) |> ignore
     
-        Assert.DoesNotThrow testDelegate
+        Assert.doesNotThrow testDelegate

--- a/tests/fsharp/Compiler/Libraries/Core/ExtraTopLevelOperators/DictionaryTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/ExtraTopLevelOperators/DictionaryTests.fs
@@ -2,12 +2,12 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
 module ``Dictionary Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Assigning to dictionary should compile``() =
         // Regression test for FSHARP1.0:5365
 
@@ -26,7 +26,7 @@ module N.M
             dict.[key] <- value
             """
 
-    [<Test>]
+    [<Fact>]
     let ``Assigning to dictionary with type constraint should compile``() =
         // Regression test for FSHARP1.0:5365
         // Used to give error: value must be local and mutable in order to mutate the contents of a value type, e.g. 'let mutable x = ...'

--- a/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/CastToUnitsTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/CastToUnitsTests.fs
@@ -2,13 +2,13 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture>]
+
 module ``Cast to Units Tests`` =
     
-    [<Test>]
+    [<Fact>]
     let ``Casting to Measures should compile``() =
         CompilerAssert.PassWithOptions [| |]
             """

--- a/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/ComparisonTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/ComparisonTests.fs
@@ -2,24 +2,24 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture>]
+
 module ``Comparison Tests`` =
 
     type 'a www = W of 'a
 
-    [<Test>]
+    [<Fact>]
     let ``Comparisons with wrapped NaN``() =
         // Regression test for FSHARP1.0:5640
         // This is a sanity test: more coverage in FSHARP suite...
 
-        Assert.IsFalse (W System.Double.NaN = W System.Double.NaN)
-        Assert.IsTrue ((W System.Double.NaN).Equals(W System.Double.NaN))
+        Assert.False (W System.Double.NaN = W System.Double.NaN)
+        Assert.True ((W System.Double.NaN).Equals(W System.Double.NaN))
         Assert.areEqual (compare (W System.Double.NaN) (W System.Double.NaN)) 0
 
-    [<Test>]
+    [<Fact>]
     let ``Comparisons with wrapped NaN in FSI``() =
         // Regression test for FSHARP1.0:5640
         // This is a sanity test: more coverage in FSHARP suite...

--- a/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/StringFormatTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/LanguagePrimitives/StringFormatTests.fs
@@ -2,13 +2,13 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture>]
+
 module ``String Format Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``sprintf with %d format specifier``() =
         // Regression test for FSHARP1.0:4120
         // format specifier %d does not work correctly with UInt64 values
@@ -32,7 +32,7 @@ module ``String Format Tests`` =
         Assert.areEqual (sprintf "%d" 1un) "1"
         Assert.areEqual (sprintf "%d" -1n) "-1"
 
-    [<Test>]
+    [<Fact>]
     let ``sprintf with %i format specifier``() =
         // Regression test for FSHARP1.0:4120
         // format specifier %i does not work correctly with UInt64 values
@@ -56,7 +56,7 @@ module ``String Format Tests`` =
         Assert.areEqual (sprintf "%i" 1un) "1"
         Assert.areEqual (sprintf "%i" -1n) "-1"
 
-    [<Test>]
+    [<Fact>]
     let ``sprintf with %u format specifier``() =
         // Regression test for FSHARP1.0:4120
         // format specifier %u does not work correctly with UInt64 values
@@ -80,7 +80,7 @@ module ``String Format Tests`` =
         Assert.areEqual (sprintf "%u" 1un) "1"
         Assert.areEqual (sprintf "%u" -1n) (if System.IntPtr.Size = 4 then "4294967295" else "18446744073709551615")
 
-    [<Test>]
+    [<Fact>]
     let ``string constructor``() =
         // Regression test for FSHARP1.0:5894
 
@@ -139,7 +139,7 @@ module ``String Format Tests`` =
         Assert.areEqual (string  nanf) "NaN"
         Assert.areEqual (string (new System.Guid("210f4d6b-cb42-4b09-baa1-f1aa8e59d4b0"))) "210f4d6b-cb42-4b09-baa1-f1aa8e59d4b0"
 
-    [<Test>]
+    [<Fact>]
     let ``string constructor in FSI``() =
         // Regression test for FSHARP1.0:5894
 

--- a/tests/fsharp/Compiler/Libraries/Core/NativeInterop/StackallocTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/NativeInterop/StackallocTests.fs
@@ -53,13 +53,11 @@ module ``Stackalloc Tests`` =
 
     [<Fact>]
     let ``Stackalloc of imported enum``() =
-        Assert.doesNotThrow (fun () -> 
-            NativeInterop.NativePtr.stackalloc<System.DayOfWeek> 1 |> ignore)
+        NativeInterop.NativePtr.stackalloc<System.DayOfWeek> 1 |> ignore
 
     [<Fact>]
     let ``Stackalloc of imported struct``() =
-        Assert.doesNotThrow (fun () -> 
-            NativeInterop.NativePtr.stackalloc<System.TimeSpan> 1 |> ignore)
+        NativeInterop.NativePtr.stackalloc<System.TimeSpan> 1 |> ignore
 
     [<Fact>]
     let ``Stackalloc of imported class``() =
@@ -174,14 +172,11 @@ let _ = NativeInterop.NativePtr.stackalloc<R> 1
         // Regression test for FSHARP1.0:
         // stackalloc<System.DateTime> 0
             
-        let testDelegate = fun () -> 
-            // check stackalloc 0 -- ok
-            let data = NativeInterop.NativePtr.stackalloc<System.DateTime> 0
+        // check stackalloc 0 -- ok
+        let data = NativeInterop.NativePtr.stackalloc<System.DateTime> 0
                         
-            // The returned pointer is undefined
-            // No allocation should happen
-            let _ = NativeInterop.NativePtr.toNativeInt data
+        // The returned pointer is undefined
+        // No allocation should happen
+        let _ = NativeInterop.NativePtr.toNativeInt data
                         
-            ()
-            
-        Assert.doesNotThrow testDelegate
+        ()

--- a/tests/fsharp/Compiler/Libraries/Core/NativeInterop/StackallocTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/NativeInterop/StackallocTests.fs
@@ -2,19 +2,19 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
 #nowarn "9"
 
-[<TestFixture>]
+
 module ``Stackalloc Tests`` =
 
     type E = | A = 1
              | B = 2
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of DateTime``() =
         let data = NativeInterop.NativePtr.stackalloc<System.DateTime> 100
         let now = System.DateTime.Now
@@ -31,7 +31,7 @@ module ``Stackalloc Tests`` =
             let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
             Assert.areEqual datai later
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of enum``() =
         let data = NativeInterop.NativePtr.stackalloc<E> 10
         
@@ -51,17 +51,17 @@ module ``Stackalloc Tests`` =
             let expected = if (i % 2)=1 then E.A else E.B
             Assert.areEqual datai expected
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of imported enum``() =
-        Assert.DoesNotThrow (TestDelegate (fun () -> 
-            NativeInterop.NativePtr.stackalloc<System.DayOfWeek> 1 |> ignore))
+        Assert.doesNotThrow (fun () -> 
+            NativeInterop.NativePtr.stackalloc<System.DayOfWeek> 1 |> ignore)
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of imported struct``() =
-        Assert.DoesNotThrow (TestDelegate (fun () -> 
-            NativeInterop.NativePtr.stackalloc<System.TimeSpan> 1 |> ignore))
+        Assert.doesNotThrow (fun () -> 
+            NativeInterop.NativePtr.stackalloc<System.TimeSpan> 1 |> ignore)
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of imported class``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -74,7 +74,7 @@ let _ = NativeInterop.NativePtr.stackalloc<System.Object> 1
             (4, 9, 4, 43)
             "A generic construct requires that the type 'System.Object' is an unmanaged type"
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of imported interface``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -87,7 +87,7 @@ let _ = NativeInterop.NativePtr.stackalloc<System.Collections.IEnumerable> 1
             (4, 9, 4, 43)
             "A generic construct requires that the type 'System.Collections.IEnumerable' is an unmanaged type"
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of imported delegate``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -100,7 +100,7 @@ let _ = NativeInterop.NativePtr.stackalloc<System.EventHandler> 1
             (4, 9, 4, 43)
             "A generic construct requires that the type 'System.EventHandler' is an unmanaged type"
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of int``() =
         let data = NativeInterop.NativePtr.stackalloc<int> 100
            
@@ -118,7 +118,7 @@ let _ = NativeInterop.NativePtr.stackalloc<System.EventHandler> 1
             let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
             Assert.areEqual datai (1-i)
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of int64``() =
         let data = NativeInterop.NativePtr.stackalloc<int64> 100
 
@@ -135,7 +135,7 @@ let _ = NativeInterop.NativePtr.stackalloc<System.EventHandler> 1
             let datai = NativeInterop.NativePtr.toByRef (NativeInterop.NativePtr.add data i)
             Assert.areEqual datai (int64 (1-i))
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of managed class``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -154,7 +154,7 @@ let _ = NativeInterop.NativePtr.stackalloc<C> 1
             (10, 9, 10, 43)
             "A generic construct requires that the type 'C' is an unmanaged type"
 
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc of managed record``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -169,12 +169,12 @@ let _ = NativeInterop.NativePtr.stackalloc<R> 1
             (6, 9, 6, 43)
             "A generic construct requires that the type 'R' is an unmanaged type"
             
-    [<Test>]
+    [<Fact>]
     let ``Stackalloc zero-size``() =
         // Regression test for FSHARP1.0:
         // stackalloc<System.DateTime> 0
             
-        let testDelegate = TestDelegate (fun () -> 
+        let testDelegate = fun () -> 
             // check stackalloc 0 -- ok
             let data = NativeInterop.NativePtr.stackalloc<System.DateTime> 0
                         
@@ -182,6 +182,6 @@ let _ = NativeInterop.NativePtr.stackalloc<R> 1
             // No allocation should happen
             let _ = NativeInterop.NativePtr.toNativeInt data
                         
-            ())
+            ()
             
-        Assert.DoesNotThrow testDelegate
+        Assert.doesNotThrow testDelegate

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/AbsTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/AbsTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.Diagnostics
 open FSharp.Test
 
-[<TestFixture>]
+
 module ``Abs Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let  ``Abs of signed integral types``() =
         // Regression test for FSHARP1.0:3470 - exception on abs of native integer
 
@@ -20,7 +20,7 @@ module ``Abs Tests`` =
         Assert.areEqual (abs -1L) 1L   // int64
         Assert.areEqual (abs -1I) 1I   // bigint
 
-    [<Test>]
+    [<Fact>]
     let ``Abs of byte``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -31,7 +31,7 @@ abs -1uy |> ignore
             (2, 6, 2, 9)
             "The type 'byte' does not support the operator 'abs'"
     
-    [<Test>]
+    [<Fact>]
     let ``Abs of uint16``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -42,7 +42,7 @@ abs -1us |> ignore
             (2, 6, 2, 9)
             "The type 'uint16' does not support the operator 'abs'"
 
-    [<Test>]
+    [<Fact>]
     let ``Abs of uint32``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -62,7 +62,7 @@ abs -1u |> ignore
             (2, 6, 2, 8)
             "The type 'uint32' does not support the operator 'abs'"
             
-    [<Test>]
+    [<Fact>]
     let ``Abs of unativeint``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -73,7 +73,7 @@ abs -1un |> ignore
             (2, 6, 2, 9)
             "The type 'unativeint' does not support the operator 'abs'"
             
-    [<Test>]
+    [<Fact>]
     let ``Abs of uint64``() =
         CompilerAssert.TypeCheckSingleError
             """

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/CastTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/CastTests.fs
@@ -9,11 +9,14 @@ open System
 
 module ``Cast Tests`` =
 
+    let inline isTypeOf<'T> x =
+        Assert.True(typeof<'T>.IsInstanceOfType(x))
+
     [<Fact>]
     let ``Cast precedence over expression forms``() =
         // Regression test for FSHARP1.0:1247
         // Precedence of type annotations :> and :?> over preceeding expression forms, e.g. if-then-else etc.
 
-        Assert.IsAssignableFrom<Object> (2 :> Object) |> ignore
-        Assert.IsAssignableFrom<Object list> [(2 :> Object)] |> ignore
-        Assert.IsAssignableFrom<Object list> [2 :> Object] |> ignore
+        isTypeOf<Object> (2 :> Object)
+        isTypeOf<Object list> [(2 :> Object)]
+        isTypeOf<Object list> [2 :> Object]

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/CastTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/CastTests.fs
@@ -2,18 +2,18 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open System
 
-[<TestFixture>]
+
 module ``Cast Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Cast precedence over expression forms``() =
         // Regression test for FSHARP1.0:1247
         // Precedence of type annotations :> and :?> over preceeding expression forms, e.g. if-then-else etc.
 
-        Assert.IsInstanceOf<Object> (2 :> Object)
-        Assert.IsInstanceOf<Object list> [(2 :> Object)]
-        Assert.IsInstanceOf<Object list> [2 :> Object]
+        Assert.IsAssignableFrom<Object> (2 :> Object) |> ignore
+        Assert.IsAssignableFrom<Object list> [(2 :> Object)] |> ignore
+        Assert.IsAssignableFrom<Object list> [2 :> Object] |> ignore

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/HashTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/HashTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.Diagnostics
 open FSharp.Test
 
-[<TestFixture>]
+
 module ``Hash Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Hash of function values``() =
         // Regression test for FSHARP1.0:5436
         // You should not be able to hash F# function values
@@ -25,7 +25,7 @@ hash id |> ignore
             (2, 6, 2, 8)
             "The type '('a -> 'a)' does not support the 'equality' constraint because it is a function type"
 
-    [<Test>]
+    [<Fact>]
     let ``Unchecked hash of function values``() =
         // Regression test for FSHARP1.0:5436
         // You should not be able to hash F# function values

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/PowTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/PowTests.fs
@@ -2,9 +2,9 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Pow Tests`` =
     
     type T() =
@@ -14,7 +14,7 @@ module ``Pow Tests`` =
             g
         static member Check() = m
 
-    [<Test>]
+    [<Fact>]
     let ``Pow of custom type``() =
         // Regression test for FSHARP1.0:4487
         // Feature request: loosen Pow operator constraints
@@ -22,4 +22,4 @@ module ``Pow Tests`` =
         let t = T()
         let _ = t ** 3.
 
-        Assert.IsTrue (T.Check())
+        Assert.True (T.Check())

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/RoundTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/RoundTests.fs
@@ -2,19 +2,19 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Round Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Round of integers``() =
         for i in [1 .. 10000] do
             Assert.areEqual (i |> float   |> round) (float   i)
             Assert.areEqual (i |> float32 |> round) (float32 i)
             Assert.areEqual (i |> decimal |> round) (decimal i)
 
-    [<Test>]
+    [<Fact>]
     let ``Round of floats``() =
         // Round down
         Assert.areEqual (round 1.1) 1.0

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/SignTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/SignTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Compiler.Diagnostics
 open FSharp.Test
 
-[<TestFixture>]
+
 module ``Sign Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Sign of signed types``() =
         Assert.areEqual (sign 1y) 1       // byte
         Assert.areEqual (sign 1s) 1       // int16
@@ -36,7 +36,7 @@ module ``Sign Tests`` =
     // #Regression #Libraries #Operators 
     // Test sign function on unsigned primitives, should get error.
 
-    [<Test>]
+    [<Fact>]
     let ``Sign of byte``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -47,7 +47,7 @@ sign 0uy |> ignore
             (2, 6, 2, 9)
             "The type 'byte' does not support the operator 'sign'"
 
-    [<Test>]
+    [<Fact>]
     let ``Sign of uint16``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -58,7 +58,7 @@ sign 0us |> ignore
             (2, 6, 2, 9)
             "The type 'uint16' does not support the operator 'sign'"
 
-    [<Test>]
+    [<Fact>]
     let ``Sign of uint32``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -69,7 +69,7 @@ sign 0u |> ignore
             (2, 6, 2, 8)
             "The type 'uint32' does not support the operator 'sign'"
 
-    [<Test>]
+    [<Fact>]
     let ``Sign of uint64``() =
         CompilerAssert.TypeCheckSingleError
             """

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/StringTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/StringTests.fs
@@ -2,10 +2,10 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open System
 
-[<TestFixture>]
+
 module ``String Tests`` =
 
     type CalcSum(x : int, y: int) = 
@@ -24,15 +24,15 @@ module ``String Tests`` =
 
         override x.ToString() = (x :> IFormattable).ToString(null, null)
 
-    [<Test>]
+    [<Fact>]
     let ``String of custom type``() =
         let calc = CalcSum(10, 20)
         Assert.areEqual (string calc) "X + Y = 30"
 
-        let testDelegate = TestDelegate (fun () ->
+        let testDelegate = fun () ->
             printfn "%s" (calc.ToString())
             Console.WriteLine("{0:S}", calc)
-            Console.Write("{0} {1} {2:D}", 10, 20, calc))
+            Console.Write("{0} {1} {2:D}", 10, 20, calc)
         let e = Assert.Throws<ArgumentException> testDelegate
         Assert.areEqual e.ParamName "D"
 
@@ -41,7 +41,7 @@ module ``String Tests`` =
       |  A  =  1
       |  B  =  2
 
-    [<Test>]
+    [<Fact>]
     let ``String of int32 based enum``() =
         let a = Foo.A
         let r = a :> System.IFormattable
@@ -53,7 +53,7 @@ module ``String Tests`` =
         | A = 3u
         | B = 4u
 
-    [<Test>]
+    [<Fact>]
     let ``String of uint32 based enum``() =
         let a = Foo2.A
         let r = a :> System.IFormattable
@@ -64,7 +64,7 @@ module ``String Tests`` =
         | A = 'a'
         | B = 'b'
 
-    [<Test>]
+    [<Fact>]
     let ``String of char based enum``() =
         let a = Foo3.A
         let r = a :> System.IFormattable
@@ -75,7 +75,7 @@ module ``String Tests`` =
         | A = 1s
         | B = 2s
         
-    [<Test>]
+    [<Fact>]
     let ``String of int16 based enum``() =
         let a = Foo4.A
         let r = a :> System.IFormattable
@@ -86,7 +86,7 @@ module ``String Tests`` =
         | A = 1us
         | B = 2us
 
-    [<Test>]
+    [<Fact>]
     let ``String of uint16 based enum``() =
         let a = Foo5.A
         let r = a :> System.IFormattable
@@ -97,7 +97,7 @@ module ``String Tests`` =
         | A = 1y
         | B = 2y
 
-    [<Test>]
+    [<Fact>]
     let ``String of sbyte based enum``() =
         let a = Foo6.A
         let r = a :> System.IFormattable
@@ -108,7 +108,7 @@ module ``String Tests`` =
         | A = 1uy
         | B = 2uy
 
-    [<Test>]
+    [<Fact>]
     let ``String of byte based enum``() =
         let a = Foo7.A
         let r = a :> System.IFormattable

--- a/tests/fsharp/Compiler/Libraries/Core/Reflection/PreComputedTupleConstructorTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Reflection/PreComputedTupleConstructorTests.fs
@@ -2,27 +2,27 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``PreComputedTupleConstructor Tests`` =
 
-    [<Test>]
+    [<Fact>]
     let ``PreComputedTupleConstructor of int and string``() =
         // Regression test for FSHARP1.0:5113
         // MT DCR: Reflection.FSharpValue.PreComputeTupleConstructor fails when executed for NetFx 2.0 by a Dev10 compiler
 
-        let testDelegate = TestDelegate (fun () -> 
-            Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box 12; box "text" |] |> ignore)
+        let testDelegate = fun () -> 
+            Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box 12; box "text" |] |> ignore
 
-        Assert.DoesNotThrow testDelegate |> ignore
+        Assert.doesNotThrow testDelegate |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``PreComputedTupleConstructor with wrong order of arguments``() =
         // Regression test for FSHARP1.0:5113
         // MT DCR: Reflection.FSharpValue.PreComputeTupleConstructor fails when executed for NetFx 2.0 by a Dev10 compiler
 
-        let testDelegate = TestDelegate (fun () -> 
-            Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box "text"; box 12; |] |> ignore)
+        let testDelegate = fun () -> 
+            Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box "text"; box 12; |] |> ignore
 
         Assert.Throws<System.InvalidCastException> testDelegate |> ignore

--- a/tests/fsharp/Compiler/Libraries/Core/Reflection/PreComputedTupleConstructorTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Reflection/PreComputedTupleConstructorTests.fs
@@ -11,11 +11,7 @@ module ``PreComputedTupleConstructor Tests`` =
     let ``PreComputedTupleConstructor of int and string``() =
         // Regression test for FSHARP1.0:5113
         // MT DCR: Reflection.FSharpValue.PreComputeTupleConstructor fails when executed for NetFx 2.0 by a Dev10 compiler
-
-        let testDelegate = fun () -> 
-            Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box 12; box "text" |] |> ignore
-
-        Assert.doesNotThrow testDelegate |> ignore
+        Reflection.FSharpValue.PreComputeTupleConstructor(typeof<int * string>) [| box 12; box "text" |] |> ignore
 
     [<Fact>]
     let ``PreComputedTupleConstructor with wrong order of arguments``() =

--- a/tests/fsharp/Compiler/Libraries/Core/Reflection/SprintfTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Reflection/SprintfTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``Sprintf Tests`` =
 
     type MyR = {c:int;b:int;a:int}
 
-    [<Test>]
+    [<Fact>]
     let ``Sprintf %A of record type``() =
         // Regression test for FSHARP1.0:5113
 
@@ -20,7 +20,7 @@ module ``Sprintf Tests`` =
 
     type MyT = MyC of int * string * bool
 
-    [<Test>]
+    [<Fact>]
     let ``Sprintf %A of discriminated union type``() =
         // Regression test for FSHARP1.0:5113
 

--- a/tests/fsharp/Compiler/Libraries/Core/Unchecked/DefaultOfTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Unchecked/DefaultOfTests.fs
@@ -2,9 +2,9 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 
-[<TestFixture>]
+
 module ``DefaultOf Tests`` =
 
     type DUType = 
@@ -31,14 +31,14 @@ module ``DefaultOf Tests`` =
         member this.SValue = this.m_svalue
     end
 
-    [<Test>]
+    [<Fact>]
     let `` Unchecked defaultof reference types``() =
         Assert.areEqual Unchecked.defaultof<ClassType|null> null
         Assert.areEqual (box Unchecked.defaultof<DUType>) null
         Assert.areEqual (box Unchecked.defaultof<RecordType>) null
         Assert.areEqual (box Unchecked.defaultof<InterfaceType>) null
 
-    [<Test>]
+    [<Fact>]
     let ``Unchecked defaultof stack types``() =
         Assert.areEqual Unchecked.defaultof<int> 0
         Assert.areEqual Unchecked.defaultof<float> 0.0
@@ -51,7 +51,7 @@ module ``DefaultOf Tests`` =
     type S = struct val mutable x : int end
     type C() = class end
 
-    [<Test>]
+    [<Fact>]
     let ``Unchecked defaultof and equality``() =
         // FSharp1.0:5417 - Unchecked.defaultof<_> on records/unions can cause structural equality check to throw
         // Check that Unchecked.defaultof<_> works correctly on various types, mostly structs/unions/records

--- a/tests/fsharp/Compiler/Regressions/ForInDoMutableRegressionTest.fs
+++ b/tests/fsharp/Compiler/Regressions/ForInDoMutableRegressionTest.fs
@@ -3,14 +3,13 @@
 namespace FSharp.Compiler.UnitTests
 
 open System
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture()>]
 module ForInDoMutableRegressionTest =
 
     /// This test is to ensure we initialize locals inside loops.
-    [<Test>]
+    [<Fact>]
     let Script_ForInDoMutableRegressionTest() =
         let script = 
             """

--- a/tests/fsharp/Compiler/Regressions/IndexerRegressionTests.fs
+++ b/tests/fsharp/Compiler/Regressions/IndexerRegressionTests.fs
@@ -3,13 +3,12 @@
 namespace FSharp.Compiler.UnitTests
 
 open System
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
-[<TestFixture()>]
 module IndexerRegressionTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Indexer has qualified type value``() =
         CompilerAssert.Pass 
             """

--- a/tests/fsharp/Compiler/Regressions/NullableOptionalRegressionTests.fs
+++ b/tests/fsharp/Compiler/Regressions/NullableOptionalRegressionTests.fs
@@ -2,10 +2,9 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test.Compiler
 
-[<TestFixture()>]
 module NullableOptionalRegressionTests =
 
     //Disabled, see RFC for nullable
@@ -35,7 +34,7 @@ let test () =
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Method should infer 'z' correctly``() =
         let fsSrc =
             """
@@ -56,7 +55,7 @@ type Test with
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Method should infer correctly``() =
         let fsSrc =
             """
@@ -77,7 +76,7 @@ type Test with
         |> shouldSucceed
         |> ignore
 
-    [<Test>]
+    [<Fact>]
     let ``Method should infer correctly 2``() =
         let fsSrc =
             """

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -125,7 +125,7 @@ let test() =
     let ``Using a CSharp reference project in-memory``() =
         AssertInMemoryCSharpReferenceIsValid() |> ignore
 
-    [<Fact>] //;NonParallelizable>]
+    [<Fact>]
     let ``Using a CSharp reference project in-memory and it gets GCed``() =
         let weakRef = AssertInMemoryCSharpReferenceIsValid()
         CompilerAssert.Checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -5,7 +5,7 @@ namespace FSharp.Compiler.UnitTests
 open System
 open System.IO
 open FSharp.Compiler.Diagnostics
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open FSharp.Test.Compiler
@@ -15,7 +15,7 @@ open Microsoft.CodeAnalysis.CSharp
 open FSharp.Compiler.Text
 open TestFramework
 
-[<TestFixture>]
+
 module MultiProjectTests =
 
     let AssertInMemoryCSharpReferenceIsValid () =
@@ -121,18 +121,18 @@ let test() =
         finally
             try File.Delete(filePath) with | _ -> ()
 
-    [<Test>]
+    [<Fact>]
     let ``Using a CSharp reference project in-memory``() =
         AssertInMemoryCSharpReferenceIsValid() |> ignore
 
-    [<Test;NonParallelizable>]
+    [<Fact>] //;NonParallelizable>]
     let ``Using a CSharp reference project in-memory and it gets GCed``() =
         let weakRef = AssertInMemoryCSharpReferenceIsValid()
         CompilerAssert.Checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
         GC.Collect(2, GCCollectionMode.Forced, true)
         Assert.shouldBeFalse(weakRef.IsAlive)
 
-    [<Test>]
+    [<Fact>]
     let ``Using compiler service, file referencing a DLL will correctly update when the referenced DLL file changes``() =
         let checker = CompilerAssert.Checker
 
@@ -168,7 +168,7 @@ let x = Script1.x
                 checker.ParseAndCheckProject(fsOptions1)
                 |> Async.RunImmediate
 
-            Assert.IsEmpty(checkProjectResults1.Diagnostics)
+            Assert.Empty(checkProjectResults1.Diagnostics)
 
             // Create script with that uses Script1 and function x and function y
             updateFileOnDisk filePath1
@@ -184,7 +184,7 @@ let y = Script1.y
                 checker.ParseAndCheckProject(fsOptions1)
                 |> Async.RunImmediate
 
-            Assert.IsNotEmpty(checkProjectResults2.Diagnostics)
+            Assert.NotEmpty(checkProjectResults2.Diagnostics)
 
             // Create an assembly with the module Script1 and function x and function y
             updateCompiledDllOnDisk checker dllPath1
@@ -200,7 +200,7 @@ let y = 1
                 checker.ParseAndCheckProject(fsOptions1)
                 |> Async.RunImmediate
 
-            Assert.IsEmpty(checkProjectResults3.Diagnostics)
+            Assert.Empty(checkProjectResults3.Diagnostics)
 
         finally
             try File.Delete(dllPath1) with | _ -> ()

--- a/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
+++ b/tests/fsharp/Compiler/Service/SignatureGenerationTests.fs
@@ -3,12 +3,11 @@
 namespace FSharp.Compiler.UnitTests
 
 open FSharp.Compiler.Diagnostics
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Test.Utilities
 open FSharp.Test.Compiler
 
-[<TestFixture>]
 module SignatureGenerationTests =
 
     let sigText (checkResults: FSharp.Compiler.CodeAnalysis.FSharpCheckFileResults) =
@@ -37,7 +36,7 @@ module SignatureGenerationTests =
 
         Assert.shouldBeEquivalentTo expected2 actual
     
-    [<Test>]
+    [<Fact>]
     let ``can generate sigs with comments`` () = 
         """
 namespace Sample
@@ -128,7 +127,7 @@ module Inner =
       member Thing: int
   """
     
-    [<Test>]
+    [<Fact>]
     let ``can generate signatures for autoproperties`` () = 
         """
 namespace Sample
@@ -180,7 +179,7 @@ module Inner =
 
       member SomeAutoPropWithGetOnly: string"""
 
-    [<Test>]
+    [<Fact>]
     let ``can generate attributes for implicit namespace`` () = 
         """
 [<AutoOpen>]
@@ -204,7 +203,7 @@ module Say =
 
   val f: a: 'a -> 'a"""
 
-    [<Test>]
+    [<Fact>]
     let ``can generate attributes for implicit namespace with multiple modules`` () = 
         """
 [<AutoOpen>]

--- a/tests/fsharp/Compiler/SourceTextTests.fs
+++ b/tests/fsharp/Compiler/SourceTextTests.fs
@@ -3,32 +3,32 @@
 namespace FSharp.Compiler.UnitTests
 
 open System
-open NUnit.Framework
+open Xunit
 
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.Text
 
-[<TestFixture>]
+
 module SourceTextTests =
 
-    [<Test>]
+    [<Fact>]
     let StringText () =
         let text = "test\ntest2\r\ntest3\n\ntest4\ntest5\rtest6\n"
         let sourceText = SourceText.ofString text
 
-        Assert.AreEqual("test",  sourceText.GetLineString(0))
-        Assert.AreEqual("test2", sourceText.GetLineString(1))
-        Assert.AreEqual("test3", sourceText.GetLineString(2))
-        Assert.AreEqual("",      sourceText.GetLineString(3))
-        Assert.AreEqual("test4", sourceText.GetLineString(4))
-        Assert.AreEqual("test5", sourceText.GetLineString(5))
-        Assert.AreEqual("test6", sourceText.GetLineString(6))
-        Assert.AreEqual("",      sourceText.GetLineString(7))
-        Assert.AreEqual(8,       sourceText.GetLineCount())
+        Assert.Equal("test",  sourceText.GetLineString(0))
+        Assert.Equal("test2", sourceText.GetLineString(1))
+        Assert.Equal("test3", sourceText.GetLineString(2))
+        Assert.Equal("",      sourceText.GetLineString(3))
+        Assert.Equal("test4", sourceText.GetLineString(4))
+        Assert.Equal("test5", sourceText.GetLineString(5))
+        Assert.Equal("test6", sourceText.GetLineString(6))
+        Assert.Equal("",      sourceText.GetLineString(7))
+        Assert.Equal(8,       sourceText.GetLineCount())
 
         let (count, length) = sourceText.GetLastCharacterPosition()
-        Assert.AreEqual(8, count)
-        Assert.AreEqual(0, length)
+        Assert.Equal(8, count)
+        Assert.Equal(0, length)
 
         Assert.True(sourceText.SubTextEquals("test", 0))
         Assert.True(sourceText.SubTextEquals("test2", 5))

--- a/tests/fsharp/Compiler/Stress/LargeExprTests.fs
+++ b/tests/fsharp/Compiler/Stress/LargeExprTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 
 #if !DEBUG // requires release version of compiler to avoid very deep stacks
-[<TestFixture>]
+
 module LargeExprTests =
 
-    [<Test>]
+    [<Fact>]
     let LargeRecordDoesNotStackOverflow() =
         CompilerAssert.CompileExe
             """
@@ -991,7 +991,7 @@ type TestRecord =
 let main _ = 0
             """
 
-    [<Test>]
+    [<Fact>]
     let LargeRecordWithStringFieldsDoesNotStackOverflow() =
         CompilerAssert.CompileExe
             """
@@ -1974,7 +1974,7 @@ type TestRecord =
 let main _ = 0
             """
 
-    [<Test>]
+    [<Fact>]
     let LargeStructRecordDoesNotStackOverflow() =
         CompilerAssert.CompileExe
             """
@@ -2987,7 +2987,7 @@ type TestRecord =
 let main _ = 0
             """
 
-    [<Test>]
+    [<Fact>]
     let LargeExprDoesNotStackOverflow() =
         CompilerAssert.CompileExe
             """
@@ -4999,7 +4999,7 @@ module Test =
 let main _ = 0
             """
 
-    [<Test>]
+    [<Fact>]
     let LargeListExprDoesNotStackOverflow() =
         let source = """
 let test () : unit =

--- a/tests/fsharp/Compiler/Warnings/AssignmentWarningTests.fs
+++ b/tests/fsharp/Compiler/Warnings/AssignmentWarningTests.fs
@@ -2,14 +2,14 @@
 
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module ``Warnings assigning to mutable and immutable objects`` =
 
-    [<Test>]
+    [<Fact>]
     let ``Unused compare with immutable when assignment might be intended``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -25,7 +25,7 @@ let changeX() =
             (6, 5, 6, 11)
             "The result of this equality expression has type 'bool' and is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to mutate a value, then mark the value 'mutable' and use the '<-' operator e.g. 'x <- expression'."
 
-    [<Test>]
+    [<Fact>]
     let ``Unused compare with mutable when assignment might be intended``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -41,7 +41,7 @@ let changeX() =
             (6, 5, 6, 11)
             "The result of this equality expression has type 'bool' and is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to mutate a value, then use the '<-' operator e.g. 'x <- expression'."
 
-    [<Test>]
+    [<Fact>]
     let ``Unused comparison of property in dotnet object when assignment might be intended``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -59,7 +59,7 @@ let changeProperty() =
             (8, 5, 8, 21)
             "The result of this equality expression has type 'bool' and is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to set a value to a property, then use the '<-' operator e.g. 'z.Enabled <- expression'."
 
-    [<Test>]
+    [<Fact>]
     let ``Unused comparison of property when assignment might be intended ``() =
         CompilerAssert.TypeCheckSingleError
             """
@@ -79,7 +79,7 @@ let changeProperty() =
             (10, 5, 10, 23)
             "The result of this equality expression has type 'bool' and is implicitly discarded. Consider using 'let' to bind the result to a name, e.g. 'let result = expression'. If you intended to set a value to a property, then use the '<-' operator e.g. 'x.Property2 <- expression'."
 
-    [<Test>]
+    [<Fact>]
     let ``Don't warn if assignment to property without setter ``() =
         CompilerAssert.TypeCheckSingleError
             """

--- a/tests/fsharp/Compiler/Warnings/ExperimentalAttributeTests.fs
+++ b/tests/fsharp/Compiler/Warnings/ExperimentalAttributeTests.fs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module ``Validate ExperimentalAttribute and LanguageVersion`` =
 
     let experimentalSource = """
@@ -17,13 +17,13 @@ module TestModule =
     if getString = "A string" then ()
 """
 
-    [<Test>]
+    [<Fact>]
     let ``ExperimentalAttribute nowarn when preview specified``() =
         CompilerAssert.PassWithOptions
             [| "--langversion:preview" |]
             experimentalSource
 
-    [<Test>]
+    [<Fact>]
     let ``ExperimentalAttribute warn when preview not specified``() =
         CompilerAssert.TypeCheckSingleError
             experimentalSource

--- a/tests/fsharp/Compiler/Warnings/PatternMatchingWarningTests.fs
+++ b/tests/fsharp/Compiler/Warnings/PatternMatchingWarningTests.fs
@@ -1,13 +1,13 @@
 ﻿namespace FSharp.Compiler.UnitTests
 
-open NUnit.Framework
+open Xunit
 open FSharp.Test
 open FSharp.Compiler.Diagnostics
 
-[<TestFixture>]
+
 module PatternMatchingWarningTests =
 
-    [<Test>]
+    [<Fact>]
     let ``Complete pattern match on byte should not trigger FS0025 warning`` () =
         CompilerAssert.Pass
             """
@@ -271,7 +271,7 @@ module PatternMatchingWarningTests =
            | 255uy -> 255
     printfn ""
             """
-    [<Test>]
+    [<Fact>]
     let ``Complete pattern match on sbyte should not trigger FS0025 warning`` () =
         CompilerAssert.Pass
             """

--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -12,7 +12,7 @@
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OtherFlags>$(OtherFlags) --warnon:1182 --langversion:preview</OtherFlags>
-    <UnitTestType>nunit</UnitTestType>
+    <UnitTestType>xunit</UnitTestType>
     <NoWarn>3186</NoWarn>
   </PropertyGroup>
 

--- a/tests/fsharp/NUnitHelpers.fs
+++ b/tests/fsharp/NUnitHelpers.fs
@@ -37,8 +37,10 @@ module Assert =
     let inline areEqual (expected: ^T) (actual: ^T) =
         Assert.Equal<^T>(expected, actual)
 
-    let inline contains (expected: string) (actual: string) = Assert.True(actual.Contains(expected))
+    // let inline contains (expected: string) (actual: string) = Assert.Contains(expected, actual)
 
-    let inline doesNotThrow (action: unit -> unit) =
-        Record.Exception action
-        |> Assert.Null
+    //let inline doesNotThrow (action: unit -> unit) =
+    //    Record.Exception action
+    //    |> Assert.Null
+
+

--- a/tests/fsharp/NUnitHelpers.fs
+++ b/tests/fsharp/NUnitHelpers.fs
@@ -1,9 +1,6 @@
 namespace Xunit
 
 open Xunit
-open Xunit.Sdk
-open System.Threading
-open System.Globalization
 
 module Assert =
 
@@ -16,11 +13,3 @@ module Assert =
 
     let inline areEqual (expected: ^T) (actual: ^T) =
         Assert.Equal<^T>(expected, actual)
-
-    // let inline contains (expected: string) (actual: string) = Assert.Contains(expected, actual)
-
-    //let inline doesNotThrow (action: unit -> unit) =
-    //    Record.Exception action
-    //    |> Assert.Null
-
-

--- a/tests/fsharp/NUnitHelpers.fs
+++ b/tests/fsharp/NUnitHelpers.fs
@@ -5,26 +5,6 @@ open Xunit.Sdk
 open System.Threading
 open System.Globalization
 
-type UseCulture(culture: string, uiCulture: string) =
-
-    inherit BeforeAfterTestAttribute()
-
-    let mutable restore = ignore
-
-    new(culture) = UseCulture(culture, culture)
-    override _.Before _ = 
-        let originalCulture = Thread.CurrentThread.CurrentCulture
-        let originalUiCulture = Thread.CurrentThread.CurrentUICulture
-
-        Thread.CurrentThread.CurrentCulture <- CultureInfo(culture)
-        Thread.CurrentThread.CurrentUICulture <- CultureInfo(uiCulture)
-
-        restore <- fun () ->
-            Thread.CurrentThread.CurrentCulture <- originalCulture
-            Thread.CurrentThread.CurrentUICulture <- originalUiCulture
-
-    override _.After _ = restore ()
-
 module Assert =
 
     [<assembly: CollectionBehavior(DisableTestParallelization = true)>]

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -7,7 +7,6 @@
 #load "../FSharp.Test.Utilities/TestFramework.fs"
 #load "single-test.fs"
 #else
-[<NUnit.Framework.Category "Type Provider";NUnit.Framework.NonParallelizable>]
 module FSharp.Test.FSharpSuite.TypeProviderTests
 #endif
 
@@ -204,7 +203,6 @@ let helloWorldCSharp () =
 [<InlineData("EVIL_PROVIDER_DoesNotHaveConstructor")>]
 [<InlineData("EVIL_PROVIDER_ConstructorThrows")>]
 [<InlineData("EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments")>]
-// [<NonParallelizable>]
 let ``negative type provider tests`` (name:string) =
     let cfg = testConfig "typeProviders/negTests"
     let dir = cfg.Directory

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -14,7 +14,7 @@ module FSharp.Test.FSharpSuite.TypeProviderTests
 open System
 open System.IO
 open System.Reflection
-open NUnit.Framework
+open Xunit
 open TestFramework
 open Scripting
 open SingleTest
@@ -36,7 +36,7 @@ let FSI = FSI_NETFX
 let inline getTestsDirectory dir = getTestsDirectory __SOURCE_DIRECTORY__ dir
 let testConfig = getTestsDirectory >> testConfig
 
-[<Test>]
+[<Fact>]
 let diamondAssembly () =
     let cfg = testConfig "typeProviders/diamondAssembly"
 
@@ -72,7 +72,7 @@ let diamondAssembly () =
 
     testOkFile.CheckExists()
 
-[<Test>]
+[<Fact>]
 let globalNamespace () =
     let cfg = testConfig "typeProviders/globalNamespace"
 
@@ -146,15 +146,15 @@ let helloWorld p =
 
     peverify cfg (bincompat2 ++ "testlib_client.exe")
 
-[<Test>]
+[<Fact>]
 let ``helloWorld fsc`` () = helloWorld FSC_OPTIMIZED
 
 #if !NETCOREAPP
-[<Test>]
+[<Fact>]
 let ``helloWorld fsi`` () = helloWorld FSI_NETFX_STDIN
 #endif
 
-[<Test>]
+[<Fact>]
 let helloWorldCSharp () =
     let cfg = testConfig "typeProviders/helloWorldCSharp"
 
@@ -176,35 +176,35 @@ let helloWorldCSharp () =
 
     exec cfg ("." ++ "test.exe") ""
 
-
-[<TestCase("neg1")>]
-[<TestCase("neg2")>]
-[<TestCase("neg2c")>]
-[<TestCase("neg2e")>]
-[<TestCase("neg2g")>]
-[<TestCase("neg2h")>]
-[<TestCase("neg4")>]
-[<TestCase("neg6")>]
-[<TestCase("InvalidInvokerExpression")>]
-[<TestCase("providerAttributeErrorConsume")>]
-[<TestCase("ProviderAttribute_EmptyConsume")>]
-[<TestCase("EVIL_PROVIDER_GetNestedNamespaces_Exception")>]
-[<TestCase("EVIL_PROVIDER_NamespaceName_Exception")>]
-[<TestCase("EVIL_PROVIDER_NamespaceName_Empty")>]
-[<TestCase("EVIL_PROVIDER_GetTypes_Exception")>]
-[<TestCase("EVIL_PROVIDER_ResolveTypeName_Exception")>]
-[<TestCase("EVIL_PROVIDER_GetNamespaces_Exception")>]
-[<TestCase("EVIL_PROVIDER_GetStaticParameters_Exception")>]
-[<TestCase("EVIL_PROVIDER_GetInvokerExpression_Exception")>]
-[<TestCase("EVIL_PROVIDER_GetTypes_Null")>]
-[<TestCase("EVIL_PROVIDER_ResolveTypeName_Null")>]
-[<TestCase("EVIL_PROVIDER_GetNamespaces_Null")>]
-[<TestCase("EVIL_PROVIDER_GetStaticParameters_Null")>]
-[<TestCase("EVIL_PROVIDER_GetInvokerExpression_Null")>]
-[<TestCase("EVIL_PROVIDER_DoesNotHaveConstructor")>]
-[<TestCase("EVIL_PROVIDER_ConstructorThrows")>]
-[<TestCase("EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments")>]
-[<NonParallelizable>]
+[<Theory>]
+[<InlineData("neg1")>]
+[<InlineData("neg2")>]
+[<InlineData("neg2c")>]
+[<InlineData("neg2e")>]
+[<InlineData("neg2g")>]
+[<InlineData("neg2h")>]
+[<InlineData("neg4")>]
+[<InlineData("neg6")>]
+[<InlineData("InvalidInvokerExpression")>]
+[<InlineData("providerAttributeErrorConsume")>]
+[<InlineData("ProviderAttribute_EmptyConsume")>]
+[<InlineData("EVIL_PROVIDER_GetNestedNamespaces_Exception")>]
+[<InlineData("EVIL_PROVIDER_NamespaceName_Exception")>]
+[<InlineData("EVIL_PROVIDER_NamespaceName_Empty")>]
+[<InlineData("EVIL_PROVIDER_GetTypes_Exception")>]
+[<InlineData("EVIL_PROVIDER_ResolveTypeName_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetNamespaces_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetStaticParameters_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetInvokerExpression_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetTypes_Null")>]
+[<InlineData("EVIL_PROVIDER_ResolveTypeName_Null")>]
+[<InlineData("EVIL_PROVIDER_GetNamespaces_Null")>]
+[<InlineData("EVIL_PROVIDER_GetStaticParameters_Null")>]
+[<InlineData("EVIL_PROVIDER_GetInvokerExpression_Null")>]
+[<InlineData("EVIL_PROVIDER_DoesNotHaveConstructor")>]
+[<InlineData("EVIL_PROVIDER_ConstructorThrows")>]
+[<InlineData("EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments")>]
+// [<NonParallelizable>]
 let ``negative type provider tests`` (name:string) =
     let cfg = testConfig "typeProviders/negTests"
     let dir = cfg.Directory
@@ -337,13 +337,13 @@ let splitAssembly subdir project =
 
     clean()
 
-[<Test>]
+[<Fact>]
 let splitAssemblyTools () = splitAssembly "tools" "typeProviders/splitAssemblyTools"
 
-[<Test>]
+[<Fact>]
 let splitAssemblyTypeProviders () = splitAssembly "typeproviders" "typeProviders/splitAssemblyTypeproviders"
 
-[<Test>]
+[<Fact>]
 let wedgeAssembly () =
     let cfg = testConfig "typeProviders/wedgeAssembly"
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -6,12 +6,13 @@ open System
 open System.IO
 open System.Reflection
 open System.Reflection.PortableExecutable
-open NUnit.Framework
+// open Xunit
 open TestFramework
 open Scripting
 open SingleTest
 open HandleExpects
 open FSharp.Test
+open Xunit
 
 #if NETCOREAPP
 // Use these lines if you want to test CoreCLR
@@ -33,12 +34,12 @@ let singleTestBuildAndRunVersion = getTestsDirectory >> singleTestBuildAndRunVer
 let testConfig = getTestsDirectory >> testConfig
 
 
-[<NonParallelizable; SetUICulture("en-US"); SetCulture("en-US")>]
+[<UseCulture("en-US")>]
 module CoreTests =
 
 
 #if !NETCOREAPP
-    [<Test>]
+    [<Fact>]
     let ``subtype-langversion-checknulls`` () =
         let cfg = testConfig "core/subtype"
 
@@ -50,7 +51,7 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``subtype-langversion-no-checknulls`` () =
         let cfg = testConfig "core/subtype"
 
@@ -62,7 +63,7 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``subtype-langversion-46`` () =
         let cfg = testConfig "core/subtype"
 
@@ -75,30 +76,30 @@ module CoreTests =
         testOkFile.CheckExists()
 
     // This test stays in FsharpSuite for a later migration phases, it uses hardcoded #r to a C# compiled cslib.dll inside
-    [<Test>]
+    [<Fact>]
     let ``quotes-FSC-FSC_DEBUG`` () = singleTestBuildAndRun "core/quotes" FSC_DEBUG
 
-    [<Test>]
+    [<Fact>]
     let ``quotes-FSC-BASIC`` () = singleTestBuildAndRun "core/quotes" FSC_OPTIMIZED
 
-    [<Test>]
+    [<Fact>]
     let ``quotes-FSI-BASIC`` () = singleTestBuildAndRun "core/quotes" FSI
 #endif
 
 
-    [<Test>]
+    [<Fact>]
     let ``SDKTests`` () =
         let cfg = testConfig "SDKTests"
         exec cfg cfg.DotNetExe ("msbuild " + Path.Combine(cfg.Directory, "AllSdkTargetsTests.proj") + " /p:Configuration=" + cfg.BUILD_CONFIG)
 
 #if !NETCOREAPP
-    [<Test>]
+    [<Fact>]
     let ``attributes-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/attributes" FSC_OPTIMIZED
 
-    [<Test>]
+    [<Fact>]
     let ``attributes-FSI`` () = singleTestBuildAndRun "core/attributes" FSI
 
-    [<Test>]
+    [<Fact>]
     let span () =
 
         let cfg = testConfig "core/span"
@@ -144,7 +145,7 @@ module CoreTests =
             //testOkFile.CheckExists()
         end
 
-    [<Test>]
+    [<Fact>]
     let asyncStackTraces () =
         let cfg = testConfig "core/asyncStackTraces"
 
@@ -156,7 +157,7 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``state-machines-non-optimized`` () = 
         let cfg = testConfig "core/state-machines"
 
@@ -170,7 +171,7 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``state-machines-optimized`` () = 
         let cfg = testConfig "core/state-machines"
 
@@ -184,18 +185,18 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``state-machines neg-resumable-01`` () =
         let cfg = testConfig "core/state-machines"
         singleVersionedNegTest cfg "preview" "neg-resumable-01"
 
 
-    [<Test>]
+    [<Fact>]
     let ``state-machines neg-resumable-02`` () =
         let cfg = testConfig "core/state-machines"
         singleVersionedNegTest cfg "preview" "neg-resumable-02"
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-conditionals``() =
         let cfg = testConfig "core/large/conditionals"
         use testOkFile = fileguard cfg "test.ok"
@@ -203,7 +204,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-conditionals-maxtested``() =
         let cfg = testConfig "core/large/conditionals"
         use testOkFile = fileguard cfg "test.ok"
@@ -211,7 +212,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-lets``() =
         let cfg = testConfig "core/large/lets"
         use testOkFile = fileguard cfg "test.ok"
@@ -219,7 +220,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-lets-maxtested``() =
         let cfg = testConfig "core/large/lets"
         use testOkFile = fileguard cfg "test.ok"
@@ -227,7 +228,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-lists``() =
         let cfg = testConfig "core/large/lists"
         use testOkFile = fileguard cfg "test.ok"
@@ -235,7 +236,7 @@ module CoreTests =
         exec cfg ("." ++ "test-500.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-matches``() =
         let cfg = testConfig "core/large/matches"
         use testOkFile = fileguard cfg "test.ok"
@@ -243,7 +244,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-matches-maxtested``() =
         let cfg = testConfig "core/large/matches"
         use testOkFile = fileguard cfg "test.ok"
@@ -251,7 +252,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-sequential-and-let``() =
         let cfg = testConfig "core/large/mixed"
         use testOkFile = fileguard cfg "test.ok"
@@ -259,7 +260,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-sequential-and-let-maxtested``() =
         let cfg = testConfig "core/large/mixed"
         use testOkFile = fileguard cfg "test.ok"
@@ -267,7 +268,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-sequential``() =
         let cfg = testConfig "core/large/sequential"
         use testOkFile = fileguard cfg "test.ok"
@@ -275,7 +276,7 @@ module CoreTests =
         exec cfg ("." ++ "test.exe") ""
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``lots-of-sequential-maxtested``() =
         let cfg = testConfig "core/large/sequential"
         use testOkFile = fileguard cfg "test.ok"
@@ -290,11 +291,11 @@ module CoreTests =
 #if !NETCOREAPP
 
     // Requires winforms will not run on coreclr
-    [<Test>]
+    [<Fact>]
     let controlWpf () = singleTestBuildAndRun "core/controlwpf" FSC_OPTIMIZED
 
     // These tests are enabled for .NET Framework
-    [<Test>]
+    [<Fact>]
     let ``anon-FSC_OPTIMIZED``() =
         let cfg = testConfig "core/anon"
 
@@ -322,7 +323,7 @@ module CoreTests =
             testOkFile.CheckExists()
         end
 
-    [<Test>]
+    [<Fact>]
     let events () =
         let cfg = testConfig "core/events"
 
@@ -349,7 +350,7 @@ module CoreTests =
     //
     //module ``FSI-Shadowcopy`` =
     //
-    //    [<Test>]
+    //    [<Fact>]
     //    // "%FSI%" %fsi_flags%                          < test1.fsx
     //    [<FSharpSuiteTestCase("core/fsi-shadowcopy", "")
     //    // "%FSI%" %fsi_flags%  --shadowcopyreferences- < test1.fsx
@@ -370,7 +371,7 @@ module CoreTests =
     //        testOkFile.CheckExists()
     //
     //
-    //    [<Test>]
+    //    [<Fact>]
     //    // "%FSI%" %fsi_flags%  /shadowcopyreferences+  < test2.fsx
     //    [<FSharpSuiteTestCase("core/fsi-shadowcopy", "/shadowcopyreferences+")
     //    // "%FSI%" %fsi_flags%  --shadowcopyreferences  < test2.fsx
@@ -393,7 +394,7 @@ module CoreTests =
     //
 
 
-    [<Test>]
+    [<Fact>]
     let forwarders () =
         let cfg = testConfig "core/forwarders"
 
@@ -426,7 +427,7 @@ module CoreTests =
 
         peverify cfg ("split" ++ "c.dll")
 
-    [<Test>]
+    [<Fact>]
     let xmldoc () =
         let cfg = testConfig "core/xmldoc"
 
@@ -440,9 +441,9 @@ module CoreTests =
         let diffs = fsdiff cfg outFile expectedFile
         match diffs with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" outFile expectedFile diffs)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" outFile expectedFile diffs
 
-    [<Test>]
+    [<Fact>]
     let fsfromcs () =
         let cfg = testConfig "core/fsfromcs"
 
@@ -462,7 +463,7 @@ module CoreTests =
 
         exec cfg ("." ++ "test--optimize.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let fsfromfsviacs () =
         let cfg = testConfig "core/fsfromfsviacs"
 
@@ -504,7 +505,7 @@ module CoreTests =
             let diffs = fsdiff cfg outFile expectedFile
             match diffs with
             | "" -> ()
-            | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" outFile expectedFile diffs)
+            | _ -> Assert.failf "'%s' and '%s' differ; %A" outFile expectedFile diffs
 
         // check error messages for some cases
         let outFile = "compilation.errors.output.txt"
@@ -514,9 +515,9 @@ module CoreTests =
         let diffs = fsdiff cfg outFile expectedFile
         match diffs with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" outFile expectedFile diffs)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" outFile expectedFile diffs
 
-    [<Test>]
+    [<Fact>]
     let ``fsi-reference`` () =
 
         let cfg = testConfig "core/fsi-reference"
@@ -529,7 +530,7 @@ module CoreTests =
             testOkFile.CheckExists()
         end
 
-    [<Test>]
+    [<Fact>]
     let ``fsi-reload`` () =
         let cfg = testConfig "core/fsi-reload"
 
@@ -555,7 +556,7 @@ module CoreTests =
         fsc cfg "" ["load2.fsx"]
 
 
-    [<Test>]
+    [<Fact>]
     let fsiAndModifiers () =
         let cfg = testConfig "core/fsiAndModifiers"
 
@@ -569,11 +570,11 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``genericmeasures-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/genericmeasures" FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
 
 
-    [<Test>]
+    [<Fact>]
     let hiding () =
         let cfg = testConfig "core/hiding"
 
@@ -589,10 +590,10 @@ module CoreTests =
 
         peverify cfg "client.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``innerpoly-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/innerpoly"  FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
 
-    [<Test>]
+    [<Fact>]
     let queriesCustomQueryOps () =
         let cfg = testConfig "core/queriesCustomQueryOps"
 
@@ -675,52 +676,52 @@ module CoreTests =
 
         match fsdiff cfg diffFileOut expectedFileOut with
         | "" -> ()
-        | diffs -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" diffFileOut expectedFileOut diffs)
+        | diffs -> Assert.failf "'%s' and '%s' differ; %A" diffFileOut expectedFileOut diffs
 
         match fsdiff cfg diffFileErr expectedFileErr with
         | "" -> ()
-        | diffs -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" diffFileErr expectedFileErr diffs)
+        | diffs -> Assert.failf "'%s' and '%s' differ; %A" diffFileErr expectedFileErr diffs
 
-    [<Test>]
+    [<Fact>]
     let ``printing`` () =
          runPrintingTest "--multiemit- --debug+" "output"
 
     // F# 5.0 changed some things printing output
-    [<Test>]
+    [<Fact>]
     let ``printing-langversion47`` () =
          runPrintingTest "--langversion:4.7" "output.47"
 
     // Output should not change with optimization off
-    [<Test>]
+    [<Fact>]
     let ``printing-optimizeoff`` () =
          runPrintingTest "--multiemit- --debug+ --optimize-" "output"
 
     // Legacy one-dynamic-assembly emit is the default for .NET Framework, which these tests are using
     // Turning that off enables multi-assembly-emit.  The printing test is useful for testing multi-assembly-emit
     // as it feeds in many incremental fragments into stdin of the FSI process.
-    [<Test>]
+    [<Fact>]
     let ``printing-multiemit`` () =
          runPrintingTest "--multiemit+ --debug+" "output.multiemit"
 
     // Multi-assembly-emit establishes some slightly different rules regarding internals, and this
     // needs to be tested with optimizations off.  The output should not change.
-    [<Test>]
+    [<Fact>]
     let ``printing-multiemit-optimizeoff`` () =
          runPrintingTest "--multiemit+ --debug+ --optimize-" "output.multiemit"
 
-    [<Test>]
+    [<Fact>]
     let ``printing-width-1000`` () =
          runPrintingTest "--use:preludePrintSize1000.fsx" "output.1000"
 
-    [<Test>]
+    [<Fact>]
     let ``printing-width-200`` () =  
          runPrintingTest "--use:preludePrintSize200.fsx" "output.200"
 
-    [<Test>]
+    [<Fact>]
     let ``printing-off`` () =
          runPrintingTest "--use:preludeShowDeclarationValuesFalse.fsx" "output.off"
 
-    [<Test>]
+    [<Fact>]
     let ``printing-quiet`` () =
          runPrintingTest "--quiet" "output.quiet"
 
@@ -757,70 +758,70 @@ module CoreTests =
             // We think the assembly is signed let's run sn -vr to verify the hashes
             sn cfg " %s    -q -vf" "" assemblyPath
 
-        Assert.AreEqual(expectedSigning, actualSigning)
+        Assert.Equal(expectedSigning, actualSigning)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-1`` () = signedtest("test-unsigned", "", SigningType.NotSigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-2`` () = signedtest("test-sha1-full-cl", "--keyfile:sha1full.snk", SigningType.PublicSigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-3`` () = signedtest("test-sha256-full-cl", "--keyfile:sha256full.snk", SigningType.PublicSigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-4`` () = signedtest("test-sha512-full-cl", "--keyfile:sha512full.snk", SigningType.PublicSigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-5`` () = signedtest("test-sha1024-full-cl", "--keyfile:sha1024full.snk", SigningType.PublicSigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-6`` () = signedtest("test-sha1-delay-cl", "--keyfile:sha1delay.snk --delaysign", SigningType.DelaySigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-7`` () = signedtest("test-sha256-delay-cl", "--keyfile:sha256delay.snk --delaysign", SigningType.DelaySigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-8`` () = signedtest("test-sha512-delay-cl", "--keyfile:sha512delay.snk --delaysign", SigningType.DelaySigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-9`` () = signedtest("test-sha1024-delay-cl", "--keyfile:sha1024delay.snk --delaysign", SigningType.DelaySigned)
 
     // Test SHA1 key full signed  Attributes
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-10`` () = signedtest("test-sha1-full-attributes", "--define:SHA1", SigningType.PublicSigned)
 
     // Test SHA1 key delay signed  Attributes
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-11`` () = signedtest("test-sha1-delay-attributes", "--keyfile:sha1delay.snk --define:SHA1 --define:DELAY", SigningType.DelaySigned)
 
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-12`` () = signedtest("test-sha256-full-attributes", "--define:SHA256", SigningType.PublicSigned)
 
     // Test SHA 256 bit key delay signed  Attributes
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-13`` () = signedtest("test-sha256-delay-attributes", "--define:SHA256 --define:DELAY", SigningType.DelaySigned)
 
     // Test SHA 512 bit key fully signed  Attributes
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-14`` () = signedtest("test-sha512-full-attributes", "--define:SHA512", SigningType.PublicSigned)
 
     // Test SHA 512 bit key delay signed Attributes
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-15`` () = signedtest("test-sha512-delay-attributes", "--define:SHA512 --define:DELAY", SigningType.DelaySigned)
 
     // Test SHA 1024 bit key fully signed  Attributes
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-16`` () = signedtest("test-sha1024-full-attributes", "--define:SHA1024", SigningType.PublicSigned)
 
     // Test fully signed with pdb generation
-    [<Test; Category("signedtest")>]
+    [<Fact; Trait("Category","signedtest")>]
     let ``signedtest-17`` () = signedtest("test-sha1-full-cl", "-g --keyfile:sha1full.snk", SigningType.PublicSigned)
 
 #endif
 
 #if !NETCOREAPP
-    [<Test>]
+    [<Fact>]
     let quotes () =
         let cfg = testConfig "core/quotes"
 
@@ -865,7 +866,7 @@ module CoreTests =
             testOkFile.CheckExists()
         end
 
-    [<Test; Category("parsing")>]
+    [<Fact; Trait("Category", "parsing")>]
     let parsing () =
         let cfg = testConfig "core/parsing"
 
@@ -875,7 +876,7 @@ module CoreTests =
 
         peverify cfg "toplet.exe"
 
-    [<Test>]
+    [<Fact>]
     let unicode () =
         let cfg = testConfig "core/unicode"
 
@@ -900,7 +901,7 @@ module CoreTests =
         fsi cfg "%s --utf8output" cfg.fsi_flags ["kanji-unicode-utf16.fs"]
 
 
-    [<Test>]
+    [<Fact>]
     let internalsvisible () =
         let cfg = testConfig "core/internalsvisible"
 
@@ -924,7 +925,7 @@ module CoreTests =
 
 
     // Repro for https://github.com/dotnet/fsharp/issues/1298
-    [<Test>]
+    [<Fact>]
     let fileorder () =
         let cfg = testConfig "core/fileorder"
 
@@ -951,7 +952,7 @@ module CoreTests =
         exec cfg ("." ++ "test2.exe") ""
 
     // Repro for https://github.com/dotnet/fsharp/issues/2679
-    [<Test>]
+    [<Fact>]
     let ``add files with same name from different folders`` () =
         let cfg = testConfig "core/samename"
 
@@ -962,7 +963,7 @@ module CoreTests =
 
         exec cfg ("." ++ "test.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``add files with same name from different folders including signature files`` () =
         let cfg = testConfig "core/samename"
 
@@ -973,7 +974,7 @@ module CoreTests =
 
         exec cfg ("." ++ "test.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``add files with same name from different folders including signature files that are not synced`` () =
         let cfg = testConfig "core/samename"
 
@@ -984,16 +985,16 @@ module CoreTests =
 
         exec cfg ("." ++ "test.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``libtest-FSI_NETFX_STDIN`` () = singleTestBuildAndRun "core/libtest" FSI_NETFX_STDIN
 
-    [<Test>]
+    [<Fact>]
     let ``libtest-unoptimized codegen`` () = singleTestBuildAndRun "core/libtest" FSC_DEBUG
 
-    [<Test>]
+    [<Fact>]
     let ``libtest-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/libtest" FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
 
-    [<Test>]
+    [<Fact>]
     let ``libtest-langversion-checknulls`` () =
         let cfg = testConfig "core/libtest"
 
@@ -1006,7 +1007,7 @@ module CoreTests =
         testOkFile.CheckExists()
 
  
-    [<Test>]
+    [<Fact>]
     let ``libtest-langversion-46`` () =
         let cfg = testConfig "core/libtest"
 
@@ -1018,7 +1019,7 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let ``no-warn-2003-tests`` () =
         // see https://github.com/dotnet/fsharp/issues/3139
         let cfg = testConfig "core/versionAttributes"
@@ -1070,15 +1071,15 @@ module CoreTests =
 
         match diffs with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs
 
         let diffs2 = fsdiff cfg stderrPath stderrBaseline
 
         match diffs2 with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
 
-    [<Test>]
+    [<Fact>]
     let ``load-script`` () =
         let cfg = testConfig "core/load-script"
 
@@ -1199,25 +1200,25 @@ module CoreTests =
 
         match diffs with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs
 
         let diffs2 = fsdiff cfg stderrPath stderrBaseline
 
         match diffs2 with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
 #endif
 
 
 
 #if !NETCOREAPP
-    [<Test>]
+    [<Fact>]
     let ``measures-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/measures" FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
 
-    [<Test>]
+    [<Fact>]
     let ``members-basics-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/members/basics" FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
 
-    [<Test>]
+    [<Fact>]
     let queriesLeafExpressionConvert () =
         let cfg = testConfig "core/queriesLeafExpressionConvert"
 
@@ -1248,7 +1249,7 @@ module CoreTests =
         testOkFile3.CheckExists()
 
 
-    [<Test>]
+    [<Fact>]
     let queriesNullableOperators () =
         let cfg = testConfig "core/queriesNullableOperators"
 
@@ -1272,7 +1273,7 @@ module CoreTests =
         exec cfg ("." ++ "test--optimize.exe") ""
         testOkFile3.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let queriesOverIEnumerable () =
         let cfg = testConfig "core/queriesOverIEnumerable"
 
@@ -1302,7 +1303,7 @@ module CoreTests =
 
         testOkFile3.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let queriesOverIQueryable () =
         let cfg = testConfig "core/queriesOverIQueryable"
 
@@ -1333,7 +1334,7 @@ module CoreTests =
         testOkFile3.CheckExists()
 
 
-    [<Test>]
+    [<Fact>]
     let quotesDebugInfo () =
         let cfg = testConfig "core/quotesDebugInfo"
 
@@ -1364,7 +1365,7 @@ module CoreTests =
         testOkFile3.CheckExists()
 
 
-    [<Test>]
+    [<Fact>]
     let quotesInMultipleModules () =
         let cfg = testConfig "core/quotesInMultipleModules"
 
@@ -1417,7 +1418,7 @@ module CoreTests =
 
 
 #if !NETCOREAPP
-    [<Test>]
+    [<Fact>]
     let refnormalization () =
         let cfg = testConfig "core/refnormalization"
 
@@ -1453,7 +1454,7 @@ module CoreTests =
         TestOk.CheckExists()
 
 
-    [<Test>]
+    [<Fact>]
     let testResources () =
         let cfg = testConfig "core/resources"
 
@@ -1481,7 +1482,7 @@ module CoreTests =
 
         exec cfg ("." ++ "test-embed-named.exe") "ResourceName"
 
-    [<Test>]
+    [<Fact>]
     let topinit () =
         let cfg = testConfig "core/topinit"
 
@@ -1609,7 +1610,7 @@ module CoreTests =
 
         exec cfg ("." ++ "test_static_init_exe--optimize.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let unitsOfMeasure () =
         let cfg = testConfig "core/unitsOfMeasure"
 
@@ -1623,7 +1624,7 @@ module CoreTests =
 
         testOkFile.CheckExists()
 
-    [<Test>]
+    [<Fact>]
     let verify () =
         let cfg = testConfig "core/verify"
 
@@ -1640,7 +1641,7 @@ module CoreTests =
         peverifyWithArgs cfg "/nologo" "xmlverify.exe"
         
         
-    [<Test>]
+    [<Fact>]
     let ``property setter in method or constructor`` () =
         let cfg = testConfig "core/members/set-only-property"
         csc cfg @"%s /target:library /out:cs.dll" cfg.csc_flags ["cs.cs"]
@@ -1650,35 +1651,34 @@ module CoreTests =
 
 #endif
 
-[<NonParallelizable>]
 module VersionTests =
-    [<Test>]
+    [<Fact>]
     let ``member-selfidentifier-version4_6``() = singleTestBuildAndRunVersion "core/members/self-identifier/version46" (FSC_BUILDONLY true) "4.6"
 
-    [<Test>]
+    [<Fact>]
     let ``member-selfidentifier-version4_7``() = singleTestBuildAndRunVersion "core/members/self-identifier/version47" (FSC_BUILDONLY true) "4.7"
 
-    [<Test>]
+    [<Fact>]
     let ``indent-version4_7``() = singleTestBuildAndRunVersion "core/indent/version47" (FSC_BUILDONLY true) "4.7"
 
-    [<Test>]
+    [<Fact>]
     let ``nameof-version4_6``() = singleTestBuildAndRunVersion "core/nameof/version46" (FSC_BUILDONLY true) "4.6"
 
-    [<Test>]
+    [<Fact>]
     let ``nameof-versionpreview``() = singleTestBuildAndRunVersion "core/nameof/preview" (FSC_BUILDONLY true) "preview"
 
-    [<Test>]
+    [<Fact>]
     let ``nameof-execute``() = singleTestBuildAndRunVersion "core/nameof/preview" FSC_OPTIMIZED "preview"
 
-    [<Test>]
+    [<Fact>]
     let ``nameof-fsi``() = singleTestBuildAndRunVersion "core/nameof/preview" FSI "preview"
 
 #if !NETCOREAPP
-[<NonParallelizable; SetUICulture("en-US"); SetCulture("en-US")>]
+[<UseCulture("en-US")>]
 module ToolsTests =
 
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/dotnet/fsharp/issues/2600
-    [<Test>]
+    [<Fact>]
     let bundle () =
         let cfg = 
             testConfig "tools/bundle" 
@@ -1700,106 +1700,105 @@ module ToolsTests =
         peverify cfg "test_two_fsharp_modules_module_2_as_dll.dll"
 #endif
 
-    [<Test>]
+    [<Fact>]
     let ``eval-FSC_OPTIMIZED`` () = singleTestBuildAndRun "tools/eval" FSC_OPTIMIZED
-    [<Test>]
+    [<Fact>]
     let ``eval-FSI`` () = singleTestBuildAndRun "tools/eval" FSI
 
-[<NonParallelizable>]
 module RegressionTests =
 
-    [<Test>]
+    [<Fact>]
     let ``literal-value-bug-2-FSC_OPTIMIZED`` () = singleTestBuildAndRun "regression/literal-value-bug-2" FSC_OPTIMIZED
 
-    [<Test>]
+    [<Fact>]
     let ``literal-value-bug-2-FSI`` () = singleTestBuildAndRun "regression/literal-value-bug-2" FSI
 
-    [<Test>]
+    [<Fact>]
     let ``OverloadResolution-bug-FSC_OPTIMIZED`` () = singleTestBuildAndRun "regression/OverloadResolution-bug" FSC_OPTIMIZED
 
-    [<Test>]
+    [<Fact>]
     let ``OverloadResolution-bug-FSI`` () = singleTestBuildAndRun "regression/OverloadResolution-bug" FSI
 
-    [<Test>]
+    [<Fact>]
     let ``struct-tuple-bug-1-FSC_OPTIMIZED`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSC_OPTIMIZED
 
-    [<Test >]
+    [<Fact>]
     let ``tuple-bug-1-FSC_OPTIMIZED`` () = singleTestBuildAndRunVersion "regression/tuple-bug-1" FSC_OPTIMIZED "supports-ml"
 
-    [<Test >]
+    [<Fact>]
     let ``12383-FSC_OPTIMIZED`` () = singleTestBuildAndRun "regression/12383" FSC_OPTIMIZED
 
-    [<Test>]
+    [<Fact>]
     let ``13219-bug-FSI`` () = singleTestBuildAndRun "regression/13219" FSI
 
-    [<Test >]
+    [<Fact>]
     let ``4715-optimized`` () =
         let cfg = testConfig "regression/4715"
         fsc cfg "%s -o:test.exe --optimize+" cfg.fsc_flags ["date.fs"; "env.fs"; "main.fs"]
 
-    [<Test>]
+    [<Fact>]
     let ``multi-package-type-provider-test-FSI`` () = singleTestBuildAndRun "regression/13710" FSI
 
 #if NETCOREAPP
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fsc.dll 64-bit fsc.dll .NET SDK generating optimized code`` () =
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:portable --define:PORTABLE_PDB" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY true)
 
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fsc.dll 64-bit .NET SDK generating debug code`` () =
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:portable --define:PORTABLE_PDB" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY false)
 
 #else
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fsc.exe 32-bit .NET Framework generating optimized code, portable PDB`` () =
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:portable --define:PORTABLE_PDB" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY true)
 
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fsc.exe 32-bit .NET Framework generating optimized code, full PDB`` () =
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:full" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY true)
 
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fsc.exe 32-bit .NET Framework generating debug code portable PDB`` () =
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:portable --define:PORTABLE_PDB" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY false)
 
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fsc.exe 32-bit .NET Framework generating debug code, full PDB`` () =
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:full" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY false)
 
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fscAnyCpu.exe 64-bit .NET Framework generating optimized code, portable PDB`` () = 
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with FSC = cfg.FSCANYCPU }
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:portable --define:PORTABLE_PDB" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY true)
 
-    [<Test >]
+    [<Fact>]
     let ``Large inputs 12322 fscAnyCpu.exe 64-bit .NET Framework generating optimized code, full PDB`` () = 
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with FSC = cfg.FSCANYCPU }
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:full " }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY true)
 
-    [<Test >]
+    [<Fact>]
     let ``12322 fscAnyCpu.exe 64-bit .NET Framework generating debug code, portable PDB`` () = 
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with FSC = cfg.FSCANYCPU }
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --debug:portable --define:PORTABLE_PDB" }
         singleTestBuildAndRunAux cfg (FSC_BUILDONLY false)
 
-    [<Test >]
+    [<Fact>]
     let ``12322 fscAnyCpu.exe 64-bit .NET Framework generating debug code, full PDB`` () = 
         let cfg = testConfig "regression/12322"
         let cfg = { cfg with FSC = cfg.FSCANYCPU }
@@ -1809,7 +1808,7 @@ module RegressionTests =
 
 #if !NETCOREAPP
 
-    [<Test>]
+    [<Fact>]
     let ``SRTP doesn't handle calling member hiding inherited members`` () =
         let cfg = 
             testConfig "regression/5531"
@@ -1825,7 +1824,7 @@ module RegressionTests =
         match diff with
         | "" -> ()
         | _ ->
-            Assert.Fail (sprintf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff)
+            Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
         let outFile2 = "output.test.txt"
         let expectedFile2 = "output.test.bsl"
@@ -1836,18 +1835,18 @@ module RegressionTests =
         match diff2 with
         | "" -> ()
         | _ ->
-            Assert.Fail (sprintf "'%s' and '%s' differ; %A" (getfullpath cfg outFile2) (getfullpath cfg expectedFile2) diff2)
+            Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile2) (getfullpath cfg expectedFile2) diff2
 #endif
 
-    [<Test>]
+    [<Fact>]
     let ``26`` () = singleTestBuildAndRunVersion "regression/26" FSC_OPTIMIZED "supports-ml"
 
-    [<Test >]
+    [<Fact>]
     let ``321`` () = singleTestBuildAndRunVersion "regression/321" FSC_OPTIMIZED "supports-ml"
 
 #if !NETCOREAPP
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/dotnet/fsharp/issues/2600
-    [<Test>]
+    [<Fact>]
     let ``655`` () =
         let cfg = testConfig "regression/655"
 
@@ -1866,7 +1865,7 @@ module RegressionTests =
         testOkFile.CheckExists()
 
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/dotnet/fsharp/issues/2600
-    [<Test >]
+    [<Fact>]
     let ``656`` () =
         let cfg = testConfig "regression/656"
 
@@ -1877,13 +1876,13 @@ module RegressionTests =
 
 #if !NETCOREAPP
     // Requires WinForms
-    [<Test>]
+    [<Fact>]
     let ``83`` () = singleTestBuildAndRunVersion "regression/83" FSC_OPTIMIZED "supports-ml"
 
-    [<Test >]
+    [<Fact>]
     let ``84`` () = singleTestBuildAndRunVersion "regression/84" FSC_OPTIMIZED "supports-ml"
 
-    [<Test >]
+    [<Fact>]
     let ``85`` () =
         let cfg = testConfig "regression/85"
 
@@ -1892,15 +1891,15 @@ module RegressionTests =
         peverify cfg "petshop.dll"
 #endif
 
-    [<Test >]
+    [<Fact>]
     let ``86`` () = singleTestBuildAndRunVersion "regression/86" FSC_OPTIMIZED "supports-ml"
 
-    [<Test >]
+    [<Fact>]
     let ``struct-tuple-bug-1-FSI`` () = singleTestBuildAndRun "regression/struct-tuple-bug-1" FSI
 
 #if !NETCOREAPP
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/dotnet/fsharp/issues/2600
-    [<Test>]
+    [<Fact>]
     let ``struct-measure-bug-1`` () =
         let cfg = testConfig "regression/struct-measure-bug-1"
 
@@ -1908,10 +1907,9 @@ module RegressionTests =
 
         peverify cfg "test.exe"
 
-[<NonParallelizable>]
 module OptimizationTests =
 
-    [<Test>]
+    [<Fact>]
     let functionSizes () =
         let cfg = testConfig "optimize/analyses"
 
@@ -1926,10 +1924,10 @@ module OptimizationTests =
         match diff with
         | "" -> ()
         | _ ->
-            Assert.Fail (sprintf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff)
+            Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
-    [<Test>]
+    [<Fact>]
     let totalSizes () =
         let cfg = testConfig "optimize/analyses"
 
@@ -1943,10 +1941,10 @@ module OptimizationTests =
 
         match diff with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
-    [<Test>]
+    [<Fact>]
     let hasEffect () =
         let cfg = testConfig "optimize/analyses"
 
@@ -1960,10 +1958,10 @@ module OptimizationTests =
 
         match diff with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
-    [<Test>]
+    [<Fact>]
     let noNeedToTailcall () =
         let cfg = testConfig "optimize/analyses"
 
@@ -1977,10 +1975,10 @@ module OptimizationTests =
 
         match diff with
         | "" -> ()
-        | _ -> Assert.Fail (sprintf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff)
+        | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
-    [<Test>]
+    [<Fact>]
     let ``inline`` () =
         let cfg = testConfig "optimize/inline"
 
@@ -2010,7 +2008,7 @@ module OptimizationTests =
         match ``test--optimize.il`` with
             | [] -> ()
             | lines ->
-                Assert.Fail (sprintf "Error: optimizations not removed.  Relevant lines from IL file follow: %A" lines)
+                Assert.failf "Error: optimizations not removed.  Relevant lines from IL file follow: %A" lines
 
         let numElim =
             File.ReadLines (getfullpath cfg "test.il")
@@ -2019,7 +2017,7 @@ module OptimizationTests =
 
         log "Ran ok - optimizations removed %d textual occurrences of optimizable identifiers from target IL" numElim
 
-    [<Test>]
+    [<Fact>]
     let stats () =
         let cfg = testConfig "optimize/stats"
 
@@ -2042,88 +2040,87 @@ module OptimizationTests =
         log "%s" m
 #endif
 
-[<NonParallelizable>]
 module TypecheckTests =
-    [<Test>]
+    [<Fact>]
     let ``full-rank-arrays`` () =
         let cfg = testConfig "typecheck/full-rank-arrays"
         SingleTest.singleTestBuildAndRunWithCopyDlls cfg "full-rank-arrays.dll" FSC_OPTIMIZED
 
 #if !NETCOREAPP
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos26`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos26.exe" cfg.fsc_flags ["pos26.fsi"; "pos26.fs"]
         peverify cfg "pos26.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos25`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos25.exe" cfg.fsc_flags ["pos25.fs"]
         peverify cfg "pos25.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos27`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos27.exe" cfg.fsc_flags ["pos27.fs"]
         peverify cfg "pos27.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos28`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos28.exe" cfg.fsc_flags ["pos28.fs"]
         peverify cfg "pos28.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos29`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos29.exe" cfg.fsc_flags ["pos29.fsi"; "pos29.fs"; "pos29.app.fs"]
         peverify cfg "pos29.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos30`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos30.exe --warnaserror+" cfg.fsc_flags ["pos30.fs"]
         peverify cfg "pos30.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos24`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos24.exe" cfg.fsc_flags ["pos24.fs"]
         peverify cfg "pos24.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos31`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos31.exe --warnaserror" cfg.fsc_flags ["pos31.fsi"; "pos31.fs"]
         peverify cfg "pos31.exe"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos32`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos32.dll --warnaserror" cfg.fsc_flags ["pos32.fs"]
         peverify cfg "pos32.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos33`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos33.dll --warnaserror" cfg.fsc_flags ["pos33.fsi"; "pos33.fs"]
         peverify cfg "pos33.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos34`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos34.dll --warnaserror" cfg.fsc_flags ["pos34.fs"]
         peverify cfg "pos34.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos35`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos35.dll --warnaserror" cfg.fsc_flags ["pos35.fs"]
         peverify cfg "pos35.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos36-srtp`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos36-srtp-lib.dll --warnaserror" cfg.fsc_flags ["pos36-srtp-lib.fs"]
@@ -2132,39 +2129,39 @@ module TypecheckTests =
         peverify cfg "pos36-srtp-app.exe"
         exec cfg ("." ++ "pos36-srtp-app.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos37`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos37.dll --warnaserror" cfg.fsc_flags ["pos37.fs"]
         peverify cfg "pos37.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos38`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos38.dll --warnaserror" cfg.fsc_flags ["pos38.fs"]
         peverify cfg "pos38.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos39`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos39.exe" cfg.fsc_flags ["pos39.fs"]
         peverify cfg "pos39.exe"
         exec cfg ("." ++ "pos39.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos40`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --langversion:6.0 --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
         peverify cfg "pos40.exe"
         exec cfg ("." ++ "pos40.exe") ""
         
-    [<Test>]
+    [<Fact>]
     let ``sigs pos41`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:library -o:pos41.dll --warnaserror" cfg.fsc_flags ["pos41.fs"]
         peverify cfg "pos41.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos1281`` () =
         let cfg = testConfig "typecheck/sigs"
         // This checks that warning 25 "incomplete matches" is not triggered
@@ -2172,117 +2169,117 @@ module TypecheckTests =
         peverify cfg "pos1281.exe"
         exec cfg ("." ++ "pos1281.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos3294`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos3294.exe --warnaserror" cfg.fsc_flags ["pos3294.fs"]
         peverify cfg "pos3294.exe"
         exec cfg ("." ++ "pos3294.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos23`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos23.exe" cfg.fsc_flags ["pos23.fs"]
         peverify cfg "pos23.exe"
         exec cfg ("." ++ "pos23.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos20`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos20.exe" cfg.fsc_flags ["pos20.fs"]
         peverify cfg "pos20.exe"
         exec cfg ("." ++ "pos20.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos19`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos19.exe" cfg.fsc_flags ["pos19.fs"]
         peverify cfg "pos19.exe"
         exec cfg ("." ++ "pos19.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos18`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos18.exe" cfg.fsc_flags ["pos18.fs"]
         peverify cfg "pos18.exe"
         exec cfg ("." ++ "pos18.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos16`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos16.exe" cfg.fsc_flags ["pos16.fs"]
         peverify cfg "pos16.exe"
         exec cfg ("." ++ "pos16.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos17`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos17.exe" cfg.fsc_flags ["pos17.fs"]
         peverify cfg "pos17.exe"
         exec cfg ("." ++ "pos17.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos15`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos15.exe" cfg.fsc_flags ["pos15.fs"]
         peverify cfg "pos15.exe"
         exec cfg ("." ++ "pos15.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos14`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos14.exe" cfg.fsc_flags ["pos14.fs"]
         peverify cfg "pos14.exe"
         exec cfg ("." ++ "pos14.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos13`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s --target:exe -o:pos13.exe" cfg.fsc_flags ["pos13.fs"]
         peverify cfg "pos13.exe"
         exec cfg ("." ++ "pos13.exe") ""
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos12 `` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos12.dll" cfg.fsc_flags ["pos12.fs"]
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos11`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos11.dll" cfg.fsc_flags ["pos11.fs"]
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos10`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos10.dll" cfg.fsc_flags ["pos10.fs"]
         peverify cfg "pos10.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos09`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos09.dll" cfg.fsc_flags ["pos09.fs"]
         peverify cfg "pos09.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos07`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos07.dll" cfg.fsc_flags ["pos07.fs"]
         peverify cfg "pos07.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos08`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos08.dll" cfg.fsc_flags ["pos08.fs"]
         peverify cfg "pos08.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos06`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos06.dll" cfg.fsc_flags ["pos06.fs"]
         peverify cfg "pos06.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos03`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos03.dll" cfg.fsc_flags ["pos03.fs"]
@@ -2290,115 +2287,114 @@ module TypecheckTests =
         fsc cfg "%s -a -o:pos03a.dll" cfg.fsc_flags ["pos03a.fsi"; "pos03a.fs"]
         peverify cfg "pos03a.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos01a`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a --langversion:5.0 --mlcompatibility -o:pos01a.dll" cfg.fsc_flags ["pos01a.fsi"; "pos01a.fs"]
         peverify cfg "pos01a.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos02`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos02.dll" cfg.fsc_flags ["pos02.fs"]
         peverify cfg "pos02.dll"
 
-    [<Test>]
+    [<Fact>]
     let ``sigs pos05`` () =
         let cfg = testConfig "typecheck/sigs"
         fsc cfg "%s -a -o:pos05.dll" cfg.fsc_flags ["pos05.fs"]
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg01`` () = singleNegTest (testConfig "typecheck/sigs") "neg01"  
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg03`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "supports-ml*" "neg03"   
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg08`` () = singleNegTest (testConfig "typecheck/sigs") "neg08"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg09`` () = singleNegTest (testConfig "typecheck/sigs") "neg09"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg10`` () = singleNegTest (testConfig "typecheck/sigs") "neg10"   
   
-    [<Test>]
+    [<Fact>]
     let ``type check neg14`` () = singleNegTest (testConfig "typecheck/sigs") "neg14"  
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg17`` () = singleNegTest (testConfig "typecheck/sigs") "neg17"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg24 version 4_6`` () =
         let cfg = testConfig "typecheck/sigs/version46"
         // For some reason this warning is off by default in the test framework but in this case we are testing for it
         let cfg = { cfg with fsc_flags = cfg.fsc_flags.Replace("--nowarn:20", "") }
         singleVersionedNegTest cfg "4.6" "neg24"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg24 version 4_7`` () =
         let cfg = testConfig "typecheck/sigs/version47"
         // For some reason this warning is off by default in the test framework but in this case we are testing for it
         let cfg = { cfg with fsc_flags = cfg.fsc_flags.Replace("--nowarn:20", "") }
         singleVersionedNegTest cfg "4.7" "neg24"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg24 version preview`` () =
         let cfg = testConfig "typecheck/sigs"
         // For some reason this warning is off by default in the test framework but in this case we are testing for it
         let cfg = { cfg with fsc_flags = cfg.fsc_flags.Replace("--nowarn:20", "") }
         singleVersionedNegTest cfg "preview" "neg24"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg27`` () = singleNegTest (testConfig "typecheck/sigs") "neg27"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg31`` () = singleNegTest (testConfig "typecheck/sigs") "neg31"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg33`` () = singleNegTest (testConfig "typecheck/sigs") "neg33"  
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg43`` () = singleNegTest (testConfig "typecheck/sigs") "neg43"   
 
 #if !DEBUG // requires release version of compiler to avoid very deep stacks
-    [<Test>]
+    [<Fact>]
     let ``type check neg45`` () = singleNegTest (testConfig "typecheck/sigs") "neg45"
 #endif
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg49`` () = singleNegTest (testConfig "typecheck/sigs") "neg49"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg56_a`` () = singleNegTest (testConfig "typecheck/sigs") "neg56_a"   
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg94`` () = singleNegTest (testConfig "typecheck/sigs") "neg94" 
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg100`` () =
         let cfg = testConfig "typecheck/sigs"
         let cfg = { cfg with fsc_flags = cfg.fsc_flags + " --warnon:3218" }
         singleNegTest cfg "neg100"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg107`` () = singleNegTest (testConfig "typecheck/sigs") "neg107"
  
-    [<Test>]
+    [<Fact>]
     let ``type check neg116`` () = singleNegTest (testConfig "typecheck/sigs") "neg116"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg117`` () = singleNegTest (testConfig "typecheck/sigs") "neg117"        
     
-    [<Test>]
+    [<Fact>]
     let ``type check neg134`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "preview" "neg134"
 
-    [<Test>]
+    [<Fact>]
     let ``type check neg135`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "preview" "neg135"  
 
-[<NonParallelizable>]
 module FscTests =
-    [<Test>]
+    [<Fact>]
     let ``should be raised if AssemblyInformationalVersion has invalid version`` () =
         let cfg = testConfig (Commands.createTempDir())
 
@@ -2423,7 +2419,7 @@ open System.Reflection
         |> Assert.areEqual (45, 2048, 0, 2)
 
 
-    [<Test>]
+    [<Fact>]
     let ``should set file version info on generated file`` () =
         let cfg = testConfig (Commands.createTempDir())
 
@@ -2466,7 +2462,6 @@ open System.Runtime.InteropServices
 #endif
 
 #if !NETCOREAPP
-[<NonParallelizable>]
 module ProductVersionTest =
 
     let informationalVersionAttrName = typeof<System.Reflection.AssemblyInformationalVersionAttribute>.FullName
@@ -2481,7 +2476,7 @@ module ProductVersionTest =
           defAssemblyVersionString, None, (Some "22.44.66.88" ), "22.44.66.88" ]
         |> List.map (fun (a,f,i,e) -> (a, f, i, e))
 
-    [<Test>]
+    [<Fact>]
     let ``should use correct fallback``() =
 
        for (assemblyVersion, fileVersion, infoVersion, expected) in fallbackTestData () do

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -6,7 +6,6 @@ open System
 open System.IO
 open System.Reflection
 open System.Reflection.PortableExecutable
-// open Xunit
 open TestFramework
 open Scripting
 open SingleTest

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -33,7 +33,6 @@ let singleTestBuildAndRunVersion = getTestsDirectory >> singleTestBuildAndRunVer
 let testConfig = getTestsDirectory >> testConfig
 
 
-[<UseCulture("en-US")>]
 module CoreTests =
 
 
@@ -1673,7 +1672,6 @@ module VersionTests =
     let ``nameof-fsi``() = singleTestBuildAndRunVersion "core/nameof/preview" FSI "preview"
 
 #if !NETCOREAPP
-[<UseCulture("en-US")>]
 module ToolsTests =
 
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/dotnet/fsharp/issues/2600

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -760,62 +760,62 @@ module CoreTests =
 
         Assert.Equal(expectedSigning, actualSigning)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-1`` () = signedtest("test-unsigned", "", SigningType.NotSigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-2`` () = signedtest("test-sha1-full-cl", "--keyfile:sha1full.snk", SigningType.PublicSigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-3`` () = signedtest("test-sha256-full-cl", "--keyfile:sha256full.snk", SigningType.PublicSigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-4`` () = signedtest("test-sha512-full-cl", "--keyfile:sha512full.snk", SigningType.PublicSigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-5`` () = signedtest("test-sha1024-full-cl", "--keyfile:sha1024full.snk", SigningType.PublicSigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-6`` () = signedtest("test-sha1-delay-cl", "--keyfile:sha1delay.snk --delaysign", SigningType.DelaySigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-7`` () = signedtest("test-sha256-delay-cl", "--keyfile:sha256delay.snk --delaysign", SigningType.DelaySigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-8`` () = signedtest("test-sha512-delay-cl", "--keyfile:sha512delay.snk --delaysign", SigningType.DelaySigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-9`` () = signedtest("test-sha1024-delay-cl", "--keyfile:sha1024delay.snk --delaysign", SigningType.DelaySigned)
 
     // Test SHA1 key full signed  Attributes
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-10`` () = signedtest("test-sha1-full-attributes", "--define:SHA1", SigningType.PublicSigned)
 
     // Test SHA1 key delay signed  Attributes
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-11`` () = signedtest("test-sha1-delay-attributes", "--keyfile:sha1delay.snk --define:SHA1 --define:DELAY", SigningType.DelaySigned)
 
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-12`` () = signedtest("test-sha256-full-attributes", "--define:SHA256", SigningType.PublicSigned)
 
     // Test SHA 256 bit key delay signed  Attributes
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-13`` () = signedtest("test-sha256-delay-attributes", "--define:SHA256 --define:DELAY", SigningType.DelaySigned)
 
     // Test SHA 512 bit key fully signed  Attributes
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-14`` () = signedtest("test-sha512-full-attributes", "--define:SHA512", SigningType.PublicSigned)
 
     // Test SHA 512 bit key delay signed Attributes
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-15`` () = signedtest("test-sha512-delay-attributes", "--define:SHA512 --define:DELAY", SigningType.DelaySigned)
 
     // Test SHA 1024 bit key fully signed  Attributes
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-16`` () = signedtest("test-sha1024-full-attributes", "--define:SHA1024", SigningType.PublicSigned)
 
     // Test fully signed with pdb generation
-    [<Fact; Trait("Category","signedtest")>]
+    [<Fact>]
     let ``signedtest-17`` () = signedtest("test-sha1-full-cl", "-g --keyfile:sha1full.snk", SigningType.PublicSigned)
 
 #endif

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/BuildProjectTests.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/BuildProjectTests.cs
@@ -29,9 +29,8 @@ let answer = 42
 
         var actualBuildSummary = await SolutionExplorer.BuildSolutionAsync(TestToken);
 
-#pragma warning disable CS8604 // Possible null reference argument.
+        Assert.NotNull(actualBuildSummary);
         Assert.Contains(expectedBuildSummary, actualBuildSummary);
-#pragma warning restore CS8604 // Possible null reference argument.
     }
 
     [IdeFact]
@@ -52,9 +51,9 @@ let answer =
         await Editor.SetTextAsync(code, TestToken);
 
         var actualBuildSummary = await SolutionExplorer.BuildSolutionAsync(TestToken);
-#pragma warning disable CS8604 // Possible null reference argument.
+
+        Assert.NotNull(actualBuildSummary);
         Assert.Contains(expectedBuildSummary, actualBuildSummary);
-#pragma warning restore CS8604 // Possible null reference argument.
 
         await ErrorList.ShowBuildErrorsAsync(TestToken);
         var errors = await ErrorList.GetBuildErrorsAsync(__VSERRORCATEGORY.EC_ERROR, TestToken);

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/BuildProjectTests.cs
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/BuildProjectTests.cs
@@ -29,7 +29,9 @@ let answer = 42
 
         var actualBuildSummary = await SolutionExplorer.BuildSolutionAsync(TestToken);
 
+#pragma warning disable CS8604 // Possible null reference argument.
         Assert.Contains(expectedBuildSummary, actualBuildSummary);
+#pragma warning restore CS8604 // Possible null reference argument.
     }
 
     [IdeFact]
@@ -50,7 +52,9 @@ let answer =
         await Editor.SetTextAsync(code, TestToken);
 
         var actualBuildSummary = await SolutionExplorer.BuildSolutionAsync(TestToken);
+#pragma warning disable CS8604 // Possible null reference argument.
         Assert.Contains(expectedBuildSummary, actualBuildSummary);
+#pragma warning restore CS8604 // Possible null reference argument.
 
         await ErrorList.ShowBuildErrorsAsync(TestToken);
         var errors = await ErrorList.GetBuildErrorsAsync(__VSERRORCATEGORY.EC_ERROR, TestToken);

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
@@ -186,14 +186,8 @@ module Xunit =
     /// <exception cref="T:System.ArgumentNullException">
     /// Thrown if <paramref name="expected"/> or <paramref name="actual"/> are null.
     /// </exception>
-    /// <exception cref="T:System.ArgumentException">
-    /// Thrown if <paramref name="expected"/> and <paramref name="actual"/> have different line counts.
-    /// </exception>
     /// <exception cref="T:Xunit.Sdk.EqualException">
-    /// Thrown if a single line in the actual code differs from the corresponding line in the expected code.
-    /// </exception>
-    /// <exception cref="T:Xunit.Sdk.AllException">
-    /// Thrown if multiple lines in the actual code differ from the lines in the expected code.
+    /// Thrown if any line in the actual code differs from the corresponding line in the expected code.
     /// </exception>
     let shouldEqual expected actual =
         if isNull expected then
@@ -208,16 +202,7 @@ module Xunit =
         let expectedLines = split expected
         let actualLines = split actual
 
-        if expectedLines.Length <> actualLines.Length then
-            Assert.Equal(expected, actual)
-        else
-            try
-                Assert.All(
-                    (expectedLines, actualLines) ||> Array.zip |> Array.rev,
-                    (fun (expected, actual) -> Assert.Equal(expected, actual))
-                )
-            with :? Xunit.Sdk.AllException as all when all.Failures.Count = 1 ->
-                raise all.Failures[0]
+        Assert.Equal<string>(expectedLines, actualLines)
 
     /// <summary>
     /// Expects no code fix to be applied to the given code.


### PR DESCRIPTION
Updates Xunit to 2.9.0.

Migrate FSharpSuite.Tests to Xunit (But the parallelization is still disabled).

In line with:
#13654
#9947