### PR TITLE
Investigating FS1189 when using a generic complete active pattern

### DIFF
--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2560,7 +2560,6 @@ typarDecl:
 postfixTyparDecls:
   | opt_HIGH_PRECEDENCE_TYAPP LESS typarDeclList opt_typeConstraints GREATER
       { let m = rhs2 parseState 2 5
-        if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), m))
         SynTyparDecls.PostfixList(List.rev $3, $4, m) }
 
 /* Any tokens in this grammar must be added to the lex filter rule 'peekAdjacentTypars' */
@@ -2578,7 +2577,6 @@ explicitValTyparDeclsCore:
 explicitValTyparDecls:
   | opt_HIGH_PRECEDENCE_TYAPP LESS explicitValTyparDeclsCore opt_typeConstraints GREATER
       { let m = rhs2 parseState 2 5
-        if not $2 then warning(Error(FSComp.SR.parsNonAdjacentTypars(), m))
         let tps, flex = $3
         let tps = SynTyparDecls.PostfixList(tps, $4, m)
         SynValTyparDecls(Some tps, flex) }

--- a/tests/FSharp.Compiler.ComponentTests/Language/ObsoleteAttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/ObsoleteAttributeCheckingTests.fs
@@ -20,6 +20,40 @@ let c = C()
         |> ignoreWarnings
         |> compile
         |> shouldSucceed
+
+    [<Fact>]
+    let ``mwtest`` () =
+        Fsx """
+let (|Case1|)<'a> (x: 'a) =
+    Case1 x
+
+let value =
+    match 3 with
+    | Case1 x -> x
+
+printf "%A" value
+        """
+        |> asExe
+        |> withOptions ["--nowarn:988"]
+        |> compile
+        |> shouldSucceed
+        |> run
+        |> verifyOutput "3"
+        // |> withDiagnostics [
+        //      (Warning 1189, Line 2, Col 14, Line 2, Col 18, """Remove spaces between the type name and type parameter, e.g. "type C<'T>", not type "C   <'T>". Type parameters must be placed directly adjacent to the type name.""")
+        // ]
+
+    [<Fact>]
+    let ``mwtest with srtp`` () =
+        Fsx """
+let inline (|IsEqual|IsNonEqual|)< ^t  when ^t : equality> (x: ^t)  =
+    if x = x then IsEqual
+    else IsNonEqual
+        """
+        |> asExe
+        |> withOptions ["--nowarn:988"]
+        |> compile
+        |> shouldSucceed
         
     [<Fact>]
     let ``Obsolete attribute warning taken into account when used instantiating a type`` () =


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Investigating these issues

Fixes
https://github.com/dotnet/fsharp/issues/14736
https://github.com/dotnet/fsharp/issues/7797


## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/release-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**