### PR TITLE
Add GH action to manage servicing branch codeflow.

### DIFF
--- a/.config/feature-branch-merge.json
+++ b/.config/feature-branch-merge.json
@@ -1,0 +1,9 @@
+{
+    "merge-flow-configurations": {
+        // feature branches
+        "main": {
+            "MergeToBranch": "feature/lsp",
+            "ExtraSwitches": "-QuietComments"
+        }
+    }
+}

--- a/.config/feature-lsp-branch-merge.json
+++ b/.config/feature-lsp-branch-merge.json
@@ -1,6 +1,5 @@
 {
     "merge-flow-configurations": {
-        // feature branches
         "main": {
             "MergeToBranch": "feature/lsp",
             "ExtraSwitches": "-QuietComments"

--- a/.config/service-branch-merge.json
+++ b/.config/service-branch-merge.json
@@ -1,6 +1,6 @@
 {
     "merge-flow-configurations": {
-        // regular branch flow -->
+        // regular branch flow
         "release/dev17.13": {
             "MergeToBranch": "main",
             "ExtraSwitches": "-QuietComments"

--- a/.config/service-branch-merge.json
+++ b/.config/service-branch-merge.json
@@ -1,0 +1,13 @@
+{
+    "merge-flow-configurations": {
+        // regular branch flow -->
+        "release/dev17.13": {
+            "MergeToBranch": "main",
+            "ExtraSwitches": "-QuietComments"
+        },
+        "main": {
+            "MergeToBranch": "release/dev17.14",
+            "ExtraSwitches": "-QuietComments"
+        }
+    }
+}

--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -1,0 +1,22 @@
+# Merges any changes from servicing branches forward.
+
+name: Flow release/prerelease changes to main
+on:
+  push:
+   branches:
+     - 'release/*'
+     - 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  servicing-flow:
+    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
+    with:
+      configuration_file_path: '.config/service-branch-merge.json'
+  feature-flow:
+    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
+    with:
+      configuration_file_path: '.config/feature-branch-merge.json'

--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -16,7 +16,7 @@ jobs:
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
       configuration_file_path: '.config/service-branch-merge.json'
-  feature-flow:
+  feature-lsp-flow:
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
-      configuration_file_path: '.config/feature-branch-merge.json'
+      configuration_file_path: '.config/feature-lsp-branch-merge.json'

--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -1,6 +1,6 @@
 # Merges any changes from servicing branches forward.
 
-name: Flow release/prerelease changes to main
+name: Flow servicing changes to main
 on:
   push:
    branches:


### PR DESCRIPTION
The Roslyn team is looking to retire their GH codeflow pipeline. This PR moves [your configuration](https://github.com/dotnet/roslyn-tools/blob/9484603dc5a76b7d285399536ed8c83e0199cba1/src/GitHubCreateMergePRs/config.xml#L37-L43) over to the Arcade [inter branch merge approach](https://github.com/dotnet/arcade/blob/main/Documentation/Maestro/New-Inter-Branch-Merge-Approach.md). There are differences between the two system as the Arcade configuration does not support merging a branch into multiple upstreams. I have compensated for this by having multiple configurations and separate jobs for each.

