### PR TITLE
Simplify Dependencies a tad

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,7 +193,6 @@
     <XUnitVersion>2.9.0</XUnitVersion>
     <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>
     <XunitXmlTestLoggerVersion>3.1.17</XunitXmlTestLoggerVersion>
-    <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <HumanizerCoreVersion>2.2.0</HumanizerCoreVersion>
     <!-- -->
     <!-- MIBC profile packages -->

--- a/tests/FSharp.Compiler.Service.Tests/FsiTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/FsiTests.fs
@@ -2,7 +2,6 @@
 
 open System
 open System.IO
-open FluentAssertions
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Test
 open Xunit
@@ -575,7 +574,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", arr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<int[]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(arr, "") |> ignore
+        Assert.shouldBe arr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is an array of a built-in reference type``() =
@@ -584,7 +583,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", arr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<string[]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(arr, "") |> ignore
+        Assert.shouldBe arr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is an array of a custom value type``() =
@@ -593,7 +592,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", arr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<CustomStruct[]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(arr, "") |> ignore
+        Assert.shouldBe arr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is an array of a custom reference type``() =
@@ -602,7 +601,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", arr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<CustomType2[]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(arr, "") |> ignore
+        Assert.shouldBe arr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is a multidimensional array of a built-in value type``() =
@@ -611,7 +610,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", mdArr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<int[,]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(mdArr, "") |> ignore
+        Assert.shouldBe mdArr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is a multidimensional array of a built-in reference type``() =
@@ -620,7 +619,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", mdArr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<string[,]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(mdArr, "") |> ignore
+        Assert.shouldBe mdArr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is a multidimensional array of a custom value type``() =
@@ -629,7 +628,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", mdArr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<CustomStruct[,]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(mdArr, "") |> ignore
+        Assert.shouldBe mdArr boundValue.Value.ReflectionValue
 
     [<Fact>]
     let ``Creation of a bound value succeeds if the value is a multidimensional array of a custom reference type``() =
@@ -638,7 +637,7 @@ module FsiTests =
         fsiSession.AddBoundValue("boundMdArray", mdArr)
         let boundValue = fsiSession.GetBoundValues() |> List.exactlyOne
         Assert.shouldBe typeof<CustomType2[,]> boundValue.Value.ReflectionType
-        boundValue.Value.ReflectionValue.Should().Be(mdArr, "") |> ignore
+        Assert.shouldBe mdArr boundValue.Value.ReflectionValue
 
     [<TheoryForNETCOREAPP>]
     [<InlineData(true)>]

--- a/tests/FSharp.Compiler.Service.Tests/ManglingNameOfProvidedTypes.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ManglingNameOfProvidedTypes.fs
@@ -32,13 +32,13 @@ type ManglingNamesOfProvidedTypesWithSingleParameter() =
     member this.DemangleDefaultValue() = 
         let name, parameters = PrettyNaming.DemangleProvidedTypeName "MyNamespace.Test,"
         Assert.shouldBe "MyNamespace.Test" name
-        Assert.shouldBeEquivalentTo [||] parameters
+        Assert.shouldBeEmpty parameters
 
     [<Fact>]
     member this.DemangleNewDefaultValue() = 
         let name, parameters = PrettyNaming.DemangleProvidedTypeName "MyNamespace.Test"
         Assert.shouldBe "MyNamespace.Test" name
-        Assert.shouldBeEquivalentTo [||] parameters
+        Assert.shouldBeEmpty parameters
 
 
 type ManglingNamesOfProvidedTypesWithMultipleParameter() = 

--- a/tests/FSharp.Compiler.Service.Tests/SuggestionBuffer.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SuggestionBuffer.fs
@@ -41,7 +41,7 @@ module SuggestionBuffer =
         let results = Array.ofSeq buffer
 
         Assert.shouldBeTrue buffer.Disabled
-        Assert.shouldBeEquivalentTo [||] results
+        Assert.shouldBeEmpty results
 
     [<Fact>]
     let BufferShouldOnlyTakeTop5Elements() =

--- a/tests/FSharp.Test.Utilities/Assert.fs
+++ b/tests/FSharp.Test.Utilities/Assert.fs
@@ -1,49 +1,48 @@
 namespace FSharp.Test
 
 module Assert =
-    open FluentAssertions
     open System.Collections
     open Xunit
     open System.IO
 
+    // Equivalent, with message
     let inline shouldBeEqualWith (expected : ^T) (message: string) (actual: ^U) =
-        actual.Should().BeEquivalentTo(expected, message) |> ignore
+        try
+            Assert.Equivalent(expected, actual)
+        with e ->
+            Assert.True(false, message);
 
     let inline shouldBeEquivalentTo (expected : ^T) (actual : ^U) =
-        actual.Should().BeEquivalentTo(expected, "") |> ignore
-        
-    let inline shouldStartWith (expected : string) (actual : string) =
-        actual.Should().StartWith(expected) |> ignore
-        
-    let inline shouldContain (needle : string) (haystack : string) =
-        haystack.Should().Contain(needle) |> ignore    
+        Assert.Equivalent(expected, actual)
 
-    // One fine day, all of the 3 things below should be purged and replaced with pure Assert.Equal.
-    // Xunit checks types by default. These are just artifacts of the testing chaos in the repo back in a day.
     let inline shouldBe (expected : ^T) (actual : ^U) =
-        actual.Should().Be(expected, "") |> ignore
+        Assert.Equal(expected :> obj, actual :> obj)
+
+    let inline shouldStartWith (expected : string) (actual : string) =
+        Assert.StartsWith(expected, actual)
+
+    let inline shouldContain (needle : string) (haystack : string) =
+        Assert.Contains(needle, haystack)
 
     let inline areEqual (expected: ^T) (actual: ^T) =
         Assert.Equal<^T>(expected, actual)
 
     let inline shouldEqual (x: 'a) (y: 'a) =
         Assert.Equal<'a>(x, y)
-    //
 
     let inline shouldBeEmpty (actual : ^T when ^T :> IEnumerable) =
-        actual.Should().BeEmpty("") |> ignore
+        Assert.Empty(actual)
 
     let inline shouldNotBeEmpty (actual : ^T when ^T :> IEnumerable) =
-        actual.Should().NotBeEmpty("") |> ignore
+        Assert.NotEmpty(actual)
 
     let shouldBeFalse (actual: bool) =
-        actual.Should().BeFalse("") |> ignore
+        Assert.False(actual)
 
     let shouldBeTrue (actual: bool) =
-        actual.Should().BeTrue("") |> ignore
+        Assert.True(actual)
 
-    let shouldBeSameMultilineStringSets expectedText actualText =      
-      
+    let shouldBeSameMultilineStringSets expectedText actualText =
         let getLines text =
             use reader = new StringReader(text)
             Seq.initInfinite (fun _ -> reader.ReadLine()) 

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -73,7 +73,6 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
   <!-- Runtime dependencies. Beware. -->
@@ -83,14 +82,12 @@
   </ItemGroup>
 
     <ItemGroup>
-
-	    <InternalsVisibleTo Include="VisualFSharp.UnitTests" />
-	    <InternalsVisibleTo Include="FSharp.Compiler.ComponentTests" />
-	    <InternalsVisibleTo Include="FSharp.Compiler.Service.Tests" />
-	    <InternalsVisibleTo Include="FSharp.Tests.FSharpSuite" />
-	    <InternalsVisibleTo Include="LanguageServiceProfiling" />
-	    <InternalsVisibleTo Include="FSharp.Compiler.Benchmarks" />
-
+      <InternalsVisibleTo Include="VisualFSharp.UnitTests" />
+      <InternalsVisibleTo Include="FSharp.Compiler.ComponentTests" />
+      <InternalsVisibleTo Include="FSharp.Compiler.Service.Tests" />
+      <InternalsVisibleTo Include="FSharp.Tests.FSharpSuite" />
+      <InternalsVisibleTo Include="LanguageServiceProfiling" />
+      <InternalsVisibleTo Include="FSharp.Compiler.Benchmarks" />
     </ItemGroup>
 
   <ItemGroup>

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,12 +19,11 @@
 
 ## Framework for testing
 
-The following test frameworks and libraries will be used for new test projects **[xUnit Test Framework](https://xunit.net/), [FluentAssertions](https://fluentassertions.com/) (+ [FsUnit](https://fsprojects.github.io/FsUnit/) and [FsCheck](https://github.com/fscheck/FsCheck) when needed)**.
+The following test frameworks and libraries will be used for new test projects **[xUnit Test Framework](https://xunit.net/) and [FsCheck](https://github.com/fscheck/FsCheck) when needed)**.
 
 **Justification:**
 
 * **xUnit** is an extensible, TDD adherent, testing framework, which was successfully adopted by many .NET engineering teams, including Roslyn, AspNetCore, EFcore, etc, has a "cleaner" approach for writing test suites (i.e. class constructor for setup, implementing IDisposable for teardown, as oppose to custom attributes). More info [here](https://xunit.net/docs/comparisons).
-* **FluentAssertions** makes it easier to write scoped assertions, provides better error messages.
 
 **Alternatives:** NUnit, MSBuild, Expecto
 

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
@@ -112,4 +112,4 @@ let cc = a.Normal "hmm"
 
     let actual = getAllHints document
 
-    actual |> Assert.shouldBe expected
+    actual |> Assert.shouldBeEquivalentTo expected

--- a/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Hints/OverallHintExperienceTests.fs
@@ -112,4 +112,4 @@ let cc = a.Normal "hmm"
 
     let actual = getAllHints document
 
-    actual |> Assert.shouldBeEquivalentTo expected
+    actual |> Assert.shouldBe expected


### PR DESCRIPTION
The test framework had a dependency on the FluentAssertions package, we barely used it.  So this PR eliminates the use of it.


/cc @vzarytovskii , @T-Gro 