### PR TITLE
"#if" directive around nullness removed refactored in HashMultiMap

### DIFF
--- a/src/Compiler/TypedTree/QuotationPickler.fs
+++ b/src/Compiler/TypedTree/QuotationPickler.fs
@@ -254,7 +254,7 @@ module SimplePickle =
     when 'T:not null
 #endif
     > =
-        { tbl: HashMultiMap<'T, int> // This should be "Dictionary"
+        { tbl: HashMultiMap<'T, int when 'T: not null> // This should be "Dictionary"
           mutable rows: 'T list
           mutable count: int }
 

--- a/src/Compiler/Utilities/HashMultiMap.fs
+++ b/src/Compiler/Utilities/HashMultiMap.fs
@@ -8,8 +8,8 @@ open System.Collections.Concurrent
 // Each entry in the HashMultiMap dictionary has at least one entry. Under normal usage each entry has _only_
 // one entry. So use two hash tables: one for the main entries and one for the overflow.
 [<Sealed>]
-type internal HashMultiMap<'Key, 'Value when 'Key:not null>
-(size: int, comparer: IEqualityComparer<'Key>, ?useConcurrentDictionary: bool) =
+type internal HashMultiMap<'Key, 'Value when 'Key:not null
+    >(size: int, comparer: IEqualityComparer<'Key>, ?useConcurrentDictionary: bool) =
 
     let comparer = comparer
 

--- a/src/Compiler/Utilities/HashMultiMap.fs
+++ b/src/Compiler/Utilities/HashMultiMap.fs
@@ -8,11 +8,8 @@ open System.Collections.Concurrent
 // Each entry in the HashMultiMap dictionary has at least one entry. Under normal usage each entry has _only_
 // one entry. So use two hash tables: one for the main entries and one for the overflow.
 [<Sealed>]
-type internal HashMultiMap<'Key, 'Value
-#if !NO_CHECKNULLS
-    when 'Key:not null
-#endif
-    >(size: int, comparer: IEqualityComparer<'Key>, ?useConcurrentDictionary: bool) =
+type internal HashMultiMap<'Key, 'Value when 'Key:not null>
+(size: int, comparer: IEqualityComparer<'Key>, ?useConcurrentDictionary: bool) =
 
     let comparer = comparer
 

--- a/src/Compiler/Utilities/HashMultiMap.fsi
+++ b/src/Compiler/Utilities/HashMultiMap.fsi
@@ -7,11 +7,7 @@ open System.Collections.Generic
 /// Hash tables, by default based on F# structural "hash" and (=) functions.
 /// The table may map a single key to multiple bindings.
 [<Sealed>]
-type internal HashMultiMap<'Key, 'Value
-#if !NO_CHECKNULLS
-    when 'Key:not null
-#endif
-    > =
+type internal HashMultiMap<'Key, 'Value when 'Key:not null> =
     /// Create a new empty mutable HashMultiMap with the given key hash/equality functions.
     new: comparer: IEqualityComparer<'Key> * ?useConcurrentDictionary: bool -> HashMultiMap<'Key, 'Value>
 


### PR DESCRIPTION
## Description
"#if" directive around nullness removed refactored in HashMultiMap src/Compiler/Utilities/HashMultiMap.fs and fsi
Related: #18061 (partially addresses)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

reopened due to closing of https://github.com/dotnet/fsharp/pull/18202 by mistake by force pushing.


