### PR TITLE
Cancellable: built-in stack guard

### DIFF
--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2327,6 +2327,7 @@ and [<Sealed>] TcImports
         async {
             CheckDisposed()
 
+            use! _holder = Cancellable.UseToken()
 
             let tcConfig = tcConfigP.Get ctok
 

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2255,7 +2255,7 @@ and [<Sealed>] TcImports
             r: AssemblyResolution
         ) : Async<(_ * (unit -> AvailableImportedAssembly list)) option> =
         async {
-            do! Cancellable.UseToken()
+            use! _holder = Cancellable.UseToken()
             CheckDisposed()
             let m = r.originalReference.Range
             let fileName = r.resolvedPath

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -891,7 +891,6 @@ type StackGuard(maxDepth: int, name: string) =
 
         try
             if depth % maxDepth = 0 then
-
                 async {
                     do! Async.SwitchToNewThread()
                     Thread.CurrentThread.Name <- $"F# Extra Compilation Thread for {name} (depth {depth})"
@@ -902,10 +901,6 @@ type StackGuard(maxDepth: int, name: string) =
                 f ()
         finally
             depth <- depth - 1
-
-    [<DebuggerHidden; DebuggerStepThrough>]
-    member x.GuardCancellable(original: Cancellable<'T>) =
-        Cancellable(fun ct -> x.Guard(fun () -> Cancellable.run ct original))
 
     static member val DefaultDepth =
 #if DEBUG

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -462,8 +462,6 @@ type StackGuard =
         [<CallerLineNumber; Optional; DefaultParameterValue(0)>] line: int ->
             'T
 
-    member GuardCancellable: Internal.Utilities.Library.Cancellable<'T> -> Internal.Utilities.Library.Cancellable<'T>
-
     static member GetDepthOption: string -> int
 
 /// This represents the global state established as each task function runs as part of the build.

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -73,13 +73,11 @@ module Cancellable =
 
     let runWithStackGuard (ct, depth) oper =
         if depth % maxDepth = 0 then
-            Async.RunSynchronously(
-                async {
-                    do! Async.SwitchToNewThread()
-                    return run (ct, depth + 1) oper
-                },
-                cancellationToken = ct
-            )
+            async {
+                do! Async.SwitchToNewThread()
+                return run (ct, depth + 1) oper
+            }
+            |> Async.RunSynchronously
         else
             run (ct, depth + 1) oper
 

--- a/src/Compiler/Utilities/Cancellable.fs
+++ b/src/Compiler/Utilities/Cancellable.fs
@@ -130,7 +130,7 @@ type CancellableBuilder() =
 
             __debugPoint ""
 
-            match Cancellable.run state comp with
+            match Cancellable.runWithStackGuard state comp with
             | ValueOrCancelled.Value v1 -> Cancellable.run state (k v1)
             | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
 
@@ -139,7 +139,7 @@ type CancellableBuilder() =
 
             __debugPoint ""
 
-            match Cancellable.run state comp with
+            match Cancellable.runWithStackGuard state comp with
             | ValueOrCancelled.Value v1 -> ValueOrCancelled.Value(k v1)
             | ValueOrCancelled.Cancelled err1 -> ValueOrCancelled.Cancelled err1)
 

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -40,6 +40,8 @@ module internal Cancellable =
     /// Run a cancellable computation using the given cancellation token
     val inline run: CancellationToken * int -> Cancellable<'T> -> ValueOrCancelled<'T>
 
+    val runWithStackGuard: CancellationToken * int -> (Cancellable<'T> -> ValueOrCancelled<'T>)
+
     val fold: f: ('State -> 'T -> Cancellable<'State>) -> acc: 'State -> seq: seq<'T> -> Cancellable<'State>
 
     /// Run the computation in a mode where it may not be cancelled. The computation never results in a

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -5,7 +5,7 @@ open System.Threading
 
 [<Sealed>]
 type Cancellable =
-    static member internal UseToken: unit -> Async<unit>
+    static member internal UseToken: unit -> Async<IDisposable>
 
     /// For use in testing only. Cancellable.token should be set only by the cancellable computation.
     static member internal UsingToken: CancellationToken -> IDisposable
@@ -31,12 +31,12 @@ type internal ValueOrCancelled<'TResult> =
 /// A cancellable computation may be cancelled via a CancellationToken, which is propagated implicitly.
 /// If cancellation occurs, it is propagated as data rather than by raising an OperationCanceledException.
 [<Struct>]
-type internal Cancellable<'T> = Cancellable of (CancellationToken -> ValueOrCancelled<'T>)
+type internal Cancellable<'T> = Cancellable of (CancellationToken * int -> ValueOrCancelled<'T>)
 
 module internal Cancellable =
 
     /// Run a cancellable computation using the given cancellation token
-    val inline run: ct: CancellationToken -> Cancellable<'T> -> ValueOrCancelled<'T>
+    val inline run: CancellationToken * int -> Cancellable<'T> -> ValueOrCancelled<'T>
 
     val fold: f: ('State -> 'T -> Cancellable<'State>) -> acc: 'State -> seq: seq<'T> -> Cancellable<'State>
 

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -35,6 +35,8 @@ type internal Cancellable<'T> = Cancellable of (CancellationToken * int -> Value
 
 module internal Cancellable =
 
+    val maxDepth: int
+
     /// Run a cancellable computation using the given cancellation token
     val inline run: CancellationToken * int -> Cancellable<'T> -> ValueOrCancelled<'T>
 

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -38,9 +38,7 @@ module internal Cancellable =
     val maxDepth: int
 
     /// Run a cancellable computation using the given cancellation token
-    val inline run: CancellationToken * int -> Cancellable<'T> -> ValueOrCancelled<'T>
-
-    val runWithStackGuard: CancellationToken * int -> (Cancellable<'T> -> ValueOrCancelled<'T>)
+    val run: CancellationToken * int -> Cancellable<'T> -> ValueOrCancelled<'T>
 
     val fold: f: ('State -> 'T -> Cancellable<'State>) -> acc: 'State -> seq: seq<'T> -> Cancellable<'State>
 

--- a/src/Compiler/Utilities/Cancellable.fsi
+++ b/src/Compiler/Utilities/Cancellable.fsi
@@ -5,10 +5,8 @@ open System.Threading
 
 [<Sealed>]
 type Cancellable =
+    /// Capture the current cancellation token for use in CheckAndThrow.
     static member internal UseToken: unit -> Async<IDisposable>
-
-    /// For use in testing only. Cancellable.token should be set only by the cancellable computation.
-    static member internal UsingToken: CancellationToken -> IDisposable
 
     static member HasCancellationToken: bool
     static member Token: CancellationToken
@@ -34,8 +32,6 @@ type internal ValueOrCancelled<'TResult> =
 type internal Cancellable<'T> = Cancellable of (CancellationToken * int -> ValueOrCancelled<'T>)
 
 module internal Cancellable =
-
-    val maxDepth: int
 
     /// Run a cancellable computation using the given cancellation token
     val run: CancellationToken * int -> Cancellable<'T> -> ValueOrCancelled<'T>

--- a/tests/FSharp.Compiler.Service.Tests/ModuleReaderCancellationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ModuleReaderCancellationTests.fs
@@ -22,7 +22,6 @@ let mutable private wasCancelled = false
 let runCancelFirstTime f =
     let mutable requestCount = 0
     fun () ->
-        use _ = Cancellable.UsingToken cts.Token
         if requestCount = 0 then
             cts.Cancel()
 
@@ -150,7 +149,6 @@ let referenceReaderProject getPreTypeDefs (cancelOnModuleAccess: bool) (options:
 let parseAndCheck path source options =
     cts <- new CancellationTokenSource()
     wasCancelled <- false
-    use _ = Cancellable.UsingToken cts.Token
 
     try
         match Async.RunSynchronously(checker.ParseAndCheckFileInProject(path, 0, SourceText.ofString source, options), cancellationToken = cts.Token) with


### PR DESCRIPTION
Experimentally moved stack guard functionality into`Cancellable.run` to make recursion in `cancellable` generally safe.

If this works, it would allow to simplify some code in CheckDeclarations.fs.
