### PR TITLE
Rendering AllowsRefStruct for type parameters

### DIFF
--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -1024,6 +1024,7 @@ and SolveTypMeetsTyparConstraints (csenv: ConstraintSolverEnv) ndeep m2 trace ty
         | TyparConstraint.IsDelegate(aty, bty, m2)       -> SolveTypeIsDelegate                 csenv ndeep m2 trace ty aty bty
         | TyparConstraint.IsNonNullableStruct m2         -> SolveTypeIsNonNullableValueType     csenv ndeep m2 trace ty
         | TyparConstraint.IsUnmanaged m2                 -> SolveTypeIsUnmanaged                csenv ndeep m2 trace ty
+        | TyparConstraint.AllowsRefStruct _              -> CompleteD
         | TyparConstraint.IsReferenceType m2             -> SolveTypeIsReferenceType            csenv ndeep m2 trace ty
         | TyparConstraint.RequiresDefaultConstructor m2  -> SolveTypeRequiresDefaultConstructor csenv ndeep m2 trace ty
         | TyparConstraint.SimpleChoice(tys, m2)          -> SolveTypeChoice                     csenv ndeep m2 trace ty tys
@@ -2465,6 +2466,7 @@ and CheckConstraintImplication (csenv: ConstraintSolverEnv) tpc1 tpc2 =
     | TyparConstraint.NotSupportsNull _, TyparConstraint.NotSupportsNull _
     | TyparConstraint.IsNonNullableStruct _, TyparConstraint.IsNonNullableStruct _
     | TyparConstraint.IsUnmanaged _, TyparConstraint.IsUnmanaged _
+    | TyparConstraint.AllowsRefStruct _, TyparConstraint.AllowsRefStruct _
     | TyparConstraint.IsReferenceType _, TyparConstraint.IsReferenceType _
     | TyparConstraint.RequiresDefaultConstructor _, TyparConstraint.RequiresDefaultConstructor _ -> true
     | TyparConstraint.SimpleChoice (tys1, _), TyparConstraint.SimpleChoice (tys2, _) -> ListSet.isSubsetOf (typeEquiv g) tys1 tys2

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -5156,6 +5156,7 @@ and TcPatLongIdentActivePatternCase warnOnUpper (cenv: cenv) (env: TcEnv) vFlags
                         | TyparConstraint.SupportsComparison _
                         | TyparConstraint.SupportsEquality _
                         | TyparConstraint.DefaultsTo (ty = Unit)
+                        | TyparConstraint.AllowsRefStruct _
                         | TyparConstraint.MayResolveMember _ -> true
 
                         // Any other kind of constraint is incompatible with unit.

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -773,8 +773,13 @@ module PrintTypes =
         | _ -> 
             if denv.abbreviateAdditionalConstraints then 
                 wordL (tagKeyword "when") ^^ wordL(tagText "<constraints>")
-            elif denv.shortConstraints then 
-                LeftL.leftParen ^^ wordL (tagKeyword "requires") ^^ sepListL (wordL (tagKeyword "and")) cxsL ^^ RightL.rightParen
+            elif denv.shortConstraints then
+                match cxs with
+                | (_,TyparConstraint.AllowsRefStruct _) :: _ ->
+                    // If the first constraint is 'allows ref struct', we do not want to prefix it with 'requires', because that just reads wrong.
+                    LeftL.leftParen ^^ sepListL (wordL (tagKeyword "and")) cxsL ^^ RightL.rightParen
+                | _ ->
+                    LeftL.leftParen ^^ wordL (tagKeyword "requires") ^^ sepListL (wordL (tagKeyword "and")) cxsL ^^ RightL.rightParen
             else
                 wordL (tagKeyword "when") ^^ sepListL (wordL (tagKeyword "and")) cxsL
 
@@ -834,6 +839,12 @@ module PrintTypes =
                 [wordL (tagKeyword "unmanaged")]
             else
                 [wordL (tagKeyword "unmanaged") |> longConstraintPrefix]
+                
+        | TyparConstraint.AllowsRefStruct _ ->
+            if denv.shortConstraints then
+                [wordL (tagKeyword "allows ref struct")]
+            else
+                [wordL (tagKeyword "allows ref struct") |> longConstraintPrefix]
 
         | TyparConstraint.IsReferenceType _ ->
             if denv.shortConstraints then 

--- a/src/Compiler/Checking/PostInferenceChecks.fs
+++ b/src/Compiler/Checking/PostInferenceChecks.fs
@@ -448,6 +448,7 @@ and CheckTypeConstraintDeep cenv f g env x =
      | TyparConstraint.NotSupportsNull _
      | TyparConstraint.IsNonNullableStruct _
      | TyparConstraint.IsUnmanaged _
+     | TyparConstraint.AllowsRefStruct _
      | TyparConstraint.IsReferenceType _
      | TyparConstraint.RequiresDefaultConstructor _ -> ()
 

--- a/src/Compiler/Checking/SignatureHash.fs
+++ b/src/Compiler/Checking/SignatureHash.fs
@@ -165,6 +165,7 @@ module rec HashTypes =
         | TyparConstraint.SimpleChoice(tys, _) -> tpHash @@ 12 @@ (tys |> hashListOrderIndependent (hashTType g))
         | TyparConstraint.RequiresDefaultConstructor _ -> tpHash @@ 13
         | TyparConstraint.NotSupportsNull(_) -> tpHash @@ 14
+        | TyparConstraint.AllowsRefStruct _ -> tpHash @@ 15
 
     /// Hash type parameter constraints
     let private hashConstraints (g: TcGlobals) cxs =

--- a/src/Compiler/Checking/TypeHierarchy.fs
+++ b/src/Compiler/Checking/TypeHierarchy.fs
@@ -285,6 +285,7 @@ let FoldHierarchyOfTypeAux followInterfaces allowMultiIntfInst skipUnref visitor
                           | TyparConstraint.NotSupportsNull _
                           | TyparConstraint.IsNonNullableStruct _
                           | TyparConstraint.IsUnmanaged _
+                          | TyparConstraint.AllowsRefStruct _
                           | TyparConstraint.IsReferenceType _
                           | TyparConstraint.SimpleChoice _
                           | TyparConstraint.RequiresDefaultConstructor _ -> vacc
@@ -412,7 +413,9 @@ let ImportReturnTypeFromMetadata amap m nullnessSource ilTy scoref tinst minst =
 
 let CopyTyparConstraints m tprefInst (tporig: Typar) =
     tporig.Constraints
-    |>  List.map (fun tpc ->
+    // F# does not have escape analysis for authoring 'allows ref struct' generic code. Therefore, typar is not copied, can only come from C# authored code
+    |> List.filter (fun tp -> match tp with | TyparConstraint.AllowsRefStruct _ -> false | _ -> true)
+    |> List.map (fun tpc ->
            match tpc with
            | TyparConstraint.CoercesTo(ty, _) ->
                TyparConstraint.CoercesTo (instType tprefInst ty, m)
@@ -434,6 +437,7 @@ let CopyTyparConstraints m tprefInst (tporig: Typar) =
                TyparConstraint.IsNonNullableStruct m
            | TyparConstraint.IsUnmanaged _ ->
                TyparConstraint.IsUnmanaged m
+           | TyparConstraint.AllowsRefStruct _ -> failwith "impossible, filtered above"
            | TyparConstraint.IsReferenceType _ ->
                TyparConstraint.IsReferenceType m
            | TyparConstraint.SimpleChoice (tys, _) ->

--- a/src/Compiler/Checking/TypeRelations.fs
+++ b/src/Compiler/Checking/TypeRelations.fs
@@ -151,19 +151,13 @@ let ChooseTyparSolutionAndRange (g: TcGlobals) amap (tp:Typar) =
              match tpc with 
              | TyparConstraint.CoercesTo(x, m) -> 
                  join m x, m
-             | TyparConstraint.MayResolveMember(_traitInfo, m) -> 
-                 (maxTy, isRefined), m
              | TyparConstraint.SimpleChoice(_, m) -> 
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInPrintf(), m))
                  (maxTy, isRefined), m
              | TyparConstraint.SupportsNull m -> 
                  ((addNullnessToTy KnownWithNull maxTy), isRefined), m
-             | TyparConstraint.NotSupportsNull m -> 
-                 (maxTy, isRefined), m // NOTE: this doesn't "force" non-nullness, since it is the default choice in 'obj' or 'int'
              | TyparConstraint.SupportsComparison m -> 
                  join m g.mk_IComparable_ty, m
-             | TyparConstraint.SupportsEquality m -> 
-                 (maxTy, isRefined), m
              | TyparConstraint.IsEnum(_, m) -> 
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInEnum(), m))
                  (maxTy, isRefined), m
@@ -175,12 +169,15 @@ let ChooseTyparSolutionAndRange (g: TcGlobals) amap (tp:Typar) =
              | TyparConstraint.IsUnmanaged m ->
                  errorR(Error(FSComp.SR.typrelCannotResolveAmbiguityInUnmanaged(), m))
                  (maxTy, isRefined), m
-             | TyparConstraint.RequiresDefaultConstructor m -> 
+             | TyparConstraint.NotSupportsNull m // NOTE: this doesn't "force" non-nullness, since it is the default choice in 'obj' or 'int'
+             | TyparConstraint.SupportsEquality m
+             | TyparConstraint.AllowsRefStruct m
+             | TyparConstraint.RequiresDefaultConstructor m
+             | TyparConstraint.IsReferenceType m
+             | TyparConstraint.MayResolveMember(_, m)
+             | TyparConstraint.DefaultsTo(_,_, m) -> 
                  (maxTy, isRefined), m
-             | TyparConstraint.IsReferenceType m -> 
-                 (maxTy, isRefined), m
-             | TyparConstraint.DefaultsTo(_priority, _ty, m) -> 
-                 (maxTy, isRefined), m)
+             )
 
     if g.langVersion.SupportsFeature LanguageFeature.DiagnosticForObjInference then
         match tp.Kind with

--- a/src/Compiler/Checking/import.fs
+++ b/src/Compiler/Checking/import.fs
@@ -647,6 +647,8 @@ let ImportILGenericParameters amap m scoref tinst (nullableFallback:Nullness.Nul
                     TyparConstraint.IsNonNullableStruct(m)
                   if gp.HasReferenceTypeConstraint then
                     TyparConstraint.IsReferenceType(m)
+                  if gp.HasAllowsRefStruct then
+                    TyparConstraint.AllowsRefStruct(m)
                   for ilTy in gp.Constraints do
                     TyparConstraint.CoercesTo(ImportILType amap m importInst (rescopeILType scoref ilTy), m) ]            
 

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -2531,6 +2531,9 @@ type TyparConstraint =
     
     /// A constraint that a type is .NET unmanaged type
     | IsUnmanaged of range: range
+    
+    /// An anti-constraint indicating that ref structs (e.g. Span<>) are allowed here
+    | AllowsRefStruct of range:range
 
     // %+A formatting is used, so this is not needed
     //[<DebuggerBrowsable(DebuggerBrowsableState.Never)>]

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -1693,6 +1693,9 @@ type TyparConstraint =
 
     /// A constraint that a type is .NET unmanaged type
     | IsUnmanaged of range: range
+    
+    /// An anti-constraint indicating that ref structs (e.g. Span<>) are allowed here
+    | AllowsRefStruct of range:range
 
     override ToString: unit -> string
 

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -272,7 +272,8 @@ and remapTyparConstraintsAux tyenv cs =
          | TyparConstraint.SupportsEquality _ 
          | TyparConstraint.SupportsNull _ 
          | TyparConstraint.NotSupportsNull _ 
-         | TyparConstraint.IsUnmanaged _ 
+         | TyparConstraint.IsUnmanaged _
+         | TyparConstraint.AllowsRefStruct _
          | TyparConstraint.IsNonNullableStruct _ 
          | TyparConstraint.IsReferenceType _ 
          | TyparConstraint.RequiresDefaultConstructor _ -> Some x)
@@ -1039,6 +1040,7 @@ and typarConstraintsAEquivAux erasureFlag g aenv tpc1 tpc2 =
     | TyparConstraint.IsNonNullableStruct _, TyparConstraint.IsNonNullableStruct _
     | TyparConstraint.IsReferenceType _, TyparConstraint.IsReferenceType _ 
     | TyparConstraint.IsUnmanaged _, TyparConstraint.IsUnmanaged _
+    | TyparConstraint.AllowsRefStruct _, TyparConstraint.AllowsRefStruct _
     | TyparConstraint.RequiresDefaultConstructor _, TyparConstraint.RequiresDefaultConstructor _ -> true
     | _ -> false
 
@@ -2345,6 +2347,7 @@ and accFreeInTyparConstraint opts tpc acc =
     | TyparConstraint.IsNonNullableStruct _ 
     | TyparConstraint.IsReferenceType _ 
     | TyparConstraint.IsUnmanaged _
+    | TyparConstraint.AllowsRefStruct _
     | TyparConstraint.RequiresDefaultConstructor _ -> acc
 
 and accFreeInTrait opts (TTrait(tys, _, _, argTys, retTy, _, sln)) acc = 
@@ -2480,6 +2483,7 @@ and accFreeInTyparConstraintLeftToRight g cxFlag thruFlag acc tpc =
     | TyparConstraint.NotSupportsNull _ 
     | TyparConstraint.IsNonNullableStruct _ 
     | TyparConstraint.IsUnmanaged _
+    | TyparConstraint.AllowsRefStruct _
     | TyparConstraint.IsReferenceType _ 
     | TyparConstraint.RequiresDefaultConstructor _ -> acc
 
@@ -4223,6 +4227,8 @@ module DebugPrint =
             wordL (tagText "not null") |> constraintPrefix
         | TyparConstraint.IsUnmanaged _ ->
             wordL (tagText "unmanaged") |> constraintPrefix
+        | TyparConstraint.AllowsRefStruct _ ->
+            wordL (tagText "allows ref struct") |> constraintPrefix
         | TyparConstraint.SimpleChoice(tys, _) ->
             bracketL (sepListL (sepL (tagText "|")) (List.map (auxTypeL env) tys)) |> constraintPrefix
         | TyparConstraint.RequiresDefaultConstructor _ ->

--- a/tests/FSharp.Compiler.Service.Tests/TooltipTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/TooltipTests.fs
@@ -470,3 +470,49 @@ let success,version = System.Version.TryParse(null)
     |> assertAndGetSingleToolTipText
     |> Assert.shouldBeEquivalentTo ("""System.Version.TryParse([<NotNullWhenAttribute (true)>] input: string | null,
                         [<NotNullWhenAttribute (true)>] result: byref<System.Version | null>) : bool""" |> normalize)
+    
+[<FactForNETCOREAPP>]
+let ``Allows ref struct is shown on BCL interface declaration`` () =   
+    let source = """module Foo
+open System
+let myAction : Action<int> | null = null
+"""
+    let checkResults = getCheckResults source [|"--checknulls+";"--langversion:preview"|]
+    checkResults.GetToolTip(3, 21, "let myAction : Action<int> | null = null", [ "Action" ], FSharpTokenTag.Identifier)   
+    |> assertAndGetSingleToolTipText
+    |> Assert.shouldStartWith ("""type Action<'T (allows ref struct)>""" |> normalize)
+    
+[<FactForNETCOREAPP>]
+let ``Allows ref struct is shown for each T on BCL interface declaration`` () =   
+    let source = """module Foo
+open System
+let myAction : Action<int,_,_,_> | null = null
+"""
+    let checkResults = getCheckResults source [|"--checknulls+";"--langversion:preview"|]
+    checkResults.GetToolTip(3, 21, "let myAction : Action<int,_,_,_> | null = null", [ "Action" ], FSharpTokenTag.Identifier)   
+    |> assertAndGetSingleToolTipText
+    |> Assert.shouldStartWith ("""type Action<'T1,'T2,'T3,'T4 (allows ref struct and allows ref struct and allows ref struct and allows ref struct)>""" |> normalize)
+    
+[<FactForNETCOREAPP>]
+let ``Allows ref struct is shown on BCL method usage`` () =
+    let source = """module Foo
+open System
+open System.Collections.Generic
+let doIt (dict:Dictionary<'a,'b>) = dict.GetAlternateLookup<'a,'b,ReadOnlySpan<char>>()
+"""
+    let checkResults = getCheckResults source [|"--langversion:preview"|]
+    checkResults.GetToolTip(4, 59, "let doIt (dict:Dictionary<'a,'b>) = dict.GetAlternateLookup<'a,'b,ReadOnlySpan<char>>()", [ "GetAlternateLookup" ], FSharpTokenTag.Identifier)   
+    |> assertAndGetSingleToolTipText
+    |> fun s -> s.Replace("(extension) ","") //BCL changes if this is instance or extension method, this test does not care
+    |> Assert.shouldStartWith ("""Dictionary.GetAlternateLookup<'TKey,'TValue,'TAlternateKey (allows ref struct)>""" |> normalize)
+    
+[<FactForNETCOREAPP>]
+let ``Allows ref struct is not shown on BCL interface usage`` () =   
+    let source = """module Foo
+open System
+let doIt(myAction : Action<int>) = myAction.Invoke(42)
+"""
+    let checkResults = getCheckResults source [|"--langversion:preview"|]
+    checkResults.GetToolTip(3, 43, "let doIt(myAction : Action<int>) = myAction.Invoke(42)", [ "myAction" ], FSharpTokenTag.Identifier)   
+    |> assertAndGetSingleToolTipText
+    |> Assert.shouldBeEquivalentTo ("""val myAction: Action<int>""" |> normalize)

--- a/tests/FSharp.Test.Utilities/Assert.fs
+++ b/tests/FSharp.Test.Utilities/Assert.fs
@@ -11,6 +11,9 @@ module Assert =
 
     let inline shouldBeEquivalentTo (expected : ^T) (actual : ^U) =
         actual.Should().BeEquivalentTo(expected, "") |> ignore
+        
+    let inline shouldStartWith (expected : string) (actual : string) =
+        actual.Should().StartWith(expected) |> ignore
 
     let inline shouldBe (expected : ^T) (actual : ^U) =
         actual.Should().Be(expected, "") |> ignore


### PR DESCRIPTION
This adds the display (e.g. tooltips) of `allows ref struct` generic anti constraint that can come from C#-authored dependencies.