### PR TITLE
Consolidate test helpers a bit

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -28,9 +28,6 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\service\FsUnit.fs">
-      <Link>FsUnit.fs</Link>
-    </Compile>
     <Compile Include="CompilerDirectives\Line.fs" />
     <Compile Include="CompilerDirectives\Ifdef.fs" />
     <Compile Include="CompilerDirectives\NonStringArgs.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/HashConstraintTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/HashConstraintTests.fs
@@ -1,7 +1,6 @@
 module Signatures.HashConstraintTests
 
 open Xunit
-open FsUnit
 open FSharp.Test.Compiler
 open Signatures.TestHelpers
 

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/MemberTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/MemberTests.fs
@@ -1,7 +1,6 @@
 ﻿module Signatures.MemberTests
 
 open Xunit
-open FsUnit
 open FSharp.Test.Compiler
 open Signatures.TestHelpers
 

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -1,7 +1,6 @@
 module Signatures.ModuleOrNamespaceTests
 
 open Xunit
-open FsUnit
 open FSharp.Test.Compiler
 open Signatures.TestHelpers
 

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/NestedTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/NestedTypeTests.fs
@@ -1,7 +1,6 @@
 ﻿module Signatures.NestedTypeTests
 
 open Xunit
-open FsUnit
 open FSharp.Test
 open FSharp.Test.Compiler
 open Signatures.TestHelpers

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/RecordTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/RecordTests.fs
@@ -1,7 +1,6 @@
 ﻿module Signatures.RecordTests
 
 open Xunit
-open FsUnit
 open FSharp.Test.Compiler
 open Signatures.TestHelpers
 

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -2,7 +2,6 @@
 
 open FSharp.Compiler.Symbols
 open Xunit
-open FsUnit
 open FSharp.Test.Compiler
 open Signatures.TestHelpers
 

--- a/tests/FSharp.Compiler.Service.Tests/AssemblyReaderShim.fs
+++ b/tests/FSharp.Compiler.Service.Tests/AssemblyReaderShim.fs
@@ -1,6 +1,5 @@
 ﻿module FSharp.Compiler.Service.Tests.AssemblyReaderShim
 
-open FsUnit
 open FSharp.Compiler.Text
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open Xunit

--- a/tests/FSharp.Compiler.Service.Tests/CSharpProjectAnalysis.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CSharpProjectAnalysis.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.CSharpProjectAnalysis
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open System.IO
 open FSharp.Compiler.Diagnostics
 open FSharp.Compiler.IO

--- a/tests/FSharp.Compiler.Service.Tests/Common.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Common.fs
@@ -13,7 +13,7 @@ open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open TestFramework
-open FsUnit
+open FSharp.Test.Assert
 open Xunit
 open FSharp.Test.Utilities
 

--- a/tests/FSharp.Compiler.Service.Tests/EditorTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/EditorTests.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.EditorTests
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Service.Tests.Common

--- a/tests/FSharp.Compiler.Service.Tests/ExprTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ExprTests.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.ExprTests
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open System
 open System.Text
 open System.Collections.Generic

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -21,9 +21,6 @@
     </Content>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="SurfaceArea.fs" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <Compile Include="..\service\FsUnit.fs">
-      <Link>FsUnit.fs</Link>
-    </Compile>
     <Compile Include="Common.fs" />
     <Compile Include="GeneratedCodeSymbolsTests.fs" />
     <Compile Include="AssemblyReaderShim.fs" />

--- a/tests/FSharp.Compiler.Service.Tests/FileSystemTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/FileSystemTests.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.FileSystemTests
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open FSharp.Test
 open System
 open System.IO

--- a/tests/FSharp.Compiler.Service.Tests/InteractiveCheckerTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/InteractiveCheckerTests.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.InteractiveCheckerTests
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open System
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Syntax

--- a/tests/FSharp.Compiler.Service.Tests/ModuleReaderCancellationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ModuleReaderCancellationTests.fs
@@ -9,7 +9,7 @@ open FSharp.Compiler.AbstractIL.IL
 open FSharp.Compiler.AbstractIL.ILBinaryReader
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Text
-open FsUnit
+open FSharp.Test.Assert
 open Internal.Utilities.Library
 open FSharp.Compiler.Service.Tests.Common
 open Xunit

--- a/tests/FSharp.Compiler.Service.Tests/MultiProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/MultiProjectAnalysisTests.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.MultiProjectAnalysisTests
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open System.IO
 open System.Collections.Generic
 open FSharp.Compiler.CodeAnalysis

--- a/tests/FSharp.Compiler.Service.Tests/ParserTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ParserTests.fs
@@ -3,7 +3,7 @@
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
-open FsUnit
+open FSharp.Test.Assert
 open Xunit
 
 [<Fact>]

--- a/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PatternMatchCompilationTests.fs
@@ -3,7 +3,7 @@ module FSharp.Compiler.Service.Tests.PatternMatchCompilationTests
 // Most tests here weren't running on desktop and fails
 
 open FSharp.Compiler.Service.Tests.Common
-open FsUnit
+open FSharp.Test.Assert
 open Xunit
 open FSharp.Test
 

--- a/tests/FSharp.Compiler.Service.Tests/PerfTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PerfTests.fs
@@ -1,7 +1,7 @@
 ﻿module FSharp.Compiler.Service.Tests.PerfTests
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open System.IO
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.IO

--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -5,7 +5,7 @@
 let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e ->  false
 
 open Xunit
-open FsUnit
+open FSharp.Test.Assert
 open FSharp.Test
 open System
 open System.IO
@@ -96,7 +96,7 @@ let mmmm2 : M.CAbbrev = new M.CAbbrev() // note, these don't count as uses of C
 let ``Test project1 whole project errors`` () =
 
     let wholeProjectResults = checker.ParseAndCheckProject(Project1.options) |> Async.RunImmediate
-    wholeProjectResults .Diagnostics.Length |> shouldEqual 2
+    wholeProjectResults.Diagnostics.Length |> shouldEqual 2
     wholeProjectResults.Diagnostics[1].Message.Contains("Incomplete pattern matches on this expression") |> shouldEqual true // yes it does
     wholeProjectResults.Diagnostics[1].ErrorNumber |> shouldEqual 25
 

--- a/tests/FSharp.Compiler.Service.Tests/RangeTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/RangeTests.fs
@@ -3,7 +3,7 @@
 open FSharp.Compiler.Text
 open FSharp.Compiler.Text.Position
 open FSharp.Compiler.Text.Range
-open FsUnit
+open FSharp.Test.Assert
 open Xunit
 
 [<Fact>]

--- a/tests/FSharp.Compiler.Service.Tests/ServiceUntypedParseTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ServiceUntypedParseTests.fs
@@ -1,7 +1,7 @@
 module FSharp.Compiler.Service.Tests.ServiceUntypedParseTests
 
 open System.IO
-open FsUnit
+open FSharp.Test.Assert
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Syntax

--- a/tests/FSharp.Compiler.Service.Tests/Symbols.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Symbols.fs
@@ -5,7 +5,7 @@ open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.SyntaxTrivia
-open FsUnit
+open FSharp.Test.Assert
 open Xunit
 
 module ActivePatterns =

--- a/tests/FSharp.Compiler.Service.Tests/XmlDocTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/XmlDocTests.fs
@@ -5,7 +5,7 @@ open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Test.Compiler
-open FsUnit
+open FSharp.Test.Assert
 open Xunit
 
 let (|Types|TypeSigs|) = function

--- a/tests/FSharp.Test.Utilities/Assert.fs
+++ b/tests/FSharp.Test.Utilities/Assert.fs
@@ -3,7 +3,7 @@ namespace FSharp.Test
 module Assert =
     open FluentAssertions
     open System.Collections
-    open System.Text
+    open Xunit
     open System.IO
 
     let inline shouldBeEqualWith (expected : ^T) (message: string) (actual: ^U) =
@@ -18,8 +18,17 @@ module Assert =
     let inline shouldContain (needle : string) (haystack : string) =
         haystack.Should().Contain(needle) |> ignore    
 
+    // One fine day, all of the 3 things below should be purged and replaced with pure Assert.Equal.
+    // Xunit checks types by default. These are just artifacts of the testing chaos in the repo back in a day.
     let inline shouldBe (expected : ^T) (actual : ^U) =
         actual.Should().Be(expected, "") |> ignore
+
+    let inline areEqual (expected: ^T) (actual: ^T) =
+        Assert.Equal<^T>(expected, actual)
+
+    let inline shouldEqual (x: 'a) (y: 'a) =
+        Assert.Equal<'a>(x, y)
+    //
 
     let inline shouldBeEmpty (actual : ^T when ^T :> IEnumerable) =
         actual.Should().BeEmpty("") |> ignore

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/CharConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/CharConstants.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``Char Constants`` =

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/DecimalConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/DecimalConstants.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``Decimal Constants`` =

--- a/tests/fsharp/Compiler/Conformance/BasicGrammarElements/IntegerConstants.fs
+++ b/tests/fsharp/Compiler/Conformance/BasicGrammarElements/IntegerConstants.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``Integer Constants`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Collections/IEnumerableTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Collections/IEnumerableTests.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``IEnumerable Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/RoundTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/RoundTests.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``Round Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Operators/StringTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Operators/StringTests.fs
@@ -4,6 +4,7 @@ namespace FSharp.Compiler.UnitTests
 
 open Xunit
 open System
+open FSharp.Test
 
 
 module ``String Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Reflection/SprintfTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Reflection/SprintfTests.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``Sprintf Tests`` =

--- a/tests/fsharp/Compiler/Libraries/Core/Unchecked/DefaultOfTests.fs
+++ b/tests/fsharp/Compiler/Libraries/Core/Unchecked/DefaultOfTests.fs
@@ -3,6 +3,7 @@
 namespace FSharp.Compiler.UnitTests
 
 open Xunit
+open FSharp.Test
 
 
 module ``DefaultOf Tests`` =

--- a/tests/fsharp/XunitHelpers.fs
+++ b/tests/fsharp/XunitHelpers.fs
@@ -6,10 +6,3 @@ module Assert =
 
     [<assembly: CollectionBehavior(DisableTestParallelization = true)>]
     do()
-
-    let inline fail message = Assert.Fail message
-
-    let inline failf fmt = Printf.kprintf fail fmt
-
-    let inline areEqual (expected: ^T) (actual: ^T) =
-        Assert.Equal<^T>(expected, actual)

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -404,7 +404,7 @@ module CoreTests =
         let diffs = fsdiff cfg outFile expectedFile
         match diffs with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" outFile expectedFile diffs
+        | _ -> failwithf "'%s' and '%s' differ; %A" outFile expectedFile diffs
 
     [<Fact>]
     let fsfromcs () =
@@ -468,7 +468,7 @@ module CoreTests =
             let diffs = fsdiff cfg outFile expectedFile
             match diffs with
             | "" -> ()
-            | _ -> Assert.failf "'%s' and '%s' differ; %A" outFile expectedFile diffs
+            | _ -> failwithf "'%s' and '%s' differ; %A" outFile expectedFile diffs
 
         // check error messages for some cases
         let outFile = "compilation.errors.output.txt"
@@ -478,7 +478,7 @@ module CoreTests =
         let diffs = fsdiff cfg outFile expectedFile
         match diffs with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" outFile expectedFile diffs
+        | _ -> failwithf "'%s' and '%s' differ; %A" outFile expectedFile diffs
 
     [<Fact>]
     let ``fsi-reference`` () =
@@ -619,11 +619,11 @@ module CoreTests =
 
         match fsdiff cfg diffFileOut expectedFileOut with
         | "" -> ()
-        | diffs -> Assert.failf "'%s' and '%s' differ; %A" diffFileOut expectedFileOut diffs
+        | diffs -> failwithf "'%s' and '%s' differ; %A" diffFileOut expectedFileOut diffs
 
         match fsdiff cfg diffFileErr expectedFileErr with
         | "" -> ()
-        | diffs -> Assert.failf "'%s' and '%s' differ; %A" diffFileErr expectedFileErr diffs
+        | diffs -> failwithf "'%s' and '%s' differ; %A" diffFileErr expectedFileErr diffs
 
     [<Fact>]
     let ``printing`` () =
@@ -1031,13 +1031,13 @@ module CoreTests =
 
         match diffs with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs
+        | _ -> failwithf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs
 
         let diffs2 = fsdiff cfg stderrPath stderrBaseline
 
         match diffs2 with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
+        | _ -> failwithf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
 
     [<Fact>]
     let ``load-script`` () =
@@ -1160,13 +1160,13 @@ module CoreTests =
 
         match diffs with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs
+        | _ -> failwithf "'%s' and '%s' differ; %A" stdoutPath stdoutBaseline diffs
 
         let diffs2 = fsdiff cfg stderrPath stderrBaseline
 
         match diffs2 with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
+        | _ -> failwithf "'%s' and '%s' differ; %A" stderrPath stderrBaseline diffs2
 #endif
 
 
@@ -1739,7 +1739,7 @@ module RegressionTests =
         match diff with
         | "" -> ()
         | _ ->
-            Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
+            failwithf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
         let outFile2 = "output.test.txt"
         let expectedFile2 = "output.test.bsl"
@@ -1750,7 +1750,7 @@ module RegressionTests =
         match diff2 with
         | "" -> ()
         | _ ->
-            Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile2) (getfullpath cfg expectedFile2) diff2
+            failwithf "'%s' and '%s' differ; %A" (getfullpath cfg outFile2) (getfullpath cfg expectedFile2) diff2
 #endif
 
     [<Fact>]
@@ -1838,7 +1838,7 @@ module OptimizationTests =
         match diff with
         | "" -> ()
         | _ ->
-            Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
+            failwithf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
     [<Fact>]
@@ -1855,7 +1855,7 @@ module OptimizationTests =
 
         match diff with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
+        | _ -> failwithf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
     [<Fact>]
@@ -1872,7 +1872,7 @@ module OptimizationTests =
 
         match diff with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
+        | _ -> failwithf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
     [<Fact>]
@@ -1889,7 +1889,7 @@ module OptimizationTests =
 
         match diff with
         | "" -> ()
-        | _ -> Assert.failf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
+        | _ -> failwithf "'%s' and '%s' differ; %A" (getfullpath cfg outFile) (getfullpath cfg expectedFile) diff
 
 
     [<Fact>]
@@ -1922,7 +1922,7 @@ module OptimizationTests =
         match ``test--optimize.il`` with
             | [] -> ()
             | lines ->
-                Assert.failf "Error: optimizations not removed.  Relevant lines from IL file follow: %A" lines
+                failwithf "Error: optimizations not removed.  Relevant lines from IL file follow: %A" lines
 
         let numElim =
             File.ReadLines (getfullpath cfg "test.il")

--- a/tests/service/FsUnit.fs
+++ b/tests/service/FsUnit.fs
@@ -1,6 +1,0 @@
-﻿module FsUnit
-
-open Xunit
-
-let shouldEqual (x: 'a) (y: 'a) =
-    Assert.Equal<'a>(x, y)


### PR DESCRIPTION
That's just something that caught my eye. 

Don't feel for x-repo replacements of everything, so just putting `Assert.Equal` variations in one place and reducing the number of helper files.