### PR TITLE
Add -sign to build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -20,6 +20,7 @@ usage()
   echo "  --rebuild                      Rebuild all projects"
   echo "  --pack                         Build nuget packages"
   echo "  --publish                      Publish build artifacts"
+  echo "  --sign                         Sign build artifacts"
   echo "  --help                         Print help and exit"
   echo ""
   echo "Test actions:"
@@ -58,6 +59,7 @@ build=false
 rebuild=false
 pack=false
 publish=false
+sign=false
 test_core_clr=false
 test_compilercomponent_tests=false
 test_benchmarks=false
@@ -128,6 +130,9 @@ while [[ $# > 0 ]]; do
       ;;
     --publish)
       publish=true
+      ;;
+    --sign)
+      sign=true
       ;;
     --testcoreclr|--test|-t)
       test_core_clr=true
@@ -297,6 +302,7 @@ function BuildSolution {
       /p:Rebuild=$rebuild \
       /p:Pack=$pack \
       /p:Publish=$publish \
+      /p:Sign=$sign \
       /p:UseRoslynAnalyzers=$enable_analyzers \
       /p:ContinuousIntegrationBuild=$ci \
       /p:QuietRestore=$quiet_restore \


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/18011

This will have to flow to the 17.13 branch in order to make it into the VMR. In the meantime, this may need to get patched to unblock https://github.com/dotnet/sdk/pull/44855#issuecomment-2480200846