### PR TITLE
Remove redundant "ok" files in core tests

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/FsharpSuiteMigrated.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/FsharpSuiteMigrated.fs
@@ -31,17 +31,9 @@ module ScriptRunner =
         let cu  = cu |> withDefines defaultDefines
         match cu with 
         | FS fsSource ->
-            File.Delete("test.ok")
             let engine = createEngine (fsSource.Options |> Array.ofList,version)
             let res = evalScriptFromDiskInSharedSession engine cu
-            match res with
-            | CompilationResult.Failure _ -> res
-            | CompilationResult.Success s -> 
-                if File.Exists("test.ok") then
-                    res
-                else
-                    failwith $"Results looked correct, but 'test.ok' file was not created. Result: %A{s}"       
-
+            res
         | _ -> failwith $"Compilation unit other than fsharp is not supported, cannot process %A{cu}"
 
 /// This test file was created by porting over (slower) FsharpSuite.Tests

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TestCasesForGenerationRoundTrip/access.fsx
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TestCasesForGenerationRoundTrip/access.fsx
@@ -278,7 +278,6 @@ let aa =
   match failures.Value with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TestCasesForGenerationRoundTrip/array.fsx
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TestCasesForGenerationRoundTrip/array.fsx
@@ -1142,7 +1142,6 @@ let aa =
   match failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TestCasesForGenerationRoundTrip/libtest.fsx
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TestCasesForGenerationRoundTrip/libtest.fsx
@@ -5651,7 +5651,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/.gitignore
+++ b/tests/fsharp/.gitignore
@@ -1,5 +1,4 @@
 build.ok
-test.ok
 test*.exe
 test*.pdb
 test*.dll

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -481,7 +481,6 @@ let _ =
   if !failures then (System.Console.Out.WriteLine "Test Failed"; exit 1) 
 
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)
             """,
             (fun verifier -> verifier.VerifyIL [

--- a/tests/fsharp/TypeProviderTests.fs
+++ b/tests/fsharp/TypeProviderTests.fs
@@ -69,11 +69,7 @@ let diamondAssembly () =
 
     exec cfg ("." ++ "test3.exe") ""
 
-    use testOkFile = fileguard cfg "test.ok"
-
     fsi cfg "%s" cfg.fsi_flags ["test3.fsx"]
-
-    testOkFile.CheckExists()
 
 [<Fact>]
 let globalNamespace () =
@@ -286,18 +282,11 @@ let splitAssembly subdir project =
     fsc cfg "--out:test.exe -r:provider.dll" ["test.fsx"]
 
     begin
-        use testOkFile = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "test.exe") ""
-
-        testOkFile.CheckExists()
     end
 
     begin
-        use testOkFile = fileguard cfg "test.ok"
-
         fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
-        testOkFile.CheckExists()
     end
 
     // Do the same thing with different load locations for the type provider design-time component
@@ -327,18 +316,11 @@ let splitAssembly subdir project =
         fsc cfg "--out:test.exe -r:provider.dll" ["test.fsx"]
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
-
             exec cfg ("." ++ "test.exe") ""
-
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
-
             fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
-            testOkFile.CheckExists()
         end
 
     clean()

--- a/tests/fsharp/core/access/test.fsx
+++ b/tests/fsharp/core/access/test.fsx
@@ -274,7 +274,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/anon/test.fsx
+++ b/tests/fsharp/core/anon/test.fsx
@@ -86,7 +86,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/apporder/test.fsx
+++ b/tests/fsharp/core/apporder/test.fsx
@@ -1130,7 +1130,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/array-no-dot/test.fsx
+++ b/tests/fsharp/core/array-no-dot/test.fsx
@@ -435,7 +435,6 @@ let aa =
   match failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/array/test.fsx
+++ b/tests/fsharp/core/array/test.fsx
@@ -1142,7 +1142,6 @@ let aa =
   match failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/asyncStackTraces/test.fsx
+++ b/tests/fsharp/core/asyncStackTraces/test.fsx
@@ -176,6 +176,5 @@ let aa =
       exit 1
   else   
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
 

--- a/tests/fsharp/core/attributes/test.fsx
+++ b/tests/fsharp/core/attributes/test.fsx
@@ -1358,7 +1358,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/auto-widen/5.0/test.fsx
+++ b/tests/fsharp/core/auto-widen/5.0/test.fsx
@@ -459,7 +459,6 @@ let aa =
   match failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       printfn "Test Failed, failures = %A" failures

--- a/tests/fsharp/core/auto-widen/minimal/test.fsx
+++ b/tests/fsharp/core/auto-widen/minimal/test.fsx
@@ -2,5 +2,4 @@
 #r "System.Xml.XDocument.dll"
 
 let ns : System.Xml.Linq.XNamespace = ""
-System.IO.File.WriteAllText("test.ok","ok")
 exit 0

--- a/tests/fsharp/core/auto-widen/preview-default-warns/test.fsx
+++ b/tests/fsharp/core/auto-widen/preview-default-warns/test.fsx
@@ -566,7 +566,6 @@ let aa =
   match failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       printfn "Test Failed, failures = %A" failures

--- a/tests/fsharp/core/auto-widen/preview/test.fsx
+++ b/tests/fsharp/core/auto-widen/preview/test.fsx
@@ -644,7 +644,6 @@ let aa =
   match failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       printfn "Test Failed, failures = %A" failures

--- a/tests/fsharp/core/comprehensions-hw/test.fsx
+++ b/tests/fsharp/core/comprehensions-hw/test.fsx
@@ -1048,7 +1048,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/comprehensions/test.fsx
+++ b/tests/fsharp/core/comprehensions/test.fsx
@@ -1488,7 +1488,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/control/test.fsx
+++ b/tests/fsharp/core/control/test.fsx
@@ -2100,7 +2100,6 @@ let aa =
       exit 1
   else   
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
 #endif
 

--- a/tests/fsharp/core/controlChamenos/test.fsx
+++ b/tests/fsharp/core/controlChamenos/test.fsx
@@ -123,6 +123,5 @@ let aa =
       exit 1
   else   
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
 #endif

--- a/tests/fsharp/core/controlMailbox/test.fsx
+++ b/tests/fsharp/core/controlMailbox/test.fsx
@@ -624,6 +624,5 @@ let aa =
       exit 1
   else   
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
 #endif

--- a/tests/fsharp/core/controlStackOverflow/test.fsx
+++ b/tests/fsharp/core/controlStackOverflow/test.fsx
@@ -415,6 +415,5 @@ let aa =
   else   
       stdout.WriteLine "Test Passed"
       log "ALL OK, HAPPY HOLIDAYS, MERRY CHRISTMAS!"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
 #endif

--- a/tests/fsharp/core/controlWebExt/test.fsx
+++ b/tests/fsharp/core/controlWebExt/test.fsx
@@ -233,12 +233,6 @@ let aa =
   if not failures.IsEmpty then (stdout.WriteLine("Test Failed, failures = {0}", failures); exit 1) 
   else (stdout.WriteLine "Test Passed"; 
         log "ALL OK, HAPPY HOLIDAYS, MERRY CHRISTMAS!"
-        System.IO.File.WriteAllText("test.ok","ok"); 
-// debug: why is the fsi test failing?  is it because test.ok does not exist?
-        if System.IO.File.Exists("test.ok") then
-            stdout.WriteLine ("test.ok found at {0}", System.IO.FileInfo("test.ok").FullName)
-        else
-            stdout.WriteLine ("test.ok not found")
         exit 0)
 
 #endif

--- a/tests/fsharp/core/controlWpf/test.fsx
+++ b/tests/fsharp/core/controlWpf/test.fsx
@@ -28,7 +28,6 @@ async {
         app.Shutdown(128)
     else
         printfn "Test Passed"
-        System.IO.File.WriteAllText("test.ok","ok")
         app.Shutdown(0)
 } |> Async.StartImmediate
 

--- a/tests/fsharp/core/csext/test.fsx
+++ b/tests/fsharp/core/csext/test.fsx
@@ -321,7 +321,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/enum/test.fsx
+++ b/tests/fsharp/core/enum/test.fsx
@@ -49,7 +49,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/events/test.fs
+++ b/tests/fsharp/core/events/test.fs
@@ -536,6 +536,5 @@ module EventWithNonPublicDelegateTypes_DevDiv271288 =
 
 let _ = 
   if failures.Length > 0 then (printfn "Tests Failed: %A" failures; exit 1) 
-  else (stdout.WriteLine "Test Passed"; 
-        System.IO.File.WriteAllText("test.ok","ok"); 
+  else (stdout.WriteLine "Test Passed";
         exit 0)

--- a/tests/fsharp/core/fileorder/test.fsx
+++ b/tests/fsharp/core/fileorder/test.fsx
@@ -19,5 +19,4 @@ let aa =
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)

--- a/tests/fsharp/core/forexpression/test.fsx
+++ b/tests/fsharp/core/forexpression/test.fsx
@@ -168,5 +168,5 @@ let RUN() = !failures
 #else
 let aa =
     if !failures then stdout.WriteLine "Test Failed"; exit 1
-    else stdout.WriteLine "Test Passed"; System.IO.File.WriteAllText("test.ok","ok"); exit 0
+    else stdout.WriteLine "Test Passed"; exit 0
 #endif

--- a/tests/fsharp/core/fsfromfsviacs/test.fsx
+++ b/tests/fsharp/core/fsfromfsviacs/test.fsx
@@ -487,7 +487,6 @@ let _ =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/fsi-load/test.fsx
+++ b/tests/fsharp/core/fsi-load/test.fsx
@@ -17,6 +17,5 @@ module OtherModule =
 
   let _ =
           stdout.WriteLine "Test Passed"
-          System.IO.File.WriteAllText("test.ok","ok")
           exit 0
 

--- a/tests/fsharp/core/fsi-reference/test.fsx
+++ b/tests/fsharp/core/fsi-reference/test.fsx
@@ -4,5 +4,4 @@ let c = new ReferenceAssembly.MyClass()
 let _ = c.X
 
 // If this fails then the jit blows up so this file will not get written.
-let os = System.IO.File.CreateText "test.ok" in os.Close() 
 exit 0

--- a/tests/fsharp/core/fsi-reload/load1.fsx
+++ b/tests/fsharp/core/fsi-reload/load1.fsx
@@ -2,4 +2,4 @@
 #load "a1.fs"
 #load "a2.fs"
 
-let os = System.IO.File.CreateText "test.ok" in os.Close() 
+exit 0

--- a/tests/fsharp/core/fsi-reload/load2.fsx
+++ b/tests/fsharp/core/fsi-reload/load2.fsx
@@ -2,4 +2,4 @@
 #load "b1.fs"
 #load "b2.fsi" "b2.fs" 
 
-let os = System.IO.File.CreateText "test.ok" in os.Close() 
+exit 0

--- a/tests/fsharp/core/fsi-reload/test1.ml
+++ b/tests/fsharp/core/fsi-reload/test1.ml
@@ -72,6 +72,6 @@ printf "x = %b\n" (X x = X 3)
 printf "x = %d\n" (3 : x_t)
 ;;
 
-begin ignore (3 : x_t); ignore (3 : Nested.x_t); ignore (3 : Test1.Nested.x_t); ignore (3 : Test1.x_t); let os = System.IO.File.CreateText "test.ok" in os.Close() end;;
+begin ignore (3 : x_t); ignore (3 : Nested.x_t); ignore (3 : Test1.Nested.x_t); ignore (3 : Test1.x_t); exit 0; end;;
 #quit;; 
 

--- a/tests/fsharp/core/fsiAndModifiers/test.fsx
+++ b/tests/fsharp/core/fsiAndModifiers/test.fsx
@@ -139,7 +139,6 @@ module PinTests =
 
 
 if errors.IsEmpty then 
-    System.IO.File.WriteAllText("test.ok", "")
     exit(0)
 else 
     for error in errors do 

--- a/tests/fsharp/core/genericmeasures/test.fsx
+++ b/tests/fsharp/core/genericmeasures/test.fsx
@@ -80,7 +80,6 @@ module Core_genericMeasures =
 #else
     RunAll();
     stdout.WriteLine "Test Passed"
-    System.IO.File.WriteAllText("test.ok","ok")
     exit 0
 #endif
 

--- a/tests/fsharp/core/indent/version46/test.fsx
+++ b/tests/fsharp/core/indent/version46/test.fsx
@@ -105,7 +105,6 @@ let aa =
   match !failures with
   | [] ->
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ ->
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/indent/version47/test.fsx
+++ b/tests/fsharp/core/indent/version47/test.fsx
@@ -85,7 +85,6 @@ let aa =
   match !failures with
   | [] ->
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ ->
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/innerpoly/test.fsx
+++ b/tests/fsharp/core/innerpoly/test.fsx
@@ -483,7 +483,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/int32/test.fsx
+++ b/tests/fsharp/core/int32/test.fsx
@@ -425,7 +425,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/large/conditionals/LargeConditionals-200.fs
+++ b/tests/fsharp/core/large/conditionals/LargeConditionals-200.fs
@@ -207,4 +207,4 @@ let expectedValues() =
     if rnd.Next(3) = 1 then 1 else 
     4
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/conditionals/LargeConditionals-maxtested.fs
+++ b/tests/fsharp/core/large/conditionals/LargeConditionals-maxtested.fs
@@ -421,4 +421,4 @@ let expectedValues() =
     if rnd.Next(3) = 1 then 1 else 
     4
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/lets/LargeLets-500.fs
+++ b/tests/fsharp/core/large/lets/LargeLets-500.fs
@@ -506,4 +506,4 @@ let expectedValues() =
     let x = x + rnd.Next(3) 
     x
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/lets/LargeLets-maxtested.fs
+++ b/tests/fsharp/core/large/lets/LargeLets-maxtested.fs
@@ -792,4 +792,4 @@ let expectedValues() =
     let x = x + rnd.Next(3) 
     x
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/lists/LargeList-500.fs
+++ b/tests/fsharp/core/large/lists/LargeList-500.fs
@@ -504,4 +504,4 @@ let expectedValues =
         1 
     ]
 printfn "length = %d" expectedValues.Length
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/matches/LargeMatches-200.fs
+++ b/tests/fsharp/core/large/matches/LargeMatches-200.fs
@@ -306,4 +306,4 @@ let expectedValues() =
     | None ->  
     4
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/matches/LargeMatches-maxtested.fs
+++ b/tests/fsharp/core/large/matches/LargeMatches-maxtested.fs
@@ -462,4 +462,4 @@ let expectedValues() =
     | None ->  
     4
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/mixed/LargeSequentialLet-500.fs
+++ b/tests/fsharp/core/large/mixed/LargeSequentialLet-500.fs
@@ -1008,4 +1008,4 @@ let expectedValues() =
     let mutable x = x + 1
     x
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/mixed/LargeSequentialLet-maxtested.fs
+++ b/tests/fsharp/core/large/mixed/LargeSequentialLet-maxtested.fs
@@ -1008,4 +1008,4 @@ let expectedValues() =
     let mutable x = x + 1
     x
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/sequential/LargeSequential-500.fs
+++ b/tests/fsharp/core/large/sequential/LargeSequential-500.fs
@@ -506,4 +506,4 @@ let expectedValues() =
     x <- x + rnd.Next(3) 
     x
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/large/sequential/LargeSequential-maxtested.fs
+++ b/tests/fsharp/core/large/sequential/LargeSequential-maxtested.fs
@@ -6712,4 +6712,4 @@ let expectedValues() =
     x <- x + rnd.Next(3) 
     x
 printfn "expectedValues() = %A" (expectedValues())
-System.IO.File.WriteAllLines("test.ok", ["ok"])
+exit 0

--- a/tests/fsharp/core/lazy/test.fsx
+++ b/tests/fsharp/core/lazy/test.fsx
@@ -78,7 +78,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/letrec-mutrec/test.fs
+++ b/tests/fsharp/core/letrec-mutrec/test.fs
@@ -203,6 +203,5 @@ do
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 #endif

--- a/tests/fsharp/core/letrec-mutrec2/test.fs
+++ b/tests/fsharp/core/letrec-mutrec2/test.fs
@@ -337,6 +337,5 @@ let aa =
 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 #endif

--- a/tests/fsharp/core/letrec/test.fsx
+++ b/tests/fsharp/core/letrec/test.fsx
@@ -812,7 +812,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/libtest/test.fsx
+++ b/tests/fsharp/core/libtest/test.fsx
@@ -5646,7 +5646,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/lift/test.fsx
+++ b/tests/fsharp/core/lift/test.fsx
@@ -64,7 +64,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/longnames/test.fsx
+++ b/tests/fsharp/core/longnames/test.fsx
@@ -695,7 +695,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/map/test.fsx
+++ b/tests/fsharp/core/map/test.fsx
@@ -177,7 +177,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/math/lalgebra/test.fsx
+++ b/tests/fsharp/core/math/lalgebra/test.fsx
@@ -313,7 +313,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/math/numbers/test.fsx
+++ b/tests/fsharp/core/math/numbers/test.fsx
@@ -290,7 +290,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/math/numbersVS2008/test.fsx
+++ b/tests/fsharp/core/math/numbersVS2008/test.fsx
@@ -276,7 +276,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/measures/test.fsx
+++ b/tests/fsharp/core/measures/test.fsx
@@ -612,7 +612,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/basics-hw-mutrec/test.fs
+++ b/tests/fsharp/core/members/basics-hw-mutrec/test.fs
@@ -36,7 +36,6 @@ module StaticInitializerTest3 =
 
 let _ = 
   if not failures.Value.IsEmpty then (eprintfn "Test Failed, failures = %A" failures.Value; exit 1) 
-  else (stdout.WriteLine "Test Passed"; 
-        System.IO.File.WriteAllText("test.ok","ok"); 
+  else (stdout.WriteLine "Test Passed";
         exit 0)
 

--- a/tests/fsharp/core/members/basics-hw/test.fsx
+++ b/tests/fsharp/core/members/basics-hw/test.fsx
@@ -5663,7 +5663,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/basics/test.fs
+++ b/tests/fsharp/core/members/basics/test.fs
@@ -3481,7 +3481,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/ctree/test.fsx
+++ b/tests/fsharp/core/members/ctree/test.fsx
@@ -64,7 +64,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/factors-mutrec/test.fs
+++ b/tests/fsharp/core/members/factors-mutrec/test.fs
@@ -151,7 +151,6 @@ let Gaussian1DPriorFactorNode((var: VariableNode<Gaussian1D>), mean, variance) =
 
 let _ = 
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
-  else (stdout.WriteLine "Test Passed"; 
-        System.IO.File.WriteAllText("test.ok","ok"); 
+  else (stdout.WriteLine "Test Passed";
         exit 0)
 

--- a/tests/fsharp/core/members/factors/test.fsx
+++ b/tests/fsharp/core/members/factors/test.fsx
@@ -276,7 +276,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/incremental-hw-mutrec/test.fsx
+++ b/tests/fsharp/core/members/incremental-hw-mutrec/test.fsx
@@ -658,7 +658,6 @@ module ExceptionsWithAugmentations =
 
 let _ = 
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
-  else (stdout.WriteLine "Test Passed"; 
-        System.IO.File.WriteAllText("test.ok","ok"); 
+  else (stdout.WriteLine "Test Passed";
         exit 0)
 

--- a/tests/fsharp/core/members/incremental-hw/test.fsx
+++ b/tests/fsharp/core/members/incremental-hw/test.fsx
@@ -740,7 +740,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/incremental/test.fsx
+++ b/tests/fsharp/core/members/incremental/test.fsx
@@ -717,7 +717,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/ops-mutrec/test.fs
+++ b/tests/fsharp/core/members/ops-mutrec/test.fs
@@ -381,7 +381,6 @@ module TraitCallsAndConstructors =
 
 let _ = 
   if !failures then (stdout.WriteLine "Test Failed"; exit 1) 
-  else (stdout.WriteLine "Test Passed"; 
-        System.IO.File.WriteAllText("test.ok","ok"); 
+  else (stdout.WriteLine "Test Passed";
         exit 0)
 

--- a/tests/fsharp/core/members/ops/test.fsx
+++ b/tests/fsharp/core/members/ops/test.fsx
@@ -416,7 +416,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"    
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/self-identifier/version46/test.fs
+++ b/tests/fsharp/core/members/self-identifier/version46/test.fs
@@ -54,7 +54,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/members/self-identifier/version47/test.fs
+++ b/tests/fsharp/core/members/self-identifier/version47/test.fs
@@ -76,7 +76,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/nameof/preview/test.fsx
+++ b/tests/fsharp/core/nameof/preview/test.fsx
@@ -417,7 +417,6 @@ let aa =
   match !failures with 
   | [] ->
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/namespaces/test2.fs
+++ b/tests/fsharp/core/namespaces/test2.fs
@@ -28,7 +28,6 @@ module UnionTestsWithSignature =
           exit 1
       else   
           stdout.WriteLine "Test Passed"
-          System.IO.File.WriteAllText("test.ok","ok")
           exit 0
 #endif
 

--- a/tests/fsharp/core/nested/test.fsx
+++ b/tests/fsharp/core/nested/test.fsx
@@ -64,7 +64,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/patterns/test.fsx
+++ b/tests/fsharp/core/patterns/test.fsx
@@ -1735,7 +1735,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/pinvoke/test.fsx
+++ b/tests/fsharp/core/pinvoke/test.fsx
@@ -152,7 +152,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | messages ->
       printfn "%A" messages

--- a/tests/fsharp/core/printf-interpolated/test.fsx
+++ b/tests/fsharp/core/printf-interpolated/test.fsx
@@ -292,7 +292,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/printf/test.fsx
+++ b/tests/fsharp/core/printf/test.fsx
@@ -9339,7 +9339,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/queriesCustomQueryOps/test.fsx
+++ b/tests/fsharp/core/queriesCustomQueryOps/test.fsx
@@ -459,7 +459,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/queriesLeafExpressionConvert/test.fsx
+++ b/tests/fsharp/core/queriesLeafExpressionConvert/test.fsx
@@ -1004,7 +1004,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/queriesNullableOperators/test.fsx
+++ b/tests/fsharp/core/queriesNullableOperators/test.fsx
@@ -311,7 +311,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/queriesOverIEnumerable/test.fsx
+++ b/tests/fsharp/core/queriesOverIEnumerable/test.fsx
@@ -1002,7 +1002,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/queriesOverIQueryable/test.fsx
+++ b/tests/fsharp/core/queriesOverIQueryable/test.fsx
@@ -2445,7 +2445,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/quotes/test.fsx
+++ b/tests/fsharp/core/quotes/test.fsx
@@ -5938,7 +5938,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | errs -> 
       printfn "Test Failed, errors = %A" errs

--- a/tests/fsharp/core/quotesDebugInfo/test.fsx
+++ b/tests/fsharp/core/quotesDebugInfo/test.fsx
@@ -646,7 +646,6 @@ let aa =
   match !failures with 
   | 0 -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/quotesInMultipleModules/module2.fsx
+++ b/tests/fsharp/core/quotesInMultipleModules/module2.fsx
@@ -37,7 +37,6 @@ if not test3 then
 
 if test1 && test2 && test3 then
     stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0
 else
     exit 1

--- a/tests/fsharp/core/recordResolution/test.fsx
+++ b/tests/fsharp/core/recordResolution/test.fsx
@@ -56,5 +56,4 @@ module Ex3 =
   let a2 = { FA = 1 }
   let r = a2 :> A2 //this produces warnings, but proves that a2 is indeed of type A2.
   
-System.IO.File.WriteAllText("test.ok","ok") 
 exit 0

--- a/tests/fsharp/core/reflect/test2.fs
+++ b/tests/fsharp/core/reflect/test2.fs
@@ -330,7 +330,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/refnormalization/test.fs
+++ b/tests/fsharp/core/refnormalization/test.fs
@@ -25,5 +25,4 @@ let main args =
         printfn "Actual: %A "   versions
         1
     else 
-        File.WriteAllText("test.ok", "ok")
         0

--- a/tests/fsharp/core/seq/test.fsx
+++ b/tests/fsharp/core/seq/test.fsx
@@ -768,7 +768,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/state-machines/test.fsx
+++ b/tests/fsharp/core/state-machines/test.fsx
@@ -663,7 +663,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/subtype/test.fsx
+++ b/tests/fsharp/core/subtype/test.fsx
@@ -2545,7 +2545,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/syntax/test.fsx
+++ b/tests/fsharp/core/syntax/test.fsx
@@ -1841,7 +1841,6 @@ let aa =
   match !failures with 
   | false -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/tlr/test.fsx
+++ b/tests/fsharp/core/tlr/test.fsx
@@ -380,7 +380,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/topinit/generate.fsx
+++ b/tests/fsharp/core/topinit/generate.fsx
@@ -132,7 +132,6 @@ let generateTests() =
                       // Touching the 'init' value should trigger initialization
                       yield sprintf "printfn \"Lib%d.forceInit = %%A\" Lib%d.forceInit" n.Value n.Value
                       yield sprintf "checkInitialized \"Lib%d\" InitFlag%d.init" n.Value n.Value
-           yield "System.IO.File.WriteAllText(\"test.ok\",\"ok\")"
            yield "exit 0" |]
     System.IO.File.WriteAllLines("test_deterministic_init.fs", lines)
     commandLine :=  commandLine.Value + " test_deterministic_init.fs"

--- a/tests/fsharp/core/topinit/test_deterministic_init.fs
+++ b/tests/fsharp/core/topinit/test_deterministic_init.fs
@@ -597,5 +597,4 @@ printfn "Touching value in module Lib85..."
 printfn "    --> Lib85.x = %A" Lib85.x
 printfn "Checking this did cause initialization of module Lib85..."
 checkInitialized "Lib85" InitFlag85.init
-System.IO.File.WriteAllText("test.ok","ok")
 exit 0

--- a/tests/fsharp/core/unicode/test.fsx
+++ b/tests/fsharp/core/unicode/test.fsx
@@ -139,7 +139,6 @@ let aa =
   match !failures with 
   | [] -> 
       stdout.WriteLine "Test Passed"
-      System.IO.File.WriteAllText("test.ok","ok")
       exit 0
   | _ -> 
       stdout.WriteLine "Test Failed"

--- a/tests/fsharp/core/unitsOfMeasure/test.fs
+++ b/tests/fsharp/core/unitsOfMeasure/test.fs
@@ -201,7 +201,6 @@ let main argv =
     // test2
     for _ in CreateBadImageFormatException () do ()
 
-    System.IO.File.WriteAllText("test.ok","ok"); 
 
     match failures with 
     | [] -> 

--- a/tests/fsharp/perf/graph/test.ml
+++ b/tests/fsharp/perf/graph/test.ml
@@ -538,5 +538,4 @@ end
   let _ = test()
 
 do   (System.Console.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText ("test.ok", "ok");
        exit 0)

--- a/tests/fsharp/perf/nbody/test.ml
+++ b/tests/fsharp/perf/nbody/test.ml
@@ -143,6 +143,5 @@ let _ = test "dce98nj" (main 500000 = "-0.169096567")
 
 
 do   (System.Console.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText ("test.ok", "ok"); 
        exit 0)
 

--- a/tests/fsharp/readme.md
+++ b/tests/fsharp/readme.md
@@ -18,7 +18,7 @@ This test case builds and runs the test case in the folder core/array
 this #define is used to exclude from the build tests that run will not run correctly on the coreclr
 __#if !NETCOREAPP__
 
-There are some older tests in this section that looks similar to:
+There are some older tests in this section that look similar to:
 ````
     [<Fact>]
     let events () = 
@@ -27,9 +27,7 @@ There are some older tests in this section that looks similar to:
         peverify cfg "test.dll"
         csc cfg """/r:"%s" /reference:test.dll /debug+""" cfg.FSCOREDLLPATH ["testcs.cs"]
         peverify cfg "testcs.exe"
-        use testOkFile = fileguard cfg "test.ok"
         fsi cfg "" ["test.fs"]
-        testOkFile.CheckExists()
         exec cfg ("." ++ "testcs.exe") ""
 ````
 These tests build, compile, peverify and run fsi.

--- a/tests/fsharp/regression/12322/test.fsx
+++ b/tests/fsharp/regression/12322/test.fsx
@@ -1489,6 +1489,5 @@ module LotsOfLets =
 
 // This is a compilation test, not a lot actually happens in the test
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)
 

--- a/tests/fsharp/regression/12383/test.fs
+++ b/tests/fsharp/regression/12383/test.fs
@@ -2940,6 +2940,5 @@ let inline translate opcode =
 let translate2 opcode = translate opcode
 
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)
 

--- a/tests/fsharp/regression/13219/test.fsx
+++ b/tests/fsharp/regression/13219/test.fsx
@@ -18,5 +18,4 @@ type System.Object with
 
 // This is a compilation test, not a lot actually happens in the test
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)

--- a/tests/fsharp/regression/13710/test.fsx
+++ b/tests/fsharp/regression/13710/test.fsx
@@ -12,6 +12,5 @@ printfn $"{auth.Test}"
 
 // This is a compilation test, not a lot actually happens in the test
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)
 

--- a/tests/fsharp/regression/26/test.ml
+++ b/tests/fsharp/regression/26/test.ml
@@ -27,6 +27,5 @@ let _ = if (compare [| |] [| |] <> 0) then fail "Test Failed (abcwlvero02)"
 let _ = System.Console.Error.WriteLine "Test Passed"
 
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)
 

--- a/tests/fsharp/regression/321/test.ml
+++ b/tests/fsharp/regression/321/test.ml
@@ -25,5 +25,4 @@ exception Bad_xml_structure of string
  
 let _ = 
       (System.Console.Out.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText("test.ok", "ok"); 
        exit 0)

--- a/tests/fsharp/regression/655/main.fs
+++ b/tests/fsharp/regression/655/main.fs
@@ -6,7 +6,6 @@ let xI = x :> Datafile
 
 let _ = 
       (System.Console.Out.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText("test.ok", "ok"); 
        exit 0)
 
 	

--- a/tests/fsharp/regression/656/form.fs
+++ b/tests/fsharp/regression/656/form.fs
@@ -928,5 +928,4 @@ do Application.Run(mainForm)
 
 let _ = 
    (System.Console.Out.WriteLine "Test Passed"; 
-        System.IO.File.WriteAllText("test.ok", "ok"); 
         exit 0)

--- a/tests/fsharp/regression/83/test.ml
+++ b/tests/fsharp/regression/83/test.ml
@@ -41,6 +41,5 @@ let _ =
   if !failures then (System.Console.Out.WriteLine "Test Failed"; exit 1) 
 
 do (System.Console.Out.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok", "ok"); 
     exit 0)
 

--- a/tests/fsharp/regression/84/test.ml
+++ b/tests/fsharp/regression/84/test.ml
@@ -5,7 +5,6 @@ let _ =
   | true -> (System.Console.Out.WriteLine "Test Failed"; exit 1) 
   | false -> 
       (System.Console.Out.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText("test.ok", "ok"); 
        exit 0)
 
 let _ = (System.Console.Out.WriteLine "Test Ended"; exit 100)

--- a/tests/fsharp/regression/86/test.ml
+++ b/tests/fsharp/regression/86/test.ml
@@ -4,7 +4,6 @@
 let _ = 
   if '\\' = '\092' & "\\" = "\092" then
       (System.Console.Out.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText("test.ok", "ok"); 
        exit 0)
 
   else (System.Console.Out.WriteLine "Test Failed"; exit 1) 

--- a/tests/fsharp/regression/OverloadResolution-bug/test.fsx
+++ b/tests/fsharp/regression/OverloadResolution-bug/test.fsx
@@ -31,5 +31,4 @@ module TestOfObj =
             | _ -> None
 
 
-    System.IO.File.WriteAllText("test.ok","ok")
     printfn "Succeeded"

--- a/tests/fsharp/regression/literal-value-bug-2/test.fsx
+++ b/tests/fsharp/regression/literal-value-bug-2/test.fsx
@@ -30,7 +30,6 @@ let result =
         1
 
 if result = 0 then 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     printfn "Succeeded" 
 else
     printfn "Failed: %d" result

--- a/tests/fsharp/regression/struct-tuple-bug-1/test.fsx
+++ b/tests/fsharp/regression/struct-tuple-bug-1/test.fsx
@@ -15,6 +15,5 @@ let _ =
         exit 1
     else
         printfn "Test Passed"
-        System.IO.File.WriteAllText("test.ok", "ok")
         exit 0
 ()

--- a/tests/fsharp/regression/tuple-bug-1/test.ml
+++ b/tests/fsharp/regression/tuple-bug-1/test.ml
@@ -25,6 +25,5 @@ let _ =
   if !failures then (System.Console.Out.WriteLine "Test Failed"; exit 1) 
   else
       (System.Console.Out.WriteLine "Test Passed"; 
-       System.IO.File.WriteAllText("test.ok", "ok"); 
        exit 0)
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -29,45 +29,32 @@ let FSI = FSI_NETFX
 
 module CoreTests =
 
-
 #if !NETCOREAPP
     [<Fact>]
     let ``subtype-langversion-checknulls`` () =
         let cfg = testConfig "core/subtype"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsc cfg "%s -o:test-checknulls.exe -g --checknulls" cfg.fsc_flags ["test.fsx"]
 
         exec cfg ("." ++ "test-checknulls.exe") ""
-
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``subtype-langversion-no-checknulls`` () =
         let cfg = testConfig "core/subtype"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsc cfg "%s -o:test-no-checknulls.exe -g --checknulls-" cfg.fsc_flags ["test.fsx"]
 
         exec cfg ("." ++ "test-no-checknulls.exe") ""
-
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``subtype-langversion-46`` () =
         let cfg = testConfig "core/subtype"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsc cfg "%s -o:test-langversion-46.exe -g --langversion:4.6" cfg.fsc_flags ["test.fsx"]
 
         exec cfg ("." ++ "test-langversion-46.exe") ""
 
-        testOkFile.CheckExists()
 #endif
-
 
     [<Fact>]
     let ``SDKTests`` () =
@@ -94,7 +81,6 @@ module CoreTests =
         let cfg = { cfg with fsc_flags = sprintf "%s --preferreduilang:en-US --test:StackSpan" cfg.fsc_flags}
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             singleNegTest cfg "test"
 
@@ -103,11 +89,9 @@ module CoreTests =
             // Execution is disabled until we can be sure .NET 4.7.2 is on the machine
             //exec cfg ("." ++ "test.exe") ""
 
-            //testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test2.ok"
 
             singleNegTest cfg "test2"
 
@@ -116,11 +100,9 @@ module CoreTests =
             // Execution is disabled until we can be sure .NET 4.7.2 is on the machine
             //exec cfg ("." ++ "test.exe") ""
 
-            //testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test3.ok"
 
             singleNegTest cfg "test3"
 
@@ -129,26 +111,19 @@ module CoreTests =
             // Execution is disabled until we can be sure .NET 4.7.2 is on the machine
             //exec cfg ("." ++ "test.exe") ""
 
-            //testOkFile.CheckExists()
         end
 
     [<Fact>]
     let asyncStackTraces () =
         let cfg = testConfig "core/asyncStackTraces"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsc cfg "%s -o:test.exe -g --tailcalls- --optimize-" cfg.fsc_flags ["test.fsx"]
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile.CheckExists()
-
     [<Fact>]
     let ``state-machines-non-optimized`` () = 
         let cfg = testConfig "core/state-machines"
-
-        use testOkFile = fileguard cfg "test.ok"
 
         fsc cfg "%s -o:test.exe -g --tailcalls- --optimize-" cfg.fsc_flags ["test.fsx"]
 
@@ -156,13 +131,9 @@ module CoreTests =
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile.CheckExists()
-
     [<Fact>]
     let ``state-machines-optimized`` () = 
         let cfg = testConfig "core/state-machines"
-
-        use testOkFile = fileguard cfg "test.ok"
 
         fsc cfg "%s -o:test.exe -g --tailcalls+ --optimize+" cfg.fsc_flags ["test.fsx"]
 
@@ -170,13 +141,10 @@ module CoreTests =
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile.CheckExists()
-
     [<Fact>]
     let ``state-machines neg-resumable-01`` () =
         let cfg = testConfig "core/state-machines"
         singleVersionedNegTest cfg "preview" "neg-resumable-01"
-
 
     [<Fact>]
     let ``state-machines neg-resumable-02`` () =
@@ -186,94 +154,70 @@ module CoreTests =
     [<Fact>]
     let ``lots-of-conditionals``() =
         let cfg = testConfig "core/large/conditionals"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeConditionals-200.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-conditionals-maxtested``() =
         let cfg = testConfig "core/large/conditionals"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeConditionals-maxtested.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-lets``() =
         let cfg = testConfig "core/large/lets"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeLets-500.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-lets-maxtested``() =
         let cfg = testConfig "core/large/lets"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeLets-maxtested.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-lists``() =
         let cfg = testConfig "core/large/lists"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test-500.exe " cfg.fsc_flags ["LargeList-500.fs"]
         exec cfg ("." ++ "test-500.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-matches``() =
         let cfg = testConfig "core/large/matches"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeMatches-200.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-matches-maxtested``() =
         let cfg = testConfig "core/large/matches"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeMatches-maxtested.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-sequential-and-let``() =
         let cfg = testConfig "core/large/mixed"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeSequentialLet-500.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-sequential-and-let-maxtested``() =
         let cfg = testConfig "core/large/mixed"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeSequentialLet-maxtested.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-sequential``() =
         let cfg = testConfig "core/large/sequential"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeSequential-500.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``lots-of-sequential-maxtested``() =
         let cfg = testConfig "core/large/sequential"
-        use testOkFile = fileguard cfg "test.ok"
         fsc cfg "%s -o:test.exe " cfg.fsc_flags ["LargeSequential-maxtested.fs"]
         exec cfg ("." ++ "test.exe") ""
-        testOkFile.CheckExists()
 
 #endif
-
-
 
 #if !NETCOREAPP
 
@@ -295,19 +239,15 @@ module CoreTests =
         peverify cfg "test.exe"
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             exec cfg ("." ++ "test.exe") ""
 
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             fsi cfg "-r:lib.dll" ["test.fsx"]
 
-            testOkFile.CheckExists()
         end
 
     [<Fact>]
@@ -322,64 +262,9 @@ module CoreTests =
 
         peverify cfg "testcs.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsi cfg "" ["test.fs"]
 
-        testOkFile.CheckExists()
-
         exec cfg ("." ++ "testcs.exe") ""
-
-
-    //
-    // Shadowcopy does not work for public signed assemblies
-    // =====================================================
-    //
-    //module ``FSI-Shadowcopy`` =
-    //
-    //    [<Fact>]
-    //    // "%FSI%" %fsi_flags%                          < test1.fsx
-    //    [<FSharpSuiteTestCase("core/fsi-shadowcopy", "")
-    //    // "%FSI%" %fsi_flags%  --shadowcopyreferences- < test1.fsx
-    //    [<FSharpSuiteTestCase("core/fsi-shadowcopy", "--shadowcopyreferences-")
-    //    let ``shadowcopy disabled`` (flags: string) =
-    //        let cfg = testConfig' ()
-    //
-    //
-    //
-    //
-    //
-    //        // if exist test1.ok (del /f /q test1.ok)
-    //        use testOkFile = fileguard cfg "test1.ok"
-    //
-    //        fsiStdin cfg "%s %s" cfg.fsi_flags flags "test1.fsx"
-    //
-    //        // if NOT EXIST test1.ok goto SetError
-    //        testOkFile.CheckExists()
-    //
-    //
-    //    [<Fact>]
-    //    // "%FSI%" %fsi_flags%  /shadowcopyreferences+  < test2.fsx
-    //    [<FSharpSuiteTestCase("core/fsi-shadowcopy", "/shadowcopyreferences+")
-    //    // "%FSI%" %fsi_flags%  --shadowcopyreferences  < test2.fsx
-    //    [<FSharpSuiteTestCase("core/fsi-shadowcopy", "--shadowcopyreferences")
-    //    let ``shadowcopy enabled`` (flags: string) =
-    //        let cfg = testConfig' ()
-    //
-    //
-    //
-    //
-    //
-    //        // if exist test2.ok (del /f /q test2.ok)
-    //        use testOkFile = fileguard cfg "test2.ok"
-    //
-    //        // "%FSI%" %fsi_flags%  /shadowcopyreferences+  < test2.fsx
-    //        fsiStdin cfg "%s %s" cfg.fsi_flags flags "test2.fsx"
-    //
-    //        // if NOT EXIST test2.ok goto SetError
-    //        testOkFile.CheckExists()
-    //
-
 
     [<Fact>]
     let forwarders () =
@@ -510,11 +395,9 @@ module CoreTests =
         let cfg = testConfig "core/fsi-reference"
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             fsc cfg @"--target:library -o:ImplementationAssembly\ReferenceAssemblyExample.dll" ["ImplementationAssembly.fs"]
             fsc cfg @"--target:library -o:ReferenceAssembly\ReferenceAssemblyExample.dll" ["ReferenceAssembly.fs"]
             fsiStdin cfg "test.fsx" "" []
-            testOkFile.CheckExists()
         end
 
     [<Fact>]
@@ -522,26 +405,19 @@ module CoreTests =
         let cfg = testConfig "core/fsi-reload"
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             fsiStdin cfg "test1.ml"  " --langversion:5.0 --mlcompatibility --maxerrors:1" []
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             fsi cfg "%s  --maxerrors:1" cfg.fsi_flags ["load1.fsx"]
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             fsi cfg "%s  --maxerrors:1" cfg.fsi_flags ["load2.fsx"]
-            testOkFile.CheckExists()
         end
 
         fsc cfg "" ["load1.fsx"]
         fsc cfg "" ["load2.fsx"]
-
 
     [<Fact>]
     let fsiAndModifiers () =
@@ -551,15 +427,10 @@ module CoreTests =
 
         fsiStdin cfg "prepare.fsx" "--maxerrors:1" []
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsiStdin cfg "test.fsx" "--maxerrors:1"  []
-
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``genericmeasures-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/genericmeasures" FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
-
 
     [<Fact>]
     let hiding () =
@@ -595,27 +466,21 @@ module CoreTests =
         singleNegTest cfg "negativetest"
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
 
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             exec cfg ("." ++ "test.exe") ""
 
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             exec cfg ("." ++ "test--optimize.exe") ""
 
-            testOkFile.CheckExists()
         end
 
     // Debug with
@@ -807,7 +672,7 @@ module CoreTests =
 
 #endif
 
-#if !NETCOREAPP    
+#if !NETCOREAPP
     [<Fact>]
     let quotes () =
         let cfg = testConfig "core/quotes"
@@ -819,9 +684,7 @@ module CoreTests =
         peverify cfg "test.exe"
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             exec cfg ("." ++ "test.exe") ""
-            testOkFile.CheckExists()
         end
 
         fsc cfg "%s -o:test-with-debug-data.exe --quotations-debug+ -r cslib.dll -g" cfg.fsc_flags ["test.fsx"]
@@ -833,23 +696,17 @@ module CoreTests =
         peverify cfg "test--optimize.exe"
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
 
             fsi cfg "%s -r cslib.dll" cfg.fsi_flags ["test.fsx"]
 
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             exec cfg ("." ++ "test-with-debug-data.exe") ""
-            testOkFile.CheckExists()
         end
 
         begin
-            use testOkFile = fileguard cfg "test.ok"
             exec cfg ("." ++ "test--optimize.exe") ""
-            testOkFile.CheckExists()
         end
 
     // Previously a comment here said:
@@ -910,7 +767,6 @@ module CoreTests =
 
         fsi cfg "%s --utf8output" cfg.fsi_flags ["kanji-unicode-utf16.fs"]
 
-
     [<Fact>]
     let internalsvisible () =
         let cfg = testConfig "core/internalsvisible"
@@ -932,7 +788,6 @@ module CoreTests =
 
         // Run F# main. Quick test!
         exec cfg ("." ++ "main.exe") ""
-
 
     // Repro for https://github.com/dotnet/fsharp/issues/1298
     [<Fact>]
@@ -1008,26 +863,17 @@ module CoreTests =
     let ``libtest-langversion-checknulls`` () =
         let cfg = testConfig "core/libtest"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsc cfg "%s -o:test-checknulls.exe -g --checknulls" cfg.fsc_flags ["test.fsx"]
 
         exec cfg ("." ++ "test-checknulls.exe") ""
 
-        testOkFile.CheckExists()
-
- 
     [<Fact>]
     let ``libtest-langversion-46`` () =
         let cfg = testConfig "core/libtest"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsc cfg "%s -o:test-langversion-46.exe -g --langversion:4.6" cfg.fsc_flags ["test.fsx"]
 
         exec cfg ("." ++ "test-langversion-46.exe") ""
-
-        testOkFile.CheckExists()
 
     [<Fact>]
     let ``no-warn-2003-tests`` () =
@@ -1219,8 +1065,6 @@ module CoreTests =
         | _ -> Assert.failf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
 #endif
 
-
-
 #if !NETCOREAPP
     [<Fact>]
     let ``measures-FSC_NETFX_TEST_ROUNDTRIP_AS_DLL`` () = singleTestBuildAndRun "core/measures" FSC_NETFX_TEST_ROUNDTRIP_AS_DLL
@@ -1240,24 +1084,11 @@ module CoreTests =
 
         peverify cfg "test--optimize.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
-
-        testOkFile.CheckExists()
-
-        use testOkFile2 = fileguard cfg "test.ok"
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile2.CheckExists()
-
-        use testOkFile3 = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "test--optimize.exe") ""
-
-        testOkFile3.CheckExists()
-
 
     [<Fact>]
     let queriesNullableOperators () =
@@ -1271,17 +1102,11 @@ module CoreTests =
 
         peverify cfg "test--optimize.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
         fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
-        testOkFile.CheckExists()
 
-        use testOkFile2 = fileguard cfg "test.ok"
         exec cfg ("." ++ "test.exe") ""
-        testOkFile2.CheckExists()
 
-        use testOkFile3 = fileguard cfg "test.ok"
         exec cfg ("." ++ "test--optimize.exe") ""
-        testOkFile3.CheckExists()
 
     [<Fact>]
     let queriesOverIEnumerable () =
@@ -1295,23 +1120,11 @@ module CoreTests =
 
         peverify cfg "test--optimize.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
-
-        testOkFile.CheckExists()
-
-        use testOkFile2 = fileguard cfg "test.ok"
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile2.CheckExists()
-
-        use testOkFile3 = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "test--optimize.exe") ""
-
-        testOkFile3.CheckExists()
 
     [<Fact>]
     let queriesOverIQueryable () =
@@ -1325,24 +1138,11 @@ module CoreTests =
 
         peverify cfg "test--optimize.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
         fsi cfg "%s" cfg.fsi_flags ["test.fsx"]
-
-        testOkFile.CheckExists()
-
-
-        use testOkFile2 = fileguard cfg "test.ok"
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile2.CheckExists()
-
-
-        use testOkFile3 = fileguard cfg "test.ok"
         exec cfg ("." ++ "test--optimize.exe") ""
-
-        testOkFile3.CheckExists()
-
 
     [<Fact>]
     let quotesDebugInfo () =
@@ -1356,24 +1156,11 @@ module CoreTests =
 
         peverify cfg "test--optimize.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
         fsi cfg "%s --quotations-debug+" cfg.fsi_flags ["test.fsx"]
-
-        testOkFile.CheckExists()
-
-
-        use testOkFile2 = fileguard cfg "test.ok"
 
         exec cfg ("." ++ "test.exe") ""
 
-        testOkFile2.CheckExists()
-
-        use testOkFile3 = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "test--optimize.exe") ""
-
-        testOkFile3.CheckExists()
-
 
     [<Fact>]
     let quotesInMultipleModules () =
@@ -1399,33 +1186,15 @@ module CoreTests =
 
         peverify cfg "module2-opt.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         fsi cfg "%s -r module1.dll" cfg.fsi_flags ["module2.fsx"]
-
-        testOkFile.CheckExists()
-
-
-        use testOkFile = fileguard cfg "test.ok"
 
         exec cfg ("." ++ "module2.exe") ""
 
-        testOkFile.CheckExists()
-
-        use testOkFile = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "module2-opt.exe") ""
-
-        testOkFile.CheckExists()
-
-        use testOkFile = fileguard cfg "test.ok"
 
         exec cfg ("." ++ "module2-staticlink.exe") ""
 
-        testOkFile.CheckExists()
 #endif
-
-
 
 #if !NETCOREAPP
     [<Fact>]
@@ -1442,27 +1211,20 @@ module CoreTests =
         //TestCase1
         // Build a program that references v2 of ascendent and v1 of dependent.
         // Note that, even though ascendent v2 references dependent v2, the reference is marked as v1.
-        use TestOk = fileguard cfg "test.ok"
         fsc cfg @"%s -o:test1.exe -r:version1\DependentAssembly.dll -r:version2\AscendentAssembly.dll --optimize- -g" cfg.fsc_flags ["test.fs"]
         exec cfg ("." ++ "test1.exe") "DependentAssembly-1.0.0.0 AscendentAssembly-2.0.0.0"
-        TestOk.CheckExists()
 
         //TestCase2
         // Build a program that references v1 of ascendent and v2 of dependent.
         // Note that, even though ascendent v1 references dependent v1, the reference is marked as v2 which was passed in.
-        use TestOk = fileguard cfg "test.ok"
         fsc cfg @"%s -o:test2.exe -r:version2\DependentAssembly.dll -r:version1\AscendentAssembly.dll --optimize- -g" cfg.fsc_flags ["test.fs"]
         exec cfg ("." ++ "test2.exe") "DependentAssembly-2.0.0.0 AscendentAssembly-1.0.0.0"
-        TestOk.CheckExists()
 
         //TestCase3
         // Build a program that references v1 of ascendent and v1 and v2 of dependent.
         // Verifies that compiler uses first version of a duplicate assembly passed on command line.
-        use TestOk = fileguard cfg "test.ok"
         fsc cfg @"%s -o:test3.exe -r:version1\DependentAssembly.dll -r:version2\DependentAssembly.dll -r:version1\AscendentAssembly.dll --optimize- -g" cfg.fsc_flags ["test.fs"]
         exec cfg ("." ++ "test3.exe") "DependentAssembly-1.0.0.0 AscendentAssembly-1.0.0.0"
-        TestOk.CheckExists()
-
 
     [<Fact>]
     let testResources () =
@@ -1628,11 +1390,7 @@ module CoreTests =
 
         peverify cfg "test.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "test.exe") ""
-
-        testOkFile.CheckExists()
 
     [<Fact>]
     let verify () =
@@ -1649,8 +1407,7 @@ module CoreTests =
         fsc cfg "%s -o:xmlverify.exe -g" cfg.fsc_flags ["xmlverify.fs"]
 
         peverifyWithArgs cfg "/nologo" "xmlverify.exe"
-        
-        
+
     [<Fact>]
     let ``property setter in method or constructor`` () =
         let cfg = testConfig "core/members/set-only-property"
@@ -1821,7 +1578,6 @@ module RegressionTests =
     let ``SRTP doesn't handle calling member hiding inherited members`` () =
         let cfg = 
             testConfig "regression/5531"
-       
 
         let outFile = "compilation.output.test.txt"
         let expectedFile = "compilation.output.test.bsl"
@@ -1867,11 +1623,7 @@ module RegressionTests =
 
         peverify cfg "test.exe"
 
-        use testOkFile = fileguard cfg "test.ok"
-
         exec cfg ("." ++ "test.exe") ""
-
-        testOkFile.CheckExists()
 
     // This test is disabled in coreclr builds dependent on fixing : https://github.com/dotnet/fsharp/issues/2600
     [<Fact>]
@@ -1935,7 +1687,6 @@ module OptimizationTests =
         | _ ->
             Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
-
     [<Fact>]
     let totalSizes () =
         let cfg = testConfig "optimize/analyses"
@@ -1951,7 +1702,6 @@ module OptimizationTests =
         match diff with
         | "" -> ()
         | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
-
 
     [<Fact>]
     let hasEffect () =
@@ -1969,7 +1719,6 @@ module OptimizationTests =
         | "" -> ()
         | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
-
     [<Fact>]
     let noNeedToTailcall () =
         let cfg = testConfig "optimize/analyses"
@@ -1985,7 +1734,6 @@ module OptimizationTests =
         match diff with
         | "" -> ()
         | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
-
 
     [<Fact>]
     let ``inline`` () =
@@ -2163,7 +1911,7 @@ module TypecheckTests =
         fsc cfg "%s --langversion:6.0 --target:exe -o:pos40.exe" cfg.fsc_flags ["pos40.fs"]
         peverify cfg "pos40.exe"
         exec cfg ("." ++ "pos40.exe") ""
-        
+
     [<Fact>]
     let ``sigs pos41`` () =
         let cfg = testConfig "typecheck/sigs"
@@ -2394,8 +2142,8 @@ module TypecheckTests =
     let ``type check neg116`` () = singleNegTest (testConfig "typecheck/sigs") "neg116"
 
     [<Fact>]
-    let ``type check neg117`` () = singleNegTest (testConfig "typecheck/sigs") "neg117"        
-    
+    let ``type check neg117`` () = singleNegTest (testConfig "typecheck/sigs") "neg117"
+
     [<Fact>]
     let ``type check neg134`` () = singleVersionedNegTest (testConfig "typecheck/sigs") "preview" "neg134"
 
@@ -2426,7 +2174,6 @@ open System.Reflection
 
         (fv.ProductMajorPart, fv.ProductMinorPart, fv.ProductBuildPart, fv.ProductPrivatePart)
         |> Assert.areEqual (45, 2048, 0, 2)
-
 
     [<Fact>]
     let ``should set file version info on generated file`` () =

--- a/tests/fsharp/tools/eval/test.fsx
+++ b/tests/fsharp/tools/eval/test.fsx
@@ -2797,5 +2797,4 @@ let _ =
       exit 1
   else  
       stdout.WriteLine "Test Passed"; 
-      System.IO.File.WriteAllText("test.ok","ok"); 
       exit 0

--- a/tests/fsharp/typeProviders/diamondAssembly/test3.fsx
+++ b/tests/fsharp/typeProviders/diamondAssembly/test3.fsx
@@ -162,7 +162,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typeProviders/globalNamespace/test.fsx
+++ b/tests/fsharp/typeProviders/globalNamespace/test.fsx
@@ -24,7 +24,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typeProviders/helloWorld/test.fsx
+++ b/tests/fsharp/typeProviders/helloWorld/test.fsx
@@ -1192,7 +1192,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typeProviders/helloWorldCSharp/test.fsx
+++ b/tests/fsharp/typeProviders/helloWorldCSharp/test.fsx
@@ -26,7 +26,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typeProviders/splitAssemblyTools/test.fsx
+++ b/tests/fsharp/typeProviders/splitAssemblyTools/test.fsx
@@ -26,7 +26,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typeProviders/splitAssemblyTypeproviders/test.fsx
+++ b/tests/fsharp/typeProviders/splitAssemblyTypeproviders/test.fsx
@@ -26,7 +26,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typeProviders/wedgeAssembly/test3.fsx
+++ b/tests/fsharp/typeProviders/wedgeAssembly/test3.fsx
@@ -108,7 +108,6 @@ let _ =
   if not failures.IsEmpty then (printfn "Test Failed, failures = %A" failures; exit 1) 
 
 do (stdout.WriteLine "Test Passed"; 
-    System.IO.File.WriteAllText("test.ok","ok"); 
     exit 0)
 
 

--- a/tests/fsharp/typecheck/full-rank-arrays/test.fsx
+++ b/tests/fsharp/typecheck/full-rank-arrays/test.fsx
@@ -107,5 +107,4 @@ let _ =
   let x = Class1()
   x.RunTests()
   System.Console.WriteLine "Test Passed"; 
-  System.IO.File.WriteAllText ("test.ok", "ok"); 
   exit 0

--- a/tests/fsharp/typecheck/misc/test.ml
+++ b/tests/fsharp/typecheck/misc/test.ml
@@ -33,5 +33,4 @@ let _ =
    * So avoid using ;;
    *)
   System.Console.WriteLine "Test Passed"; 
-  System.IO.File.WriteAllText ("test.ok", "ok"); 
   exit 0


### PR DESCRIPTION
This is to help @majocha in his journey for test parallelization [here](#17662).

We noticed these ubiquitous "test.ok" files creation in the tests. Most of them are in the tests/fsharp (core tests) - and this is the target of this PR.

Usually the files are created just before sending "exit 0" signal from tests. After this, they are sometimes checked (sometimes not). Now, there is no need for this really, because the test engine would fail the test if the exit code is different anyway. 

At the same time, files contaminate the logs and the file system which turns out to be one of the biggest obstacles for proper test parallelization.

Take this example, [quotesInMultipleModules](https://github.com/dotnet/fsharp/blob/main/tests/fsharp/core/quotesInMultipleModules/module2.fsx) tests. They do some tests and then print this "ok file". Now, let's remove the "ok file" and break the very first assertion:
```fsharp
let a = Module1.Test.bar()
let b = sprintf "%A" (Module1.Test.run())

let test1 = (a=b)
``` 
so that it's 
```
let test1 = (a <> b)
```

The tests fails:

![image](https://github.com/user-attachments/assets/0d259a79-15fc-44d3-aaa1-a3e151df363e)

I tested a few more cases just for sanity checks, but anyway the files are just the artifacts of ancient ways of testing we had here. 