### PR TITLE
CompilerOrder: set metadata for CompileFirst items

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -131,6 +131,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
 
+    <CompileFirst>
+      <CompileOrder>CompileFirst</CompileOrder>
+    </CompileFirst>
+
     <CompileBefore>
       <CompileOrder>CompileBefore</CompileOrder>
     </CompileBefore>


### PR DESCRIPTION
Follow-up for #17791. Fixes the remaining case.