### PR TITLE
reenable attribute usage in F# 9.0

### DIFF
--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -212,9 +212,9 @@ type LanguageVersion(versionText) =
                 LanguageFeature.LowerSimpleMappingsInComprehensionsToFastLoops, languageVersion90
                 LanguageFeature.ParsedHashDirectiveArgumentNonQuotes, languageVersion90
                 LanguageFeature.EmptyBodiedComputationExpressions, languageVersion90
+                LanguageFeature.EnforceAttributeTargets, languageVersion90
 
                 // F# preview
-                LanguageFeature.EnforceAttributeTargets, previewVersion // waiting for fix of https://github.com/dotnet/fsharp/issues/17731
                 LanguageFeature.UnmanagedConstraintCsharpInterop, previewVersion // not enabled because: https://github.com/dotnet/fsharp/issues/17509
                 LanguageFeature.FromEndSlicing, previewVersion // Unfinished features --- needs work
                 LanguageFeature.AllowAccessModifiersToAutoPropertiesGettersAndSetters, previewVersion

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -98,7 +98,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargets01.fs"|])>]
     let ``E_AttributeTargets01_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -134,7 +134,7 @@ module CustomAttributes_AttributeUsage =
     let ``E_AttributeTargetIsField01_fs`` compilation =
         compilation
         |> withOptions ["--nowarn:25"]
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -187,7 +187,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsMethod02.fs"|])>]
     let ``E_AttributeTargetIsMethod02_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> withOptions ["--nowarn:25"]
         |> verifyCompile
         |> shouldFail
@@ -218,7 +218,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsMethod03.fs"|])>]
     let ``E_AttributeTargetIsMethod03_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> withOptions ["--nowarn:25"]
         |> verifyCompile
         |> shouldFail
@@ -336,7 +336,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsStruct.fs"|])>]
     let ``E_AttributeTargetIsStruct_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -366,7 +366,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsClass.fs"|])>]
     let ``E_AttributeTargetIsClass_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -387,7 +387,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsClass01.fs"|])>]
     let ``E_AttributeTargetIsClass01_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -485,7 +485,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsField03.fs"|])>]
     let ``E_AttributeTargetIsField03_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -505,7 +505,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsProperty01.fs"|])>]
     let ``E_AttributeTargetIsProperty01_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -525,7 +525,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsCtor01.fs"|])>]
     let ``E_AttributeTargetIsCtor01_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -562,7 +562,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsEnum01.fs"|])>]
     let ``E_AttributeTargetIsEnum01_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -599,7 +599,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsDelegate01.fs"|])>]
     let ``E_AttributeTargetsIsDelegate01_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -648,7 +648,7 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsInterface.fs"|])>]
     let ``E_AttributeTargetIsInterface_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -670,7 +670,7 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsClass02.fs"|])>]
     let ``E_AttributeTargetIsClass02_fs`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -698,9 +698,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=CLIMutableAttribute01.fs	# CLIMutableAttribute01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"CLIMutableAttribute01.fs"|])>]
-    let ``CLIMutableAttribute01 preview`` compilation =
+    let ``CLIMutableAttribute01 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldSucceed
         
@@ -724,9 +724,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=E_CLIMutableAttribute.fs	# E_CLIMutableAttribute.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_CLIMutableAttribute.fs"|])>]
-    let ``E_CLIMutableAttribute preview`` compilation =
+    let ``E_CLIMutableAttribute 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -761,9 +761,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=E_AllowNullLiteral.fs	# E_AllowNullLiteral.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AllowNullLiteral.fs"|])>]
-    let ``E_AllowNullLiteral preview`` compilation =
+    let ``E_AllowNullLiteral 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -788,9 +788,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=AllowNullLiteral01.fs	# AllowNullLiteral01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AllowNullLiteral01.fs"|])>]
-    let ``AllowNullLiteral01 preview`` compilation =
+    let ``AllowNullLiteral01 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldSucceed
         
@@ -816,9 +816,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=E_VolatileField.fs	# E_VolatileField.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_VolatileField.fs"|])>]
-    let ``E_VolatileField preview`` compilation =
+    let ``E_VolatileField 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -844,9 +844,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=VolatileField01.fs	# VolatileField01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"VolatileField01.fs"|])>]
-    let ``VolatileField01 preview`` compilation =
+    let ``VolatileField01 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldSucceed
         
@@ -865,9 +865,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     
     // SOURCE=E_SealedAttribute01.fs	# E_SealedAttribute01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_SealedAttribute01.fs"|])>]
-    let ``E_SealedAttribute01 preview`` compilation =
+    let ``E_SealedAttribute01 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -893,9 +893,9 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
 
     // SOURCE=E_StructLayout01.fs	# E_StructLayout01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_StructLayout01.fs"|])>]
-    let ``E_StructLayout01 preview`` compilation =
+    let ``E_StructLayout01 90`` compilation =
         compilation
-        |> withLangVersionPreview
+        |> withLangVersion90
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -925,7 +925,7 @@ and [<ApplicationTenantJsonDerivedType>]
         """
 
     [<InlineData("8.0")>]
-    [<InlineData("preview")>]
+    [<InlineData("9.0")>]
     [<Theory>]
     let ``Regression for - F# 9 compiler cannot find constructor for attribute`` langVersion =
         FSharp missingConstructorRepro


### PR DESCRIPTION
EnforceAttributeTargets was reset back to preview over the weekend.

The bug was fixed but the fix didn't re-enable the feature as part of F# 9.0

This makes it part of 9.0 so that when 9.1 ships the feature will be active as part of 9.0

/cc @vzarytovskii 