### PR TITLE
Improve active pattern error reporting

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -42,5 +42,6 @@
 * Ensure that isinteractive multi-emit backing fields are not public. ([Issue #17439](https://github.com/dotnet/fsharp/issues/17438)), ([PR #17439](https://github.com/dotnet/fsharp/pull/17439))
 * Better error reporting for unions with duplicated fields. ([PR #17521](https://github.com/dotnet/fsharp/pull/17521))
 * Optimize ILTypeDef interface impls reading from metadata. ([PR #17382](https://github.com/dotnet/fsharp/pull/17382))
+* Better error reporting for active patterns. ([PR #17666](https://github.com/dotnet/fsharp/pull/17666))
 
 ### Breaking Changes

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -8668,14 +8668,14 @@ and TcUnionCaseOrExnCaseOrActivePatternResultItemThen (cenv: cenv) overallTy env
     let ucaseAppTy = NewInferenceType g
     let mkConstrApp, argTys, argNames =
         match item with
-        | Item.ActivePatternResult(apinfo, _apOverallTy, n, _) ->
+        | Item.ActivePatternResult(apinfo, _apOverallTy, n, m) ->
             let aparity = apinfo.ActiveTags.Length
             match aparity with
             | 0 | 1 ->
                 let mkConstrApp _mArgs = function [arg] -> arg | _ -> error(InternalError("ApplyUnionCaseOrExn", mItem))
                 mkConstrApp, [ucaseAppTy], [ for s, m in apinfo.ActiveTagsWithRanges -> mkSynId m s ]
             | _ ->
-                let ucref = mkChoiceCaseRef g mItem aparity n
+                let ucref = mkChoiceCaseRef g m aparity n
                 let _, _, tinst, _ = FreshenTyconRef2 g mItem ucref.TyconRef
                 let ucinfo = UnionCaseInfo (tinst, ucref)
                 ApplyUnionCaseOrExnTypes mItem cenv env ucaseAppTy (Item.UnionCase(ucinfo, false))
@@ -11046,7 +11046,7 @@ and TcNormalizedBinding declKind (cenv: cenv) env tpenv overallTy safeThisValOpt
             else rhsExprChecked
 
         match apinfoOpt with
-        | Some (apinfo, apOverallTy, _) ->
+        | Some (apinfo, apOverallTy, m) ->
             let activePatResTys = NewInferenceTypes g apinfo.ActiveTags
             let _, apReturnTy = stripFunTy g apOverallTy
             let apRetTy =
@@ -11067,7 +11067,7 @@ and TcNormalizedBinding declKind (cenv: cenv) env tpenv overallTy safeThisValOpt
                 checkLanguageFeatureError g.langVersion LanguageFeature.StructActivePattern mBinding
             | ActivePatternReturnKind.RefTypeWrapper -> ()
 
-            UnifyTypes cenv env mBinding (apinfo.ResultType g rhsExpr.Range activePatResTys apRetTy) apReturnTy
+            UnifyTypes cenv env mBinding (apinfo.ResultType g m activePatResTys apRetTy) apReturnTy
 
         | None ->
             if isStructRetTy then

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Named/E_LargeActivePat01.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Named/E_LargeActivePat01.fs
@@ -5,3 +5,14 @@
 
 let (|One|Two|Three|Four|Five|Six|Seven|Eight|) x = One
 
+let (|A|B|C|D|E|F|G|H|) x =
+    match x with
+    | 0 -> A
+    | 1 -> B
+    | 2 -> C
+    | 3 -> D
+    | 4 -> E
+    | 5 -> F
+    | 6 -> G
+    | _ -> H
+

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Named/Named.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/PatternMatching/Named/Named.fs
@@ -365,8 +365,10 @@ but here has type
         |> withOptions ["--test:ErrorRanges"]
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 265, Line 6, Col 53, Line 6, Col 56, "Active patterns cannot return more than 7 possibilities")
-        
+        |> withDiagnostics [
+            (Error 265, Line 6, Col 6, Line 6, Col 47, "Active patterns cannot return more than 7 possibilities")
+            (Error 265, Line 8, Col 6, Line 8, Col 23, "Active patterns cannot return more than 7 possibilities")
+        ]
     
     // This test was automatically generated (moved from FSharpQA suite - Conformance/PatternMatching/Named)
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_MulticasePartialNotAllowed01.fs"|])>]


### PR DESCRIPTION
## Description

Active patterns errors are currently reported using the RHS expr, with can lead to:
- Inaccurate error ranges
- Hiding other errors
- Overall bad user experience 

I propose we use the LHS pat range to make this more accurate.

`Active patterns cannot return more than 7 possibilities`

### Before

<img width="380" alt="Screenshot 2024-09-04 at 19 58 03" src="https://github.com/user-attachments/assets/a2bb674a-76e0-4669-8531-b7f8e910b821">


### After

```fsharp
let (|A|B|C|D|E|F|G|H|) x =
     ^^^^^^^^^^^^^^^^^
    match x with
    | 0 -> A
    | 1 -> B
    | 2 -> C
    | 3 -> D
    | 4 -> E
    | 5 -> F
    | 6 -> G
    | _ -> H
```

## Checklist

- [x] Test cases added
- [x] Release notes entry updated 