### PR TITLE
Requires tactics approval - Fix17773 - cherry pick optimized equals bug fixes to 8.0.4*

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>8</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>401</FSBuildVersion>
+    <FSBuildVersion>402</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->

--- a/src/Compiler/Checking/AugmentWithHashCompare.fs
+++ b/src/Compiler/Checking/AugmentWithHashCompare.fs
@@ -1333,7 +1333,7 @@ let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
             g
             tcref
             ty
-            vis
+            tcref.Accessibility
             (if tcref.Deref.IsFSharpException then
                  None
              else
@@ -1376,7 +1376,7 @@ let MakeValsForEqualityWithComparerAugmentation g (tcref: TyconRef) =
             g 
             tcref 
             ty
-            vis
+            tcref.Accessibility
             // This doesn't implement any interface.
             None 
             "Equals" 

--- a/src/Compiler/Checking/AugmentWithHashCompare.fs
+++ b/src/Compiler/Checking/AugmentWithHashCompare.fs
@@ -1322,7 +1322,7 @@ let MakeValsForCompareWithComparerAugmentation g (tcref: TyconRef) =
 let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
     let m = tcref.Range
     let _, ty = mkMinimalTy g tcref
-    let vis = tcref.TypeReprAccessibility
+    let vis = tcref.Accessibility
     let tps = tcref.Typars m
 
     let objEqualsVal =
@@ -1333,7 +1333,7 @@ let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
             g
             tcref
             ty
-            tcref.Accessibility
+            vis
             (if tcref.Deref.IsFSharpException then
                  None
              else
@@ -1347,16 +1347,13 @@ let MakeValsForEqualsAugmentation g (tcref: TyconRef) =
 
 let MakeValsForEqualityWithComparerAugmentation g (tcref: TyconRef) =
     let _, ty = mkMinimalTy g tcref
-    let vis =
-        // Equality method for union types match the union type visibility rather than the TypeReprAccessibility
-        if tcref.IsUnionTycon then tcref.Accessibility
-        else tcref.TypeReprAccessibility
+    let vis = tcref.Accessibility
     let tps = tcref.Typars tcref.Range
 
     let objGetHashCodeVal =
         mkValSpec g tcref ty vis (Some(mkGetHashCodeSlotSig g)) "GetHashCode" (tps +-> (mkHashTy g ty)) unitArg false
 
-    let withcGetHashCodeVal =
+    let withGetHashCodeVal =
         mkValSpec
             g
             tcref
@@ -1368,27 +1365,27 @@ let MakeValsForEqualityWithComparerAugmentation g (tcref: TyconRef) =
             unaryArg
             false
 
-    let withcEqualsVal =
+    let withEqualsVal =
         mkValSpec g tcref ty vis (Some(mkIStructuralEquatableEqualsSlotSig g)) "Equals" (tps +-> (mkEqualsWithComparerTy g ty)) tupArg false
 
-    let withcEqualsValExact =
+    let withEqualsExactWithComparer =
+        let vis = TAccess (updateSyntaxAccessForCompPath (vis.CompilationPaths) SyntaxAccess.Public)
         mkValSpec
             g 
             tcref 
             ty
-            tcref.Accessibility
+            vis
             // This doesn't implement any interface.
             None 
             "Equals" 
             (tps +-> (mkEqualsWithComparerTyExact g ty)) 
             tupArg 
             false
-
     {
         GetHashCode = objGetHashCodeVal
-        GetHashCodeWithComparer = withcGetHashCodeVal
-        EqualsWithComparer = withcEqualsVal
-        EqualsExactWithComparer = withcEqualsValExact
+        GetHashCodeWithComparer = withGetHashCodeVal
+        EqualsWithComparer = withEqualsVal
+        EqualsExactWithComparer = withEqualsExactWithComparer
     }    
 
 let MakeBindingsForCompareAugmentation g (tycon: Tycon) =

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/TypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/TypeConstraints/IWSAMsAndSRTPs/IWSAMsAndSRTPsTests.fs
@@ -769,9 +769,7 @@ let main _ =
         |> shouldSucceed
         |> verifyIL [
             """
-            .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>
-                  '|IsEqual|IsNonEqual|'<(class [Potato]Potato.Lib/IPotato`1<!!T>) T>(!!T x,
-                                                                                      !!T y) cil managed
+            .method public specialname static class [FSharp.Core]Microsoft.FSharp.Core.FSharpChoice`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> '|IsEqual|IsNonEqual|'<(class [Potato]Potato.Lib/IPotato`1<!!T>) T>(!!T x, !!T y) cil managed
             {
 
             .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionStructTypes.fs
@@ -877,8 +877,7 @@ let main args =
       IL_0002:  newobj     instance void Foo/StructUnion::.ctor(int32)
       IL_0007:  ret
     }""";(*This is a 'maker method' New{CaseName} used for cases which do have fields associated with them, + the _tag gets initialized*)"""
-            NewCase3(string _field1_3,
-                     string _field2_3) cil managed
+            NewCase3(string _field1_3, string _field2_3) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 02 00 00 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ByRefTests.fs
@@ -283,9 +283,7 @@ type C() =
           .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname
-                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)  get_X() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -313,9 +311,7 @@ type C() =
           .get instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname
-                instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname instance int32& modreq([netstandard]System.Runtime.InteropServices.InAttribute)  get_X() cil managed
         {
           .param [0]
           .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -452,9 +448,7 @@ type C<'T>() =
     abstract X<'U> : unit -> inref<'U>
             """
 
-        let verifyMethod = """.method public hidebysig abstract virtual
-                instance !!U& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                X<U>() cil managed
+        let verifyMethod = """.method public hidebysig abstract virtual instance !!U& modreq([runtime]System.Runtime.InteropServices.InAttribute)  X<U>() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""
@@ -481,9 +475,7 @@ type C =
           .get instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute) Test/C::get_X()
         }"""
 
-        let verifyMethod = """.method public hidebysig specialname abstract virtual
-                instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)
-                get_X() cil managed
+        let verifyMethod = """.method public hidebysig specialname abstract virtual instance int32& modreq([runtime]System.Runtime.InteropServices.InAttribute)  get_X() cil managed
         {
           .param [0]
           .custom instance void [runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )"""

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CCtorDUWithMember/CCtorDUWithMember.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CCtorDUWithMember/CCtorDUWithMember.fs
@@ -146,3 +146,59 @@ type ILArrayShape =
             ]
         |> shouldSucceed
 
+    [<InlineData(true, "public")>]          // RealSig
+    [<InlineData(false, "assembly")>]       // Regular
+    [<Theory>]
+    let ``private DU in module`` (realSig, expected) =
+        FSharp """
+module RealInternalSignature
+module Module =
+    type private DU = ABC | YYZ
+
+    let publicFunction () : bool =
+        ABC = YYZ
+
+Module.publicFunction () |> printfn "%b"
+"""
+        |> asExe
+        |> withRealInternalSignature realSig
+        |> compileAndRun
+        |> withILContains [
+            $$"""
+      .method {{expected}} hidebysig instance bool Equals(class RealInternalSignature/Module/DU obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      {
+        .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        
+        .maxstack  4
+        .locals init (int32 V_0,
+                 int32 V_1)
+        IL_0000:  ldarg.0
+        IL_0001:  brfalse.s  IL_001b
+
+        IL_0003:  ldarg.1
+        IL_0004:  brfalse.s  IL_0019
+
+        IL_0006:  ldarg.0
+        IL_0007:  ldfld      int32 RealInternalSignature/Module/DU::_tag
+        IL_000c:  stloc.0
+        IL_000d:  ldarg.1
+        IL_000e:  ldfld      int32 RealInternalSignature/Module/DU::_tag
+        IL_0013:  stloc.1
+        IL_0014:  ldloc.0
+        IL_0015:  ldloc.1
+        IL_0016:  ceq
+        IL_0018:  ret
+
+        IL_0019:  ldc.i4.0
+        IL_001a:  ret
+
+        IL_001b:  ldarg.1
+        IL_001c:  ldnull
+        IL_001d:  cgt.un
+        IL_001f:  ldc.i4.0
+        IL_0020:  ceq
+        IL_0022:  ret
+      } 
+"""
+            ]
+        |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/CrossAssembly.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/CrossAssembly.fs
@@ -7,87 +7,239 @@ open FSharp.Test.Compiler
 
 module GenericComparisonCrossAssembly =
 
-    [<Fact>]
-    let ``fslib``() =
+    [<InlineData(true)>]        // RealSig
+    [<InlineData(false)>]       // Regular
+    [<Theory>]
+    let ``fslib``(realsig) =
         FSharpWithFileName "Program.fs"
             """
 ValueSome (1, 2) = ValueSome (2, 3) |> ignore"""
+        |> withRealInternalSignature realsig
         |> withOptimize
         |> compileExeAndRun
         |> shouldSucceed
         |> verifyIL [ """
-  .method assembly specialname static void staticInitialization@() cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldc.i4.1
-    IL_0001:  ldc.i4.2
-    IL_0002:  newobj     instance void class [runtime]System.Tuple`2<int32,int32>::.ctor(!0,
-                                                                                          !1)
-    IL_0007:  call       valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<!0> valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>>::NewValueSome(!0)
-    IL_000c:  stsfld     valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>> Program::x@1
-    IL_0011:  ldc.i4.2
-    IL_0012:  ldc.i4.3
-    IL_0013:  newobj     instance void class [runtime]System.Tuple`2<int32,int32>::.ctor(!0,
-                                                                                          !1)
-    IL_0018:  call       valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<!0> valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>>::NewValueSome(!0)
-    IL_001d:  stsfld     valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>> Program::y@1
-    IL_0022:  ldsflda    valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>> Program::x@1
-    IL_0027:  call       valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>> Program::get_y@1()
     IL_002c:  call       class [runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
     IL_0031:  call       instance bool valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<class [runtime]System.Tuple`2<int32,int32>>::Equals(valuetype [FSharp.Core]Microsoft.FSharp.Core.FSharpValueOption`1<!0>,
-                                                                                                                                                             class [runtime]System.Collections.IEqualityComparer)
-    IL_0036:  stsfld     bool Program::arg@1
-    IL_003b:  ret
-  } 
 """ ]
 
-    [<Fact>]
-    let ``Another assembly``() =
-        let module1 =
+    [<InlineData(true)>]        // RealSig
+    [<InlineData(false)>]       // Regular
+    [<Theory>]
+    let ``Another Assembly - record with private fields`` (realsig) =
+        let library =
             FSharpWithFileName "Module1.fs"
                 """
 module Module1
     
-    [<Struct>]
-    type Struct(v: int, u: int) =
-        member _.V = v
-        member _.U = u """
+type Value =
+    private { value: uint32 }
+
+    static member Zero = { value = 0u }
+    static member Create(value: int) = { value = uint value } """
+            |> withRealInternalSignature realsig
             |> withOptimize
             |> asLibrary
             |> withName "module1"
 
-        let module2 = 
+        let mainModule = 
             FSharpWithFileName "Program.fs"
-                """
-Module1.Struct(1, 2) = Module1.Struct(2, 3) |> ignore"""
+                $"""
+open Module1
+Value.Zero = Value.Create 0 |> ignore"""
 
-        module2
-        |> withReferences [module1]
-        |> withOptimize
+        mainModule
+        |> withRealInternalSignature realsig
+        |> withReferences [ library ]
         |> compileExeAndRun
         |> shouldSucceed
-        |> verifyIL [ """
-  .method assembly specialname static void staticInitialization@() cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldc.i4.1
-    IL_0001:  ldc.i4.2
-    IL_0002:  newobj     instance void [module1]Module1/Struct::.ctor(int32,
-                                                                      int32)
-    IL_0007:  stsfld     valuetype [module1]Module1/Struct Program::x@1
-    IL_000c:  ldc.i4.2
-    IL_000d:  ldc.i4.3
-    IL_000e:  newobj     instance void [module1]Module1/Struct::.ctor(int32,
-                                                                      int32)
-    IL_0013:  stsfld     valuetype [module1]Module1/Struct Program::y@1
-    IL_0018:  ldsflda    valuetype [module1]Module1/Struct Program::x@1
-    IL_001d:  call       valuetype [module1]Module1/Struct Program::get_y@1()
-    IL_0022:  call       class [runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-    IL_0027:  call       instance bool [module1]Module1/Struct::Equals(valuetype [module1]Module1/Struct,
-                                                                       class [runtime]System.Collections.IEqualityComparer)
-    IL_002c:  stsfld     bool Program::arg@1
-    IL_0031:  ret
-  } 
-""" ]
+
+    [<InlineData(false, "private",  "assembly")>]   // Legacy, private WrapType, private visibility in IL
+    [<InlineData(false, "internal", "assembly")>]   // RealSig, internal WrapType, assembly visibility in IL
+    [<InlineData(false, "public",   "public")>]     // Legacy, public WrapType, public visibility in IL
+    [<InlineData(true,  "private",  "private")>]    // RealSig, private WrapType, private visibility in IL
+    [<InlineData(true,  "internal", "assembly")>]   // RealSig, internal WrapType, assembly visibility in IL
+    [<InlineData(true,  "public",   "public")>]     // RealSig, public WrapType, public visibility in IL
+    [<Theory>]
+    let ``Generated typed Equals`` (realsig, typeScope, targetVisibility) =
+        let library = 
+            FSharpWithFileName "Program.fs"
+                $"""
+module Module1 =
+
+    [<Struct>]
+    type {typeScope} Struct(v: int, u: int) =
+        member _.V = v
+        member _.U = u"""
+
+        library
+        |> asExe
+        |> withNoWarn 988
+        |> withRealInternalSignature realsig
+        |> withOptimize
+        |> compile
+        |> shouldSucceed
+        |> verifyIL [
+            $"""
+      .method {targetVisibility} hidebysig instance bool 
+              Equals(valuetype Program/Module1/Struct obj,
+                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      {{
+        .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        
+        .maxstack  8
+        IL_0000:  ldarg.0
+        IL_0001:  ldfld      int32 Program/Module1/Struct::v
+        IL_0006:  ldarga.s   obj
+        IL_0008:  ldfld      int32 Program/Module1/Struct::v
+        IL_000d:  bne.un.s   IL_001f
+
+        IL_000f:  ldarg.0
+        IL_0010:  ldfld      int32 Program/Module1/Struct::u
+        IL_0015:  ldarga.s   obj
+        IL_0017:  ldfld      int32 Program/Module1/Struct::u
+        IL_001c:  ceq
+        IL_001e:  ret
+
+        IL_001f:  ldc.i4.0
+        IL_0020:  ret
+      }} """ ]
+
+
+    [<InlineData(false, "private")>]        // Legacy, private record fields, private visibility in IL
+    [<InlineData(false, "internal")>]       // RealSig, internal record fields, assembly visibility in IL
+    [<InlineData(false, "public")>]         // Legacy, public record fields, public visibility in IL
+    [<InlineData(true,  "private")>]        // RealSig, private record fields, private visibility in IL
+    [<InlineData(true,  "internal")>]       // RealSig, internal record fields, assembly visibility in IL
+    [<InlineData(true,  "public")>]         // RealSig, public record fields, public visibility in IL
+    [<Theory>]
+    let ``Record with various fields`` (realsig, fieldScope) =
+
+        let mainModule = 
+            FSharpWithFileName "Program.fs"
+                $"""
+module Module1 =
+    type Value =
+        {fieldScope} {{ value: uint32 }}
+
+        static member Zero = {{ value = 0u }}
+        static member Create(value: int) = {{ value = uint value }}
+
+    Value.Zero = Value.Create 0 |> ignore
+    printfn "Hello, World" """
+
+        mainModule
+        |> withRealInternalSignature realsig
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> verifyIL [
+            """
+      .method public hidebysig virtual final instance bool  Equals(class Program/Module1/Value obj) cil managed
+      {
+        .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        
+        .maxstack  8
+        IL_0000:  ldarg.0
+        IL_0001:  brfalse.s  IL_0017
+
+        IL_0003:  ldarg.1
+        IL_0004:  brfalse.s  IL_0015
+
+        IL_0006:  ldarg.0
+        IL_0007:  ldfld      uint32 Program/Module1/Value::value@
+        IL_000c:  ldarg.1
+        IL_000d:  ldfld      uint32 Program/Module1/Value::value@
+        IL_0012:  ceq
+        IL_0014:  ret
+
+        IL_0015:  ldc.i4.0
+        IL_0016:  ret
+
+        IL_0017:  ldarg.1
+        IL_0018:  ldnull
+        IL_0019:  cgt.un
+        IL_001b:  ldc.i4.0
+        IL_001c:  ceq
+        IL_001e:  ret
+      } """
+            """
+    IL_0020:  call       class [runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
+    IL_0025:  callvirt   instance bool Program/Module1/Value::Equals(class Program/Module1/Value,
+                                                                     class [runtime]System.Collections.IEqualityComparer)
+        """ ]
+
+
+    [<InlineData(false, "private",  "assembly")>]   // Legacy, private WrapType, private visibility in IL
+    [<InlineData(false, "internal", "assembly")>]   // RealSig, internal WrapType, assembly visibility in IL
+    [<InlineData(false, "public",   "public")>]     // Legacy, public WrapType, public visibility in IL
+    [<InlineData(true,  "private",  "private")>]    // RealSig, private WrapType, private visibility in IL
+    [<InlineData(true,  "internal", "assembly")>]   // RealSig, internal WrapType, assembly visibility in IL
+    [<InlineData(true,  "public",   "public")>]     // RealSig, public WrapType, public visibility in IL
+    [<Theory>]
+    let ``scoped type arg`` (realsig, argScope, targetVisibility) =
+        let mainModule = 
+            FSharpWithFileName "Program.fs"
+                $"""
+module IPartialEqualityComparer =
+    open System.Collections.Generic
+
+    [<StructuralEquality; NoComparison>]
+    type {argScope} WrapType<'T> = Wrap of 'T
+"""
+        mainModule
+        |> asExe
+        |> withNoWarn 988
+        |> withRealInternalSignature realsig
+        |> withOptimize
+        |> compile
+        |> shouldSucceed
+        |> verifyIL [
+            $"""
+      .method {targetVisibility} hidebysig instance bool 
+              Equals(class Program/IPartialEqualityComparer/WrapType`1<!T> obj,
+                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      {{
+        .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+        
+        .maxstack  5
+        .locals init (class Program/IPartialEqualityComparer/WrapType`1<!T> V_0,
+                 class Program/IPartialEqualityComparer/WrapType`1<!T> V_1,
+                 !T V_2,
+                 !T V_3)
+        IL_0000:  ldarg.0
+        IL_0001:  brfalse.s  IL_0027
+
+        IL_0003:  ldarg.1
+        IL_0004:  brfalse.s  IL_0025
+
+        IL_0006:  ldarg.0
+        IL_0007:  pop
+        IL_0008:  ldarg.0
+        IL_0009:  stloc.0
+        IL_000a:  ldarg.1
+        IL_000b:  stloc.1
+        IL_000c:  ldloc.0
+        IL_000d:  ldfld      !0 class Program/IPartialEqualityComparer/WrapType`1<!T>::item
+        IL_0012:  stloc.2
+        IL_0013:  ldloc.1
+        IL_0014:  ldfld      !0 class Program/IPartialEqualityComparer/WrapType`1<!T>::item
+        IL_0019:  stloc.3
+        IL_001a:  ldarg.2
+        IL_001b:  ldloc.2
+        IL_001c:  ldloc.3
+        IL_001d:  tail.
+        IL_001f:  call       bool [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives/HashCompare::GenericEqualityWithComparerIntrinsic<!T>(class [runtime]System.Collections.IEqualityComparer,
+                                                                                                                                              !!0,
+                                                                                                                                              !!0)
+        IL_0024:  ret
+
+        IL_0025:  ldc.i4.0
+        IL_0026:  ret
+
+        IL_0027:  ldarg.1
+        IL_0028:  ldnull
+        IL_0029:  cgt.un
+        IL_002b:  ldc.i4.0
+        IL_002c:  ceq
+        IL_002e:  ret
+      }} """ ]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.net472.bsl
@@ -128,9 +128,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -235,9 +233,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -259,9 +255,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -285,9 +279,7 @@
         IL_0019:  ret
       } 
 
-      .method public specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method public specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         
         .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals16.fsx.il.netcore.bsl
@@ -128,9 +128,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -235,9 +233,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeStruct obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -259,9 +255,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -285,9 +279,7 @@
         IL_0019:  ret
       } 
 
-      .method public specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method public specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         
         .maxstack  8

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.net472.bsl
@@ -67,9 +67,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion 
-              NewSomeUnion(int32 item1,
-                           int32 item2) cil managed
+      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion NewSomeUnion(int32 item1, int32 item2) cil managed
       {
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -222,9 +220,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -335,9 +331,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -361,9 +355,7 @@
         IL_0022:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals17.fsx.il.netcore.bsl
@@ -67,9 +67,7 @@
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion 
-              NewSomeUnion(int32 item1,
-                           int32 item2) cil managed
+      .method assembly static valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion NewSomeUnion(int32 item1, int32 item2) cil managed
       {
         .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                     int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -222,9 +220,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -335,9 +331,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeUnion obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -361,9 +355,7 @@
         IL_0022:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.net472.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.net472.bsl
@@ -87,9 +87,7 @@
         IL_0006:  ret
       } 
 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 39 45 71 75 61 6C 73 31 38 2B   
@@ -191,9 +189,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -298,9 +294,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -322,9 +316,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -560,9 +552,7 @@
   .field private class [runtime]System.Type Type@
   .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-  .method public specialname rtspecialname 
-          instance void  .ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType,
-                               class [runtime]System.Type Type) cil managed
+  .method public specialname rtspecialname instance void  .ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberType, class [runtime]System.Type Type) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.netcore.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/Equals18.fsx.il.netcore.bsl
@@ -87,9 +87,7 @@
         IL_0006:  ret
       } 
 
-      .method assembly specialname rtspecialname 
-              instance void  .ctor(int32 v,
-                                   int32 u) cil managed
+      .method assembly specialname rtspecialname instance void  .ctor(int32 v, int32 u) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 39 45 71 75 61 6C 73 31 38 2B   
@@ -191,9 +189,7 @@
         IL_000c:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance int32  CompareTo(object obj,
-                                        class [runtime]System.Collections.IComparer comp) cil managed
+      .method public hidebysig virtual final instance int32  CompareTo(object obj, class [runtime]System.Collections.IComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -298,9 +294,7 @@
         IL_000b:  ret
       } 
 
-      .method assembly hidebysig instance bool 
-              Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj,
-                     class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig instance bool Equals(valuetype assembly/EqualsMicroPerfAndCodeGenerationTests/SomeRecord obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         
@@ -322,9 +316,7 @@
         IL_0020:  ret
       } 
 
-      .method public hidebysig virtual final 
-              instance bool  Equals(object obj,
-                                    class [runtime]System.Collections.IEqualityComparer comp) cil managed
+      .method public hidebysig virtual final instance bool  Equals(object obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
       {
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/GenericComparison.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/GenericComparison/GenericComparison.fs
@@ -85,7 +85,6 @@ module GenericComparison =
         |> verifyCompilation
 
 
-
     // SOURCE=Hash01.fsx SCFLAGS="-a -g --optimize+" COMPILE_ONLY=1 POSTCMD="..\\CompareIL.cmd Hash01.dll"          # Hash01.fs -
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"Hash01.fsx"|])>]
     let ``Hash01_fsx`` compilation =

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -598,6 +598,12 @@ module rec Compiler =
         | FS fs -> FS { fs with Options = fs.Options @ ["--realsig+"] }
         | _ -> failwith "withRealInternalSignatureOn only supported by f#"
 
+    let withRealInternalSignature (realSig: bool) (cUnit: CompilationUnit) : CompilationUnit  =
+        if realSig then
+            cUnit |>  withRealInternalSignatureOn
+        else
+            cUnit |>  withRealInternalSignatureOff
+
     let asExe (cUnit: CompilationUnit) : CompilationUnit =
         withOutputType CompileOutput.Exe cUnit
 

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -36,8 +36,8 @@ module ILChecker =
         let strings = @"""((\\[^\n]|[^""\n])*)"""
         let verbatimStrings = @"@(""[^""]*"")+"
         let methodSingleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(\s*\{)"
-        let methodMultiLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
-
+        let methodDoubleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
+        let methodTripleLine = "^(\s*\.method.*)(?: \s*)$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(?: \s*)(.*)\s*$[\r?\n?]^(\s*\{)"
         let normalizeNewLines (text: string) = text.Replace("\r\n", "\n").Replace("\r\n", "\r")
 
         let stripComments (text:string) =
@@ -52,8 +52,9 @@ module ILChecker =
 
         let unifyMethodLine (text:string) =
             let text1 = Regex.Replace(text, $"{methodSingleLine}", (fun me -> $"{me.Groups[1].Value}\n{me.Groups[2].Value}"), RegexOptions.Multiline)
-            let text2 = Regex.Replace(text1, $"{methodMultiLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value}\n{me.Groups[3].Value}"), RegexOptions.Multiline)
-            text2
+            let text2 = Regex.Replace(text1, $"{methodDoubleLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value}\n{me.Groups[3].Value}"), RegexOptions.Multiline)
+            let text3 = Regex.Replace(text2, $"{methodTripleLine}", (fun me -> $"{me.Groups[1].Value} {me.Groups[2].Value} {me.Groups[3].Value}\n{me.Groups[4].Value}"), RegexOptions.Multiline)
+            text3
 
         let replace input (pattern, replacement: string) = Regex.Replace(input, pattern, replacement, RegexOptions.Singleline)
 

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/ReferenceAssemblyTests.fs
@@ -203,8 +203,7 @@ module Nested =
         IL_0001:  throw
       } 
 
-      .method public specialname rtspecialname 
-              instance void  .ctor(int32 x) cil managed
+      .method public specialname rtspecialname instance void  .ctor(int32 x) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 1D 52 65 66 65 72 65 6E 63 65   
@@ -1216,9 +1215,7 @@ type Person(name : string, age : int) =
             extends [runtime]System.Object
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 )
-    .method public specialname rtspecialname
-               instance void  .ctor(string name,
-                                    int32 age) cil managed
+    .method public specialname rtspecialname instance void  .ctor(string name, int32 age) cil managed
     {
 
       .maxstack  8


### PR DESCRIPTION
We caused a regression in 8.0.401 which breaks cross assembly equality comparison for F# Discriminated unions and records.

Issue: https://github.com/dotnet/fsharp/issues/17773

The issue was raised by an external customer.  The bug crept in due to a test hole, the PR addresses this with additional regression tests.  The bug was already fixed in dotnet 9.0 this PR cherry-picks the fix back to the LTS branch.


