### PR TITLE
Run more tests in temporary directory

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/XmlDoc.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/XmlDoc.fs
@@ -30,7 +30,7 @@ let xmlFileContents signature = $"""<?xml version="1.0" encoding="utf-8"?>
 [<InlineData("P:Microsoft.FSharp.Collections.FSharpList`1.Length")>]
 [<InlineData("P:Microsoft.FSharp.Collections.FSharpList`1.Length'")>]
 let ``Can extract XML docs from a file for a signature`` signature =
-    let xmlFileName = tryCreateTemporaryFileName () + ".xml"
+    let xmlFileName = getTemporaryFileName () + ".xml"
 
     try
         File.WriteAllText(xmlFileName, xmlFileContents signature)

--- a/tests/FSharp.Compiler.Service.Tests/CSharpProjectAnalysis.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CSharpProjectAnalysis.fs
@@ -12,7 +12,7 @@ open TestFramework
 let internal getProjectReferences (content: string, dllFiles, libDirs, otherFlags) =
     let otherFlags = defaultArg otherFlags []
     let libDirs = defaultArg libDirs []
-    let base1 = tryCreateTemporaryFileName ()
+    let base1 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base1, ".dll")
     let fileName1 = Path.ChangeExtension(base1, ".fs")
     let projFileName = Path.ChangeExtension(base1, ".fsproj")

--- a/tests/FSharp.Compiler.Service.Tests/Common.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Common.fs
@@ -34,7 +34,7 @@ type Async with
 let checker = FSharpChecker.Create(useTransparentCompiler=FSharp.Compiler.CompilerConfig.FSharpExperimentalFeaturesEnabledAutomatically)
 
 type TempFile(ext, contents: string) =
-    let tmpFile =  Path.ChangeExtension(tryCreateTemporaryFileName (), ext)
+    let tmpFile =  Path.ChangeExtension(getTemporaryFileName (), ext)
     do FileSystem.OpenFileForWriteShim(tmpFile).Write(contents)
 
     interface IDisposable with
@@ -130,8 +130,8 @@ let mkProjectCommandLineArgsForScript (dllName, fileNames) =
 #endif
 
 let mkTestFileAndOptions source additionalArgs =
-    let fileName = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let project = tryCreateTemporaryFileName ()
+    let fileName = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let project = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(project, ".dll")
     let projFileName = Path.ChangeExtension(project, ".fsproj")
     let fileSource1 = "module M"
@@ -481,7 +481,7 @@ module TempDirUtils =
     /// Returns the file name part of a temp file name created with tryCreateTemporaryFileName ()
     /// and an added process id and thread id to ensure uniqueness between threads.
     let getTempFileName() =
-        let tempFileName = tryCreateTemporaryFileName ()
+        let tempFileName = getTemporaryFileName ()
         try
             let tempFile, tempExt = Path.GetFileNameWithoutExtension tempFileName, Path.GetExtension tempFileName
             let procId, threadId = Process.GetCurrentProcess().Id, Thread.CurrentThread.ManagedThreadId

--- a/tests/FSharp.Compiler.Service.Tests/ExprTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ExprTests.fs
@@ -3155,7 +3155,7 @@ let ``Test expressions of declarations stress big expressions`` useTransparentCo
     printDeclarations None (List.ofSeq file1.Declarations) |> Seq.toList |> ignore
 
 #if !NETFRAMEWORK && DEBUG
-[<Fact(Skip = "Test is known to fail in DEBUG when not using NetFramework. Use RELEASE configuration or NetFramework to run it.")>]
+[<Theory(Skip = "Test is known to fail in DEBUG when not using NetFramework. Use RELEASE configuration or NetFramework to run it.")>]
 #else
 [<Theory>]
 [<InlineData(false)>]

--- a/tests/FSharp.Compiler.Service.Tests/MultiProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/MultiProjectAnalysisTests.fs
@@ -23,8 +23,8 @@ let internal tups (m:range) = (m.StartLine, m.StartColumn), (m.EndLine, m.EndCol
 
 module internal Project1A =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
     let fileSource1 = """
@@ -69,8 +69,8 @@ type U =
 //-----------------------------------------------------------------------------------------
 module internal Project1B =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
     let fileSource1 = """
@@ -96,8 +96,8 @@ let x =
 // A project referencing two sub-projects
 module internal MultiProject1 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
     let fileSource1 = """
@@ -271,7 +271,7 @@ module internal ManyProjectsStressTest =
     type Project = { ModuleName: string; FileName: string; Options: FSharpProjectOptions; DllName: string }
     let projects =
         [ for i in 1 .. numProjectsForStressTest do
-                let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+                let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
                 let moduleName = "Project" + string i
                 let fileSource1 = "module " + moduleName + """
 
@@ -287,7 +287,7 @@ let p = C.Print()
 
     """
                 FileSystem.OpenFileForWriteShim(fileName1).Write(fileSource1)
-                let baseName = tryCreateTemporaryFileName ()
+                let baseName = getTemporaryFileName ()
                 let dllName = Path.ChangeExtension(baseName, ".dll")
                 let projFileName = Path.ChangeExtension(baseName, ".fsproj")
                 let fileNames = [|fileName1|]
@@ -296,8 +296,8 @@ let p = C.Print()
                 yield { ModuleName = moduleName; FileName=fileName1; Options = options; DllName=dllName } ]
 
     let jointProject =
-        let fileName = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-        let dllBase = tryCreateTemporaryFileName ()
+        let fileName = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+        let dllBase = getTemporaryFileName ()
         let dllName = Path.ChangeExtension(dllBase, ".dll")
         let projFileName = Path.ChangeExtension(dllBase, ".fsproj")
         let fileSource =
@@ -396,8 +396,8 @@ let ``Test ManyProjectsStressTest all symbols`` useTransparentCompiler =
 
 module internal MultiProjectDirty1 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
     let content = """module Project1
@@ -418,8 +418,8 @@ let x = "F#"
 module internal MultiProjectDirty2 =
 
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
 
@@ -609,10 +609,10 @@ let ``Test multi project symbols should pick up changes in dependent projects`` 
 
 module internal Project2A =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName(), ".fs")
-    let baseName1 = tryCreateTemporaryFileName ()
-    let baseName2 = tryCreateTemporaryFileName ()
-    let baseName3 = tryCreateTemporaryFileName () // this one doesn't get InternalsVisibleTo rights
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName(), ".fs")
+    let baseName1 = getTemporaryFileName ()
+    let baseName2 = getTemporaryFileName ()
+    let baseName3 = getTemporaryFileName () // this one doesn't get InternalsVisibleTo rights
     let dllShortName = Path.GetFileNameWithoutExtension(baseName2)
     let dllName = Path.ChangeExtension(baseName1, ".dll")
     let projFileName = Path.ChangeExtension(baseName1, ".fsproj")
@@ -638,7 +638,7 @@ type C() =
 // A project referencing Project2A
 module internal Project2B =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     let dllName = Path.ChangeExtension(Project2A.baseName2, ".dll")
     let projFileName = Path.ChangeExtension(Project2A.baseName2, ".fsproj")
     let fileSource1 = """
@@ -662,7 +662,7 @@ let v = Project2A.C().InternalMember // access an internal symbol
 // A project referencing Project2A but without access to the internals of A
 module internal Project2C =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     let dllName = Path.ChangeExtension(Project2A.baseName3, ".dll")
     let projFileName = Path.ChangeExtension(Project2A.baseName3, ".fsproj")
     let fileSource1 = """
@@ -733,8 +733,8 @@ let ``Test multi project 2 all symbols`` useTransparentCompiler =
 
 module internal Project3A =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
     let fileSource1 = """
@@ -756,8 +756,8 @@ let (|DivisibleBy|_|) by n =
 // A project referencing a sub-project
 module internal MultiProject3 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let baseName = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let baseName = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(baseName, ".dll")
     let projFileName = Path.ChangeExtension(baseName, ".fsproj")
     let fileSource1 = """

--- a/tests/FSharp.Compiler.Service.Tests/PerfTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PerfTests.fs
@@ -14,8 +14,8 @@ let internal checker = FSharpChecker.Create()
 
 module internal Project1 =
 
-    let fileNamesI = [ for i in 1 .. 10 -> (i, Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")) ]
-    let base2 = tryCreateTemporaryFileName ()
+    let fileNamesI = [ for i in 1 .. 10 -> (i, Path.ChangeExtension(getTemporaryFileName (), ".fs")) ]
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSources = [ for i,f in fileNamesI -> (f, "module M" + string i) ]

--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -4399,7 +4399,7 @@ let ``Test Project33 extension methods`` () =
              ("GetValue", ["member"; "extmem"])]
 
 module internal Project34 =
-    let directoryPath = tryCreateTemporaryDirectory ()
+    let directoryPath = tryCreateTemporaryDirectory "Project34"
     let sourceFileName = Path.Combine(directoryPath, "Program.fs")
     let dllName = Path.ChangeExtension(sourceFileName, ".dll")
     let projFileName = Path.ChangeExtension(sourceFileName, ".fsproj")

--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -21,8 +21,8 @@ open TestFramework
 
 module internal Project1 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let fileName2 = Path.ChangeExtension(base2, ".fs")
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
@@ -639,8 +639,8 @@ let ``Test file explicit parse all symbols`` () =
 
 module internal Project2 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -835,8 +835,8 @@ let ``Test project2 all uses of all symbols`` () =
 
 module internal Project3 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1278,8 +1278,8 @@ let ``Test project3 all uses of all signature symbols`` () =
 
 module internal Project4 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1433,8 +1433,8 @@ let ``Test project4 T symbols`` () =
 module internal Project5 =
 
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1661,8 +1661,8 @@ let ``Test partial active patterns' exact ranges from uses of symbols`` () =
 
 module internal Project6 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1714,8 +1714,8 @@ let ``Test project 6 all symbols`` () =
 
 module internal Project7 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1775,8 +1775,8 @@ let ``Test project 7 all symbols`` () =
 //-----------------------------------------------------------------------------------------
 module internal Project8 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1859,8 +1859,8 @@ let ``Test project 8 all symbols`` () =
 //-----------------------------------------------------------------------------------------
 module internal Project9 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -1936,8 +1936,8 @@ let ``Test project 9 all symbols`` () =
 
 module internal Project10 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2018,8 +2018,8 @@ let ``Test Project10 all symbols`` () =
 
 module internal Project11 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2085,8 +2085,8 @@ let ``Test Project11 all symbols`` () =
 
 module internal Project12 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2153,8 +2153,8 @@ let ``Test Project12 all symbols`` () =
 
 module internal Project13 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2309,8 +2309,8 @@ let ``Test Project13 all symbols`` () =
 
 module internal Project14 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2378,8 +2378,8 @@ let ``Test Project14 all symbols`` () =
 
 module internal Project15 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2437,9 +2437,9 @@ let ``Test Project15 all symbols`` () =
 
 module internal Project16 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     let sigFileName1 = Path.ChangeExtension(fileName1, ".fsi")
-    let base2 = tryCreateTemporaryFileName ()
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1Text = """
@@ -2732,8 +2732,8 @@ let ``Test project16 DeclaringEntity`` () =
 
 module internal Project17 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2825,8 +2825,8 @@ let ``Test Project17 all symbols`` () =
 
 module internal Project18 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2875,8 +2875,8 @@ let ``Test Project18 all symbols`` () =
 
 module internal Project19 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -2954,8 +2954,8 @@ let ``Test Project19 all symbols`` () =
 
 module internal Project20 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3006,8 +3006,8 @@ let ``Test Project20 all symbols`` () =
 
 module internal Project21 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3084,8 +3084,8 @@ let ``Test Project21 all symbols`` () =
 
 module internal Project22 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3223,8 +3223,8 @@ let ``Test Project22 IList properties`` () =
 
 module internal Project23 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3357,8 +3357,8 @@ let ``Test Project23 extension properties' getters/setters should refer to the c
 // Misc - property symbols
 module internal Project24 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3660,8 +3660,8 @@ let ``Test symbol uses of properties with both getters and setters`` () =
 // Misc - type provider symbols
 module internal Project25 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3794,8 +3794,8 @@ let ``Test symbol uses of fully-qualified records`` () =
 
 module internal Project26 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3885,8 +3885,8 @@ let ``Test Project26 parameter symbols`` () =
 
 module internal Project27 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -3930,8 +3930,8 @@ let ``Test project27 all symbols in signature`` () =
 
 module internal Project28 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4034,8 +4034,8 @@ let ``Test project28 all symbols in signature`` () =
 #endif
 module internal Project29 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4090,8 +4090,8 @@ let ``Test project29 event symbols`` () =
 
 module internal Project30 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4150,8 +4150,8 @@ let ``Test project30 Format attributes`` () =
 
 module internal Project31 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4283,9 +4283,9 @@ let ``Test project31 Format C# method attributes`` () =
 
 module internal Project32 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     let sigFileName1 = Path.ChangeExtension(fileName1, ".fsi")
-    let base2 = tryCreateTemporaryFileName ()
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4355,8 +4355,8 @@ let ``Test Project32 should be able to find impl symbols`` () =
 
 module internal Project33 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4399,7 +4399,7 @@ let ``Test Project33 extension methods`` () =
              ("GetValue", ["member"; "extmem"])]
 
 module internal Project34 =
-    let directoryPath = tryCreateTemporaryDirectory "Project34"
+    let directoryPath = createTemporaryDirectory "Project34"
     let sourceFileName = Path.Combine(directoryPath, "Program.fs")
     let dllName = Path.ChangeExtension(sourceFileName, ".dll")
     let projFileName = Path.ChangeExtension(sourceFileName, ".fsproj")
@@ -4471,8 +4471,8 @@ let ``Test project34 should report correct accessibility for System.Data.Listene
 
 module internal Project35 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4548,7 +4548,7 @@ let ``Test project35 CurriedParameterGroups should be available for nested funct
 
 module internal Project35b =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fsx")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fsx")
     let fileSource1Text = """
 #r "System.dll"
 #r "notexist.dll"
@@ -4612,8 +4612,8 @@ let ``Test project35b Dependency files for check of project`` () =
 
 module internal Project36 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """module Project36
@@ -4709,8 +4709,8 @@ let ``Test project36 FSharpMemberOrFunctionOrValue.LiteralValue`` useTransparent
 
 module internal Project37 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let fileName2 = Path.ChangeExtension(base2, ".fs")
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
@@ -4860,8 +4860,8 @@ let ``Test project37 DeclaringEntity`` () =
 
 module internal Project38 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -4962,8 +4962,8 @@ let ``Test project38 abstract slot information`` () =
 
 module internal Project39 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -5042,8 +5042,8 @@ let ``Test project39 all symbols`` () =
 
 module internal Project40 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -5108,9 +5108,9 @@ let ``Test Project40 all symbols`` () =
 
 module internal Project41 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     // We need to us a stable name to keep the hashes stable
-    let base2 = Path.Combine(Path.GetDirectoryName(tryCreateTemporaryFileName ()), "stabletmp.tmp")
+    let base2 = Path.Combine(Path.GetDirectoryName(getTemporaryFileName ()), "stabletmp.tmp")
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -5208,10 +5208,10 @@ let ``Test project41 all symbols`` () =
 
 module internal Project42 =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let fileName2 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let fileName2 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     // We need to us a stable name to keep the hashes stable
-    let base2 = Path.Combine(Path.GetDirectoryName(tryCreateTemporaryFileName ()), "stabletmp.tmp")
+    let base2 = Path.Combine(Path.GetDirectoryName(getTemporaryFileName ()), "stabletmp.tmp")
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -5254,8 +5254,8 @@ let ``Test project42 to ensure cached checked results are invalidated`` () =
 
 module internal ProjectBig =
 
-    let fileNamesI = [ for i in 1 .. 10 -> (i, Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")) ]
-    let base2 = tryCreateTemporaryFileName ()
+    let fileNamesI = [ for i in 1 .. 10 -> (i, Path.ChangeExtension(getTemporaryFileName (), ".fs")) ]
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSources = [ for i,f in fileNamesI -> (f, "module M" + string i) ]
@@ -5290,8 +5290,8 @@ let ``add files with same name from different folders`` () =
 
 module internal ProjectStructUnions =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1 = """
@@ -5342,8 +5342,8 @@ let ``Test typed AST for struct unions`` useTransparentCompiler = // See https:/
 
 module internal ProjectLineDirectives =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1Text = """
@@ -5409,8 +5409,8 @@ let ``Test diagnostics with line directives ignored`` () =
 [<InlineData false>]
 let ``ParseAndCheckFileResults contains ImplFile list if FSharpChecker is created with keepAssemblyContent flag set to true`` useTransparentCompiler =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1Text = """
@@ -5495,8 +5495,8 @@ let ``#4030, Incremental builder creation warnings 5`` () =
 [<InlineData false>]
 let ``Unused opens in rec module smoke test 1`` useTransparentCompiler =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1Text = """
@@ -5570,8 +5570,8 @@ type UseTheThings(i:int) =
 [<InlineData false>]
 let ``Unused opens in non rec module smoke test 1`` useTransparentCompiler =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1Text = """
@@ -5659,8 +5659,8 @@ type UseTheThings(i:int) =
 [<InlineData false>]
 let ``Unused opens smoke test auto open`` useTransparentCompiler =
 
-    let fileName1 = Path.ChangeExtension(tryCreateTemporaryFileName (), ".fs")
-    let base2 = tryCreateTemporaryFileName ()
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
     let fileSource1Text = """
@@ -5816,7 +5816,7 @@ let ``References from #r nuget are included in script project options`` () =
     assemblyNames |> should contain "Dapper.dll"
 
 module internal EmptyProject =
-    let base2 = tryCreateTemporaryFileName ()
+    let base2 = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(base2, ".dll")
     let projFileName = Path.ChangeExtension(base2, ".fsproj")
 

--- a/tests/FSharp.Compiler.Service.Tests/ScriptOptionsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ScriptOptionsTests.fs
@@ -41,9 +41,9 @@ let ``can generate options for different frameworks regardless of execution envi
 [<InlineData("--targetprofile:netcore")>]
 [<InlineData("--targetprofile:netstandard")>]
 let ``can resolve nuget packages to right target framework for different frameworks regardless of execution environment``(flag) =
-    let path = DirectoryInfo(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location))
-    let file = (tryCreateTemporaryFileNameInDirectory path) + ".fsx"
-    let scriptFullPath = Path.Combine(path.FullName, file)
+    let path = DirectoryInfo(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)).FullName
+    let file = (getTemporaryFileNameInDirectory path) + ".fsx"
+    let scriptFullPath = Path.Combine(path, file)
     let scriptSource = """
 #r "nuget: FSharp.Data, 3.3.3"
 open System

--- a/tests/FSharp.Compiler.Service.Tests/ScriptOptionsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ScriptOptionsTests.fs
@@ -42,7 +42,7 @@ let ``can generate options for different frameworks regardless of execution envi
 [<InlineData("--targetprofile:netstandard")>]
 let ``can resolve nuget packages to right target framework for different frameworks regardless of execution environment``(flag) =
     let path = DirectoryInfo(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location))
-    let file = tryCreateTemporaryFileNameInDirectory(path) + ".fsx"
+    let file = (tryCreateTemporaryFileNameInDirectory path) + ".fsx"
     let scriptFullPath = Path.Combine(path.FullName, file)
     let scriptSource = """
 #r "nuget: FSharp.Data, 3.3.3"

--- a/tests/FSharp.Compiler.Service.Tests/ScriptOptionsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ScriptOptionsTests.fs
@@ -26,7 +26,7 @@ let pi = Math.PI
 [<InlineData(true, true, "--targetprofile:netcore")>]
 let ``can generate options for different frameworks regardless of execution environment - useSdkRefs = false``(assumeDotNetFramework, useSdkRefs, flag) =
     let path = Path.GetTempPath()
-    let file = tryCreateTemporaryFileName () + ".fsx"
+    let file = getTemporaryFileName () + ".fsx"
     let tempFile = Path.Combine(path, file)
     let _, errors =
         checker.GetProjectOptionsFromScript(tempFile, SourceText.ofString scriptSource, assumeDotNetFramework = assumeDotNetFramework, useSdkRefs = useSdkRefs, otherFlags = [| flag |])

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -730,7 +730,7 @@ module rec Compiler =
         let outputDirectory =
             match fs.OutputDirectory with
             | Some di -> di
-            | None -> DirectoryInfo(tryCreateTemporaryDirectory "compileFSharp")
+            | None -> DirectoryInfo(createTemporaryDirectory "compileFSharp")
         let references = processReferences fs.References outputDirectory
         let compilation = Compilation.CreateFromSources([fs.Source] @ fs.AdditionalSources, output, options, fs.TargetFramework, references, name, outputDirectory)
         compileFSharpCompilation compilation fs.IgnoreWarnings (FS fs)
@@ -775,12 +775,12 @@ module rec Compiler =
     let private compileCSharp (csSource: CSharpCompilationSource) : CompilationResult =
 
         let source = csSource.Source.GetSourceText |> Option.defaultValue ""
-        let name = defaultArg csSource.Name (tryCreateTemporaryFileName())
+        let name = defaultArg csSource.Name (getTemporaryFileName())
 
         let outputDirectory =
             match csSource.OutputDirectory with
             | Some di -> di
-            | None -> DirectoryInfo(tryCreateTemporaryDirectory "compileCSharp")
+            | None -> DirectoryInfo(createTemporaryDirectory "compileCSharp")
 
         let additionalReferences =
             processReferences csSource.References outputDirectory
@@ -922,7 +922,7 @@ module rec Compiler =
                 let outputDirectory =
                     match fsSource.OutputDirectory with
                     | Some di -> di
-                    | None -> DirectoryInfo(tryCreateTemporaryDirectory "typecheckResults")
+                    | None -> DirectoryInfo(createTemporaryDirectory "typecheckResults")
                 let references = processReferences fsSource.References outputDirectory
                 if references.IsEmpty then
                     Array.empty
@@ -1058,7 +1058,7 @@ module rec Compiler =
                 let outputDirectory =
                     match fs.OutputDirectory with
                     | Some di -> di
-                    | None -> DirectoryInfo(tryCreateTemporaryDirectory "runFsi")
+                    | None -> DirectoryInfo(createTemporaryDirectory "runFsi")
                 outputDirectory.Create()
                 disposals.Add({ new IDisposable with member _.Dispose() = outputDirectory.Delete(true) })
 

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -730,7 +730,7 @@ module rec Compiler =
         let outputDirectory =
             match fs.OutputDirectory with
             | Some di -> di
-            | None -> DirectoryInfo(tryCreateTemporaryDirectory())
+            | None -> DirectoryInfo(tryCreateTemporaryDirectory "compileFSharp")
         let references = processReferences fs.References outputDirectory
         let compilation = Compilation.CreateFromSources([fs.Source] @ fs.AdditionalSources, output, options, fs.TargetFramework, references, name, outputDirectory)
         compileFSharpCompilation compilation fs.IgnoreWarnings (FS fs)
@@ -780,7 +780,7 @@ module rec Compiler =
         let outputDirectory =
             match csSource.OutputDirectory with
             | Some di -> di
-            | None -> DirectoryInfo(tryCreateTemporaryDirectory())
+            | None -> DirectoryInfo(tryCreateTemporaryDirectory "compileCSharp")
 
         let additionalReferences =
             processReferences csSource.References outputDirectory
@@ -922,7 +922,7 @@ module rec Compiler =
                 let outputDirectory =
                     match fsSource.OutputDirectory with
                     | Some di -> di
-                    | None -> DirectoryInfo(tryCreateTemporaryDirectory())
+                    | None -> DirectoryInfo(tryCreateTemporaryDirectory "typecheckResults")
                 let references = processReferences fsSource.References outputDirectory
                 if references.IsEmpty then
                     Array.empty
@@ -1058,7 +1058,7 @@ module rec Compiler =
                 let outputDirectory =
                     match fs.OutputDirectory with
                     | Some di -> di
-                    | None -> DirectoryInfo(tryCreateTemporaryDirectory())
+                    | None -> DirectoryInfo(tryCreateTemporaryDirectory "runFsi")
                 outputDirectory.Create()
                 disposals.Add({ new IDisposable with member _.Dispose() = outputDirectory.Delete(true) })
 
@@ -1522,9 +1522,9 @@ Actual:
                       | Some (ExecutionOutput output) ->
                           sprintf "----output-----\n%s\n----error-------\n%s\n----------" output.StdOut output.StdErr
                       | Some (EvalOutput (Result.Error exn) ) ->
-                          sprintf "----script error-----\n%s\n----------" (exn.ToString())
+                                sprintf "----script error-----\n%s\n----------" (exn.ToString())
                       | Some (EvalOutput (Result.Ok fsiVal) ) ->
-                          sprintf "----script output-----\n%A\n----------" (fsiVal)
+                                sprintf "----script output-----\n%A\n----------" (fsiVal)
                       | _ -> () ]
                     |> String.concat "\n"
                 failwith message

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -1522,9 +1522,9 @@ Actual:
                       | Some (ExecutionOutput output) ->
                           sprintf "----output-----\n%s\n----error-------\n%s\n----------" output.StdOut output.StdErr
                       | Some (EvalOutput (Result.Error exn) ) ->
-                                sprintf "----script error-----\n%s\n----------" (exn.ToString())
+                          sprintf "----script error-----\n%s\n----------" (exn.ToString())
                       | Some (EvalOutput (Result.Ok fsiVal) ) ->
-                                sprintf "----script output-----\n%A\n----------" (fsiVal)
+                          sprintf "----script output-----\n%A\n----------" (fsiVal)
                       | _ -> () ]
                     |> String.concat "\n"
                 failwith message

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -220,7 +220,7 @@ type CompilationUtil private () =
     static member CreateILCompilation (source: string) =
         let compute =
             lazy
-                let ilFilePath = tryCreateTemporaryFileName() + ".il"
+                let ilFilePath = getTemporaryFileName() + ".il"
                 let dllFilePath = Path.ChangeExtension (ilFilePath, ".dll")
                 try
                     File.WriteAllText (ilFilePath, source)
@@ -505,14 +505,14 @@ module rec CompilerAssertHelpers =
             match source.GetSourceText with
             | Some text ->
                 // In memory source file copy it to the build directory
-                let sourceWithTempFileName = source.WithFileName(tryCreateTemporaryFileName ()).ChangeExtension
+                let sourceWithTempFileName = source.WithFileName(getTemporaryFileName ()).ChangeExtension
                 File.WriteAllText(sourceWithTempFileName.GetSourceFileName, text)
                 sourceWithTempFileName
             | None ->
                 // On Disk file
                 source
 
-        let outputFilePath = Path.ChangeExtension (tryCreateTemporaryFileName (), if isExe then ".exe" else ".dll")
+        let outputFilePath = Path.ChangeExtension (getTemporaryFileName (), if isExe then ".exe" else ".dll")
         try
             f (rawCompile outputFilePath isExe options TargetFramework.Current [sourceFile])
         finally
@@ -584,7 +584,7 @@ module rec CompilerAssertHelpers =
     let compileCompilation ignoreWarnings (cmpl: Compilation) f =
         let disposals = ResizeArray()
         try
-            let outputDirectory = DirectoryInfo(tryCreateTemporaryDirectory "compileCompilation")
+            let outputDirectory = DirectoryInfo(createTemporaryDirectory "compileCompilation")
             disposals.Add({ new IDisposable with member _.Dispose() = try File.Delete (outputDirectory.FullName) with | _ -> () })
             f (compileCompilationAux outputDirectory disposals ignoreWarnings cmpl)
         finally
@@ -598,7 +598,7 @@ module rec CompilerAssertHelpers =
         let outputDirectory =
             match cmpl with
             | Compilation(outputDirectory = Some outputDirectory) -> DirectoryInfo(outputDirectory.FullName)
-            | Compilation _ -> DirectoryInfo(tryCreateTemporaryDirectory "returnCompilation")
+            | Compilation _ -> DirectoryInfo(createTemporaryDirectory "returnCompilation")
 
         outputDirectory.Create()
         compileCompilationAux outputDirectory (ResizeArray()) ignoreWarnings cmpl

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -244,7 +244,8 @@ type SyntheticProject =
       UseScriptResolutionRules: bool }
 
     static member Create(?name: string) =
-        let name = defaultArg name $"TestProject_{Guid.NewGuid().ToString()[..7]}"
+        let name = defaultArg name "TestProject"
+        let name = $"{name}_{Guid.NewGuid().ToString()[..7]}"
         let dir = Path.GetFullPath projectRoot
 
         { Name = name

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -21,13 +21,13 @@ let tempDirectoryOfThisTestRun =
 
 // Temporary directory is TempPath + "/FSharp.Test.Utilities/yyy-MM-dd/{part}-xxxxxxx"
 // Throws exception if it Fails
-let tryCreateTemporaryDirectory (part: string) =
+let createTemporaryDirectory (part: string) =
     DirectoryInfo(tempDirectoryOfThisTestRun)
         .CreateSubdirectory($"{part}-{getShortId()}")
         .FullName
 
-let tryCreateTemporaryFileName () =
-    (tryCreateTemporaryDirectory "temp") ++ $"tmp_{getShortId()}"
+let getTemporaryFileName () =
+    (createTemporaryDirectory "temp") ++ $"tmp_{getShortId()}"
 
 let tryCreateTemporaryFileNameInDirectory (directory: DirectoryInfo) =
     directory.FullName ++ $"tmp_{getShortId()}"
@@ -57,7 +57,7 @@ let rec copyDirectory (sourceDir: string) (destinationDir: string) (recursive: b
 
 let copyTestDirectoryToTempLocation source (destinationSubDir: string) =
     let description = destinationSubDir.Split('\\', '/') |> String.concat "-"
-    let tempTestRoot = tryCreateTemporaryDirectory description
+    let tempTestRoot = createTemporaryDirectory description
     let tempTestDir =
         DirectoryInfo(tempTestRoot)
             .CreateSubdirectory(destinationSubDir)
@@ -498,7 +498,7 @@ let testConfig sourceDir (testSubDir: string) =
 
 let testConfigWithoutSourceDirectory() =
     let cfg = suiteHelpers.Value
-    { cfg with Directory = tryCreateTemporaryDirectory "temp" }
+    { cfg with Directory = createTemporaryDirectory "temp" }
 
 [<AllowNullLiteral>]
 type FileGuard(path: string) =

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -12,6 +12,7 @@ open FSharp.Compiler.IO
 
 let getShortId() = Guid.NewGuid().ToString().[..7]
 
+// Temporary directory is TempPath + "/FSharp.Test.Utilities/yyy-MM-dd-xxxxxxx/"
 let tempDirectoryOfThisTestRun =
     let tempDir = Path.GetTempPath()
     let today = DateTime.Now.ToString("yyyy-MM-dd")
@@ -19,8 +20,6 @@ let tempDirectoryOfThisTestRun =
         .CreateSubdirectory($"FSharp.Test.Utilities/{today}-{getShortId()}")
         .FullName
 
-// Temporary directory is TempPath + "/FSharp.Test.Utilities/yyy-MM-dd/{part}-xxxxxxx"
-// Throws exception if it Fails
 let createTemporaryDirectory (part: string) =
     DirectoryInfo(tempDirectoryOfThisTestRun)
         .CreateSubdirectory($"{part}-{getShortId()}")

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -28,8 +28,8 @@ let createTemporaryDirectory (part: string) =
 let getTemporaryFileName () =
     (createTemporaryDirectory "temp") ++ $"tmp_{getShortId()}"
 
-let tryCreateTemporaryFileNameInDirectory (directory: DirectoryInfo) =
-    directory.FullName ++ $"tmp_{getShortId()}"
+let getTemporaryFileNameInDirectory (directory: string) =
+    directory ++ $"tmp_{getShortId()}"
 
 // Well, this function is AI generated.
 let rec copyDirectory (sourceDir: string) (destinationDir: string) (recursive: bool) =

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -493,12 +493,6 @@ let testConfig sourceDir (relativePathToTestFixture: string) =
 
     { cfg with Directory = tempTestDir }
 
-/// Returns config with original test directory. Does not copy the test fixture to temp directory.
-let testConfigOldBehavior sourceDir (testSubDir: string) =
-    let cfg = suiteHelpers.Value
-    let testDir = Path.GetFullPath(sourceDir ++ testSubDir)
-    { cfg with Directory = testDir }
-
 let createConfigWithEmptyDirectory() =
     let cfg = suiteHelpers.Value
     { cfg with Directory = createTemporaryDirectory "temp" }

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -490,12 +490,18 @@ let suiteHelpers = lazy (initializeSuite ())
 
 let testConfig sourceDir (testSubDir: string) =
     let cfg = suiteHelpers.Value
-    let testDir = Path.GetFullPath( sourceDir + "\\" + testSubDir )
+    let testDir = Path.GetFullPath(sourceDir ++ testSubDir)
 
     let testDir = copyTestDirectoryToTempLocation testDir testSubDir
     { cfg with Directory = testDir }
 
-let testConfigWithoutSourceDirectory() =
+/// Returns config with original test directory. Does not copy the test fixture to temp directory.
+let testConfigOldBehavior sourceDir (testSubDir: string) =
+    let cfg = suiteHelpers.Value
+    let testDir = Path.GetFullPath(sourceDir ++ testSubDir)
+    { cfg with Directory = testDir }
+
+let createConfigWithEmptyDirectory() =
     let cfg = suiteHelpers.Value
     { cfg with Directory = createTemporaryDirectory "temp" }
 

--- a/tests/fsharp/Compiler/Language/WitnessTests.fs
+++ b/tests/fsharp/Compiler/Language/WitnessTests.fs
@@ -15,7 +15,7 @@ module WitnessTests =
 
     [<Fact>]
     let ``Witness expressions are created as a result of compiling the type provider tests`` () =
-        let dir = getTestsDirectory __SOURCE_DIRECTORY__ "../../typeProviders/helloWorld"
+        let dir = __SOURCE_DIRECTORY__ ++ "../../typeProviders/helloWorld"
         Fsx (sprintf """
 #load @"%s"
         """ (dir ++ "provider.fsx"))

--- a/tests/fsharp/Compiler/Service/MultiProjectTests.fs
+++ b/tests/fsharp/Compiler/Service/MultiProjectTests.fs
@@ -87,14 +87,14 @@ let test() =
             reraise()
 
     let createOnDisk (src: string) =
-        let tmpFilePath = tryCreateTemporaryFileName ()
+        let tmpFilePath = getTemporaryFileName ()
         let tmpRealFilePath = Path.ChangeExtension(tmpFilePath, ".fs")
         try File.Delete(tmpFilePath) with | _ -> ()
         File.WriteAllText(tmpRealFilePath, src)
         tmpRealFilePath
 
     let createOnDiskCompiledAsDll checker (src: string) =
-        let tmpFilePath = tryCreateTemporaryFileName ()
+        let tmpFilePath = getTemporaryFileName ()
         let tmpRealFilePath = Path.ChangeExtension(tmpFilePath, ".fs")
         try File.Delete(tmpFilePath) with | _ -> ()
         File.WriteAllText(tmpRealFilePath, src)

--- a/tests/fsharp/SDKTests/tests/PackageTest.props
+++ b/tests/fsharp/SDKTests/tests/PackageTest.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\eng\Versions.props" />
+  <Import Project="$(FSharpRepositoryPath)\eng\Versions.props" />
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net472</TargetFramework>
@@ -8,7 +8,7 @@
     <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
 
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <TargetsDirectory>..\..\..\..\artifacts\bin\FSharpSuite.Tests\$(Configuration)\$(TARGETFRAMEWORK)</TargetsDirectory>
+    <TargetsDirectory>$(FSharpRepositoryPath)\artifacts\bin\FSharpSuite.Tests\$(Configuration)\$(TARGETFRAMEWORK)</TargetsDirectory>
 
     <!-- these properties don't really matter, but they're necessary to make MSBuild happy -->
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>

--- a/tests/fsharp/SDKTests/tests/ToolsTest.props
+++ b/tests/fsharp/SDKTests/tests/ToolsTest.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\eng\Versions.props" />
+  <Import Project="$(FSharpRepositoryPath)\eng\Versions.props" />
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net472</TargetFramework>
@@ -8,7 +8,7 @@
     <TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">.NETFramework</TargetFrameworkIdentifier>
 
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <TargetsDirectory>$(MSBuildThisFileDirectory)..\..\..\..\artifacts\bin\FSharpSuite.Tests\$(Configuration)\$(TARGETFRAMEWORK)</TargetsDirectory>
+    <TargetsDirectory>$(FSharpRepositoryPath)\artifacts\bin\FSharpSuite.Tests\$(Configuration)\$(TARGETFRAMEWORK)</TargetsDirectory>
 
     <!-- these properties don't really matter, but they're necessary to make MSBuild happy -->
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -32,12 +32,16 @@ let FSC_OPTIMIZED = FSC_NETFX (true, false)
 let FSI = FSI_NETFX
 #endif
 
-let inline getTestsDirectory dir = getTestsDirectory __SOURCE_DIRECTORY__ dir
-let testConfig = getTestsDirectory >> testConfig
+let copyHelloWorld cfgDirectory =
+    for helloDir in DirectoryInfo(__SOURCE_DIRECTORY__ + "/typeProviders").GetDirectories("hello*") do
+        DirectoryInfo(cfgDirectory + "\\..").CreateSubdirectory(helloDir.Name).FullName
+        |> copyFilesToDest helloDir.FullName
 
 [<Fact>]
 let diamondAssembly () =
     let cfg = testConfig "typeProviders/diamondAssembly"
+
+    copyHelloWorld cfg.Directory
 
     rm cfg "provider.dll"
 
@@ -175,41 +179,14 @@ let helloWorldCSharp () =
 
     exec cfg ("." ++ "test.exe") ""
 
-[<Theory>]
-[<InlineData("neg1")>]
-[<InlineData("neg2")>]
-[<InlineData("neg2c")>]
-[<InlineData("neg2e")>]
-[<InlineData("neg2g")>]
-[<InlineData("neg2h")>]
-[<InlineData("neg4")>]
-[<InlineData("neg6")>]
-[<InlineData("InvalidInvokerExpression")>]
-[<InlineData("providerAttributeErrorConsume")>]
-[<InlineData("ProviderAttribute_EmptyConsume")>]
-[<InlineData("EVIL_PROVIDER_GetNestedNamespaces_Exception")>]
-[<InlineData("EVIL_PROVIDER_NamespaceName_Exception")>]
-[<InlineData("EVIL_PROVIDER_NamespaceName_Empty")>]
-[<InlineData("EVIL_PROVIDER_GetTypes_Exception")>]
-[<InlineData("EVIL_PROVIDER_ResolveTypeName_Exception")>]
-[<InlineData("EVIL_PROVIDER_GetNamespaces_Exception")>]
-[<InlineData("EVIL_PROVIDER_GetStaticParameters_Exception")>]
-[<InlineData("EVIL_PROVIDER_GetInvokerExpression_Exception")>]
-[<InlineData("EVIL_PROVIDER_GetTypes_Null")>]
-[<InlineData("EVIL_PROVIDER_ResolveTypeName_Null")>]
-[<InlineData("EVIL_PROVIDER_GetNamespaces_Null")>]
-[<InlineData("EVIL_PROVIDER_GetStaticParameters_Null")>]
-[<InlineData("EVIL_PROVIDER_GetInvokerExpression_Null")>]
-[<InlineData("EVIL_PROVIDER_DoesNotHaveConstructor")>]
-[<InlineData("EVIL_PROVIDER_ConstructorThrows")>]
-[<InlineData("EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments")>]
-let ``negative type provider tests`` (name:string) =
+let singleNegTest name =
     let cfg = testConfig "typeProviders/negTests"
-    let dir = cfg.Directory
+
+    copyHelloWorld cfg.Directory
 
     if requireENCulture () then
 
-        let fileExists = Commands.fileExists dir >> Option.isSome
+        let fileExists = Commands.fileExists cfg.Directory >> Option.isSome
 
         rm cfg "provided.dll"
 
@@ -240,7 +217,7 @@ let ``negative type provider tests`` (name:string) =
         fsc cfg "--out:MostBasicProvider.dll -g --optimize- -a" ["MostBasicProvider.fsx"]
 
         let preprocess name pref =
-            let dirp = (dir |> Commands.pathAddBackslash)
+            let dirp = (cfg.Directory |> Commands.pathAddBackslash)
             do
             FileSystem.OpenFileForReadShim(sprintf "%s%s.%sbslpp" dirp name pref)
                       .ReadAllText()
@@ -258,9 +235,40 @@ let ``negative type provider tests`` (name:string) =
 
         SingleTest.singleNegTest cfg name
 
+[<Theory>]
+[<InlineData("neg1")>]
+[<InlineData("neg2")>]
+[<InlineData("neg2c")>]
+[<InlineData("neg2e")>]
+[<InlineData("neg2g")>]
+[<InlineData("neg2h")>]
+[<InlineData("neg4")>]
+[<InlineData("neg6")>]
+[<InlineData("InvalidInvokerExpression")>]
+[<InlineData("providerAttributeErrorConsume")>]
+[<InlineData("ProviderAttribute_EmptyConsume")>]
+[<InlineData("EVIL_PROVIDER_GetNestedNamespaces_Exception")>]
+[<InlineData("EVIL_PROVIDER_NamespaceName_Exception")>]
+[<InlineData("EVIL_PROVIDER_NamespaceName_Empty")>]
+[<InlineData("EVIL_PROVIDER_GetTypes_Exception")>]
+[<InlineData("EVIL_PROVIDER_ResolveTypeName_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetNamespaces_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetStaticParameters_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetInvokerExpression_Exception")>]
+[<InlineData("EVIL_PROVIDER_GetTypes_Null")>]
+[<InlineData("EVIL_PROVIDER_ResolveTypeName_Null")>]
+[<InlineData("EVIL_PROVIDER_GetNamespaces_Null")>]
+[<InlineData("EVIL_PROVIDER_GetStaticParameters_Null")>]
+[<InlineData("EVIL_PROVIDER_GetInvokerExpression_Null")>]
+[<InlineData("EVIL_PROVIDER_DoesNotHaveConstructor")>]
+[<InlineData("EVIL_PROVIDER_ConstructorThrows")>]
+[<InlineData("EVIL_PROVIDER_ReturnsTypeWithIncorrectNameFromApplyStaticArguments")>]
+let ``negative type provider tests`` (name:string) = singleNegTest name
+
 let splitAssembly subdir project =
-    let subdir = getTestsDirectory subdir
     let cfg = testConfig project
+
+    copyHelloWorld cfg.Directory
 
     let clean() =
         rm cfg "providerDesigner.dll"
@@ -344,6 +352,8 @@ let splitAssemblyTypeProviders () = splitAssembly "typeproviders" "typeProviders
 [<Fact>]
 let wedgeAssembly () =
     let cfg = testConfig "typeProviders/wedgeAssembly"
+
+    copyHelloWorld cfg.Directory
 
     rm cfg "provider.dll"
 

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -7,6 +7,8 @@ open TestFramework
 open HandleExpects
 open FSharp.Compiler.IO
 
+let testConfig = testConfig __SOURCE_DIRECTORY__
+
 type Permutation =
 #if NETCOREAPP
     | FSC_NETCORE of optimized: bool * buildOnly: bool

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -71,8 +71,11 @@ module CoreTests =
 
     [<Fact>]
     let ``SDKTests`` () =
-        let cfg = testConfigOldBehavior __SOURCE_DIRECTORY__ "SDKTests"
-        exec cfg cfg.DotNetExe ("msbuild " + Path.Combine(cfg.Directory, "AllSdkTargetsTests.proj") + " /p:Configuration=" + cfg.BUILD_CONFIG)
+        let cfg = testConfig "SDKTests"
+
+        let FSharpRepositoryPath = Path.GetFullPath(__SOURCE_DIRECTORY__ ++ ".." ++ "..")
+
+        exec cfg cfg.DotNetExe ($"msbuild {cfg.Directory}\AllSdkTargetsTests.proj /p:Configuration={cfg.BUILD_CONFIG} -property:FSharpRepositoryPath={FSharpRepositoryPath}")
 
 #if !NETCOREAPP
     [<Fact>]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -27,12 +27,6 @@ let FSI = FSI_NETFX
 #endif
 // ^^^^^^^^^^^^ To run these tests in F# Interactive , 'build net40', then send this chunk, then evaluate body of a test ^^^^^^^^^^^^
 
-let inline getTestsDirectory dir = getTestsDirectory __SOURCE_DIRECTORY__ dir
-let singleTestBuildAndRun = getTestsDirectory >> singleTestBuildAndRun
-let singleTestBuildAndRunVersion = getTestsDirectory >> singleTestBuildAndRunVersion
-let testConfig = getTestsDirectory >> testConfig
-
-
 module CoreTests =
 
 
@@ -75,7 +69,7 @@ module CoreTests =
 #endif
 
 
-    [<Fact>]
+    [<Fact(Skip="Need to deal with hardcoded paths?")>]
     let ``SDKTests`` () =
         let cfg = testConfig "SDKTests"
         exec cfg cfg.DotNetExe ("msbuild " + Path.Combine(cfg.Directory, "AllSdkTargetsTests.proj") + " /p:Configuration=" + cfg.BUILD_CONFIG)
@@ -861,21 +855,21 @@ module CoreTests =
         let cfg = testConfig "core/quotes"
         csc cfg """/nologo  /target:library /out:cslib.dll""" ["cslib.cs"]
 
-        singleTestBuildAndRun "core/quotes" FSC_DEBUG
+        singleTestBuildAndRunAux cfg FSC_DEBUG
 
     [<Fact>]
     let ``quotes-FSC-BASIC`` () =
         let cfg = testConfig "core/quotes"
         csc cfg """/nologo  /target:library /out:cslib.dll""" ["cslib.cs"]
 
-        singleTestBuildAndRun "core/quotes" FSC_OPTIMIZED
+        singleTestBuildAndRunAux cfg FSC_OPTIMIZED
 
     [<Fact>]
     let ``quotes-FSI-BASIC`` () =
         let cfg = testConfig "core/quotes"
         csc cfg """/nologo  /target:library /out:cslib.dll""" ["cslib.cs"]
 
-        singleTestBuildAndRun "core/quotes" FSI
+        singleTestBuildAndRunAux cfg FSI
 
     [<Fact; Trait("Category", "parsing")>]
     let parsing () =
@@ -2406,7 +2400,7 @@ module TypecheckTests =
 module FscTests =
     [<Fact>]
     let ``should be raised if AssemblyInformationalVersion has invalid version`` () =
-        let cfg = testConfig (Commands.createTempDir())
+        let cfg = testConfigWithoutSourceDirectory()
 
         let code  =
             """
@@ -2431,7 +2425,7 @@ open System.Reflection
 
     [<Fact>]
     let ``should set file version info on generated file`` () =
-        let cfg = testConfig (Commands.createTempDir())
+        let cfg = testConfigWithoutSourceDirectory()
 
         let code =
             """
@@ -2490,7 +2484,7 @@ module ProductVersionTest =
     let ``should use correct fallback``() =
 
        for (assemblyVersion, fileVersion, infoVersion, expected) in fallbackTestData () do
-        let cfg = testConfig (Commands.createTempDir())
+        let cfg = testConfigWithoutSourceDirectory()
         let dir = cfg.Directory
 
         printfn "Directory: %s" dir

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -75,7 +75,9 @@ module CoreTests =
 
         let FSharpRepositoryPath = Path.GetFullPath(__SOURCE_DIRECTORY__ ++ ".." ++ "..")
 
-        exec cfg cfg.DotNetExe ($"msbuild {cfg.Directory}\AllSdkTargetsTests.proj /p:Configuration={cfg.BUILD_CONFIG} -property:FSharpRepositoryPath={FSharpRepositoryPath}")
+        let projectFile = cfg.Directory ++ "AllSdkTargetsTests.proj"
+
+        exec cfg cfg.DotNetExe ($"msbuild {projectFile} /p:Configuration={cfg.BUILD_CONFIG} -property:FSharpRepositoryPath={FSharpRepositoryPath}")
 
 #if !NETCOREAPP
     [<Fact>]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -69,9 +69,9 @@ module CoreTests =
 #endif
 
 
-    [<Fact(Skip="Need to deal with hardcoded paths?")>]
+    [<Fact>]
     let ``SDKTests`` () =
-        let cfg = testConfig "SDKTests"
+        let cfg = testConfigOldBehavior __SOURCE_DIRECTORY__ "SDKTests"
         exec cfg cfg.DotNetExe ("msbuild " + Path.Combine(cfg.Directory, "AllSdkTargetsTests.proj") + " /p:Configuration=" + cfg.BUILD_CONFIG)
 
 #if !NETCOREAPP
@@ -2400,7 +2400,7 @@ module TypecheckTests =
 module FscTests =
     [<Fact>]
     let ``should be raised if AssemblyInformationalVersion has invalid version`` () =
-        let cfg = testConfigWithoutSourceDirectory()
+        let cfg = createConfigWithEmptyDirectory()
 
         let code  =
             """
@@ -2425,7 +2425,7 @@ open System.Reflection
 
     [<Fact>]
     let ``should set file version info on generated file`` () =
-        let cfg = testConfigWithoutSourceDirectory()
+        let cfg = createConfigWithEmptyDirectory()
 
         let code =
             """
@@ -2484,7 +2484,7 @@ module ProductVersionTest =
     let ``should use correct fallback``() =
 
        for (assemblyVersion, fileVersion, infoVersion, expected) in fallbackTestData () do
-        let cfg = testConfigWithoutSourceDirectory()
+        let cfg = createConfigWithEmptyDirectory()
         let dir = cfg.Directory
 
         printfn "Directory: %s" dir

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -635,8 +635,8 @@ module CoreTests =
 
         let fsc_flags_errors_ok = ""
 
-        let rawFileOut = tryCreateTemporaryFileName ()
-        let rawFileErr = tryCreateTemporaryFileName ()
+        let rawFileOut = getTemporaryFileName ()
+        let rawFileErr = getTemporaryFileName ()
         ``fsi <a >b 2>c`` "%s --nologo --preferreduilang:en-US %s" fsc_flags_errors_ok flag ("test.fsx", rawFileOut, rawFileErr)
 
         let removeCDandHelp fromFile toFile =


### PR DESCRIPTION
Some tests cases were executing in this repo subfolders, often many tests reusing the same folders. This had disadvantages.
You can't run such tests cases concurrently and sometimes git changes get polluted with test artifacts.

The idea is to simply copy the directory required by the test, with subfolders, to temp.

On each test run a subfolder is created in `%TEMP%/FSharp.Test.Utilities/` named with current date and a short uinque id: `%TEMP%/FSharp.Test.Utilities/yyy-MM-dd-xxxxxxx/`.
Test cases executed during the test run create separate uniquely named folders inside.

This PR is extracted from the experiments in test parallelization.
