### PR TITLE
Tests: redirect log to test output

### DIFF
--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -11,7 +11,7 @@ open TestFramework
 
 [<RequireQualifiedAccess>]
 module ILChecker =
-    let config = initializeSuite ()
+    let config = initialConfig
 
     let private exec exe args =
         let arguments = args |> String.concat " "

--- a/tests/FSharp.Test.Utilities/ILVerifierModule.fs
+++ b/tests/FSharp.Test.Utilities/ILVerifierModule.fs
@@ -8,7 +8,7 @@ open TestFramework
 
 [<AutoOpen>]
 module ILVerifierModule =
-    let config = initializeSuite ()
+    let config = initialConfig
 
     let fsharpCoreReference = $"--reference \"{typeof<unit>.Assembly.Location}\""
 

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -410,7 +410,7 @@ let logConfig (cfg: TestConfig) =
     log "FSCOREDLLPATH            = %s" cfg.FSCOREDLLPATH
     log "FSI                      = %s" cfg.FSI
 #if NETCOREAPP
-    log "DotNetExe                =%s" cfg.DotNetExe
+    log "DotNetExe                = %s" cfg.DotNetExe
     log "DOTNET_MULTILEVEL_LOOKUP = %s" cfg.DotNetMultiLevelLookup
     log "DOTNET_ROOT              = %s" cfg.DotNetRoot
 #else
@@ -447,7 +447,7 @@ let envVars () =
     |> Seq.map (fun d -> d.Key :?> string, d.Value :?> string)
     |> Map.ofSeq
 
-let initializeSuite () =
+let initialConfig =
 
 #if DEBUG
     let configurationName = "Debug"
@@ -461,15 +461,9 @@ let initializeSuite () =
         let usedEnvVars = c.EnvironmentVariables  |> Map.add "FSC" c.FSC
         { c with EnvironmentVariables = usedEnvVars }
 
-    logConfig cfg
-
     cfg
 
-
-let suiteHelpers = lazy (initializeSuite ())
-
 let testConfig sourceDir (relativePathToTestFixture: string) =
-    let cfg = suiteHelpers.Value
     let testFixtureFullPath = Path.GetFullPath(sourceDir ++ relativePathToTestFixture)
 
     let tempTestDir =
@@ -478,11 +472,10 @@ let testConfig sourceDir (relativePathToTestFixture: string) =
             .FullName
     copyDirectory testFixtureFullPath tempTestDir true
 
-    { cfg with Directory = tempTestDir }
+    { initialConfig with Directory = tempTestDir }
 
 let createConfigWithEmptyDirectory() =
-    let cfg = suiteHelpers.Value
-    { cfg with Directory = createTemporaryDirectory().FullName }
+    { initialConfig with Directory = createTemporaryDirectory().FullName }
 
 type RedirectToType =
     | Overwrite of FilePath

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -138,7 +138,7 @@ module Utilities =
     [<RequireQualifiedAccess>]
     module public TargetFrameworkUtil =
 
-        let private config = TestFramework.initializeSuite ()
+        let private config = initialConfig
 
         // Do a one time dotnet sdk build to compute the proper set of reference assemblies to pass to the compiler
         let private projectFile = """

--- a/tests/scripts/scriptlib.fsx
+++ b/tests/scripts/scriptlib.fsx
@@ -10,14 +10,6 @@ open System.IO
 open System.Text
 open System.Diagnostics
 
-module MessageSink =
-    let sinkWriter =
-#if DEBUG
-        Console.Out
-#else
-        TextWriter.Null
-#endif
-
 [<AutoOpen>]
 module Scripting =
 
@@ -85,7 +77,7 @@ module Scripting =
         if Directory.Exists output then 
             Directory.Delete(output, true) 
 
-    let log format = fprintfn MessageSink.sinkWriter format
+    let log format = printfn format
 
     type FilePath = string
 


### PR DESCRIPTION
## Description

In the test suite `log` was originally an alias for `printfn`:
```fsharp
    let log format = printfn format
```

My previous changes made its output to essentially go nowhere. There are however many `log` calls in the tests. As it is essentially `printfn`, it should print to the output of the respective test case, just like `printfn`.

Fixes:
result of
![image](https://github.com/user-attachments/assets/afacc45a-f414-4da3-92ca-f8bfd63c1824)
can be seen in test output:

![image](https://github.com/user-attachments/assets/d915dfb3-2e1b-45c1-ad9d-ee62ccb0f0dd)
