### PR TITLE
Re-enable TransparentCompiler tests, an errata

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/CompilerService/AsyncMemoize.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerService/AsyncMemoize.fs
@@ -15,14 +15,14 @@ let tap f x = f x; x
 
 let internal record (cache: AsyncMemoize<_,_,_>) =
 
-    let events = ResizeArray()
+    let events = Collections.Concurrent.ConcurrentQueue()
 
     let waitForIdle() = SpinWait.SpinUntil(fun () -> not cache.Updating)
 
     waitForIdle()
     cache.Event
     |> Event.map (fun (e, (_, k, _)) -> e, k)
-    |> Event.add events.Add
+    |> Event.add events.Enqueue
 
     let getEvents () =
         waitForIdle()

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -31,7 +31,7 @@ let fileName fileId = $"File%s{fileId}.fs"
 
 let internal recordAllEvents groupBy =
     let mutable cache : AsyncMemoize<_,_,_> option = None
-    let events = ResizeArray()
+    let events = ConcurrentQueue()
 
     let waitForIdle() = SpinWait.SpinUntil(fun () -> not cache.Value.Updating)
 
@@ -40,7 +40,7 @@ let internal recordAllEvents groupBy =
         waitForIdle()
         cache.Value.Event
         |> Event.map (fun (e, k) -> groupBy k, e)
-        |> Event.add events.Add
+        |> Event.add events.Enqueue
 
     let getEvents () =
         waitForIdle()


### PR DESCRIPTION
`AsyncMemoize` events need to be collected in a thread-safe way.

Fixes:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=865720&view=ms.vss-test-web.build-test-results-tab&runId=22526688&resultId=100194&paneView=debug


