### PR TITLE
Bugfix for breaking change when using Option.ofObj :: Type parameter constraint `null` implies `not struct`

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -17,6 +17,7 @@
 * Add support for C# `Experimental` attribute. ([PR #18253](https://github.com/dotnet/fsharp/pull/18253))
 * Nullness warnings are issued for signature<>implementation conformance ([PR #18186](https://github.com/dotnet/fsharp/pull/18186))
 * Symbols: Add FSharpAssembly.IsFSharp ([PR #18290](https://github.com/dotnet/fsharp/pull/18290))
+* Type parameter constraint `null` in generic code will now automatically imply `not struct` ([Issue #18320](https://github.com/dotnet/fsharp/issues/18320), [PR #18323](https://github.com/dotnet/fsharp/pull/18323))
 
 ### Changed
 

--- a/src/Compiler/Checking/ConstraintSolver.fs
+++ b/src/Compiler/Checking/ConstraintSolver.fs
@@ -2478,6 +2478,8 @@ and CheckConstraintImplication (csenv: ConstraintSolverEnv) tpc1 tpc2 =
     | TyparConstraint.SupportsEquality _, TyparConstraint.SupportsEquality _
     // comparison implies equality
     | TyparConstraint.SupportsComparison _, TyparConstraint.SupportsEquality _
+    // 'null' implies reference type ('not struct')
+    | TyparConstraint.SupportsNull _, TyparConstraint.IsReferenceType _
     | TyparConstraint.SupportsNull _, TyparConstraint.SupportsNull _
     | TyparConstraint.NotSupportsNull _, TyparConstraint.NotSupportsNull _
     | TyparConstraint.IsNonNullableStruct _, TyparConstraint.IsNonNullableStruct _

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -5679,6 +5679,7 @@ and GenGenericParam cenv eenv (tp: Typar) =
         tp.Constraints
         |> List.exists (function
             | TyparConstraint.IsReferenceType _
+            // 'null' automatically implies 'not struct'
             | TyparConstraint.SupportsNull _ -> true
             | _ -> false)
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/SupportsNull.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/SupportsNull.fs
@@ -26,6 +26,7 @@ let iAcceptNullWithNullAnnotation(arg: 'a | null when 'a: not struct) =
     else
         0
 
+// This test case emits the `class T` constraint in IL
 let iAcceptNullExplicitAnnotation(arg: 'T when 'T:null) =
     if isNull arg then
         1

--- a/tests/FSharp.Compiler.ComponentTests/Language/Nullness/NullableReferenceTypesTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/Nullness/NullableReferenceTypesTests.fs
@@ -17,6 +17,17 @@ let typeCheckWithStrictNullness cu =
     |> withNullnessOptions
     |> typecheck
 
+
+[<Fact>]
+let ``Can imply notstruct for classconstraint`` () =
+    FSharp """module Foo =
+    let failIfNull<'a when 'a : null> (a : 'a) : 'a option =
+        (a |> Option.ofObj)
+    """
+    |> asLibrary
+    |> typecheck  // This has nullable off!
+    |> shouldSucceed  
+
 [<Fact>]
 let ``Warning on nullness hidden behind interface upcast`` () =
     FSharp """module Test


### PR DESCRIPTION
Fixes #18320 