### PR TITLE
Convert OCE to empty value on certain VS operations

### DIFF
--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
@@ -295,6 +295,7 @@ type internal FSharpClassificationService [<ImportingConstructor>] () =
 
                             addSemanticClassification sourceText textSpan classificationData result
             }
+            |> CancellableTask.ifCanceledReturn ()
             |> CancellableTask.startAsTask cancellationToken
 
         // Do not perform classification if we don't have project options (#defines matter)

--- a/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
@@ -1119,11 +1119,14 @@ module CancellableTasks =
 
         let inline ignore ([<InlineIfLambda>] ctask: CancellableTask<_>) = toUnit ctask
 
+        /// If this CancellableTask gets canceled for another reason than the token being canceled, return the specified value.
         let inline ifCanceledReturn value (ctask : CancellableTask<_>) =
             cancellableTask {
+                let! ct = getCancellationToken ()
+
                 try
                     return! ctask
-                with :? OperationCanceledException ->
+                with :? OperationCanceledException when ct.IsCancellationRequested = false ->
                     return value
             }
 

--- a/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
@@ -19,7 +19,7 @@
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- 
+
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 // Don't warn about the resumable code invocation
@@ -467,8 +467,8 @@ module CancellableTasks =
         // Low priority extensions
         type CancellableTaskBuilderBase with
 
-            [<NoEagerConstraintApplication>]            
-            member inline _.Source(awaiter: CancellableTask<unit array>) = 
+            [<NoEagerConstraintApplication>]
+            member inline _.Source(awaiter: CancellableTask<unit array>) =
                 (fun (token) -> (awaiter token :> Task).GetAwaiter())
 
             /// <summary>
@@ -611,10 +611,10 @@ module CancellableTasks =
                     fun sm ->
                         if __useResumableCode then
                             sm.Data.ThrowIfCancellationRequested()
-                            
+
                             let mutable awaiter = getAwaiter
                             let mutable __stack_fin = true
-                            
+
                             if not (Awaiter.isCompleted awaiter) then
                                 let __stack_yield_fin = ResumableCode.Yield().Invoke(&sm)
                                 __stack_fin <- __stack_yield_fin
@@ -706,7 +706,7 @@ module CancellableTasks =
                 (task: 'Awaitable)
                 : 'Awaiter =
                     Awaitable.getAwaiter task
-                
+
 
             /// <summary>Allows the computation expression to turn other types into CancellationToken -> 'Awaiter</summary>
             ///
@@ -1118,6 +1118,14 @@ module CancellableTasks =
             }
 
         let inline ignore ([<InlineIfLambda>] ctask: CancellableTask<_>) = toUnit ctask
+
+        let inline ifCanceledReturn value (ctask : CancellableTask<_>) =
+            cancellableTask {
+                try
+                    return! ctask
+                with :? OperationCanceledException ->
+                    return value
+            }
 
     /// <exclude />
     [<AutoOpen>]

--- a/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
+++ b/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
@@ -156,6 +156,8 @@ open CancellableTasks
 [<Export(typeof<IFSharpBlockStructureService>)>]
 type internal FSharpBlockStructureService [<ImportingConstructor>] () =
 
+    let emptyValue = FSharpBlockStructure ImmutableArray.empty
+
     interface IFSharpBlockStructureService with
 
         member _.GetBlockStructureAsync(document, cancellationToken) : Task<FSharpBlockStructure> =
@@ -171,4 +173,5 @@ type internal FSharpBlockStructureService [<ImportingConstructor>] () =
                     |> Seq.toImmutableArray
                     |> FSharpBlockStructure
             }
+            |> CancellableTask.ifCanceledReturn emptyValue
             |> CancellableTask.start cancellationToken


### PR DESCRIPTION
## Description

There are `OperationCancelledException`s in telemetry originating from `FSharp project options not found.` in `AddSemanticClassificationsAsync` and `GetBlockStructureAsync` operations. 

There's not much we can do without options but maybe we can just return empty results instead of propagating OCE further up. 

One reason we don't have options is that when project is loading and an F# file is already open VS asks as for semantic classification, block structure (and some other things) using a `MiscellaneousFiles` workspace. There could potentially be other cases.

This proposed change converts all OCEs in those operations to empty results, unless cancellation has been requested by the caller through the CT they passed us.

