### PR TITLE
Cancellable: add safer APIs to check the token

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -32,6 +32,7 @@
 * Sink: report SynPat.ArrayOrList type ([PR #18127](https://github.com/dotnet/fsharp/pull/18127))
 * Show the default value of compiler options ([PR #18054](https://github.com/dotnet/fsharp/pull/18054))
 * Support ValueOption + Struct attribute as optional parameter for methods ([Language suggestion #1136](https://github.com/fsharp/fslang-suggestions/issues/1136), [PR #18098](https://github.com/dotnet/fsharp/pull/18098))
+* Cancellable: add safer APIs to check the token ([PR #18175](https://github.com/dotnet/fsharp/pull/18175))
 
 ### Changed
 

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -14,8 +14,7 @@ type Cancellable =
         tokenHolder.Value
         |> ValueOption.defaultWith (fun () -> if guard then failwith msg else CancellationToken.None)
 
-    static member HasCancellationToken =
-        tokenHolder.Value.IsSome
+    static member HasCancellationToken = tokenHolder.Value.IsSome
 
     static member Token = ensureToken "Token not available outside of Cancellable computation."
 

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -14,6 +14,9 @@ type Cancellable =
         tokenHolder.Value
         |> ValueOption.defaultWith (fun () -> if guard then failwith msg else CancellationToken.None)
 
+    static member HasCancellationToken =
+        tokenHolder.Value.IsSome
+
     static member Token = ensureToken "Token not available outside of Cancellable computation."
 
     static member UsingToken(ct) =
@@ -27,6 +30,11 @@ type Cancellable =
     static member CheckAndThrow() =
         let token = ensureToken "CheckAndThrow invoked outside of Cancellable computation."
         token.ThrowIfCancellationRequested()
+
+    static member TryCheckAndThrow() =
+        match tokenHolder.Value with
+        | ValueNone -> ()
+        | ValueSome token -> token.ThrowIfCancellationRequested()
 
 namespace Internal.Utilities.Library
 

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -7,8 +7,12 @@ open System.Threading
 type Cancellable =
     /// For use in testing only. Cancellable.token should be set only by the cancellable computation.
     static member internal UsingToken: CancellationToken -> IDisposable
+
+    static member HasCancellationToken: bool
     static member Token: CancellationToken
+
     static member CheckAndThrow: unit -> unit
+    static member TryCheckAndThrow: unit -> unit
 
 namespace Internal.Utilities.Library
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -2011,9 +2011,12 @@ FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryRe
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+MetadataOnlyFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+ReduceMemoryFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+Shim
+FSharp.Compiler.Cancellable: Boolean HasCancellationToken
+FSharp.Compiler.Cancellable: Boolean get_HasCancellationToken()
 FSharp.Compiler.Cancellable: System.Threading.CancellationToken Token
 FSharp.Compiler.Cancellable: System.Threading.CancellationToken get_Token()
 FSharp.Compiler.Cancellable: Void CheckAndThrow()
+FSharp.Compiler.Cancellable: Void TryCheckAndThrow()
 FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String OutputFile
 FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String get_OutputFile()
 FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -2011,9 +2011,12 @@ FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryRe
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+MetadataOnlyFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+ReduceMemoryFlag
 FSharp.Compiler.AbstractIL.ILBinaryReader: FSharp.Compiler.AbstractIL.ILBinaryReader+Shim
+FSharp.Compiler.Cancellable: Boolean HasCancellationToken
+FSharp.Compiler.Cancellable: Boolean get_HasCancellationToken()
 FSharp.Compiler.Cancellable: System.Threading.CancellationToken Token
 FSharp.Compiler.Cancellable: System.Threading.CancellationToken get_Token()
 FSharp.Compiler.Cancellable: Void CheckAndThrow()
+FSharp.Compiler.Cancellable: Void TryCheckAndThrow()
 FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String OutputFile
 FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: System.String get_OutputFile()
 FSharp.Compiler.CodeAnalysis.DelayedILModuleReader: Void .ctor(System.String, Microsoft.FSharp.Core.FSharpFunc`2[System.Threading.CancellationToken,Microsoft.FSharp.Core.FSharpOption`1[System.IO.Stream]])


### PR DESCRIPTION
There're cases where reading an assembly metadata may happen outside of the type checking routine. For example, computing code completion suggestions or Parameter Info signature may trigger reading of types that haven't been imported during the checking. We want to be able to check if the metadata reading is happening inside a `Cancellable` context and to check for interruptions in a safer way.