### PR TITLE
Fix 17731 - Regression, F# 9 compiler cannot find constructor for attribute

### DIFF
--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -1010,6 +1010,13 @@ let TranslatePartialValReprInfo tps (PrelimValReprInfo (argsData, retData)) =
 // Members
 //-------------------------------------------------------------------------
 
+
+[<RequireQualifiedAccess>]
+type TcCanFail =
+    | IgnoreMemberResoutionError
+    | IgnoreAllErrors
+    | ReportAllErrors
+
 let TcAddNullnessToType (warn: bool) (cenv: cenv) (env: TcEnv) nullness innerTyC m =
     let g = cenv.g
     if g.langFeatureNullness then
@@ -10869,7 +10876,7 @@ and TcNormalizedBinding declKind (cenv: cenv) env tpenv overallTy safeThisValOpt
             // For all but attributes positioned at the return value, disallow implicitly
             // targeting the return value.
             let tgtEx = if isRet then enum 0 else AttributeTargets.ReturnValue
-            let attrs, _ = TcAttributesMaybeFailEx false cenv envinner tgt tgtEx attrs
+            let attrs, _ = TcAttributesMaybeFailEx TcCanFail.ReportAllErrors cenv envinner tgt tgtEx attrs
             let attrs: Attrib list = attrs
             if attrTgt = enum 0 && not (isNil attrs) then
                 for attr in attrs do
@@ -11131,7 +11138,7 @@ and TcAttributeTargetsOnLetBindings (cenv: cenv) env attrs overallPatTy overallE
         else
             AttributeTargets.ReturnValue ||| AttributeTargets.Field ||| AttributeTargets.Property
 
-    TcAttributesWithPossibleTargets false cenv env attrTgt attrs |> ignore
+    TcAttributesWithPossibleTargets TcCanFail.ReportAllErrors cenv env attrTgt attrs |> ignore
 
 and TcLiteral (cenv: cenv) overallTy env tpenv (attrs, synLiteralValExpr) =
 
@@ -11291,7 +11298,7 @@ and TcAttributeEx canFail (cenv: cenv) (env: TcEnv) attrTgt attrEx (synAttr: Syn
                 error(Error(FSComp.SR.tcAttributeIsNotValidForLanguageElement(), mAttr))
 
         match ResolveObjectConstructor cenv.nameResolver env.DisplayEnv mAttr ad ty with
-        | Exception _ when canFail -> [ ], true
+        | Exception _ when canFail = TcCanFail.IgnoreAllErrors || canFail = TcCanFail.IgnoreMemberResoutionError -> [ ], true
         | res ->
 
         let item = ForceRaise res
@@ -11396,11 +11403,11 @@ and TcAttributesMaybeFail canFail cenv env attrTgt synAttribs =
     TcAttributesMaybeFailEx canFail cenv env attrTgt (enum 0) synAttribs
 
 and TcAttributesCanFail cenv env attrTgt synAttribs =
-    let attrs, didFail = TcAttributesMaybeFail true cenv env attrTgt synAttribs
+    let attrs, didFail = TcAttributesMaybeFail TcCanFail.IgnoreAllErrors cenv env attrTgt synAttribs
     attrs, (fun () -> if didFail then TcAttributes cenv env attrTgt synAttribs else attrs)
 
 and TcAttributes cenv env attrTgt synAttribs =
-    TcAttributesMaybeFail false cenv env attrTgt synAttribs |> fst
+    TcAttributesMaybeFail TcCanFail.ReportAllErrors cenv env attrTgt synAttribs |> fst
 
 //-------------------------------------------------------------------------
 // TcLetBinding

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fsi
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fsi
@@ -347,9 +347,9 @@ type PostSpecialValsRecursiveBinding =
 
 [<RequireQualifiedAccess>]
 type TcCanFail =
-     | IgnoreMemberResoutionError
-     | IgnoreAllErrors
-     | ReportAllErrors
+    | IgnoreMemberResoutionError
+    | IgnoreAllErrors
+    | ReportAllErrors
 
 /// Represents a recursive binding after it has been both checked and generalized, but
 /// before initialization recursion has been rewritten

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fsi
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fsi
@@ -345,6 +345,12 @@ type PostSpecialValsRecursiveBinding =
     { ValScheme: ValScheme
       Binding: Binding }
 
+[<RequireQualifiedAccess>]
+type TcCanFail =
+     | IgnoreMemberResoutionError
+     | IgnoreAllErrors
+     | ReportAllErrors
+
 /// Represents a recursive binding after it has been both checked and generalized, but
 /// before initialization recursion has been rewritten
 type PreInitializationGraphEliminationBinding =
@@ -598,7 +604,7 @@ val TcAttributesCanFail:
 
 /// Check a set of attributes which can only target specific elements
 val TcAttributesWithPossibleTargets:
-    canFail: bool ->
+    canFail: TcCanFail ->
     cenv: TcFileState ->
     env: TcEnv ->
     attrTgt: AttributeTargets ->


### PR DESCRIPTION
Fix #17731 

This fixes the issue:  Regression, F# 9 compiler cannot find constructor for attribute.

The issue was caused by the introduction of the Attribute usage validation code.

First the validation does a pass with validation reporting disabled, it does this because:
````
        // 'Check' the attributes. We return the results to avoid having to re-check them in all other phases. 
        // Allow failure of constructor resolution because Vals for members in the same recursive group are not yet available
````
Then it does more validation, however, this time around it turns on validation reporting so that it can be notified of attribute use errors.  Unfortunately the Vals for members in the same recursive group are still not available since it's only a few lines of code later.

The fix is to perform validation reporting with the constructor validation disabled. 

This is okay, because the F# 8.0 code which has worked forever, just never did the pass with validation reporting enabled.

