### PR TITLE
Exclude FileSystemTests from parallelization

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -220,7 +220,7 @@ function Test() {
   projectname="${projectname%.*}"
   testlogpath="$artifacts_dir/TestResults/$configuration/${projectname}_$targetframework.xml"
   args="test \"$testproject\" --no-restore --no-build -c $configuration -f $targetframework --test-adapter-path . --logger \"xunit;LogFilePath=$testlogpath\" --blame-hang-timeout 5minutes --results-directory $artifacts_dir/TestResults/$configuration -p:vstestusemsbuildoutput=false"
-  args+=" -- xUnit.MaxParallelThreads=3"
+  args+=" -- xUnit.MaxParallelThreads=2"
   "$DOTNET_INSTALL_DIR/dotnet" $args || exit $?
 }
 

--- a/tests/FSharp.Compiler.Service.Tests/FileSystemTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/FileSystemTests.fs
@@ -1,4 +1,6 @@
-﻿module FSharp.Compiler.Service.Tests.FileSystemTests
+﻿// FileSystem is a global shared resource.
+[<Xunit.Collection(nameof FSharp.Test.NotThreadSafeResourceCollection)>]
+module FSharp.Compiler.Service.Tests.FileSystemTests
 
 open Xunit
 open FSharp.Test.Assert
@@ -25,8 +27,6 @@ let file2 = """
 module File2
 let B = File1.A + File1.A"""
 
-// FileSystem is a global shared resource.
-[<Collection(nameof NotThreadSafeResourceCollection)>]
 type internal MyFileSystem() =
     inherit DefaultFileSystem()
         static member FilesCache = dict [(fileName1, file1); (fileName2, file2)]


### PR DESCRIPTION
`FileSystem` is a not thread-safe resource. These tests need to be excluded from parallelization.
