### PR TITLE
Fix potential OCE in graph processing

### DIFF
--- a/src/Compiler/Driver/GraphChecking/GraphProcessing.fs
+++ b/src/Compiler/Driver/GraphChecking/GraphProcessing.fs
@@ -252,6 +252,7 @@ let processGraphAsync<'Item, 'Result when 'Item: equality and 'Item: comparison>
         let rec queueNode node =
             Async.Start(
                 async {
+                    use! _catch = Async.OnCancel(completionSignal.TrySetCanceled >> ignore)
                     let! res = processNode node |> Async.Catch
 
                     match res with


### PR DESCRIPTION
Surveying the code base for unobserved background jobs that may throw I noticed this `Async.Start` that takes a cancellation token but is not effectively catching cancellations. Theoretically it is possible that the cancellation occurs before `processNode` starts, resulting in an unhandled OperationCancelledException.

This could potentially impact Transparent Compiler (?), I might have also observed it when running tests concurrently in #17872.