### PR TITLE
Fix one test

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModule.fs
@@ -469,27 +469,29 @@ type AsyncModule() =
     member _.``error on one workflow should cancel all others``() =
         task {
             use failOnlyOne = new Semaphore(0, 1)
-            // Start from 1.
-            let mutable running = new CountdownEvent(1)
+            let mutable cancelled = 0
+            let mutable started = 0
 
             let job i = async {
-                use! holder = Async.OnCancel (running.Signal >> ignore)
-                running.AddCount 1
-                do! failOnlyOne |> Async.AwaitWaitHandle |> Async.Ignore
-                running.Signal() |> ignore
-                failwith "boom" 
+                let! ct = Async.CancellationToken
+                Interlocked.Increment &started |> ignore
+                try
+                    do! failOnlyOne |> Async.AwaitWaitHandle |> Async.Ignore
+                    failwith "boom" 
+                finally
+                    if ct.IsCancellationRequested then
+                        Interlocked.Increment &cancelled |> ignore
+
             }
 
             let test = Async.Parallel [ for i in 1 .. 100 -> job i ] |> Async.Catch |> Async.Ignore |> Async.StartAsTask
             // Wait for more than one job to start
-            while running.CurrentCount < 2 do
+            while started < 2 do
                 do! Task.Yield()
-            printfn $"started jobs: {running.CurrentCount - 1}"
+            printfn $"started jobs: {started}"
             failOnlyOne.Release() |> ignore
             do! test
-            // running.CurrentCount should eventually settle back at 1. Signal it one more time and it should be 0.
-            running.Signal() |> ignore
-            return! Async.AwaitWaitHandle running.WaitHandle
+            Assert.Equal(cancelled, started - 1)
         }
 
     [<Fact>]


### PR DESCRIPTION
## Description

`error on one workflow should cancel all others` test` became flaky after my changes.
This became very apparent when running tests in parallel in CI.

The mistake was to rely on `Async.OnCancel` to detect cancellation inside the computation. This is absolutely unreliable because the computation can check for cancellation before `Async.OnCancel` manages to register its callback. Even inside `Async.OnCancel` implementation, there's a bind that will check cancellation and prevent the callback from executing.

## Checklist

- [x] Ran locally a few thousand parallel iterations to make sure this is good.
