### PR TITLE
Allow empty ItemsToSign when building VisualFSharp with core msbuild

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,5 +1,13 @@
 <Project>
 
+  <!--
+    VisualFSharp.sln only produces artifacts files when built with full framework MSBuild,
+    so we need to allow empty sign list when building VisualFSharp.sln with Core MSBuild.
+   -->
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core' and $(Projects.Contains('VisualFSharp.sln'))">
+    <AllowEmptySignList>true</AllowEmptySignList>
+  </PropertyGroup>
+
   <ItemGroup>
     <FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="None" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="None" />


### PR DESCRIPTION
Needed for https://github.com/dotnet/sdk/pull/44855

VisualFSharp.sln only produces artifacts files when built with full framework MSBuild, so we need to allow empty sign list when building VisualFSharp.sln with Core MSBuild in order to pass `-sign`.