### PR TITLE
Use library-packs also when RestoreAdditionalProjectSources is explicitly set.

### DIFF
--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.targets
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.targets
@@ -11,7 +11,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 ***********************************************************************************************
 -->
 
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project TreatAsLocalProperty="RestoreAdditionalProjectSources" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="MapSourceRoots" AssemblyFile="$(FSharpBuildAssemblyFile)" />
   
   <PropertyGroup>


### PR DESCRIPTION
library-packs are SDK features that implemented using bundled NuGet package files.

When a user sets RestoreAdditionalProjectSources, these features must remain available.

To disable library-packs features, a user may set DisableImplicitLibraryPacksFolder.

Fixes https://github.com/dotnet/sdk/issues/44547.

@dsplaisted @nkolev92 @baronfel ptal.