### PR TITLE
Remove non-existing file from a project

### DIFF
--- a/tests/fsharp/FSharpSuite.Tests.fsproj
+++ b/tests/fsharp/FSharpSuite.Tests.fsproj
@@ -95,7 +95,6 @@
     <Compile Include="Compiler\Libraries\Core\Reflection\SprintfTests.fs" />
     <Compile Include="Compiler\Libraries\Core\Reflection\PreComputedTupleConstructorTests.fs" />
     <Compile Include="Compiler\Libraries\Core\Unchecked\DefaultOfTests.fs" />
-    <None Include="update.base.line.with.actuals.fsx" />
     <!-- don't include test resources in subdirectories -->
     <EmbeddedResource Remove="**" />
   </ItemGroup>


### PR DESCRIPTION
This:
![image](https://github.com/user-attachments/assets/b460794d-f1c9-423e-b53a-15f7b408b182)

The file was added [here](https://github.com/dotnet/fsharp/pull/5117) and removed [here](https://github.com/dotnet/fsharp/pull/6596), because of some test framework simplifications. Hence just remnants of a cleanup.