### PR TITLE
Replace internal option–voption conversions with FSharp.Core funcs

### DIFF
--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -229,11 +229,6 @@ type TcInfoExtras =
     member x.TcSymbolUses =
         x.tcSymbolUses
 
-module ValueOption =
-    let toOption = function
-        | ValueSome x -> Some x
-        | _ -> None
-
 type private SingleFileDiagnostics = (PhasedDiagnostic * FSharpDiagnosticSeverity) array
 type private TypeCheck = TcInfo * TcResultsSinkImpl * CheckedImplFile option * string * SingleFileDiagnostics
 

--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -2122,7 +2122,7 @@ type ModuleOrNamespaceType(kind: ModuleOrNamespaceKind, vals: QueueList<Val>, en
           |> List.tryFind (fun v -> match key.TypeForLinkage with 
                                     | None -> true
                                     | Some keyTy -> ccu.MemberSignatureEquality(keyTy, v.Type))
-          |> ValueOptionInternal.ofOption
+          |> ValueOption.ofOption
 
     /// Get a table of values indexed by logical name
     member _.AllValsByLogicalName = 
@@ -4237,7 +4237,7 @@ type UnionCaseRef =
     /// Try to dereference the reference 
     member x.TryUnionCase =
         x.TyconRef.TryDeref 
-        |> ValueOptionInternal.bind (fun tcref -> tcref.GetUnionCaseByName x.CaseName |> ValueOptionInternal.ofOption)
+        |> ValueOption.bind (fun tcref -> tcref.GetUnionCaseByName x.CaseName |> ValueOption.ofOption)
 
     /// Get the attributes associated with the union case
     member x.Attribs = x.UnionCase.Attribs
@@ -4300,7 +4300,7 @@ type RecdFieldRef =
     /// Try to dereference the reference 
     member x.TryRecdField = 
         x.TyconRef.TryDeref 
-        |> ValueOptionInternal.bind (fun tcref -> tcref.GetFieldByName x.FieldName |> ValueOptionInternal.ofOption)
+        |> ValueOption.bind (fun tcref -> tcref.GetFieldByName x.FieldName |> ValueOption.ofOption)
 
     /// Get the attributes associated with the compiled property of the record field 
     member x.PropertyAttribs = x.RecdField.PropertyAttribs

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -3526,11 +3526,11 @@ let IsMatchingFSharpAttributeOpt g attrOpt (Attrib(tcref2, _, _, _, _, _, _)) = 
 
 [<return: Struct>]
 let (|ExtractAttribNamedArg|_|) nm args = 
-    args |> List.tryPick (function AttribNamedArg(nm2, _, _, v) when nm = nm2 -> Some v | _ -> None) |> ValueOptionInternal.ofOption
-    
+    args |> List.tryPick (function AttribNamedArg(nm2, _, _, v) when nm = nm2 -> Some v | _ -> None) |> ValueOption.ofOption
+
 [<return: Struct>]
 let (|ExtractILAttributeNamedArg|_|) nm (args: ILAttributeNamedArg list) = 
-    args |> List.tryPick (function nm2, _, _, v when nm = nm2 -> Some v | _ -> None) |> ValueOptionInternal.ofOption
+    args |> List.tryPick (function nm2, _, _, v when nm = nm2 -> Some v | _ -> None) |> ValueOption.ofOption
 
 [<return: Struct>]
 let (|StringExpr|_|) = function Expr.Const (Const.String n, _, _) -> ValueSome n | _ -> ValueNone

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -715,18 +715,6 @@ module Span =
 
         state
 
-module ValueOptionInternal =
-
-    let inline ofOption x =
-        match x with
-        | Some x -> ValueSome x
-        | None -> ValueNone
-
-    let inline bind ([<InlineIfLambda>] f) x =
-        match x with
-        | ValueSome x -> f x
-        | ValueNone -> ValueNone
-
 module String =
     let make (n: int) (c: char) : string = String(c, n)
 

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -243,12 +243,6 @@ module internal ResizeArray =
 module internal Span =
     val inline exists: predicate: ('T -> bool) -> span: Span<'T> -> bool
 
-module internal ValueOptionInternal =
-
-    val inline ofOption: x: 'a option -> 'a voption
-
-    val inline bind: f: ('a -> 'b voption) -> x: 'a voption -> 'b voption
-
 module internal String =
 
     val make: n: int -> c: char -> string

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -328,19 +328,6 @@ module Option =
             None
 
 [<RequireQualifiedAccess>]
-module ValueOption =
-
-    let inline ofOption o =
-        match o with
-        | Some v -> ValueSome v
-        | _ -> ValueNone
-
-    let inline toOption o =
-        match o with
-        | ValueSome v -> Some v
-        | _ -> None
-
-[<RequireQualifiedAccess>]
 module IEnumerator =
     let chooseV f (e: IEnumerator<'T>) =
         let mutable started = false

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/CodeFixTestFramework.fs
@@ -33,16 +33,6 @@ type Mode =
     | WithSettings of CodeFixesOptions
 
 module ValueOption =
-    let inline toOption o =
-        match o with
-        | ValueSome v -> Some v
-        | _ -> None
-
-    let inline ofOption o =
-        match o with
-        | Some v -> ValueSome v
-        | _ -> ValueNone
-
     let inline either f y o =
         match o with
         | ValueSome v -> f v


### PR DESCRIPTION
## Description

Reprise of #17457, now that FSharp.Core 9 has shipped.

- Remove internal option–voption conversion functions in this repo and replace their usage with the FSharp.Core ones added in #17436.

Resolves #17460.

## Checklist

- These changes are internal only, so release notes shouldn't be needed.