### PR TITLE
Calling protected static base member from static should not raise a MethodAccessException

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -13,6 +13,7 @@
 * Fix missing nullness warning in case of method resolution multiple candidates ([PR #17917](https://github.com/dotnet/fsharp/pull/17918))
 * Fix failure to use bound values in `when` clauses of `try-with` in `seq` expressions ([PR #17990](https://github.com/dotnet/fsharp/pull/17990))
 * Fix locals allocating for the special `copyOfStruct` defensive copy ([PR #18025](https://github.com/dotnet/fsharp/pull/18025))
+* Fix `MethodAccessException` when calling protected static base member from static ([PR #18095](https://github.com/dotnet/fsharp/pull/18095))
 
 ### Added
 

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -1837,6 +1837,10 @@ module MutRecBindingChecking =
                     [ for defnB in defnAs do
                         match defnB with
                         | Phase2AIncrClassCtor (_, Some incrCtorInfo) -> yield incrCtorInfo.InstanceCtorVal
+                        | Phase2AInherit(_, _, baseValOpt, _) -> 
+                                match baseValOpt with 
+                                | Some baseVal -> yield baseVal
+                                | None -> ()
                         | _ -> () ])
 
                 let envForDeclsUpdated = 

--- a/tests/FSharp.Compiler.ComponentTests/Language/StaticClassTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/StaticClassTests.fs
@@ -779,3 +779,38 @@ type T =
              (Warning 3558, Line 10, Col 9, Line 10, Col 10, "If a type uses both [<Sealed>] and [<AbstractClass>] attributes, it means it is static. Explicit field declarations are not allowed.")
              (Warning 3558, Line 11, Col 17, Line 11, Col 18, "If a type uses both [<Sealed>] and [<AbstractClass>] attributes, it means it is static. Explicit field declarations are not allowed.")
          ]
+
+    [<Fact>]
+    let ``Calling protected static base member from static should not raise a MethodAccessException`` () =
+        Fsx """
+#nowarn "44" // using Uri.EscapeString just because it's protected static
+
+type C(str : string) =
+    inherit System.Uri(str)
+    
+    static do
+        System.Uri.EscapeString("data") |> ignore
+
+C("http://example.com") |> ignore
+        """
+         |> compileAndRun
+         |> shouldSucceed
+
+    [<Fact>]
+    let ``Calling protected static base member from static should not raise a MethodAccessException 2`` () =
+        Fsx """
+#nowarn "44" // using Uri.EscapeString just because it's protected static
+
+type C(str : string) =
+    inherit System.Uri(str)
+    
+    static do
+        C.Do()
+
+    static member internal Do() =
+        System.Uri.EscapeString("data") |> ignore
+
+C("http://example.com") |> ignore
+        """
+         |> compileAndRun
+         |> shouldSucceed


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #11929

### Before

- MethodAccessException [sharplab](https://sharplab.io/#v2:DYLgZgzgNALiBOBXAdlAJiA1AHwMTIHsB3AQ3mQAIAiAFhqooHpGLEIBLZAcwoFV52AOgCiEAMYkADgFMAyjAHcKAKzYwKAI2kS20iuxgByCBUnwCMbZbQUIMEjHZiAsACg3MAJ4yKAYQAUdvAUILYKnFwAlBQAvG4UCfrIABbSAuqynnbSALaC/OyBCpHxiaUJdg5OFGgE5YkJmdl5BSLiUnLh3P5UaA4kVNHYAHz6XITw0m5uAVSpwMAEgxQjYxPSQA===)

```
System.MethodAccessException: Attempt by method '<StartupCode$_>.$_.main@()' to access method 'System.Uri.EscapeString(System.String)' failed.
   at <StartupCode$_>.$_.main@()
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

```fsharp
#nowarn "44" // using Uri.EscapeString just because it's protected static

type C(str : string) =
    inherit System.Uri(str)
    
    static do
        System.Uri.EscapeString("data") |> ignore

C("hello") |> ignore
```

### After

- Compiles and run successfully

## Checklist

- [x] Test cases added
- [x] Release notes entry updated