### PR TITLE
Fix #18055 - Add null annotation to Async.SwitchToContext

### DIFF
--- a/docs/release-notes/.FSharp.Core/9.0.200.md
+++ b/docs/release-notes/.FSharp.Core/9.0.200.md
@@ -1,6 +1,7 @@
 ### Fixed
 
 * Fix exception on Post after MailboxProcessor was disposed ([Issue #17849](https://github.com/dotnet/fsharp/issues/17849), [PR #17922](https://github.com/dotnet/fsharp/pull/17922))
+* Fix missing null annotation in Async.SwitchToContext ([Issue #18055](https://github.com/dotnet/fsharp/issues/18055), [PR #18059](https://github.com/dotnet/fsharp/pull/18059))
 
 ### Added
 

--- a/src/FSharp.Core/async.fs
+++ b/src/FSharp.Core/async.fs
@@ -868,11 +868,7 @@ module AsyncPrimitives =
 
     ///   - Initial cancellation check
     ///   - Call syncCtxt.Post with exception protection. This may fail as it is arbitrary user code
-#if BUILDING_WITH_LKG || NO_NULLCHECKING_LIB_SUPPORT
     let CreateSwitchToAsync (syncCtxt: SynchronizationContext) =
-#else
-    let CreateSwitchToAsync (syncCtxt: SynchronizationContext | null) =
-#endif
         MakeAsyncWithCancelCheck(fun ctxt -> ctxt.PostWithTrampoline syncCtxt ctxt.cont)
 
     ///   - Initial cancellation check

--- a/src/FSharp.Core/async.fsi
+++ b/src/FSharp.Core/async.fsi
@@ -647,7 +647,7 @@ namespace Microsoft.FSharp.Control
         /// <category index="4">Threads and Contexts</category>
         ///
         /// <example-tbd></example-tbd>
-        static member SwitchToContext :  syncContext:System.Threading.SynchronizationContext -> Async<unit> 
+        static member SwitchToContext : syncContext:(System.Threading.SynchronizationContext | null) -> Async<unit> 
 
         /// <summary>Creates an asynchronous computation that captures the current
         /// success, exception and cancellation continuations. The callback must 


### PR DESCRIPTION
## Description

Fixes #18055

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/release-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**