### PR TITLE
Better ranges for CE `let!` and `use!` error reporting.

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -7,5 +7,6 @@
 ### Changed
 
 * Make ILTypeDef interface impls calculation lazy. ([PR #17392](https://github.com/dotnet/fsharp/pull/17392))
+* Better ranges for CE `let!` and `use!` error reporting. ([PR #17712](https://github.com/dotnet/fsharp/pull/17712))
 
 ### Breaking Changes

--- a/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
@@ -1854,7 +1854,14 @@ let rec TryTranslateComputationExpression
         //  or
         //    --> build.BindReturn(e1, (fun _argN -> match _argN with pat -> expr-without-return))
         | SynExpr.LetOrUseBang(
-            bindDebugPoint = spBind; isUse = false; isFromSource = isFromSource; pat = pat; rhs = rhsExpr; andBangs = []; body = innerComp; trivia = { LetOrUseBangKeyword = mBind }) ->
+            bindDebugPoint = spBind
+            isUse = false
+            isFromSource = isFromSource
+            pat = pat
+            rhs = rhsExpr
+            andBangs = []
+            body = innerComp
+            trivia = { LetOrUseBangKeyword = mBind }) ->
 
             if ceenv.isQuery then
                 error (Error(FSComp.SR.tcBindMayNotBeUsedInQueries (), mBind))

--- a/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
@@ -1589,10 +1589,10 @@ let rec TryTranslateComputationExpression
                 Some(TranslateComputationExpression ceenv CompExprTranslationPass.Initial q varSpace innerComp2 translatedCtxt)
 
             else
-
                 if ceenv.isQuery && not (innerComp1.IsArbExprAndThusAlreadyReportedError) then
                     match innerComp1 with
-                    | SynExpr.JoinIn _ -> () // an error will be reported later when we process innerComp1 as a sequential
+                    | SynExpr.JoinIn _ -> ()
+                    | SynExpr.DoBang(range = m) -> errorR (Error(FSComp.SR.tcBindMayNotBeUsedInQueries (), m))
                     | _ -> errorR (Error(FSComp.SR.tcUnrecognizedQueryOperator (), innerComp1.RangeOfFirstPortion))
 
                 match

--- a/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
@@ -2014,7 +2014,12 @@ let rec TryTranslateComputationExpression
             body = innerComp
             trivia = { LetOrUseBangKeyword = mBind }) ->
             if not (cenv.g.langVersion.SupportsFeature LanguageFeature.AndBang) then
-                error (Error(FSComp.SR.tcAndBangNotSupported (), mBind))
+                let andBangRange =
+                    match andBangBindings with
+                    | [] -> comp.Range
+                    | h :: _ -> h.Trivia.AndBangKeyword
+
+                error (Error(FSComp.SR.tcAndBangNotSupported (), andBangRange))
 
             if ceenv.isQuery then
                 error (Error(FSComp.SR.tcBindMayNotBeUsedInQueries (), mBind))

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -97,7 +97,11 @@ type SynExprLetOrUseBangTrivia =
         EqualsRange: range option
     }
 
-    static member Zero: SynExprLetOrUseBangTrivia = { LetOrUseBangKeyword = Range.Zero; EqualsRange = None }
+    static member Zero: SynExprLetOrUseBangTrivia =
+        {
+            LetOrUseBangKeyword = Range.Zero
+            EqualsRange = None
+        }
 
 [<NoEquality; NoComparison>]
 type SynExprMatchTrivia =

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -93,10 +93,11 @@ type SynExprLetOrUseTrivia =
 [<NoEquality; NoComparison>]
 type SynExprLetOrUseBangTrivia =
     {
+        LetOrUseBangKeyword: range
         EqualsRange: range option
     }
 
-    static member Zero: SynExprLetOrUseBangTrivia = { EqualsRange = None }
+    static member Zero: SynExprLetOrUseBangTrivia = { LetOrUseBangKeyword = Range.Zero; EqualsRange = None }
 
 [<NoEquality; NoComparison>]
 type SynExprMatchTrivia =

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -139,6 +139,8 @@ type SynExprLetOrUseTrivia =
 [<NoEquality; NoComparison>]
 type SynExprLetOrUseBangTrivia =
     {
+        /// The syntax range of the `let!` or `use!` keyword.
+        LetOrUseBangKeyword: range
         /// The syntax range of the `=` token.
         EqualsRange: range option
     }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4419,7 +4419,7 @@ declExpr:
      { let spBind = DebugPointAtBinding.Yes(rhs2 parseState 1 5)
        let mEquals = rhs parseState 3
        let m = unionRanges (rhs parseState 1) $8.Range
-       let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = Some mEquals }
+       let trivia: SynExprLetOrUseBangTrivia = { LetOrUseBangKeyword = rhs parseState 1 ; EqualsRange = Some mEquals }
        SynExpr.LetOrUseBang(spBind, ($1 = "use"), true, $2, $4, $7, $8, m, trivia) }
 
   | OBINDER headBindingPattern EQUALS typedSequentialExprBlock hardwhiteDefnBindingsTerminator opt_OBLOCKSEP moreBinders typedSequentialExprBlock %prec expr_let
@@ -4428,7 +4428,7 @@ declExpr:
        let spBind = DebugPointAtBinding.Yes(unionRanges (rhs parseState 1) $4.Range)
        let mEquals = rhs parseState 3
        let m = unionRanges (rhs parseState 1) $8.Range
-       let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = Some mEquals }
+       let trivia: SynExprLetOrUseBangTrivia = { LetOrUseBangKeyword = rhs parseState 1 ; EqualsRange = Some mEquals }
        SynExpr.LetOrUseBang(spBind, ($1 = "use"), true, $2, $4, $7, $8, m, trivia) }
 
   | OBINDER headBindingPattern EQUALS typedSequentialExprBlock hardwhiteDefnBindingsTerminator opt_OBLOCKSEP error %prec expr_let
@@ -4437,12 +4437,12 @@ declExpr:
        let mEquals = rhs parseState 3
        let mAll = unionRanges (rhs parseState 1) (rhs parseState 7)
        let m = $4.Range.EndRange // zero-width range
-       let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = Some mEquals }
+       let trivia: SynExprLetOrUseBangTrivia = { LetOrUseBangKeyword = rhs parseState 1 ; EqualsRange = Some mEquals }
        SynExpr.LetOrUseBang(spBind, ($1 = "use"), true, $2, $4, [], SynExpr.ImplicitZero m, mAll, trivia) }
 
   | DO_BANG typedSequentialExpr IN opt_OBLOCKSEP typedSequentialExprBlock %prec expr_let
      { let spBind = DebugPointAtBinding.NoneAtDo
-       let trivia: SynExprLetOrUseBangTrivia = { EqualsRange = None }
+       let trivia: SynExprLetOrUseBangTrivia = { LetOrUseBangKeyword = Range.Zero; EqualsRange = None }
        SynExpr.LetOrUseBang(spBind, false, true, SynPat.Const(SynConst.Unit, $2.Range), $2, [], $5, unionRanges (rhs parseState 1) $5.Range, trivia) }
 
   | ODO_BANG typedSequentialExprBlock hardwhiteDefnBindingsTerminator %prec expr_let

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -282,3 +282,129 @@ let run r2 r3 =
         |> withDiagnostics [
             (Error 708, Line 23, Col 9, Line 23, Col 13, "This control construct may only be used if the computation expression builder defines a 'Bind' method")
         ]
+    
+    [<Fact>]
+    let ``do! expressions may not be used in queries`` () =
+        Fsx """
+query {
+    do! failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 3, Col 5, Line 3, Col 20, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]
+        
+    [<Fact>]
+    let ``let! expressions may not be used in queries`` () =
+        Fsx """
+query {
+    let! x = failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 3, Col 5, Line 3, Col 9, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]
+            
+    [<Fact>]
+    let ``let!, and! expressions may not be used in queries`` () =
+        Fsx """
+query {
+    let! x = failwith ""
+    and! y = failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 3, Col 5, Line 3, Col 9, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]
+        
+    [<Fact>]
+    let ``use! expressions may not be used in queries`` () =
+        Fsx """
+query {
+    use! x = failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 3, Col 5, Line 3, Col 9, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]
+
+    [<Fact>]
+    let ``do! expressions may not be used in queries(SynExpr.Sequential)`` () =
+        Fsx """
+query {
+    for c in [1..10] do
+    do! failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 4, Col 5, Line 4, Col 20, "'let!', 'use!' and 'do!' expressions may not be used in queries")  
+        ]
+        
+    [<Fact>]
+    let ``let! expressions may not be used in queries(SynExpr.Sequential)`` () =
+        Fsx """
+query {
+    for c in [1..10] do
+    let! x = failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 4, Col 5, Line 4, Col 9, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]
+        
+    [<Fact>]
+    let ``let!, and! expressions may not be used in queries(SynExpr.Sequential)`` () =
+        Fsx """
+query {
+    for c in [1..10] do
+    let! x = failwith ""
+    and! y = failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 4, Col 5, Line 4, Col 9, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]
+        
+    [<Fact>]
+    let ``use! expressions may not be used in queries(SynExpr.Sequential)`` () =
+        Fsx """
+query {
+    for c in [1..10] do
+    use! x = failwith ""
+    yield 1
+}
+    """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 3143, Line 4, Col 5, Line 4, Col 9, "'let!', 'use!' and 'do!' expressions may not be used in queries")
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -284,6 +284,41 @@ let run r2 r3 =
         ]
     
     [<Fact>]
+    let ``This control construct may only be used if the computation expression builder defines a 'Using' method`` () =
+        Fsx """
+module Result =
+    let zip x1 x2 =
+        match x1,x2 with
+        | Ok x1res, Ok x2res -> Ok (x1res, x2res)
+        | Error e, _ -> Error e
+        | _, Error e -> Error e
+
+type ResultBuilder() =
+    member _.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = Result.zip t1 t2
+    member _.BindReturn(x: Result<'T,'U>, f) = Result.map f x
+    member _.Delay(f) = f()
+    
+    member _.TryWith(r: Result<'T,'U>, f) =
+        match r with
+        | Ok x -> Ok x
+        | Error e -> f e
+
+let result = ResultBuilder()
+
+let run r2 r3 =
+    result {
+        use! a = r2
+        return! a
+    }
+        """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 708, Line 23, Col 9, Line 23, Col 13, "This control construct may only be used if the computation expression builder defines a 'Using' method")
+        ]
+    
+    [<Fact>]
     let ``do! expressions may not be used in queries`` () =
         Fsx """
 query {

--- a/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ComputationExpressionTests.fs
@@ -247,3 +247,38 @@ let run r2 r3 =
         |> withDiagnostics [
             (Error 3345, Line 22, Col 9, Line 22, Col 13, "use! may not be combined with and!")
         ]
+
+    [<Fact>]
+    let ``This control construct may only be used if the computation expression builder defines a 'Bind' method`` () =
+        Fsx """
+module Result =
+    let zip x1 x2 =
+        match x1,x2 with
+        | Ok x1res, Ok x2res -> Ok (x1res, x2res)
+        | Error e, _ -> Error e
+        | _, Error e -> Error e
+
+type ResultBuilder() =
+    member _.MergeSources(t1: Result<'T,'U>, t2: Result<'T1,'U>) = Result.zip t1 t2
+    member _.BindReturn(x: Result<'T,'U>, f) = Result.map f x
+    member _.Delay(f) = f()
+    
+    member _.TryWith(r: Result<'T,'U>, f) =
+        match r with
+        | Ok x -> Ok x
+        | Error e -> f e
+
+let result = ResultBuilder()
+
+let run r2 r3 =
+    result {
+        let! a = r2
+        return! a
+    }
+        """
+        |> ignoreWarnings
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 708, Line 23, Col 9, Line 23, Col 13, "This control construct may only be used if the computation expression builder defines a 'Bind' method")
+        ]

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -10203,7 +10203,9 @@ FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: FSharp.Compiler.SyntaxTr
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] EqualsRange
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_EqualsRange()
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: FSharp.Compiler.Text.Range LetOrUseBangKeyword
+FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: FSharp.Compiler.Text.Range get_LetOrUseBangKeyword()
+FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Void .ctor(FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia: FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia Zero
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia: FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia get_Zero()
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] InKeyword

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -10203,7 +10203,9 @@ FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: FSharp.Compiler.SyntaxTr
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] EqualsRange
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_EqualsRange()
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: System.String ToString()
-FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Void .ctor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: FSharp.Compiler.Text.Range LetOrUseBangKeyword
+FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: FSharp.Compiler.Text.Range get_LetOrUseBangKeyword()
+FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseBangTrivia: Void .ctor(FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range])
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia: FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia Zero
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia: FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia get_Zero()
 FSharp.Compiler.SyntaxTrivia.SynExprLetOrUseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] InKeyword

--- a/tests/fsharp/Compiler/Conformance/DataExpressions/ComputationExpressions.fs
+++ b/tests/fsharp/Compiler/Conformance/DataExpressions/ComputationExpressions.fs
@@ -281,7 +281,7 @@ let ceResult : Trace<int> =
         return if y then x else -1
     }
             """
-            [| FSharpDiagnosticSeverity.Error, 3344, (6, 9, 8, 35), "This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature." |]
+            [| FSharpDiagnosticSeverity.Error, 3344, (7, 9, 7, 13), "This feature is not supported in this version of F#. You may need to add /langversion:preview to use this feature." |]
 
     [<Fact>]
     let ``AndBang TraceMultiBindingMonoid`` () =
@@ -582,7 +582,7 @@ let _ =
         return x + y
     }
     """
-            [|(FSharpDiagnosticSeverity.Error, 3343, (6, 9, 6, 25), "The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a 'Bind2' method or appropriate 'MergeSources' and 'Bind' methods")|]
+            [|(FSharpDiagnosticSeverity.Error, 3343, (6, 9, 6, 13), "The 'let! ... and! ...' construct may only be used if the computation expression builder defines either a 'Bind2' method or appropriate 'MergeSources' and 'Bind' methods")|]
 
     [<Fact>]
     let ``AndBang Negative TraceApplicative missing Bind and BindReturn`` () =
@@ -596,7 +596,7 @@ let _ =
         return x + y
     }
     """
-            [|(FSharpDiagnosticSeverity.Error, 708, (6, 9, 6, 25), "This control construct may only be used if the computation expression builder defines a 'Bind' method")|]
+            [|(FSharpDiagnosticSeverity.Error, 708, (6, 9, 6, 13), "This control construct may only be used if the computation expression builder defines a 'Bind' method")|]
 
 
     [<Fact>]
@@ -612,7 +612,7 @@ let _ =
         return x + y
     }
     """
-            [| FSharpDiagnosticSeverity.Error, 708, (7, 9, 7, 25), "This control construct may only be used if the computation expression builder defines a 'Bind' method" |]
+            [| FSharpDiagnosticSeverity.Error, 708, (7, 9, 7, 13), "This control construct may only be used if the computation expression builder defines a 'Bind' method" |]
 
     [<Fact>]
     let ``AndBang TraceApplicative with do-bang`` () =

--- a/tests/fsharp/typecheck/sigs/neg61.bsl
+++ b/tests/fsharp/typecheck/sigs/neg61.bsl
@@ -61,8 +61,6 @@ neg61.fs(92,13,92,70): typecheck error FS3142: 'use' expressions may not be used
 
 neg61.fs(97,13,97,17): typecheck error FS3143: 'let!', 'use!' and 'do!' expressions may not be used in queries
 
-neg61.fs(102,13,102,28): typecheck error FS3145: This is not a known query operator. Query operators are identifiers such as 'select', 'where', 'sortBy', 'thenBy', 'groupBy', 'groupValBy', 'join', 'groupJoin', 'sumBy' and 'averageBy', defined using corresponding methods on the 'QueryBuilder' type.
-
 neg61.fs(102,13,102,28): typecheck error FS3143: 'let!', 'use!' and 'do!' expressions may not be used in queries
 
 neg61.fs(107,13,107,21): typecheck error FS3144: 'return' and 'return!' may not be used in queries

--- a/tests/fsharp/typecheck/sigs/neg61.bsl
+++ b/tests/fsharp/typecheck/sigs/neg61.bsl
@@ -59,7 +59,7 @@ neg61.fs(86,13,86,16): typecheck error FS3141: 'try/finally' expressions may not
 
 neg61.fs(92,13,92,70): typecheck error FS3142: 'use' expressions may not be used in queries
 
-neg61.fs(97,13,97,33): typecheck error FS3143: 'let!', 'use!' and 'do!' expressions may not be used in queries
+neg61.fs(97,13,97,17): typecheck error FS3143: 'let!', 'use!' and 'do!' expressions may not be used in queries
 
 neg61.fs(102,13,102,28): typecheck error FS3145: This is not a known query operator. Query operators are identifiers such as 'select', 'where', 'sortBy', 'thenBy', 'groupBy', 'groupValBy', 'join', 'groupJoin', 'sumBy' and 'averageBy', defined using corresponding methods on the 'QueryBuilder' type.
 

--- a/tests/service/data/SyntaxTree/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/ComputationExpression/MultipleSynExprAndBangHaveRangeThatStartsAtAndAndEndsAfterExpression.fs.bsl
@@ -40,7 +40,8 @@ ImplFile
                                           EqualsRange = (5,13--5,14)
                                           InKeyword = None })],
                        YieldOrReturn ((false, true), Ident bar, (6,4--6,14)),
-                       (3,4--6,14), { EqualsRange = Some (3,13--3,14) }),
+                       (3,4--6,14), { LetOrUseBangKeyword = (3,4--3,8)
+                                      EqualsRange = Some (3,13--3,14) }),
                     (2,6--7,1)), (2,0--7,1)), (2,0--7,1))], PreXmlDocEmpty, [],
           None, (2,0--7,1), { LeadingKeyword = None })], (true, true),
       { ConditionalDirectives = []

--- a/tests/service/data/SyntaxTree/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/ComputationExpression/SynExprAndBangRangeStartsAtAndAndEndsAfterExpression.fs.bsl
@@ -29,7 +29,8 @@ ImplFile
                                           EqualsRange = (5,13--5,14)
                                           InKeyword = None })],
                        YieldOrReturn ((false, true), Ident bar, (7,4--7,14)),
-                       (3,4--7,14), { EqualsRange = Some (3,13--3,14) }),
+                       (3,4--7,14), { LetOrUseBangKeyword = (3,4--3,8)
+                                      EqualsRange = Some (3,13--3,14) }),
                     (2,6--8,1)), (2,0--8,1)), (2,0--8,1))], PreXmlDocEmpty, [],
           None, (2,0--8,1), { LeadingKeyword = None })], (true, true),
       { ConditionalDirectives = []

--- a/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprLetOrUseBangContainsTheRangeOfTheEqualsSign.fs.bsl
@@ -27,7 +27,8 @@ ImplFile
                                           InKeyword = None })],
                        YieldOrReturn
                          ((false, true), Const (Unit, (5,11--5,13)), (5,4--5,13)),
-                       (3,4--5,13), { EqualsRange = Some (3,11--3,12) }),
+                       (3,4--5,13), { LetOrUseBangKeyword = (3,4--3,8)
+                                      EqualsRange = Some (3,11--3,12) }),
                     (2,5--6,1)), (2,0--6,1)), (2,0--6,1))], PreXmlDocEmpty, [],
           None, (2,0--6,1), { LeadingKeyword = None })], (true, true),
       { ConditionalDirectives = []


### PR DESCRIPTION
## Description

Better ranges for CE `let!` and `use!` error reporting. Continuation of https://github.com/dotnet/fsharp/pull/17671

### Before
- **`let!` in an CE builder**

<img width="243" alt="Screenshot 2024-09-20 at 11 20 12" src="https://github.com/user-attachments/assets/6a414f8d-100e-4228-a9c6-c06eda13fe3c">

- **`let!` in a `query` builder**
<img width="322" alt="Screenshot 2024-09-20 at 11 20 49" src="https://github.com/user-attachments/assets/3e242fb1-70b0-4e6c-9168-65086e701243">


- **`use!` in an CE builder**
<img width="253" alt="Screenshot 2024-09-20 at 11 26 03" src="https://github.com/user-attachments/assets/18fa31bd-087e-434e-8420-20003407906a">

- **`use!` in a `query` builder**
<img width="327" alt="Screenshot 2024-09-20 at 11 28 00" src="https://github.com/user-attachments/assets/ac9de843-fa85-4ea2-818b-ceeac97bcbdd">

### After 

- **`let!` in an CE builder**

```fsharp
let run r2 r3 =
    result {
        let! a = r2
        ^^^^
        return! a
    }
```

- **`let!` in a `query` builder**
```fsharp
query {
    let! x = failwith ""
    ^^^^
    yield 1
}
```

- **`use!` in an CE builder**

```fsharp
let run r2 r3 =
    result {
        use! a = r2
        ^^^^
        return! a
    }
```

- **`use!` in a `query` builder**

```fsharp
query {
    use! x = failwith ""
    ^^^^
    yield 1
}
```


## Checklist

- [x] Test cases added
- [x] Release notes entry updated