### PR TITLE
Better `inherit` error reporting

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -19,5 +19,6 @@
 * Better ranges for CE `return, yield, return! and yield!` error reporting. ([PR #17792](https://github.com/dotnet/fsharp/pull/17792))
 * Better ranges for CE `match!`. ([PR #17789](https://github.com/dotnet/fsharp/pull/17789))
 * Better ranges for CE `use` error reporting. ([PR #17811](https://github.com/dotnet/fsharp/pull/17811))
+* Better ranges for `inherit` error reporting. ([PR #17879](https://github.com/dotnet/fsharp/pull/17879))
 
 ### Breaking Changes

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -220,7 +220,7 @@ let visitSynMemberDefn (md: SynMemberDefn) : FileContentEntry list =
         | SynMemberDefn.Interface(interfaceType, _, members, _) ->
             yield! visitSynType interfaceType
             yield! collectFromOption (List.collect visitSynMemberDefn) members
-        | SynMemberDefn.Inherit(baseType, _, _) -> yield! visitSynType baseType
+        | SynMemberDefn.Inherit(baseType= t) -> yield! visitSynType t
         | SynMemberDefn.ValField(fieldInfo, _) -> yield! visitSynField fieldInfo
         | SynMemberDefn.NestedType _ -> ()
         | SynMemberDefn.AutoProperty(attributes = attributes; typeOpt = typeOpt; synExpr = synExpr) ->

--- a/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
+++ b/src/Compiler/Driver/GraphChecking/FileContentMapping.fs
@@ -220,7 +220,7 @@ let visitSynMemberDefn (md: SynMemberDefn) : FileContentEntry list =
         | SynMemberDefn.Interface(interfaceType, _, members, _) ->
             yield! visitSynType interfaceType
             yield! collectFromOption (List.collect visitSynMemberDefn) members
-        | SynMemberDefn.Inherit(baseType= t) -> yield! visitSynType t
+        | SynMemberDefn.Inherit(baseType = t) -> yield! visitSynType t
         | SynMemberDefn.ValField(fieldInfo, _) -> yield! visitSynField fieldInfo
         | SynMemberDefn.NestedType _ -> ()
         | SynMemberDefn.AutoProperty(attributes = attributes; typeOpt = typeOpt; synExpr = synExpr) ->

--- a/src/Compiler/Service/FSharpParseFileResults.fs
+++ b/src/Compiler/Service/FSharpParseFileResults.fs
@@ -814,7 +814,7 @@ type FSharpParseFileResults(diagnostics: FSharpDiagnostic[], input: ParsedInput,
                         | SynMemberDefn.Interface(members = Some membs) ->
                             for m in membs do
                                 yield! walkMember m
-                        | SynMemberDefn.Inherit(_, _, m) ->
+                        | SynMemberDefn.Inherit(range = m) ->
                             // can break on the "inherit" clause
                             yield! checkRange m
                         | SynMemberDefn.ImplicitInherit(_, arg, _, m) ->

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -996,7 +996,7 @@ module SyntaxTraversal =
 
                         |> pick x
                 | ok -> ok
-            | SynMemberDefn.Inherit(synType, _identOption, range) -> traverseInherit (synType, range)
+            | SynMemberDefn.Inherit(synType, _identOption, range, _) -> traverseInherit (synType, range)
             | SynMemberDefn.ValField _ -> None
             | SynMemberDefn.NestedType(synTypeDefn, _synAccessOption, _range) -> traverseSynTypeDefn path synTypeDefn
 

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -913,7 +913,7 @@ module ParsedInput =
                 walkType t
                 |> Option.orElseWith (fun () -> members |> Option.bind (List.tryPick walkMember))
 
-            | SynMemberDefn.Inherit(t, _, _) -> walkType t
+            | SynMemberDefn.Inherit(baseType = t) -> walkType t
 
             | SynMemberDefn.ValField(fieldInfo = field) -> walkField field
 
@@ -2240,7 +2240,7 @@ module ParsedInput =
             | SynMemberDefn.Interface(interfaceType = t; members = members) ->
                 walkType t
                 members |> Option.iter (List.iter walkMember)
-            | SynMemberDefn.Inherit(t, _, _) -> walkType t
+            | SynMemberDefn.Inherit(baseType= t) -> walkType t
             | SynMemberDefn.ValField(fieldInfo = field) -> walkField field
             | SynMemberDefn.NestedType(tdef, _, _) -> walkTypeDefn tdef
             | SynMemberDefn.AutoProperty(attributes = Attributes attrs; typeOpt = t; synExpr = e) ->

--- a/src/Compiler/Service/ServiceParsedInputOps.fs
+++ b/src/Compiler/Service/ServiceParsedInputOps.fs
@@ -2240,7 +2240,7 @@ module ParsedInput =
             | SynMemberDefn.Interface(interfaceType = t; members = members) ->
                 walkType t
                 members |> Option.iter (List.iter walkMember)
-            | SynMemberDefn.Inherit(baseType= t) -> walkType t
+            | SynMemberDefn.Inherit(baseType = t) -> walkType t
             | SynMemberDefn.ValField(fieldInfo = field) -> walkField field
             | SynMemberDefn.NestedType(tdef, _, _) -> walkTypeDefn tdef
             | SynMemberDefn.AutoProperty(attributes = Attributes attrs; typeOpt = t; synExpr = e) ->

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -1496,7 +1496,7 @@ type SynMemberDefn =
 
     | Interface of interfaceType: SynType * withKeyword: range option * members: SynMemberDefns option * range: range
 
-    | Inherit of baseType: SynType * asIdent: Ident option * range: range
+    | Inherit of baseType: SynType * asIdent: Ident option * range: range * trivia: SynMemberDefnInheritTrivia
 
     | ValField of fieldInfo: SynField * range: range
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -1670,7 +1670,7 @@ type SynMemberDefn =
     | Interface of interfaceType: SynType * withKeyword: range option * members: SynMemberDefns option * range: range
 
     /// An 'inherit' definition within a class
-    | Inherit of baseType: SynType * asIdent: Ident option * range: range
+    | Inherit of baseType: SynType * asIdent: Ident option * range: range * trivia: SynMemberDefnInheritTrivia
 
     /// A 'val' definition within a class
     | ValField of fieldInfo: SynField * range: range

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -419,6 +419,12 @@ type SynMemberDefnAbstractSlotTrivia =
     }
 
     static member Zero = { GetSetKeywords = None }
+ 
+[<NoEquality; NoComparison>]
+type SynMemberDefnInheritTrivia =
+    {
+        InheritKeyword: range
+    }
 
 [<NoEquality; NoComparison>]
 type SynFieldTrivia =

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fs
@@ -419,12 +419,9 @@ type SynMemberDefnAbstractSlotTrivia =
     }
 
     static member Zero = { GetSetKeywords = None }
- 
+
 [<NoEquality; NoComparison>]
-type SynMemberDefnInheritTrivia =
-    {
-        InheritKeyword: range
-    }
+type SynMemberDefnInheritTrivia = { InheritKeyword: range }
 
 [<NoEquality; NoComparison>]
 type SynFieldTrivia =

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -524,10 +524,7 @@ type SynMemberDefnAbstractSlotTrivia =
 
 /// Represents additional information for SynMemberDefn.Inherit
 [<NoEquality; NoComparison>]
-type SynMemberDefnInheritTrivia =
-    {
-        InheritKeyword: range
-    }
+type SynMemberDefnInheritTrivia = { InheritKeyword: range }
 
 /// Represents additional information for SynField
 [<NoEquality; NoComparison>]

--- a/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTrivia.fsi
@@ -522,6 +522,13 @@ type SynMemberDefnAbstractSlotTrivia =
 
     static member Zero: SynMemberDefnAbstractSlotTrivia
 
+/// Represents additional information for SynMemberDefn.Inherit
+[<NoEquality; NoComparison>]
+type SynMemberDefnInheritTrivia =
+    {
+        InheritKeyword: range
+    }
+
 /// Represents additional information for SynField
 [<NoEquality; NoComparison>]
 type SynFieldTrivia =

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -2316,7 +2316,8 @@ opt_classDefn:
 inheritsDefn:
   | INHERIT atomTypeNonAtomicDeprecated optBaseSpec
      { let mDecl = unionRanges (rhs parseState 1) $2.Range
-       SynMemberDefn.Inherit($2, $3, mDecl) }
+       let trivia = { InheritKeyword = rhs parseState 1 }
+       SynMemberDefn.Inherit($2, $3, mDecl, trivia) }
 
   | INHERIT atomTypeNonAtomicDeprecated opt_HIGH_PRECEDENCE_APP atomicExprAfterType optBaseSpec
      { let mDecl = unionRanges (rhs parseState 1) $4.Range
@@ -2324,8 +2325,9 @@ inheritsDefn:
 
   | INHERIT ends_coming_soon_or_recover
      { let mDecl = (rhs parseState 1)
+       let trivia = { InheritKeyword = (rhs parseState 1) }
        if not $2 then errorR (Error(FSComp.SR.parsTypeNameCannotBeEmpty (), mDecl))
-       SynMemberDefn.Inherit(SynType.LongIdent(SynLongIdent([], [], [])), None, mDecl) }
+       SynMemberDefn.Inherit(SynType.LongIdent(SynLongIdent([], [], [])), None, mDecl, trivia) }
 
 optAsSpec:
   | asSpec

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/ExceptionDefinitions/ExceptionDefinitions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/ExceptionDefinitions/ExceptionDefinitions.fs
@@ -289,7 +289,7 @@ module ExceptionDefinition =
         |> compile
         |> shouldFail
         |> withDiagnostics [
-            (Error 945, Line 9, Col 5, Line 9, Col 24, "Cannot inherit a sealed type")
+            (Error 945, Line 9, Col 13, Line 9, Col 22, "Cannot inherit a sealed type")
             (Error 1133, Line 9, Col 5, Line 9, Col 24, "No constructors are available for the type 'FSharpExn'")
         ]
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/TypeAbbreviations/TypeAbbreviations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/TypeAbbreviations/TypeAbbreviations.fs
@@ -157,7 +157,7 @@ module TypeAbbreviations =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 945, Line 9, Col 9, Line 9, Col 22, "Cannot inherit a sealed type")
+            (Error 945, Line 9, Col 17, Line 9, Col 22, "Cannot inherit a sealed type")
         ]
 
     //SOURCE=E_PrivateTypeAbbreviation02.fs SCFLAGS="--test:ErrorRanges"                                        # E_PrivateTypeAbbreviation02.fs

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionTypes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Types/UnionTypes/UnionTypes.fs
@@ -195,8 +195,8 @@ module UnionTypes =
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
-            (Error 961, Line 10, Col 5, Line 10, Col 22, "This 'inherit' declaration specifies the inherited type but no arguments. Consider supplying arguments, e.g. 'inherit BaseType(args)'.")
-            (Error 945, Line 10, Col 5, Line 10, Col 22, "Cannot inherit a sealed type")
+            (Error 961, Line 10, Col 5, Line 10, Col 12, "This 'inherit' declaration specifies the inherited type but no arguments. Consider supplying arguments, e.g. 'inherit BaseType(args)'.")
+            (Error 945, Line 10, Col 13, Line 10, Col 22, "Cannot inherit a sealed type")
         ]
 
     //SOURCE=E_LowercaseDT.fs                                                                     # E_LowercaseDT.fs

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ClassesTests.fs
@@ -816,3 +816,18 @@ type A() =
             """
             |> typecheck
             |> shouldSucceed
+            
+    [<Fact>]
+    let ``This 'inherit' declaration specifies the inherited type but no arguments. Consider supplying arguments, e. g. 'inherit BaseType(args)'`` () =
+        Fsx """
+type IA = interface end
+
+type Class() =
+    inherit IA
+        """
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 961, Line 5, Col 5, Line 5, Col 12, "This 'inherit' declaration specifies the inherited type but no arguments. Consider supplying arguments, e.g. 'inherit BaseType(args)'.")
+            (Error 946, Line 5, Col 13, Line 5, Col 15, "Cannot inherit from interface type. Use interface ... with instead.")
+        ]

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -8151,7 +8151,13 @@ FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAu
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewGetSetMember(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynBinding], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynMemberGetSetTrivia)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitCtor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynMemberDefnImplicitCtorTrivia)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitInherit(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia get_trivia()
+FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia trivia
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia)
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: FSharp.Compiler.Text.Range InheritKeyword
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: FSharp.Compiler.Text.Range get_InheritKeyword()
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: Void .ctor(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInterface(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewLetBindings(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Boolean, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewMember(FSharp.Compiler.Syntax.SynBinding, FSharp.Compiler.Text.Range)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -8151,7 +8151,13 @@ FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewAu
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewGetSetMember(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynBinding], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynMemberGetSetTrivia)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitCtor(Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynAccess], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynAttributeList], FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Xml.PreXmlDoc, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynMemberDefnImplicitCtorTrivia)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewImplicitInherit(FSharp.Compiler.Syntax.SynType, FSharp.Compiler.Syntax.SynExpr, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia get_trivia()
+FSharp.Compiler.Syntax.SynMemberDefn+Inherit: FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia trivia
+FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInherit(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia)
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: FSharp.Compiler.Text.Range InheritKeyword
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: FSharp.Compiler.Text.Range get_InheritKeyword()
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: System.String ToString()
+FSharp.Compiler.SyntaxTrivia.SynMemberDefnInheritTrivia: Void .ctor(FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewInterface(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn]], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewLetBindings(Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Boolean, Boolean, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynMemberDefn: FSharp.Compiler.Syntax.SynMemberDefn NewMember(FSharp.Compiler.Syntax.SynBinding, FSharp.Compiler.Text.Range)

--- a/tests/fsharp/typecheck/sigs/neg06.bsl
+++ b/tests/fsharp/typecheck/sigs/neg06.bsl
@@ -10,7 +10,7 @@ neg06.fs(24,6,24,30): typecheck error FS0944: Abbreviated types cannot be given 
 
 neg06.fs(27,6,27,33): typecheck error FS0942: Delegate types are always sealed
 
-neg06.fs(31,9,31,29): typecheck error FS0945: Cannot inherit a sealed type
+neg06.fs(31,17,31,27): typecheck error FS0945: Cannot inherit a sealed type
 
 neg06.fs(37,6,37,29): typecheck error FS0954: This type definition involves an immediate cyclic reference through a struct field or inheritance relation
 

--- a/tests/fsharp/typecheck/sigs/neg10.bsl
+++ b/tests/fsharp/typecheck/sigs/neg10.bsl
@@ -1,9 +1,9 @@
 
 neg10.fsi(9,6,9,7): typecheck error FS0249: Two type definitions named 'x' occur in namespace 'N' in two parts of this assembly
 
-neg10.fs(11,17,11,27): typecheck error FS0946: Cannot inherit from interface type. Use interface ... with instead.
+neg10.fs(11,25,11,27): typecheck error FS0946: Cannot inherit from interface type. Use interface ... with instead.
 
-neg10.fs(13,17,13,26): typecheck error FS0945: Cannot inherit a sealed type
+neg10.fs(13,25,13,26): typecheck error FS0945: Cannot inherit a sealed type
 
 neg10.fs(15,22,15,32): typecheck error FS0887: The type 'C1' is not an interface type
 

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/StructTypes/E_StructInheritance01b.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/StructTypes/E_StructInheritance01b.fs
@@ -2,7 +2,7 @@
 // Verify error when trying to inherit from a struct type
 // Regression test for FSHARP1.0:2803
 //<Expects status="notin">FS0191: Cannot inherit from interface type</Expects>
-//<Expects id="FS0945" status="error" span="(17,5)">Cannot inherit a sealed type</Expects>
+//<Expects id="FS0945" status="error" span="(17,13)">Cannot inherit a sealed type</Expects>
 
 
 type StructType = struct

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/TypeKindInference/infer_interface002e.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/TypeKindInference/infer_interface002e.fs
@@ -2,10 +2,10 @@
 // attribute must match inferred type
 //<Expects id="FS0927" span="(16,6-16,15)" status="error">The kind of the type specified by its attributes does not match the kind implied by its definition</Expects>
 //<Expects id="FS0931" span="(20,4-20,20)" status="error">Structs, interfaces, enums and delegates cannot inherit from other types</Expects>
-//<Expects id="FS0946" span="(20,4-20,20)" status="error">Cannot inherit from interface type\. Use interface \.\.\. with instead</Expects>
+//<Expects id="FS0946" span="(20,12-20,20)" status="error">Cannot inherit from interface type\. Use interface \.\.\. with instead</Expects>
 //<Expects id="FS0927" span="(28,6-28,15)" status="error">The kind of the type specified by its attributes does not match the kind implied by its definition</Expects>
 //<Expects id="FS0931" span="(32,4-32,20)" status="error">Structs, interfaces, enums and delegates cannot inherit from other types</Expects>
-//<Expects id="FS0946" span="(32,4-32,20)" status="error">Cannot inherit from interface type\. Use interface \.\.\. with instead</Expects>
+//<Expects id="FS0946" span="(32,12-32,20)" status="error">Cannot inherit from interface type\. Use interface \.\.\. with instead</Expects>
 
 // An interface
 type TK_I_003 = interface 

--- a/tests/service/data/SyntaxTree/Member/Inherit 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit 01.fs.bsl
@@ -13,7 +13,8 @@ ImplFile
                     (Unspecified,
                      [Inherit
                         (LongIdent (SynLongIdent ([I], [], [None])), None,
-                         (4,4--4,13))], (4,4--4,13)), [], None, (3,5--4,13),
+                         (4,4--4,13), { InheritKeyword = (4,4--4,11) })],
+                     (4,4--4,13)), [], None, (3,5--4,13),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,13))],

--- a/tests/service/data/SyntaxTree/Member/Inherit 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit 03.fs.bsl
@@ -13,7 +13,8 @@ ImplFile
                     (Unspecified,
                      [Inherit
                         (LongIdent (SynLongIdent ([], [], [])), None,
-                         (4,4--4,11))], (4,4--4,11)), [], None, (3,5--4,11),
+                         (4,4--4,11), { InheritKeyword = (4,4--4,11) })],
+                     (4,4--4,11)), [], None, (3,5--4,11),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,11))],

--- a/tests/service/data/SyntaxTree/Member/Inherit 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit 04.fs.bsl
@@ -13,7 +13,8 @@ ImplFile
                     (Unspecified,
                      [Inherit
                         (LongIdent (SynLongIdent ([], [], [])), None,
-                         (4,4--4,11))], (4,4--4,11)), [], None, (3,5--4,11),
+                         (4,4--4,11), { InheritKeyword = (4,4--4,11) })],
+                     (4,4--4,11)), [], None, (3,5--4,11),
                   { LeadingKeyword = Type (3,0--3,4)
                     EqualsRange = Some (3,7--3,8)
                     WithKeyword = None })], (3,0--4,11));

--- a/tests/service/data/SyntaxTree/Member/Inherit 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit 05.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                     (Unspecified,
                      [Inherit
                         (LongIdent (SynLongIdent ([], [], [])), None,
-                         (4,4--4,11));
+                         (4,4--4,11), { InheritKeyword = (4,4--4,11) });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],

--- a/tests/service/data/SyntaxTree/Member/Inherit 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Inherit 08.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                     (Unspecified,
                      [Inherit
                         (LongIdent (SynLongIdent ([], [], [])), None,
-                         (4,4--4,11));
+                         (4,4--4,11), { InheritKeyword = (4,4--4,11) });
                       Member
                         (SynBinding
                            (None, Normal, false, false, [],


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Bette error reporting for `inherit`.

### **Before**

![Screenshot 2024-10-15 at 09 04 39](https://github.com/user-attachments/assets/92546357-16ac-47f2-8ebc-757249fe9168)

![Screenshot 2024-10-15 at 09 05 56](https://github.com/user-attachments/assets/e223cf06-b99c-433b-9341-9491b48dd449)

![Screenshot 2024-10-15 at 09 07 55](https://github.com/user-attachments/assets/55ed5c44-e7c8-462e-b09b-03348455aeb6)


### **After**

```fsharp
type IA = interface end
type Class() =
    inherit IA
    ^^^^^^^ ^^
    
[<Sealed>]
type BaseClass() = class end

type Class2() =
    inherit BaseClass()
            ^^^^^^^^^
    
    
// Another interface 
type TK_I_005 =
  abstract M  : unit -> unit
  
[<Struct>]
type TK_I_006b = 
   inherit TK_I_005
           ^^^^^^^^
```


## Checklist

- [x] Test cases added
- [x] Release notes entry updated