### PR TITLE
Sink: report SynPat.ArrayOrList type

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -25,6 +25,7 @@
 * Added type conversions cache, only enabled for compiler runs, guarded by language version preview ([PR #17668](https://github.com/dotnet/fsharp/pull/17668))
 * Added project property ParallelCompilation which turns on graph based type checking, parallel ILXGen and parallel optimization. By default on for users of langversion=preview ([PR #17948](https://github.com/dotnet/fsharp/pull/17948))
 * Adding warning when consuming generic method returning T|null for types not supporting nullness (structs,anons,tuples) ([PR #18057](https://github.com/dotnet/fsharp/pull/18057))
+* Sink: report SynPat.ArrayOrList type ([PR #18127](https://github.com/dotnet/fsharp/pull/18127))
 
 ### Changed
 

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -313,6 +313,7 @@ and TcPat warnOnUpper (cenv: cenv) env valReprInfo vFlags (patEnv: TcPatLinearEn
         TcPat warnOnUpper cenv env None vFlags patEnv ty p
 
     | SynPat.ArrayOrList (isArray, args, m) ->
+        CallExprHasTypeSink cenv.tcSink (m, env.NameEnv, ty, env.AccessRights)
         TcPatArrayOrList warnOnUpper cenv env vFlags patEnv ty isArray args m
 
     | SynPat.Record (flds, m) ->


### PR DESCRIPTION
Reports the inferred `SynPat.ArrayOrList` type to the sink. This can be used in features like type hints.