### PR TITLE
Add reminder to check `/.dotnet` dir when tests fail to find SDK

### DIFF
--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -239,7 +239,7 @@ let main argv = 0"""
 Project directory: %s{projectDirectory}
 STDOUT: %s{output}
 STDERR: %s{errors}
-An error occurred getting netcoreapp references: %A{e}
+An error occurred getting netcoreapp references (compare the output of `dotnet --list-sdks` and/or the contents of the local `/.dotnet` directory against what is in `global.json`): %A{e}
 """
                     raise (Exception (message, e))
             finally


### PR DESCRIPTION
## Description

- This augments #16324 with a reminder to compare the output of `dotnet --list-sdks` and/or the contents of the temporary `/.dotnet` directory against `global.json`.

  The exception from #16324 can be thrown when you have a stale local version of the SDK in the local `/.dotnet` directory, but you _do_ have a version of the SDK installed globally that matches `global.json`. Doing a restore doesn't help, because it won't replace the contents of `/.dotnet`, because you already have the version requested in `global.json` installed globally. This can be super confusing, and it happens seldom enough that I never remember that all I need to do is delete the stale `/.dotnet` directory. I know some people just reflexively do `git clean -xdf` all the time, but not everyone always has the patience and a fast enough computer and/or network connection to do a clean build every time :)

## Checklist

No release notes necessary.