### PR TITLE
Remove redundant ifdef

### DIFF
--- a/src/Compiler/TypedTree/TypeProviders.fs
+++ b/src/Compiler/TypedTree/TypeProviders.fs
@@ -122,7 +122,6 @@ let CreateTypeProvider (
 
         // Create the TypeProviderConfig to pass to the type provider constructor
         let e =
-#if FSHARPCORE_USE_PACKAGE
             TypeProviderConfig(systemRuntimeContainsType,
                 ReferencedAssemblies=getReferencedAssemblies(),
                 ResolutionFolder=resolutionEnvironment.ResolutionFolder, 
@@ -131,16 +130,7 @@ let CreateTypeProvider (
                 IsInvalidationSupported=isInvalidationSupported, 
                 IsHostedExecution= isInteractive, 
                 SystemRuntimeAssemblyVersion = systemRuntimeAssemblyVersion)
-#else
-            TypeProviderConfig(systemRuntimeContainsType,
-                ReferencedAssemblies=getReferencedAssemblies(),
-                ResolutionFolder=resolutionEnvironment.ResolutionFolder, 
-                RuntimeAssembly=runtimeAssemblyPath, 
-                TemporaryFolder=resolutionEnvironment.TemporaryFolder, 
-                IsInvalidationSupported=isInvalidationSupported, 
-                IsHostedExecution= isInteractive, 
-                SystemRuntimeAssemblyVersion = systemRuntimeAssemblyVersion)
-#endif
+
         protect (fun () -> !!(Activator.CreateInstance(typeProviderImplementationType, [| box e|])) :?> ITypeProvider )
 
     elif not(isNull(typeProviderImplementationType.GetConstructor [| |])) then 


### PR DESCRIPTION
Looks like the code in both `#if` branches is exactly the same:
https://github.com/dotnet/fsharp/blob/2edab1216843f20a00a7d8f171aca52cbc35d7fd/src/Compiler/TypedTree/TypeProviders.fs#L125-L143