### PR TITLE
Switch to new VMR control set (#17703) (port from main)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <RepoRoot Condition="'$(RepoRoot)' == ''">$(MSBuildThisFileDirectory)</RepoRoot>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <FSharpNetCoreProductDefaultTargetFramework>net9.0</FSharpNetCoreProductDefaultTargetFramework>
-    <IgnoreMibc Condition="'$(IgnoreMibc)' == ''">$(DotNetBuildFromSource)</IgnoreMibc>
+    <IgnoreMibc Condition="'$(IgnoreMibc)' == ''">$(DotNetBuildSourceOnly)</IgnoreMibc>
   </PropertyGroup>
 
   <!--
@@ -73,7 +73,7 @@
          we should also support $(NetPrevious) for all releases.
          This will likely include FCS and FSharp.Core as well as shipped products.
          Right now, it only covers products we ship (FSC and FSI), not NuGet packages. -->
-    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">
+    <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' == 'true'">
       <PropertyGroup>
         <FSharpNetCoreProductTargetFramework>$(NetCurrent)</FSharpNetCoreProductTargetFramework>
       </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,7 +26,7 @@
     When .NET gets built from source, make the SDK aware there are bootstrap packages
     for Microsoft.NETCore.App.Runtime.<rid> and Microsoft.NETCore.App.Crossgen2.<rid>.
   -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <KnownRuntimePack Update="Microsoft.NETCore.App">
       <RuntimePackRuntimeIdentifiers
         Condition="'%(TargetFramework)' == '$(NetCurrent)'">%(RuntimePackRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier)</RuntimePackRuntimeIdentifiers>

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -73,8 +73,8 @@
     <EnableXlfLocalization Condition="'$(EnableXlfLocalization)' == '' AND ('$(Configuration)' == 'Proto' OR '$(MonoPackaging)' == 'true')">false</EnableXlfLocalization>    
   </PropertyGroup>
 
-  <!-- source build -->
-  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true' OR '$(ArcadeBuildFromSource)' == 'true'">
+  <!-- Do not publish in source-only modes. This switch is present in both inner and outer builds. -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <PublishWindowsPdb>false</PublishWindowsPdb>
   </PropertyGroup>
 

--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -292,6 +292,8 @@ function BuildSolution([string] $solutionName, $nopack) {
     # Do not set the property to true explicitly, since that would override value projects might set.
     $suppressExtensionDeployment = if (!$deployExtensions) { "/p:DeployExtension=false" } else { "" }
 
+    $sourceBuildArgs = if ($sourceBuild) { "/p:DotNetBuildSourceOnly=true /p:DotNetBuildRepo=true" } else { "" }
+
     $BUILDING_USING_DOTNET_ORIG = $env:BUILDING_USING_DOTNET
 
     $env:BUILDING_USING_DOTNET="false"
@@ -314,10 +316,10 @@ function BuildSolution([string] $solutionName, $nopack) {
         /p:QuietRestore=$quietRestore `
         /p:QuietRestoreBinaryLog=$binaryLog `
         /p:TestTargetFrameworks=$testTargetFrameworks `
-        /p:DotNetBuildFromSource=$sourceBuild `
         /p:CompressAllMetadata=$CompressAllMetadata `
         /p:BuildNoRealsig=$buildnorealsig `
         /v:$verbosity `
+        $sourceBuildArgs `
         $suppressExtensionDeployment `
         @properties
 

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -13,7 +13,7 @@
   -->
   <Target Name="ConfigureInnerBuildArg"
           BeforeTargets="GetSourceBuildCommandConfiguration"
-          Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">
+          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <PropertyGroup>
       <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Microsoft.FSharp.Compiler.sln"</InnerBuildArgs>
     </PropertyGroup>
@@ -26,7 +26,7 @@
   <Target Name="BuildBootstrap"
           DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
           BeforeTargets="RunInnerSourceBuildCommand"
-          Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">
+          Condition="'$(DotNetBuildSourceOnly)' == 'true'">
           
     <PropertyGroup>
       <SourceBuildBootstrapTfmArg Condition="$(SourceBuildBootstrapTfm) != ''">--tfm $(SourceBuildBootstrapTfm)</SourceBuildBootstrapTfmArg>
@@ -41,9 +41,9 @@
          -bl enables the binlogs for the tools and Proto builds, which make debugging failures here easier
     -->
     <Exec
-      Command="./build.sh --bootstrap --skipBuild -bl $(SourceBuildBootstrapTfmArg) /p:SourceBuildUseMonoRuntime=$(SourceBuildUseMonoRuntime)"
+      Command="./build.sh --bootstrap --skipBuild -bl $(SourceBuildBootstrapTfmArg) /p:SourceBuildUseMonoRuntime=$(SourceBuildUseMonoRuntime) /p:DotNetBuildSourceOnly=true /p:DotNetBuildInnerRepo=true /p:DotNetBuildRepo=true /p:DotNetBuildOrchestrator=$(DotNetBuildOrchestrator)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
-      EnvironmentVariables="@(InnerBuildEnv);DotNetBuildFromSource=true" />
+      EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>
 
 </Project>

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -241,6 +241,11 @@ function BuildSolution {
   if [[ "$UNAME" == "Darwin" ]]; then
     enable_analyzers=false
   fi
+  
+  local source_build_args=""
+  if [[ "$source_build" == true ]]; then
+    source_build_args="/p:DotNetBuildRepo=true /p:DotNetBuildSourceOnly=true"
+  fi
 
   # NuGet often exceeds the limit of open files on Mac and Linux
   # https://github.com/NuGet/Home/issues/2163
@@ -274,7 +279,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto /p:ArcadeBuildFromSource=$source_build $properties"
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $source_build_args $properties"
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi
@@ -296,8 +301,8 @@ function BuildSolution {
       /p:ContinuousIntegrationBuild=$ci \
       /p:QuietRestore=$quiet_restore \
       /p:QuietRestoreBinaryLog="$binary_log" \
-      /p:ArcadeBuildFromSource=$source_build \
       /p:BuildNoRealsig=$buildnorealsig \
+      $source_build_args \
       $properties
   fi
 }

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -78,7 +78,7 @@ function Run-Build([string]$rootDir, [string]$increment) {
     /p:ContinuousIntegrationBuild=false `
     /p:OfficialBuildId="" `
     /p:QuietRestore=false `
-    /p:DotNetBuildFromSource=false `
+    /p:DotNetBuildSourceOnly=false `
     /p:Deterministic=true `
     /p:DebugDeterminism=true `
     /p:Features="debug-determinism" `

--- a/proto.proj
+++ b/proto.proj
@@ -4,8 +4,10 @@
     <RootDir Condition="'$(RootDir)'==''">Bootstrap</RootDir>
   </PropertyGroup>
 
-  <!-- Skip on sourcebuild -->
-  <ItemGroup Condition="'$(ArcadeBuildFromSource)'!='true'">
+  <!-- This needs to be built only in the inner VMR build proto invocation, but not the outer VMR build invocation.
+       The project does not import Arcade targets so we only have the properties that were passed in, rather than
+       calculated properties like DotNetBuildPhase. -->
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)'!='true' or '$(DotNetBuildInnerRepo)' == 'true'">
     <Projects Include="buildtools\fslex\fslex.fsproj" />
     <Projects Include="buildtools\fsyacc\fsyacc.fsproj" />
     <Projects Include="buildtools\AssemblyCheck\AssemblyCheck.fsproj" />

--- a/setup/Directory.Build.props
+++ b/setup/Directory.Build.props
@@ -12,7 +12,7 @@
     <IntermediateOutputPath>$(ArtifactsDir)\VSSetup.obj\$(Configuration)\$(MSBuildProjectName)</IntermediateOutputPath>
     <VsixBuildLocation>$(SetupRootFolder)..\artifacts\VSSetup\$(Configuration)</VsixBuildLocation>
     <InsertionDir>$(SetupRootFolder)..\artifacts\VSSetup\$(Configuration)\Insertion</InsertionDir>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <SetupProductArch>Neutral</SetupProductArch>
   </PropertyGroup>
 

--- a/setup/Swix/Directory.Build.targets
+++ b/setup/Swix/Directory.Build.targets
@@ -15,7 +15,7 @@
 
   <Target Name="Build"
           DependsOnTargets="ResolveProjectReferences"
-          Condition="'$(DotNetBuildFromSource)' != 'true' AND '$(ArcadeBuildFromSource)' != 'true'">
+          Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <MakeDir Directories="$(IntermediateOutputPath)" ContinueOnError="True"/>
   </Target>
 

--- a/src/fsc/fscAnyCpuProject/fscAnyCpu.fsproj
+++ b/src/fsc/fscAnyCpuProject/fscAnyCpu.fsproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('fsc.targets', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/fsc/fscArm64Project/fscArm64.fsproj
+++ b/src/fsc/fscArm64Project/fscArm64.fsproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
     <PlatformTarget>arm64</PlatformTarget>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('fsc.targets', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/fsi/fsiAnyCpuProject/fsiAnyCpu.fsproj
+++ b/src/fsi/fsiAnyCpuProject/fsiAnyCpu.fsproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER</DefineConstants>
   </PropertyGroup>
 

--- a/src/fsi/fsiArm64Project/fsiArm64.fsproj
+++ b/src/fsi/fsiArm64Project/fsiArm64.fsproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
     <PlatformTarget>arm64</PlatformTarget>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <DefineConstants>$(DefineConstants);FSI_SHADOW_COPY_REFERENCES;FSI_SERVER</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -10,7 +10,7 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UnitTestType>xunit</UnitTestType>
     <IsTestProject>true</IsTestProject>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharp.Compiler.Private.Scripting.UnitTests.fsproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UnitTestType>xunit</UnitTestType>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <NoWarn>$(NoWarn);44</NoWarn> <!-- Obsolete -->
   </PropertyGroup>
 

--- a/vsintegration/Directory.Build.props
+++ b/vsintegration/Directory.Build.props
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseVsMicroBuildAssemblyVersion>true</UseVsMicroBuildAssemblyVersion>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <SetupProductArch>Neutral</SetupProductArch>
     <BypassVsixValidation>true</BypassVsixValidation>
   </PropertyGroup>

--- a/vsintegration/tests/MockTypeProviders/Directory.Build.props
+++ b/vsintegration/tests/MockTypeProviders/Directory.Build.props
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <EnableXlfLocalization>false</EnableXlfLocalization>
-    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">


### PR DESCRIPTION
* Now that fsharp is on 9.0, we can switch to the new control set. Generally:
- DotNetBuildFromSource -> DotNetBuildSourceOnly - Building a source-only build.
- DotnetBuildFromSourceFlavor == Product -> DotNetBuildOrchestrator == true - Building in the VMR, could be source-only or MS's build.
- ArcadeBuildFromSource -> DotNetBuildRepo == true -> Indicates an outer repo build.
- ExcludeFromSourceBuild -> ExcludeFromSourceOnlyBuild