### PR TITLE
Bugfix:: Make bound values available to filter clause for try-with in seq{}

### DIFF
--- a/src/Compiler/Checking/Expressions/CheckSequenceExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckSequenceExpressions.fs
@@ -340,7 +340,7 @@ let TcSequenceExpression (cenv: TcFileState) env tpenv comp (overallTy: OverallT
                         MatchClause(patR, condR, TTarget(vspecs, matchBody, None), patR.Range)
 
                     let filterClause =
-                        MatchClause(patR, condR, TTarget([], Expr.Const(Const.Int32 1, m, g.int_ty), None), patR.Range)
+                        MatchClause(patR, condR, TTarget(vspecs, Expr.Const(Const.Int32 1, m, g.int_ty), None), patR.Range)
 
                     (handlerClause, filterClause), tpenv)
 


### PR DESCRIPTION
Fixes #17930 .


Before this PR, bound values were not available to the code in `when` filter clauses.
Even without a compiler error, this later lead to ilxgen issue of not having the values available as locals.

(the filter is compiled as a separate function returning 0/1)