### PR TITLE
Fix build script breaking when current directory contains spaces

### DIFF
--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -243,7 +243,7 @@ function Make-BootstrapBuild() {
 
     # prepare compiler
     $projectpath = "$RepoRoot" + "proto.proj"
-    $args = "publish $projectpath -c $bootstrapConfiguration"
+    $args = "publish `"$projectpath`" -c $bootstrapConfiguration"
     if ($binaryLog) {
         $logFilePath = Join-Path $LogDir "bootstrap.binlog"
         $args += " /bl:`"$logFilePath`""


### PR DESCRIPTION
## Description

Tried cloning the repo on a branch new machine and the project wouldn't build; turns out it was because I have spaces in my user directory. Just needs a little escaping

## Checklist

N/A. Simple build script fix.