### PR TITLE
OpenTelemetry instrumentation for xUnit tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,7 @@
     <!-- System.* packages -->
     <!-- If a System.* package is stuck on version 4.3.x, targets .NET Standard 1.x and hasn't been
     updated in years, you most likely DON'T need it, please exercise caution when adding it to the list. -->
-    <SystemPackageVersionVersion>8.0.0</SystemPackageVersionVersion>
+    <SystemPackageVersionVersion>9.0.0</SystemPackageVersionVersion>
     <SystemBuffersVersion>4.6.0</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>$(SystemPackageVersionVersion)</SystemCollectionsImmutableVersion>
     <SystemComponentModelCompositionVersion>$(SystemPackageVersionVersion)</SystemComponentModelCompositionVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,7 @@
     <!-- System.* packages -->
     <!-- If a System.* package is stuck on version 4.3.x, targets .NET Standard 1.x and hasn't been
     updated in years, you most likely DON'T need it, please exercise caution when adding it to the list. -->
-    <SystemPackageVersionVersion>9.0.0</SystemPackageVersionVersion>
+    <SystemPackageVersionVersion>8.0.0</SystemPackageVersionVersion>
     <SystemBuffersVersion>4.6.0</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>$(SystemPackageVersionVersion)</SystemCollectionsImmutableVersion>
     <SystemComponentModelCompositionVersion>$(SystemPackageVersionVersion)</SystemComponentModelCompositionVersion>

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/CommonWorkflows.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/CommonWorkflows.fs
@@ -143,14 +143,6 @@ let ``Using getSource and notifications instead of filesystem`` () =
 
 [<Fact>]
 let GetAllUsesOfAllSymbols() =
-    let traceProvider =
-        Sdk.CreateTracerProviderBuilder()
-                .AddSource("fsc")
-                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName="F#", serviceVersion = "1"))
-                .AddJaegerExporter()
-                .Build()
-
-    use _ = Activity.start "GetAllUsesOfAllSymbols" [  ]
 
     let result =
         async {
@@ -161,9 +153,6 @@ let GetAllUsesOfAllSymbols() =
             let! checkProjectResults = checker.ParseAndCheckProject(options)
             return checkProjectResults.GetAllUsesOfAllSymbols()
         } |> Async.RunSynchronously
-
-    traceProvider.ForceFlush() |> ignore
-    traceProvider.Dispose()
 
     if result.Length <> 79 then failwith $"Expected 81 symbolUses, got {result.Length}:\n%A{result}"
 

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/TransparentCompiler.fs
@@ -556,13 +556,6 @@ let fuzzingTest seed (project: SyntheticProject) = task {
             do! Task.Delay (rng.Next maxCheckingDelayMs)
     }
 
-    use _tracerProvider =
-        Sdk.CreateTracerProviderBuilder()
-            .AddSource("fsc")
-            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName="F# Fuzzing", serviceVersion = "1"))
-            .AddJaegerExporter()
-            .Build()
-
     use _ = Activity.start $"Fuzzing {project.Name}" [ Activity.Tags.project, project.Name; "seed", seed.ToString() ]
 
     do! task {

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -108,7 +108,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
     <PackageReference Include="Microsoft.NETCore.App.Ref" Version="6.0.0" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -98,7 +98,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <!--<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />-->
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -108,7 +108,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
     <PackageReference Include="Microsoft.NETCore.App.Ref" Version="6.0.0" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
 	  <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -98,7 +98,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" GeneratePathProperty="true" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
+    <!--<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />-->
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/FSharp.Test.Utilities/ProjectGeneration.fs
+++ b/tests/FSharp.Test.Utilities/ProjectGeneration.fs
@@ -961,7 +961,6 @@ type ProjectWorkflowBuilder
 
     let mutable latestProject = initialProject
     let mutable activity = None
-    let mutable tracerProvider = None
 
     let getSource f = f |> getSourceText latestProject :> ISourceText |> Some |> async.Return
 
@@ -1010,13 +1009,6 @@ type ProjectWorkflowBuilder
 
     member this.Yield _ = async {
         let! ctx = getInitialContext()
-        tracerProvider <-
-            Sdk.CreateTracerProviderBuilder()
-                .AddSource("fsc")
-                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName="F#", serviceVersion = "1"))
-                .AddJaegerExporter()
-                .Build()
-            |> Some
         activity <- Activity.start ctx.Project.Name [ Activity.Tags.project, ctx.Project.Name; "UsingTransparentCompiler", useTransparentCompiler.ToString() ] |> Some
         return ctx
     }
@@ -1032,9 +1024,6 @@ type ProjectWorkflowBuilder
             if initialContext.IsNone && not isExistingProject then
                 this.DeleteProjectDir()
             activity |> Option.iter (fun x -> if not (isNull x) then x.Dispose())
-            tracerProvider |> Option.iter (fun x ->
-                x.ForceFlush() |> ignore
-                x.Dispose())
 
     member this.Run(workflow: Async<WorkflowContext>) =
         if autoStart then

--- a/tests/FSharp.Test.Utilities/XunitHelpers.fs
+++ b/tests/FSharp.Test.Utilities/XunitHelpers.fs
@@ -146,19 +146,24 @@ type FSharpXunitFramework(sink: IMessageSink) =
         log "FSharpXunitFramework with XUNIT_EXTRAS installing TestConsole redirection"
         TestConsole.install()
 
+// TODO: Currently does not work with Desktop .NET Framework. Upcoming OpenTelemetry 1.11.0 may change it.
+#if NETCOREAPP
     let traceProvider =
         Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivityNames.FscSourceName)
                 .SetResourceBuilder(
                     ResourceBuilder.CreateDefault().AddService(serviceName="F#", serviceVersion = "1.0.0"))
                 .AddOtlpExporter()
-                .Build() 
+                .Build()
+#endif
 
     interface IDisposable with
         member _.Dispose() =
             cleanUpTemporaryDirectoryOfThisTestRun ()
+#if NETCOREAPP
             traceProvider.ForceFlush() |> ignore
             traceProvider.Dispose()
+#endif
             base.Dispose()        
 
     override this.CreateDiscoverer (assemblyInfo) =

--- a/tests/FSharp.Test.Utilities/XunitHelpers.fs
+++ b/tests/FSharp.Test.Utilities/XunitHelpers.fs
@@ -10,6 +10,13 @@ open Xunit.Abstractions
 
 open TestFramework
 
+open FSharp.Compiler.Diagnostics
+
+open OpenTelemetry
+open OpenTelemetry.Resources
+open OpenTelemetry.Trace
+open FSharp.Compiler.Diagnostics
+
 /// Disables custom internal parallelization added with XUNIT_EXTRAS.
 /// Execute test cases in a class or a module one by one instead of all at once. Allow other collections to run simultaneously.
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Method, AllowMultiple = false)>]
@@ -45,6 +52,7 @@ type ConsoleCapturingTestRunner(test, messageBus, testClass, constructorArgument
     override this.InvokeTestAsync (aggregator: ExceptionAggregator) =
         task {
             use capture = new TestConsole.ExecutionCapture()
+            use _ = Activity.start test.DisplayName [  ]
             let! executionTime = this.BaseInvokeTestMethodAsync aggregator
             let output =
                 seq {
@@ -139,9 +147,19 @@ type FSharpXunitFramework(sink: IMessageSink) =
         log "FSharpXunitFramework with XUNIT_EXTRAS installing TestConsole redirection"
         TestConsole.install()
 
+    let traceProvider =
+        Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivityNames.FscSourceName)
+                .SetResourceBuilder(
+                    ResourceBuilder.CreateDefault().AddService(serviceName="F#", serviceVersion = "1.0.0"))
+                .AddOtlpExporter()
+                .Build() 
+
     interface IDisposable with
         member _.Dispose() =
             cleanUpTemporaryDirectoryOfThisTestRun ()
+            traceProvider.ForceFlush() |> ignore
+            traceProvider.Dispose()
             base.Dispose()        
 
     override this.CreateDiscoverer (assemblyInfo) =

--- a/tests/FSharp.Test.Utilities/XunitHelpers.fs
+++ b/tests/FSharp.Test.Utilities/XunitHelpers.fs
@@ -15,7 +15,6 @@ open FSharp.Compiler.Diagnostics
 open OpenTelemetry
 open OpenTelemetry.Resources
 open OpenTelemetry.Trace
-open FSharp.Compiler.Diagnostics
 
 /// Disables custom internal parallelization added with XUNIT_EXTRAS.
 /// Execute test cases in a class or a module one by one instead of all at once. Allow other collections to run simultaneously.


### PR DESCRIPTION
Some tests were already instrumented ad-hoc.
This applies the instrumentation to the whole test assembly instead, so no additional work is needed to capture any test case.
Also replace deprecated Jaeger package.
It seems to work locally, at least with the net9.0 target.
Traces can be inspected in Jager all-in-one. If nothing interesting is produced, at least the test case name and duration is captured.