### PR TITLE
Bump MacOS

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -589,7 +589,7 @@ stages:
         # MacOS
         - job: MacOS
           pool:
-            vmImage: macos-12
+            vmImage: macos-15
           timeoutInMinutes: 120
           variables:
           - name: _SignType
@@ -727,7 +727,7 @@ stages:
         # Plain FCS build Mac
         - job: Plain_Build_MacOS
           pool:
-            vmImage: macos-12
+            vmImage: macos-15
           variables:
           - name: _BuildConfig
             value: Debug

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -589,7 +589,7 @@ stages:
         # MacOS
         - job: MacOS
           pool:
-            vmImage: macos-15
+            vmImage: macos-latest
           timeoutInMinutes: 120
           variables:
           - name: _SignType

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -727,7 +727,7 @@ stages:
         # Plain FCS build Mac
         - job: Plain_Build_MacOS
           pool:
-            vmImage: macos-15
+            vmImage: macos-latest
           variables:
           - name: _BuildConfig
             value: Debug


### PR DESCRIPTION
MacOS-12 got deprecated, bump MacOS as per [this](https://github.com/actions/runner-images/issues/10721).