### PR TITLE
Backport to dev17.11 - Bugfix  extension method in dotnet interactive

### DIFF
--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -2149,6 +2149,7 @@ and typeDefReader ctxtH : ILTypeDefStored =
                     ctxt.fileName.EndsWith("System.Runtime.dll")
                     || ctxt.fileName.EndsWith("mscorlib.dll")
                     || ctxt.fileName.EndsWith("netstandard.dll")
+                    || ctxt.fileName.EndsWith("System.Private.CoreLib.dll")
 
                 while attrIdx <= attrsEndIdx && not containsExtensionMethods do
                     let mutable addr = ctxt.rowAddr TableNames.CustomAttribute attrIdx

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -353,6 +353,22 @@ tInput.Length
         Assert.Equal(4L, downcast value.ReflectionValue)
 
     [<Fact>]
+    member _.``ML - use assembly with ref dependencies and without refing SMemory``() =
+        let code = """
+#r "nuget:Microsoft.ML.OnnxTransformer,1.4.0"
+
+open System
+open System.Numerics.Tensors
+let inputValues = [| 12.0; 10.0; 17.0; 5.0 |]
+let tInput = new DenseTensor<float>(inputValues.AsMemory(), new ReadOnlySpan<int>([|4|]))
+tInput.Length
+"""
+        use script = new FSharpScript(additionalArgs=[| "/usesdkrefs-" |])
+        let opt = script.Eval(code)  |> getValue
+        let value = opt.Value
+        Assert.Equal(4L, downcast value.ReflectionValue)
+
+    [<Fact>]
     member _.``System.Device.Gpio - Ensure we reference the runtime version of the assembly``() =
         let code = """
 #r "nuget:System.Device.Gpio, 1.0.0"

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -352,7 +352,7 @@ tInput.Length
         let value = opt.Value
         Assert.Equal(4L, downcast value.ReflectionValue)
 
-    [<Fact>]
+    [<FSharp.Test.FactForNETCOREAPP>] // usessdkrefs is not a valid option for desktop compiler
     member _.``ML - use assembly with ref dependencies and without refing SMemory``() =
         let code = """
 #r "nuget:Microsoft.ML.OnnxTransformer,1.4.0"


### PR DESCRIPTION
Backport of 
* Fix extension methods support for non-reference system assemblies ([PR #17799](https://github.com/dotnet/fsharp/pull/17799))