### PR TITLE
Deparallelize net9.0 tests in CI

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -609,7 +609,7 @@ try {
     }
 
     if ($testCoreClr) {
-        $cpuLimit = if ($ci) { "-m:2 -- xUnit.MaxParallelThreads=0.25x" } else { "" }
+        $cpuLimit = if ($ci) { "-m:1 -- xUnit.MaxParallelThreads=1" } else { "" }
         TestUsingMSBuild -testProject "$RepoRoot\FSharp.sln" -targetFramework $script:coreclrTargetFramework -testadapterpath "$ArtifactsDir\bin\FSharp.Compiler.ComponentTests\" -settings $cpuLimit
     }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -220,7 +220,7 @@ function Test() {
   projectname="${projectname%.*}"
   testlogpath="$artifacts_dir/TestResults/$configuration/${projectname}_$targetframework.xml"
   args="test \"$testproject\" --no-restore --no-build -c $configuration -f $targetframework --test-adapter-path . --logger \"xunit;LogFilePath=$testlogpath\" --blame-hang-timeout 5minutes --results-directory $artifacts_dir/TestResults/$configuration -p:vstestusemsbuildoutput=false"
-  args+=" -- xUnit.MaxParallelThreads=2"
+  args+=" -- xUnit.MaxParallelThreads=1"
   "$DOTNET_INSTALL_DIR/dotnet" $args || exit $?
 }
 


### PR DESCRIPTION
Hoping this will mitigate the `Internal CLR error` crashes in CI until the underlying issue is dealt with.