### PR TITLE
.NET 9rc2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 {
     "name": "F#",
-    "image": "mcr.microsoft.com/dotnet/sdk:9.0.100-rc.1",
+    "image": "mcr.microsoft.com/dotnet/sdk:9.0.100-rc.2",
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2.5.1": {},
         "ghcr.io/devcontainers/features/git:1.3.2": {},

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,8 +47,7 @@
   <PropertyGroup Condition="'$(BUILDING_USING_DOTNET)' == 'true'">
     <DisableAutoSetFscCompilerPath>false</DisableAutoSetFscCompilerPath>
 
-    <!-- TODO(vlza): This probably should be `true` once fslib with nullness ships, since shipped library is preferred by default when building this solution. -->
-    <FSHARPCORE_USE_PACKAGE Condition="'$(FSHARPCORE_USE_PACKAGE)' == ''">false</FSHARPCORE_USE_PACKAGE>
+    <FSHARPCORE_USE_PACKAGE Condition="'$(FSHARPCORE_USE_PACKAGE)' == ''">true</FSHARPCORE_USE_PACKAGE>
 
     <DISABLE_ARCADE Condition="'$(DISABLE_ARCADE)' == ''">true</DISABLE_ARCADE>
     <ArtifactsDir>$(MSBuildThisFileDirectory)artifacts/</ArtifactsDir>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- TODO: This needs to be removed once we merge/release the new SDK. -->
-    <NoWarn>$(NoWarn);FS0064</NoWarn>
+    <!-- TODO: These need to be removed once we merge/release the new SDK with noward and line fixes. -->
+    <NoWarn>$(NoWarn);FS0064;FS1182</NoWarn>
   </PropertyGroup>
 
   <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,11 @@
     <IgnoreMibc Condition="'$(IgnoreMibc)' == ''">$(DotNetBuildSourceOnly)</IgnoreMibc>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- TODO: This needs to be removed once we merge/release the new SDK. -->
+    <NoWarn>$(NoWarn);FS0064</NoWarn>
+  </PropertyGroup>
+
   <!--
    When developers load the FSharp.Compiler.Service solution we set FSHARPCORE_USE_PACKAGE to true if it hasn't already been set to a value.
    This option ensures that building and testing uses the specified FSharp.Core nuget package instead of the local FSharp.Core project.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <FSharpLibrariesChangelogVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSharpLibrariesChangelogVersion>
     <!-- -->
     <!-- The current published nuget package -->
-    <FSharpCoreShippedPackageVersionValue>8.0.400</FSharpCoreShippedPackageVersionValue>
+    <FSharpCoreShippedPackageVersionValue>9.0.100-beta.24466.6</FSharpCoreShippedPackageVersionValue>
     <!-- -->
     <!-- The pattern for specifying the preview package -->
     <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).*</FSharpCorePreviewPackageVersionValue>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.1.24452.12",
+    "version": "9.0.100-rc.2.24474.11",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "9.0.100-rc.1.24452.12",
+    "dotnet": "9.0.100-rc.2.24474.11",
     "vs": {
       "version": "17.8",
       "components": [

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -10,10 +10,6 @@
     <NoWarn>$(NoWarn);75</NoWarn> <!-- InternalCommandLineOption -->
     <NoWarn>$(NoWarn);1204</NoWarn> <!-- This construct is for use in the FSharp.Core library and should not be used directly -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
-
-    <!-- TODO: This needs to be removed once we merge/release the new SDK with noward and line fixes. -->
-    <NoWarn>$(NoWarn);1182</NoWarn>
-
     <AssemblyName>FSharp.Compiler.Service</AssemblyName>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
@@ -28,8 +24,10 @@
     <TargetFrameworks Condition=" '$(OfficialBuildId)' == '' AND '$(FSharpNetCoreProductDefaultTargetFramework)' != '' AND '$(Configuration)' != 'Proto' AND '$(SKIP_NETCURRENT_FSC_BUILD)' != 'true' ">$(FSharpNetCoreProductDefaultTargetFramework);$(TargetFrameworks)</TargetFrameworks>
     <DefineConstants Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">$(DefineConstants);FSHARPCORE_USE_PACKAGE</DefineConstants>
     <OtherFlags>$(OtherFlags) --extraoptimizationloops:1</OtherFlags>
-    <!-- 1182: Unused variables -->
-    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
+
+    <!-- TODO: This needs to be re-enabled once we merge/release the new SDK with noward and line fixes. -->
+    <!-- 1182: Unused variables
+    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags> -->
     <!-- 3218: ArgumentsInSigAndImplMismatch -->
     <OtherFlags>$(OtherFlags) --warnon:3218</OtherFlags>
     <!-- 3390: xmlDocBadlyFormed -->

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -27,7 +27,7 @@
 
     <!-- TODO: This needs to be re-enabled once we merge/release the new SDK with noward and line fixes. -->
     <!-- 1182: Unused variables -->
-    <OtherFlags>$(OtherFlags) --warnoff:1182</OtherFlags>
+    <OtherFlags>$(OtherFlags) --nowarn:1182</OtherFlags>
 
     <!-- 3218: ArgumentsInSigAndImplMismatch -->
     <OtherFlags>$(OtherFlags) --warnon:3218</OtherFlags>

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -10,6 +10,10 @@
     <NoWarn>$(NoWarn);75</NoWarn> <!-- InternalCommandLineOption -->
     <NoWarn>$(NoWarn);1204</NoWarn> <!-- This construct is for use in the FSharp.Core library and should not be used directly -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
+
+    <!-- TODO: This needs to be removed once we merge/release the new SDK with noward and line fixes. -->
+    <NoWarn>$(NoWarn);1182</NoWarn>
+
     <AssemblyName>FSharp.Compiler.Service</AssemblyName>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -26,8 +26,9 @@
     <OtherFlags>$(OtherFlags) --extraoptimizationloops:1</OtherFlags>
 
     <!-- TODO: This needs to be re-enabled once we merge/release the new SDK with noward and line fixes. -->
-    <!-- 1182: Unused variables
-    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags> -->
+    <!-- 1182: Unused variables -->
+    <OtherFlags>$(OtherFlags) --warnoff:1182</OtherFlags>
+
     <!-- 3218: ArgumentsInSigAndImplMismatch -->
     <OtherFlags>$(OtherFlags) --warnon:3218</OtherFlags>
     <!-- 3390: xmlDocBadlyFormed -->


### PR DESCRIPTION
Updates to rc2, updates FSharp.Core to latest (it will be the same which goes to release, despite it says "beta"), removes using fsharp.core project.