### PR TITLE
Shim/file system: fix leaks of the shim

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -17,6 +17,7 @@
 * Add missing nullable-metadata for C# consumers of records,exceptions and DU subtypes generated from F# code. [PR #18079](https://github.com/dotnet/fsharp/pull/18079)
 * Fix a race condition in file book keeping in the compiler service ([#18008](https://github.com/dotnet/fsharp/pull/18008))
 * Fix trimming '%' characters when lowering interpolated string to a concat call [PR #18123](https://github.com/dotnet/fsharp/pull/18123)
+* Shim/file system: fix leaks of the shim [PR #18144](https://github.com/dotnet/fsharp/pull/18144)
 
 ### Added
 

--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -1129,7 +1129,10 @@ let main6
     DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent ctok
 
     let pdbfile =
-        pdbfile |> Option.map (tcConfig.MakePathAbsolute >> FileSystem.GetFullPathShim)
+        pdbfile |> Option.map (fun s ->
+            let absolutePath = tcConfig.MakePathAbsolute s
+            FileSystem.GetFullPathShim(absolutePath)
+        )
 
     let normalizeAssemblyRefs (aref: ILAssemblyRef) =
         match tcImports.TryFindDllInfo(ctok, rangeStartup, aref.Name, lookupOnly = false) with

--- a/src/Compiler/Driver/fsc.fs
+++ b/src/Compiler/Driver/fsc.fs
@@ -1129,10 +1129,10 @@ let main6
     DoesNotRequireCompilerThreadTokenAndCouldPossiblyBeMadeConcurrent ctok
 
     let pdbfile =
-        pdbfile |> Option.map (fun s ->
+        pdbfile
+        |> Option.map (fun s ->
             let absolutePath = tcConfig.MakePathAbsolute s
-            FileSystem.GetFullPathShim(absolutePath)
-        )
+            FileSystem.GetFullPathShim(absolutePath))
 
     let normalizeAssemblyRefs (aref: ILAssemblyRef) =
         match tcImports.TryFindDllInfo(ctok, rangeStartup, aref.Name, lookupOnly = false) with

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -680,8 +680,14 @@ type TcGlobals(
 
   let mkSourceDoc fileName = ILSourceDocument.Create(language=None, vendor=None, documentType=None, file=fileName)
 
+  let compute i =
+      let path = fileOfFileIndex i
+      let fullPath = FileSystem.GetFullFilePathInDirectoryShim directoryToResolveRelativePaths path
+      mkSourceDoc fullPath
+
   // Build the memoization table for files
-  let v_memoize_file = MemoizationTable<int, ILSourceDocument>((fileOfFileIndex >> FileSystem.GetFullFilePathInDirectoryShim directoryToResolveRelativePaths >> mkSourceDoc), keyComparer=HashIdentity.Structural)
+  let v_memoize_file =
+      MemoizationTable<int, ILSourceDocument>(compute, keyComparer = HashIdentity.Structural)
 
   let v_and_info =                   makeIntrinsicValRef(fslib_MFIntrinsicOperators_nleref,                    CompileOpName "&"                      , None                 , None          , [],         mk_rel_sig v_bool_ty)
   let v_addrof_info =                makeIntrinsicValRef(fslib_MFIntrinsicOperators_nleref,                    CompileOpName "~&"                     , None                 , None          , [vara],     ([[varaTy]], mkByrefTy varaTy))

--- a/src/LegacyMSBuildResolver/LegacyMSBuildReferenceResolver.fs
+++ b/src/LegacyMSBuildResolver/LegacyMSBuildReferenceResolver.fs
@@ -432,7 +432,7 @@ let getResolver () =
                 |]
 
             let rooted, unrooted =
-                references |> Array.partition (fst >> FileSystem.IsPathRootedShim)
+                references |> Array.partition (fun (path, _) -> FileSystem.IsPathRootedShim(path))
 
             let rootedResults =
                 ResolveCore(

--- a/src/LegacyMSBuildResolver/LegacyMSBuildReferenceResolver.fs
+++ b/src/LegacyMSBuildResolver/LegacyMSBuildReferenceResolver.fs
@@ -432,7 +432,8 @@ let getResolver () =
                 |]
 
             let rooted, unrooted =
-                references |> Array.partition (fun (path, _) -> FileSystem.IsPathRootedShim(path))
+                references
+                |> Array.partition (fun (path, _) -> FileSystem.IsPathRootedShim(path))
 
             let rootedResults =
                 ResolveCore(

--- a/tests/FSharp.Compiler.Service.Tests/FileSystemTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/FileSystemTests.fs
@@ -82,3 +82,21 @@ let ``FileSystem compilation test``() =
     results.AssemblySignature.Entities.Count |> shouldEqual 2
     results.AssemblySignature.Entities[0].MembersFunctionsAndValues.Count |> shouldEqual 1
     results.AssemblySignature.Entities[0].MembersFunctionsAndValues[0].DisplayName |> shouldEqual "B"
+
+let checkEmptyScriptWithFsShim () =
+    let shim = DefaultFileSystem()
+    let ref: WeakReference = WeakReference(shim)
+
+    use _ = useFileSystemShim shim
+    getParseAndCheckResults "" |> ignore
+
+    ref
+
+[<Fact>]
+let ``File system shim should not leak`` () =
+    let shimRef = checkEmptyScriptWithFsShim ()
+
+    GC.Collect()
+    GC.WaitForPendingFinalizers()
+
+    Assert.False(shimRef.IsAlive)


### PR DESCRIPTION
Fixes the file system shim is leaked after a solution is closed:

<img width="981" alt="Screenshot 2024-12-13 at 21 31 43" src="https://github.com/user-attachments/assets/67608e94-dff4-4b6d-ba60-36c5b36b240f" />
