### PR TITLE
Requires tactics Approval:  Restore the ability to identify CompileBefore and CompileAfter values

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>8</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>402</FSBuildVersion>
+    <FSBuildVersion>403</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->

--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -131,6 +131,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
 
+    <CompileFirst>
+      <CompileOrder>CompileFirst</CompileOrder>
+    </CompileFirst>
+
     <CompileBefore>
       <CompileOrder>CompileBefore</CompileOrder>
     </CompileBefore>

--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -130,6 +130,18 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <PackageReference>
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
+
+    <CompileBefore>
+      <CompileOrder>CompileBefore</CompileOrder>
+    </CompileBefore>
+
+    <CompileAfter>
+      <CompileOrder>CompileAfter</CompileOrder>
+    </CompileAfter>
+
+    <CompileLast>
+      <CompileOrder>CompileLast</CompileOrder>
+    </CompileLast>
   </ItemDefinitionGroup>
 
 </Project>


### PR DESCRIPTION
We fixed an issue that impacted SourceLink generation for F# developers, this broke an existing rider feature, that depended on the ability to identify CompileBefore and CompileAfter values.  We value our users being able to use the LTS release with their current preferred dev tooling.

This PR cherry picks the two fix PRs from main into LTS.

We failed to discover this issue locally because we no longer use the feature rider depended on.  @auduchinok has modified Rider to use the updated implementation but that is only in F# 9.0 and Rider needs to support LTS and that branch does not contain these fixes.  that includes these cherrypicks and has verified the fixes work with Rider.

