### PR TITLE
fix OriginalLine processing in lexing

### DIFF
--- a/src/Compiler/Facilities/prim-lexing.fs
+++ b/src/Compiler/Facilities/prim-lexing.fs
@@ -238,13 +238,13 @@ type internal Position =
         Position(x.FileIndex, x.Line, x.OriginalLine, x.StartOfLineAbsoluteOffset, x.StartOfLineAbsoluteOffset - 1)
 
     member x.ApplyLineDirective(fileIdx, line) =
-        Position(fileIdx, line, x.OriginalLine, x.AbsoluteOffset, x.AbsoluteOffset)
+        Position(fileIdx, line, x.OriginalLine + 1, x.AbsoluteOffset, x.AbsoluteOffset)
 
     override p.ToString() = $"({p.Line},{p.Column})"
 
     static member Empty = Position()
 
-    static member FirstLine fileIdx = Position(fileIdx, 1, 0, 0, 0)
+    static member FirstLine fileIdx = Position(fileIdx, 1, 1, 0, 0)
 
 type internal LexBufferFiller<'Char> = LexBuffer<'Char> -> unit
 

--- a/tests/FSharp.Compiler.ComponentTests/CompilerDirectives/Line.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerDirectives/Line.fs
@@ -2,16 +2,20 @@ namespace CompilerDirectives
 
 open Microsoft.FSharp.Control
 open Xunit
-open FSharp.Test.Compiler
+open Internal.Utilities
+open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis
-open FSharp.Compiler.Text
+open FSharp.Compiler.DiagnosticsLogger
+open FSharp.Compiler.Features
+open FSharp.Compiler.Lexhelp
 open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+open FSharp.Compiler.UnicodeLexing
 
 module Line =
 
-    let checker = FSharpChecker.Create()
-
     let parse (source: string) =
+        let checker = FSharpChecker.Create()
         let langVersion = "preview"
         let sourceFileName = __SOURCE_FILE__
         let parsingOptions =
@@ -63,4 +67,51 @@ printfn ""
             | ParsedInput.SigFile _ -> failwith "unexpected: sig file"
         if exprRange <> expectedRange then
             failwith $"case{case}: expected: {expectedRange}, found {exprRange}"
-        
+
+
+
+
+
+    let private getTokens sourceText =
+        let langVersion = LanguageVersion.Default
+        let lexargs =
+            mkLexargs (
+                [],
+                IndentationAwareSyntaxStatus(true, false),
+                LexResourceManager(),
+                [],
+                DiscardErrorsLogger,
+                PathMap.empty,
+                true
+            )
+        let lexbuf = StringAsLexbuf(true, langVersion, None, sourceText)
+        resetLexbufPos "test.fs" lexbuf
+        let tokenizer _ =
+            let t = Lexer.token lexargs true lexbuf
+            let p = lexbuf.StartPos
+            t, FileIndex.fileOfFileIndex p.FileIndex, p.OriginalLine, p.Line
+        let isNotEof(t,_,_,_) = match t with Parser.EOF _ -> false | _ -> true
+        Seq.initInfinite tokenizer |> Seq.takeWhile isNotEof |> Seq.toList
+
+    let private code = """
+1
+#line 5 "other.fs"
+2
+#line 10 "test.fs"
+3
+"""
+
+    let private expected = [
+        "test.fs", 2, 2
+        "other.fs", 4, 5
+        "test.fs", 6, 10
+    ]
+
+    [<Fact>]
+    let checkOriginalLineNumbers() =
+        let tokens = getTokens code
+        Assert.Equal(expected.Length, tokens.Length)
+        for ((e_idx, e_oLine, e_line), (_, idx, oLine, line)) in List.zip expected tokens do
+            Assert.Equal(e_idx, idx)
+            Assert.Equal(e_oLine, oLine)
+            Assert.Equal(e_line, line)


### PR DESCRIPTION
## Description

This PR fixes two bugs in processing `Position.OriginalLine` during lexing.
This field is foreseen in FsLex, but was hardly used in the compiler, and only for equality checks.
Therefore this fix does not change current compiler behavior, but will enable features like "scoped nowarn" that will depend on correct values of `OriginalLine`.
Note that this is not a FsLex issue, but only present in the compiler.
A test has been added to check the line numbers.

## Checklist

- [X] Test cases added