### PR TITLE
Add trivia to Nullness nodes in SyntaxTree.

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.100.md
@@ -36,6 +36,8 @@
 * Enable LanguageFeature.EnforceAttributeTargets in F# 9.0. ([Issue #17514](https://github.com/dotnet/fsharp/issues/17558), [PR #17516](https://github.com/dotnet/fsharp/pull/17558))
 * Parser: better recovery for unfinished patterns ([PR #17231](https://github.com/dotnet/fsharp/pull/17231), [PR #17232](https://github.com/dotnet/fsharp/pull/17232)))
 * Enable consuming generic arguments defined as `allows ref struct` in C# ([Issue #17597](https://github.com/dotnet/fsharp/issues/17597)
+* Trivia for SynTypeConstraint.WhereTyparNotSupportsNull. ([Issue #17721](https://github.com/dotnet/fsharp/issues/17721), [PR #17745](https://github.com/dotnet/fsharp/pull/17745))
+* Trivia for SynType.WithNull. ([Issue #17720](https://github.com/dotnet/fsharp/issues/17720), [PR #17745](https://github.com/dotnet/fsharp/pull/17745))
 
 ### Changed
 

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -4028,7 +4028,7 @@ let rec TcTyparConstraint ridx (cenv: cenv) newOk checkConstraints occ (env: TcE
     | SynTypeConstraint.WhereTyparSupportsNull(tp, m) ->
         TcSimpleTyparConstraint cenv env newOk tpenv tp m AddCxTypeUseSupportsNull
 
-    | SynTypeConstraint.WhereTyparNotSupportsNull(tp, m) ->
+    | SynTypeConstraint.WhereTyparNotSupportsNull(tp, m, _) ->
         if g.langFeatureNullness then
             TcSimpleTyparConstraint cenv env newOk tpenv tp m AddCxTypeDefnNotSupportsNull
         else
@@ -4472,7 +4472,7 @@ and TcTypeOrMeasure kindOpt (cenv: cenv) newOk checkConstraints occ (iwsam: Warn
         errorR(Error(FSComp.SR.parsInvalidLiteralInType(), m))
         NewErrorType (), tpenv
 
-    | SynType.WithNull(innerTy, ambivalent, m) ->
+    | SynType.WithNull(innerTy, ambivalent, m, _) ->
         let innerTyC, tpenv = TcTypeAndRecover cenv newOk checkConstraints occ WarnOnIWSAM.Yes env tpenv innerTy
         let nullness = if ambivalent then KnownAmbivalentToNull else KnownWithNull
         let tyWithNull = TcAddNullnessToType false cenv env nullness innerTyC m

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -838,7 +838,7 @@ module SyntaxTraversal =
                 | SynType.Fun(argType = ty1; returnType = ty2) -> [ ty1; ty2 ] |> List.tryPick (traverseSynType path)
                 | SynType.MeasurePower(ty, _, _)
                 | SynType.HashConstraint(ty, _)
-                | SynType.WithNull(ty, _, _)
+                | SynType.WithNull(innerType = ty)
                 | SynType.WithGlobalConstraints(ty, _, _)
                 | SynType.Array(_, ty, _) -> traverseSynType path ty
                 | SynType.StaticConstantNamed(ty1, ty2, _)

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -647,7 +647,7 @@ module ParsedInput =
             | SynTypeConstraint.WhereTyparIsReferenceType(t, _) -> walkTypar t
             | SynTypeConstraint.WhereTyparIsUnmanaged(t, _) -> walkTypar t
             | SynTypeConstraint.WhereTyparSupportsNull(t, _) -> walkTypar t
-            | SynTypeConstraint.WhereTyparNotSupportsNull(t, _) -> walkTypar t
+            | SynTypeConstraint.WhereTyparNotSupportsNull(genericName = t) -> walkTypar t
             | SynTypeConstraint.WhereTyparIsComparable(t, _) -> walkTypar t
             | SynTypeConstraint.WhereTyparIsEquatable(t, _) -> walkTypar t
             | SynTypeConstraint.WhereTyparSubtypeOfType(t, ty, _) -> walkTypar t |> Option.orElseWith (fun () -> walkType ty)
@@ -711,7 +711,7 @@ module ParsedInput =
             | SynType.Array(_, t, _) -> walkType t
             | SynType.Fun(argType = t1; returnType = t2) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
             | SynType.WithGlobalConstraints(t, _, _) -> walkType t
-            | SynType.WithNull(t, _, _)
+            | SynType.WithNull(innerType = t)
             | SynType.HashConstraint(t, _) -> walkType t
             | SynType.Or(t1, t2, _, _) -> walkType t1 |> Option.orElseWith (fun () -> walkType t2)
             | SynType.MeasurePower(t, _, _) -> walkType t
@@ -1914,7 +1914,7 @@ module ParsedInput =
             | SynTypeConstraint.WhereTyparIsReferenceType(t, _)
             | SynTypeConstraint.WhereTyparIsUnmanaged(t, _)
             | SynTypeConstraint.WhereTyparSupportsNull(t, _)
-            | SynTypeConstraint.WhereTyparNotSupportsNull(t, _)
+            | SynTypeConstraint.WhereTyparNotSupportsNull(genericName = t)
             | SynTypeConstraint.WhereTyparIsComparable(t, _)
             | SynTypeConstraint.WhereTyparIsEquatable(t, _) -> walkTypar t
             | SynTypeConstraint.WhereTyparDefaultsToType(t, ty, _)
@@ -1976,7 +1976,7 @@ module ParsedInput =
             | SynType.Array(_, t, _)
             | SynType.HashConstraint(t, _)
             | SynType.MeasurePower(t, _, _)
-            | SynType.WithNull(t, _, _)
+            | SynType.WithNull(innerType = t)
             | SynType.Paren(t, _)
             | SynType.SignatureParameter(usedType = t) -> walkType t
             | SynType.Fun(argType = t1; returnType = t2)

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -332,7 +332,7 @@ type SynTypeConstraint =
 
     | WhereTyparSupportsNull of typar: SynTypar * range: range
 
-    | WhereTyparNotSupportsNull of genericName: SynTypar * range: range
+    | WhereTyparNotSupportsNull of genericName: SynTypar * range: range * trivia: SynTypeConstraintWhereTyparNotSupportsNullTrivia
 
     | WhereTyparIsComparable of typar: SynTypar * range: range
 
@@ -465,7 +465,7 @@ type SynType =
 
     | StaticConstantNamed of ident: SynType * value: SynType * range: range
 
-    | WithNull of innerType: SynType * ambivalent: bool * range: range
+    | WithNull of innerType: SynType * ambivalent: bool * range: range * trivia: SynTypeWithNullTrivia
 
     | Paren of innerType: SynType * range: range
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -409,7 +409,10 @@ type SynTypeConstraint =
     | WhereTyparSupportsNull of typar: SynTypar * range: range
 
     /// F# syntax is 'typar : null
-    | WhereTyparNotSupportsNull of genericName: SynTypar * range: range
+    | WhereTyparNotSupportsNull of
+        genericName: SynTypar *
+        range: range *
+        trivia: SynTypeConstraintWhereTyparNotSupportsNullTrivia
 
     /// F# syntax is 'typar: comparison
     | WhereTyparIsComparable of typar: SynTypar * range: range
@@ -527,7 +530,7 @@ type SynType =
     /// F# syntax: ident=1 etc., used in static parameters to type providers
     | StaticConstantNamed of ident: SynType * value: SynType * range: range
 
-    | WithNull of innerType: SynType * ambivalent: bool * range: range
+    | WithNull of innerType: SynType * ambivalent: bool * range: range * trivia: SynTypeWithNullTrivia
 
     | Paren of innerType: SynType * range: range
 

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -405,6 +405,9 @@ type SynFieldTrivia =
 type SynTypeOrTrivia = { OrKeyword: range }
 
 [<NoEquality; NoComparison>]
+type SynTypeWithNullTrivia = { BarRange: range }
+
+[<NoEquality; NoComparison>]
 type SynBindingReturnInfoTrivia = { ColonRange: range option }
 
 [<NoEquality; NoComparison>]
@@ -429,3 +432,6 @@ type SynMeasureConstantTrivia =
         LessRange: range
         GreaterRange: range
     }
+
+[<NoEquality; NoComparison>]
+type SynTypeConstraintWhereTyparNotSupportsNullTrivia = { ColonRange: range; NotRange: range }

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -512,6 +512,14 @@ type SynTypeOrTrivia =
         OrKeyword: range
     }
 
+/// Represents additional information for SynType.WithNull
+[<NoEquality; NoComparison>]
+type SynTypeWithNullTrivia =
+    {
+        /// The syntax range of the `|` token
+        BarRange: range
+    }
+
 /// Represents additional information for SynBindingReturnInfo
 [<NoEquality; NoComparison>]
 type SynBindingReturnInfoTrivia =
@@ -545,3 +553,14 @@ type SynTyparDeclTrivia =
 type SynMeasureConstantTrivia =
     { LessRange: range
       GreaterRange: range }
+
+/// Represents additional information for SynTypeConstraint.WhereTyparNotSupportsNull
+[<NoEquality; NoComparison>]
+type SynTypeConstraintWhereTyparNotSupportsNullTrivia =
+    {
+        /// The syntax range of `:`
+        ColonRange: range
+
+        /// The syntax range of `not`
+        NotRange: range
+    }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2652,8 +2652,9 @@ typeConstraint:
      { SynTypeConstraint.WhereTyparSupportsNull($1, lhs parseState) }
 
   | typar COLON IDENT NULL
-      { if $3 <> "not" then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedIdentifier($3 + " (2)"))  
-        SynTypeConstraint.WhereTyparNotSupportsNull($1, lhs parseState) }
+      { if $3 <> "not" then reportParseErrorAt (rhs parseState 3) (FSComp.SR.parsUnexpectedIdentifier($3 + " (2)"))
+        let trivia : SynTypeConstraintWhereTyparNotSupportsNullTrivia = { ColonRange = rhs parseState 2; NotRange = rhs parseState 3 }
+        SynTypeConstraint.WhereTyparNotSupportsNull($1, lhs parseState, trivia) }
 
   | typar COLON LPAREN classMemberSpfn rparen
      { let tp = $1
@@ -3241,7 +3242,7 @@ cType:
        SynType.App(SynType.LongIdent(SynLongIdent([ident("nativeptr", m)], [], [ Some(IdentTrivia.OriginalNotation "*") ])), None, [$1], [], None, true, m) }
 
   | cType BAR_JUST_BEFORE_NULL NULL
-    { SynType.WithNull($1, false, lhs parseState) }
+    { SynType.WithNull($1, false, lhs parseState, { BarRange = rhs parseState 2 }) }
 
   | cType AMP
      { let m = lhs parseState
@@ -6193,7 +6194,7 @@ appTypeConPower:
 
 appTypeCanBeNullable:
   | appTypeWithoutNull BAR_JUST_BEFORE_NULL NULL
-    { SynType.WithNull($1, false, lhs parseState) }
+    { SynType.WithNull($1, false, lhs parseState, { BarRange = rhs parseState 2 }) }
 
   | appTypeWithoutNull
     { $1 }

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -9197,6 +9197,8 @@ FSharp.Compiler.Syntax.SynType+WithNull: Boolean ambivalent
 FSharp.Compiler.Syntax.SynType+WithNull: Boolean get_ambivalent()
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Syntax.SynType get_innerType()
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Syntax.SynType innerType
+FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia get_trivia()
+FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia trivia
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynType: Boolean IsAnon
@@ -9264,7 +9266,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewStaticConstant
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewTuple(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTupleTypeSegment], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewVar(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewWithGlobalConstraints(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewWithNull(FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewWithNull(FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Anon
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+AnonRecd
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+App
@@ -9350,6 +9352,8 @@ FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparIsValueType: FSharp.Compiler.
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparIsValueType: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Syntax.SynTypar genericName
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Syntax.SynTypar get_genericName()
+FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia get_trivia()
+FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia trivia
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparSubtypeOfType: FSharp.Compiler.Syntax.SynTypar get_typar()
@@ -9403,7 +9407,7 @@ FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstrai
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparIsReferenceType(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparIsUnmanaged(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparIsValueType(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparNotSupportsNull(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparNotSupportsNull(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparSubtypeOfType(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparSupportsMember(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynMemberSig, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparSupportsNull(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
@@ -10573,6 +10577,12 @@ FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: Microsoft.FSharp.Collections.FS
 FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_AmpersandRanges()
 FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: Void .ctor(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range ColonRange
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range NotRange
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range get_ColonRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range get_NotRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: Void .ctor(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And: FSharp.Compiler.Text.Range Item
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And: FSharp.Compiler.Text.Range get_Item()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType: FSharp.Compiler.Text.Range get_staticRange()
@@ -10635,6 +10645,10 @@ FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: FSharp.Compiler.Text.Range OrKeywo
 FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: FSharp.Compiler.Text.Range get_OrKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: Void .ctor(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: FSharp.Compiler.Text.Range BarRange
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: FSharp.Compiler.Text.Range get_BarRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: Void .ctor(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] BarRange
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_BarRange()
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: System.String ToString()

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -9197,6 +9197,8 @@ FSharp.Compiler.Syntax.SynType+WithNull: Boolean ambivalent
 FSharp.Compiler.Syntax.SynType+WithNull: Boolean get_ambivalent()
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Syntax.SynType get_innerType()
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Syntax.SynType innerType
+FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia get_trivia()
+FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia trivia
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynType+WithNull: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynType: Boolean IsAnon
@@ -9264,7 +9266,7 @@ FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewStaticConstant
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewTuple(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTupleTypeSegment], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewVar(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewWithGlobalConstraints(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynTypeConstraint], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewWithNull(FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType NewWithNull(FSharp.Compiler.Syntax.SynType, Boolean, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia)
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+Anon
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+AnonRecd
 FSharp.Compiler.Syntax.SynType: FSharp.Compiler.Syntax.SynType+App
@@ -9350,6 +9352,8 @@ FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparIsValueType: FSharp.Compiler.
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparIsValueType: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Syntax.SynTypar genericName
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Syntax.SynTypar get_genericName()
+FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia get_trivia()
+FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia trivia
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparNotSupportsNull: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynTypeConstraint+WhereTyparSubtypeOfType: FSharp.Compiler.Syntax.SynTypar get_typar()
@@ -9403,7 +9407,7 @@ FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstrai
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparIsReferenceType(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparIsUnmanaged(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparIsValueType(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparNotSupportsNull(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparNotSupportsNull(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparSubtypeOfType(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparSupportsMember(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynMemberSig, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynTypeConstraint: FSharp.Compiler.Syntax.SynTypeConstraint NewWhereTyparSupportsNull(FSharp.Compiler.Syntax.SynTypar, FSharp.Compiler.Text.Range)
@@ -10573,6 +10577,12 @@ FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: Microsoft.FSharp.Collections.FS
 FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range] get_AmpersandRanges()
 FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynTyparDeclTrivia: Void .ctor(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Text.Range])
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range ColonRange
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range NotRange
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range get_ColonRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: FSharp.Compiler.Text.Range get_NotRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynTypeConstraintWhereTyparNotSupportsNullTrivia: Void .ctor(FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And: FSharp.Compiler.Text.Range Item
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+And: FSharp.Compiler.Text.Range get_Item()
 FSharp.Compiler.SyntaxTrivia.SynTypeDefnLeadingKeyword+StaticType: FSharp.Compiler.Text.Range get_staticRange()
@@ -10635,6 +10645,10 @@ FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: FSharp.Compiler.Text.Range OrKeywo
 FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: FSharp.Compiler.Text.Range get_OrKeyword()
 FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: System.String ToString()
 FSharp.Compiler.SyntaxTrivia.SynTypeOrTrivia: Void .ctor(FSharp.Compiler.Text.Range)
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: FSharp.Compiler.Text.Range BarRange
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: FSharp.Compiler.Text.Range get_BarRange()
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynTypeWithNullTrivia: Void .ctor(FSharp.Compiler.Text.Range)
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] BarRange
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_BarRange()
 FSharp.Compiler.SyntaxTrivia.SynUnionCaseTrivia: System.String ToString()

--- a/tests/service/data/SyntaxTree/Nullness/AbstractClassProperty.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/AbstractClassProperty.fs.bsl
@@ -29,7 +29,7 @@ ImplFile
                             SynValTyparDecls (None, true),
                             WithNull
                               (LongIdent (SynLongIdent ([string], [], [None])),
-                               false, (3,24--3,37)),
+                               false, (3,24--3,37), { BarRange = (3,31--3,32) }),
                             SynValInfo ([], SynArgInfo ([], false, None)), false,
                             false,
                             PreXmlDoc ((3,3), FSharp.Compiler.Xml.XmlDocCollector),

--- a/tests/service/data/SyntaxTree/Nullness/DuCaseStringOrNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/DuCaseStringOrNull.fs.bsl
@@ -22,8 +22,9 @@ ImplFile
                                     (WithNull
                                        (LongIdent
                                           (SynLongIdent ([string], [], [None])),
-                                        false, (1,21--1,34)), (1,20--1,35)),
-                                  false,
+                                        false, (1,21--1,34),
+                                        { BarRange = (1,28--1,29) }),
+                                     (1,20--1,35)), false,
                                   PreXmlDoc ((1,20), FSharp.Compiler.Xml.XmlDocCollector),
                                   None, (1,20--1,35), { LeadingKeyword = None
                                                         MutableKeyword = None })],

--- a/tests/service/data/SyntaxTree/Nullness/DuCaseTuplePrecedence.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/DuCaseTuplePrecedence.fs.bsl
@@ -22,8 +22,9 @@ ImplFile
                                     (WithNull
                                        (LongIdent
                                           (SynLongIdent ([string], [], [None])),
-                                        false, (1,21--1,34)), (1,20--1,35)),
-                                  false,
+                                        false, (1,21--1,34),
+                                        { BarRange = (1,28--1,29) }),
+                                     (1,20--1,35)), false,
                                   PreXmlDoc ((1,20), FSharp.Compiler.Xml.XmlDocCollector),
                                   None, (1,20--1,35), { LeadingKeyword = None
                                                         MutableKeyword = None });

--- a/tests/service/data/SyntaxTree/Nullness/ExplicitField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/ExplicitField.fs.bsl
@@ -17,7 +17,8 @@ ImplFile
                            ([], false, Some myString,
                             WithNull
                               (LongIdent (SynLongIdent ([string], [], [None])),
-                               false, (3,31--3,44)), true,
+                               false, (3,31--3,44), { BarRange = (3,38--3,39) }),
+                            true,
                             PreXmlDoc ((3,8), FSharp.Compiler.Xml.XmlDocCollector),
                             None, (3,8--3,44),
                             { LeadingKeyword = Some (Val (3,8--3,11))

--- a/tests/service/data/SyntaxTree/Nullness/FunctionArgAsPatternWithNullCase.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/FunctionArgAsPatternWithNullCase.fs.bsl
@@ -30,8 +30,10 @@ ImplFile
                                     WithNull
                                       (LongIdent
                                          (SynLongIdent ([string], [], [None])),
-                                       false, (1,25--1,38)), (1,20--1,38)),
-                                 (1,12--1,38), { BarRange = (1,18--1,19) }),
+                                       false, (1,25--1,38),
+                                       { BarRange = (1,32--1,33) }),
+                                    (1,20--1,38)), (1,12--1,38),
+                                 { BarRange = (1,18--1,19) }),
                               Const
                                 (String ("123", Regular, (1,41--1,46)),
                                  (1,41--1,46)), (1,12--1,46),

--- a/tests/service/data/SyntaxTree/Nullness/GenericFunctionTyparNotNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/GenericFunctionTyparNotNull.fs.bsl
@@ -24,13 +24,14 @@ ImplFile
                               WithGlobalConstraints
                                 (Var (SynTypar (T, None, false), (1,15--1,17)),
                                  [WhereTyparNotSupportsNull
-                                    (SynTypar (T, None, false), (1,23--1,35))],
-                                 (1,15--1,35)), (1,12--1,35)), (1,11--1,36))],
-                     None, (1,4--1,36)), None, Const (Int32 42, (1,39--1,41)),
-                  (1,4--1,36), NoneAtLet, { LeadingKeyword = Let (1,0--1,3)
-                                            InlineKeyword = None
-                                            EqualsRange = Some (1,37--1,38) })],
-              (1,0--1,41))], PreXmlDocEmpty, [], None, (1,0--2,0),
-          { LeadingKeyword = None })], (true, true),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                                    (SynTypar (T, None, false), (1,23--1,35),
+                                     { ColonRange = (1,25--1,26)
+                                       NotRange = (1,27--1,30) })], (1,15--1,35)),
+                              (1,12--1,35)), (1,11--1,36))], None, (1,4--1,36)),
+                  None, Const (Int32 42, (1,39--1,41)), (1,4--1,36), NoneAtLet,
+                  { LeadingKeyword = Let (1,0--1,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (1,37--1,38) })], (1,0--1,41))],
+          PreXmlDocEmpty, [], None, (1,0--2,0), { LeadingKeyword = None })],
+      (true, true), { ConditionalDirectives = []
+                      CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Nullness/GenericTypeNotNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/GenericTypeNotNull.fs.bsl
@@ -14,9 +14,10 @@ ImplFile
                               ([], SynTypar (T, None, false), [],
                                { AmpersandRanges = [] })],
                            [WhereTyparNotSupportsNull
-                              (SynTypar (T, None, false), (1,15--1,27))],
-                           (1,6--1,28))), [], [C],
-                     PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector),
+                              (SynTypar (T, None, false), (1,15--1,27),
+                               { ColonRange = (1,17--1,18)
+                                 NotRange = (1,19--1,22) })], (1,6--1,28))), [],
+                     [C], PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector),
                      true, None, (1,5--1,6)),
                   ObjectModel (Class, [], (1,31--1,40)), [], None, (1,5--1,40),
                   { LeadingKeyword = Type (1,0--1,4)

--- a/tests/service/data/SyntaxTree/Nullness/GenericTypeNotNullAndOtherConstraint.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/GenericTypeNotNullAndOtherConstraint.fs.bsl
@@ -14,7 +14,9 @@ ImplFile
                               ([], SynTypar (T, None, false), [],
                                { AmpersandRanges = [] })],
                            [WhereTyparNotSupportsNull
-                              (SynTypar (T, None, false), (1,15--1,27));
+                              (SynTypar (T, None, false), (1,15--1,27),
+                               { ColonRange = (1,17--1,18)
+                                 NotRange = (1,19--1,22) });
                             WhereTyparIsEquatable
                               (SynTypar (T, None, false), (1,32--1,43))],
                            (1,6--1,44))), [], [C],

--- a/tests/service/data/SyntaxTree/Nullness/GenericTypeOtherConstraintAndThenNotNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/GenericTypeOtherConstraintAndThenNotNull.fs.bsl
@@ -16,9 +16,10 @@ ImplFile
                            [WhereTyparIsEquatable
                               (SynTypar (T, None, false), (1,15--1,26));
                             WhereTyparNotSupportsNull
-                              (SynTypar (T, None, false), (1,31--1,43))],
-                           (1,6--1,44))), [], [C],
-                     PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector),
+                              (SynTypar (T, None, false), (1,31--1,43),
+                               { ColonRange = (1,33--1,34)
+                                 NotRange = (1,35--1,38) })], (1,6--1,44))), [],
+                     [C], PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector),
                      true, None, (1,5--1,6)),
                   ObjectModel (Class, [], (1,47--1,56)), [], None, (1,5--1,56),
                   { LeadingKeyword = Type (1,0--1,4)

--- a/tests/service/data/SyntaxTree/Nullness/IntListOrNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/IntListOrNull.fs.bsl
@@ -19,19 +19,21 @@ ImplFile
                              (LongIdent (SynLongIdent ([list], [], [None])),
                               None,
                               [LongIdent (SynLongIdent ([int], [], [None]))], [],
-                              None, true, (1,8--1,16)), false, (1,8--1,23)),
-                        (1,8--1,23), [], { ColonRange = Some (1,6--1,7) })),
+                              None, true, (1,8--1,16)), false, (1,8--1,23),
+                           { BarRange = (1,17--1,18) }), (1,8--1,23), [],
+                        { ColonRange = Some (1,6--1,7) })),
                   Typed
                     (ArrayOrList (false, [], (1,26--1,28)),
                      WithNull
                        (App
                           (LongIdent (SynLongIdent ([list], [], [None])), None,
                            [LongIdent (SynLongIdent ([int], [], [None]))], [],
-                           None, true, (1,8--1,16)), false, (1,8--1,23)),
-                     (1,26--1,28)), (1,4--1,5), Yes (1,0--1,28),
-                  { LeadingKeyword = Let (1,0--1,3)
-                    InlineKeyword = None
-                    EqualsRange = Some (1,24--1,25) })], (1,0--1,28))],
-          PreXmlDocEmpty, [], None, (1,0--2,0), { LeadingKeyword = None })],
-      (true, true), { ConditionalDirectives = []
-                      CodeComments = [] }, set []))
+                           None, true, (1,8--1,16)), false, (1,8--1,23),
+                        { BarRange = (1,17--1,18) }), (1,26--1,28)), (1,4--1,5),
+                  Yes (1,0--1,28), { LeadingKeyword = Let (1,0--1,3)
+                                     InlineKeyword = None
+                                     EqualsRange = Some (1,24--1,25) })],
+              (1,0--1,28))], PreXmlDocEmpty, [], None, (1,0--2,0),
+          { LeadingKeyword = None })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Nullness/IntListOrNullOrNullOrNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/IntListOrNullOrNullOrNull.fs.bsl
@@ -19,21 +19,22 @@ ImplFile
                              (LongIdent (SynLongIdent ([list], [], [None])),
                               None,
                               [LongIdent (SynLongIdent ([int], [], [None]))], [],
-                              None, true, (1,8--1,16)), false, (1,8--1,23)),
-                        (1,8--1,23), [], { ColonRange = Some (1,6--1,7) })),
+                              None, true, (1,8--1,16)), false, (1,8--1,23),
+                           { BarRange = (1,17--1,18) }), (1,8--1,23), [],
+                        { ColonRange = Some (1,6--1,7) })),
                   Typed
                     (ArbitraryAfterError ("localBinding2", (1,23--1,23)),
                      WithNull
                        (App
                           (LongIdent (SynLongIdent ([list], [], [None])), None,
                            [LongIdent (SynLongIdent ([int], [], [None]))], [],
-                           None, true, (1,8--1,16)), false, (1,8--1,23)),
-                     (1,23--1,23)), (1,4--1,5), Yes (1,0--1,23),
-                  { LeadingKeyword = Let (1,0--1,3)
-                    InlineKeyword = None
-                    EqualsRange = None })], (1,0--1,23))], PreXmlDocEmpty, [],
-          None, (1,0--2,0), { LeadingKeyword = None })], (true, true),
-      { ConditionalDirectives = []
-        CodeComments = [] }, set []))
+                           None, true, (1,8--1,16)), false, (1,8--1,23),
+                        { BarRange = (1,17--1,18) }), (1,23--1,23)), (1,4--1,5),
+                  Yes (1,0--1,23), { LeadingKeyword = Let (1,0--1,3)
+                                     InlineKeyword = None
+                                     EqualsRange = None })], (1,0--1,23))],
+          PreXmlDocEmpty, [], None, (1,0--2,0), { LeadingKeyword = None })],
+      (true, true), { ConditionalDirectives = []
+                      CodeComments = [] }, set []))
 
 (1,24)-(1,25) parse error Unexpected symbol '|' (directly before 'null') in binding. Expected '=' or other token.

--- a/tests/service/data/SyntaxTree/Nullness/MatchWithTypeCastParens.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/MatchWithTypeCastParens.fs.bsl
@@ -12,8 +12,9 @@ ImplFile
                        (Paren
                           (WithNull
                              (LongIdent (SynLongIdent ([string], [], [None])),
-                              false, (2,6--2,19)), (2,5--2,20)), (2,2--2,20)),
-                     None, Const (Unit, (2,24--2,26)), (2,2--2,26), Yes,
+                              false, (2,6--2,19), { BarRange = (2,13--2,14) }),
+                           (2,5--2,20)), (2,2--2,20)), None,
+                     Const (Unit, (2,24--2,26)), (2,2--2,26), Yes,
                      { ArrowRange = Some (2,21--2,23)
                        BarRange = Some (2,0--2,1) })], (1,0--2,26),
                  { MatchKeyword = (1,0--1,5)

--- a/tests/service/data/SyntaxTree/Nullness/MatchWithTypeCastParensAndSeparateNullCase.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/MatchWithTypeCastParensAndSeparateNullCase.fs.bsl
@@ -13,9 +13,9 @@ ImplFile
                           (Paren
                              (WithNull
                                 (LongIdent (SynLongIdent ([string], [], [None])),
-                                 false, (2,6--2,19)), (2,5--2,20)), (2,2--2,20)),
-                        Null (2,23--2,27), (2,2--2,27),
-                        { BarRange = (2,21--2,22) }), None,
+                                 false, (2,6--2,19), { BarRange = (2,13--2,14) }),
+                              (2,5--2,20)), (2,2--2,20)), Null (2,23--2,27),
+                        (2,2--2,27), { BarRange = (2,21--2,22) }), None,
                      Const (Unit, (2,31--2,33)), (2,2--2,33), Yes,
                      { ArrowRange = Some (2,28--2,30)
                        BarRange = Some (2,0--2,1) })], (1,0--2,33),

--- a/tests/service/data/SyntaxTree/Nullness/NullAnnotatedExpression.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/NullAnnotatedExpression.fs.bsl
@@ -27,14 +27,18 @@ ImplFile
                                      [WithNull
                                         (LongIdent
                                            (SynLongIdent ([string], [], [None])),
-                                         false, (1,24--1,37));
+                                         false, (1,24--1,37),
+                                         { BarRange = (1,31--1,32) });
                                       WithNull
                                         (LongIdent
                                            (SynLongIdent ([T], [], [None])),
-                                         false, (1,39--1,47))], [(1,37--1,38)],
-                                     Some (1,47--1,48), false, (1,19--1,48)),
-                                  false, (1,19--1,55))], [], Some (1,55--1,56),
-                              false, (1,8--1,56)), false, (1,8--1,63)),
+                                         false, (1,39--1,47),
+                                         { BarRange = (1,41--1,42) })],
+                                     [(1,37--1,38)], Some (1,47--1,48), false,
+                                     (1,19--1,48)), false, (1,19--1,55),
+                                  { BarRange = (1,49--1,50) })], [],
+                              Some (1,55--1,56), false, (1,8--1,56)), false,
+                           (1,8--1,63), { BarRange = (1,57--1,58) }),
                         (1,8--1,63), [], { ColonRange = Some (1,6--1,7) })),
                   Typed
                     (Null (1,66--1,70),
@@ -49,13 +53,17 @@ ImplFile
                                   [WithNull
                                      (LongIdent
                                         (SynLongIdent ([string], [], [None])),
-                                      false, (1,24--1,37));
+                                      false, (1,24--1,37),
+                                      { BarRange = (1,31--1,32) });
                                    WithNull
                                      (LongIdent (SynLongIdent ([T], [], [None])),
-                                      false, (1,39--1,47))], [(1,37--1,38)],
-                                  Some (1,47--1,48), false, (1,19--1,48)), false,
-                               (1,19--1,55))], [], Some (1,55--1,56), false,
-                           (1,8--1,56)), false, (1,8--1,63)), (1,66--1,70)),
+                                      false, (1,39--1,47),
+                                      { BarRange = (1,41--1,42) })],
+                                  [(1,37--1,38)], Some (1,47--1,48), false,
+                                  (1,19--1,48)), false, (1,19--1,55),
+                               { BarRange = (1,49--1,50) })], [],
+                           Some (1,55--1,56), false, (1,8--1,56)), false,
+                        (1,8--1,63), { BarRange = (1,57--1,58) }), (1,66--1,70)),
                   (1,4--1,5), Yes (1,0--1,70),
                   { LeadingKeyword = Let (1,0--1,3)
                     InlineKeyword = None

--- a/tests/service/data/SyntaxTree/Nullness/RegressionAnnotatedInlinePatternMatch.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/RegressionAnnotatedInlinePatternMatch.fs.bsl
@@ -15,7 +15,7 @@ ImplFile
                         Fun
                           (WithNull
                              (LongIdent (SynLongIdent ([string], [], [None])),
-                              false, (2,15--2,28)),
+                              false, (2,15--2,28), { BarRange = (2,22--2,23) }),
                            StaticConstant
                              (String ("456", Regular, (2,32--2,37)),
                               (2,32--2,37)), (2,15--2,37),

--- a/tests/service/data/SyntaxTree/Nullness/SignatureInAbstractMember.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/SignatureInAbstractMember.fs.bsl
@@ -24,12 +24,12 @@ ImplFile
                               (WithNull
                                  (LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
-                                  (2,31--2,44)),
+                                  (2,31--2,44), { BarRange = (2,38--2,39) }),
                                WithNull
                                  (LongIdent
                                     (SynLongIdent ([string], [], [None])), false,
-                                  (2,48--2,61)), (2,31--2,61),
-                               { ArrowRange = (2,45--2,47) }),
+                                  (2,48--2,61), { BarRange = (2,55--2,56) }),
+                               (2,31--2,61), { ArrowRange = (2,45--2,47) }),
                             SynValInfo
                               ([[SynArgInfo ([], false, None)]],
                                SynArgInfo ([], false, None)), false, false,

--- a/tests/service/data/SyntaxTree/Nullness/StringOrNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/StringOrNull.fs.bsl
@@ -16,13 +16,14 @@ ImplFile
                     (SynBindingReturnInfo
                        (WithNull
                           (LongIdent (SynLongIdent ([string], [], [None])),
-                           false, (1,8--1,21)), (1,8--1,21), [],
-                        { ColonRange = Some (1,6--1,7) })),
+                           false, (1,8--1,21), { BarRange = (1,15--1,16) }),
+                        (1,8--1,21), [], { ColonRange = Some (1,6--1,7) })),
                   Typed
                     (Null (1,24--1,28),
                      WithNull
                        (LongIdent (SynLongIdent ([string], [], [None])), false,
-                        (1,8--1,21)), (1,24--1,28)), (1,4--1,5), Yes (1,0--1,28),
+                        (1,8--1,21), { BarRange = (1,15--1,16) }), (1,24--1,28)),
+                  (1,4--1,5), Yes (1,0--1,28),
                   { LeadingKeyword = Let (1,0--1,3)
                     InlineKeyword = None
                     EqualsRange = Some (1,22--1,23) })], (1,0--1,28))],

--- a/tests/service/data/SyntaxTree/Nullness/StringOrNullInFunctionArg.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/StringOrNullInFunctionArg.fs.bsl
@@ -25,7 +25,8 @@ ImplFile
                                 (WithNull
                                    (LongIdent
                                       (SynLongIdent ([string], [], [None])),
-                                    false, (1,16--1,29)), (1,15--1,30)),
+                                    false, (1,16--1,29),
+                                    { BarRange = (1,23--1,24) }), (1,15--1,30)),
                               (1,12--1,30)), (1,11--1,31))], None, (1,4--1,31)),
                   None, Const (Int32 42, (1,34--1,36)), (1,4--1,31), NoneAtLet,
                   { LeadingKeyword = Let (1,0--1,3)

--- a/tests/service/data/SyntaxTree/Nullness/TypeAbbreviationAddingWithNull.fs.bsl
+++ b/tests/service/data/SyntaxTree/Nullness/TypeAbbreviationAddingWithNull.fs.bsl
@@ -15,10 +15,11 @@ ImplFile
                        (Ok,
                         WithNull
                           (LongIdent (SynLongIdent ([string], [], [None])),
-                           false, (1,20--1,33)), (1,20--1,33)), (1,20--1,33)),
-                  [], None, (1,5--1,33), { LeadingKeyword = Type (1,0--1,4)
-                                           EqualsRange = Some (1,18--1,19)
-                                           WithKeyword = None })], (1,0--1,33))],
-          PreXmlDocEmpty, [], None, (1,0--1,33), { LeadingKeyword = None })],
-      (true, true), { ConditionalDirectives = []
-                      CodeComments = [] }, set []))
+                           false, (1,20--1,33), { BarRange = (1,27--1,28) }),
+                        (1,20--1,33)), (1,20--1,33)), [], None, (1,5--1,33),
+                  { LeadingKeyword = Type (1,0--1,4)
+                    EqualsRange = Some (1,18--1,19)
+                    WithKeyword = None })], (1,0--1,33))], PreXmlDocEmpty, [],
+          None, (1,0--1,33), { LeadingKeyword = None })], (true, true),
+      { ConditionalDirectives = []
+        CodeComments = [] }, set []))


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #17720
Fixes #17721

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/release-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**