### PR TITLE
Cancellable: only cancel on OCE with own token

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -2,6 +2,7 @@
 * Fix Realsig+ generates nested closures with incorrect Generic  ([Issue #17797](https://github.com/dotnet/fsharp/issues/17797), [PR #17877](https://github.com/dotnet/fsharp/pull/17877))
 * Fix internal error when missing measure attribute in an unsolved measure typar. ([Issue #7491](https://github.com/dotnet/fsharp/issues/7491), [PR #18234](https://github.com/dotnet/fsharp/pull/18234)==
 * Set `Cancellable.token` from async computation ([Issue #18235](https://github.com/dotnet/fsharp/issues/18235), [PR #18238](https://github.com/dotnet/fsharp/pull/18238))
+* Cancellable: only cancel on OCE with own token ([PR #18277](https://github.com/dotnet/fsharp/pull/18277))
 
 ### Added
 * Added missing type constraints in FCS. ([PR #18241](https://github.com/dotnet/fsharp/pull/18241))

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5479,7 +5479,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
 and [<TailCall>] TcModuleOrNamespaceElementsNonMutRec cenv parent typeNames endm (defsSoFar, env, envAtEnd) (moreDefs: SynModuleDecl list) (ct: CancellationToken) =
 
     if ct.IsCancellationRequested then
-        ValueOrCancelled.Cancelled (OperationCanceledException())
+        ValueOrCancelled.Cancelled(OperationCanceledException ct)
     else
         match moreDefs with
         | [] ->

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -69,10 +69,8 @@ module Cancellable =
                 use _ = Cancellable.UsingToken(ct)
                 oper ct
             with
-                | :? OperationCanceledException as e when e.CancellationToken = ct ->
-                    ValueOrCancelled.Cancelled e
-                | :? OperationCanceledException as e ->
-                    InvalidOperationException("Wrong cancellation token", e) |> raise
+            | :? OperationCanceledException as e when e.CancellationToken = ct -> ValueOrCancelled.Cancelled e
+            | :? OperationCanceledException as e -> InvalidOperationException("Wrong cancellation token", e) |> raise
 
     let fold f acc seq =
         Cancellable(fun ct ->

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -68,8 +68,11 @@ module Cancellable =
             try
                 use _ = Cancellable.UsingToken(ct)
                 oper ct
-            with :? OperationCanceledException as e ->
-                ValueOrCancelled.Cancelled(OperationCanceledException e.CancellationToken)
+            with
+                | :? OperationCanceledException as e when e.CancellationToken = ct ->
+                    ValueOrCancelled.Cancelled e
+                | :? OperationCanceledException as e ->
+                    InvalidOperationException("Wrong cancellation token", e) |> raise
 
     let fold f acc seq =
         Cancellable(fun ct ->

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -69,7 +69,7 @@ module Cancellable =
                 use _ = Cancellable.UsingToken(ct)
                 oper ct
             with
-            | :? OperationCanceledException as e when e.CancellationToken = ct -> ValueOrCancelled.Cancelled e
+            | :? OperationCanceledException as e when ct.IsCancellationRequested -> ValueOrCancelled.Cancelled e
             | :? OperationCanceledException as e -> InvalidOperationException("Wrong cancellation token", e) |> raise
 
     let fold f acc seq =


### PR DESCRIPTION
I think `Cancellable` should only cancel when getting an `OCE` with its own cancellation token. When another token is encountered in such exception, it probably means something is not right.