### PR TITLE
Tests: Fix flaky `AssemblyVersion` tests

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -243,6 +243,16 @@ or
 > Please note, that by default, **Release** version of IL baseline tests will be running in CI, so when updating baseline (.bsl) files, make sure to add `-c Release` flag to the build command.
 
 
+### Parallel execution of tests
+
+Tests utilizing xUnit framework by default run in parallel. If your tests depend on some shared state or are time-critical, you can add the module to predefined `NotThreadSafeResourceCollection` to prevent parallel execution.
+For example:
+```fsharp
+[<Collection(nameof NotThreadSafeResourceCollection)>]
+module TimeCritical =
+```
+
+
 ### Updating FCS surface area baselines
 
 ```bash

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -34,21 +34,23 @@ module CustomAttributes_AttributeUsage =
         |> verifyCompileAndRun
         |> shouldSucceed
 
-    // SOURCE=AssemblyVersion03.fs                          # AssemblyVersion03.fs
-    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyVersion03.fs"|])>]
-    let ``AssemblyVersion03_fs`` compilation =
-        compilation
-        |> withOptions ["--nowarn:52"]
-        |> verifyCompileAndRun
-        |> shouldSucceed
+    [<Collection(nameof NotThreadSafeResourceCollection)>]
+    module TimeCritical =
+        // SOURCE=AssemblyVersion03.fs                          # AssemblyVersion03.fs
+        [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyVersion03.fs"|])>]
+        let ``AssemblyVersion03_fs`` compilation =
+            compilation
+            |> withOptions ["--nowarn:52"]
+            |> verifyCompileAndRun
+            |> shouldSucceed
 
-    // SOURCE=AssemblyVersion04.fs							# AssemblyVersion04.fs
-    [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyVersion04.fs"|])>]
-    let ``AssemblyVersion04_fs`` compilation =
-        compilation
-        |> withOptions ["--nowarn:52"]
-        |> verifyCompileAndRun
-        |> shouldSucceed
+        // SOURCE=AssemblyVersion04.fs							# AssemblyVersion04.fs
+        [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AssemblyVersion04.fs"|])>]
+        let ``AssemblyVersion04_fs`` compilation =
+            compilation
+            |> withOptions ["--nowarn:52"]
+            |> verifyCompileAndRun
+            |> shouldSucceed
 
     // SOURCE=AttributeTargetsIsCtor01.fs				# AttributeTargetsIsCtor01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"AttributeTargetsIsCtor01.fs"|])>]


### PR DESCRIPTION
These tests depend on a 30 sec time window, which apparently is too tight for parallel test execution.

The fix adds the two tests to `NotThreadSafeResourceCollection`, so they run separately and sequentially.

I also added a mention about parallelism in xUnit tests in the DEVGUIDE.