### PR TITLE
Empty notes added for FSharp.Core 9.0.101 (nuget package points to this URL)

### DIFF
--- a/docs/release-notes/.FSharp.Core/9.0.101.md
+++ b/docs/release-notes/.FSharp.Core/9.0.101.md
@@ -1,0 +1,17 @@
+## FSharp.Core 9.0.101 did not change compared to version 9.0.100. Below are the changes for FSharp.Core 9.0.100
+
+### Fixed
+* Struct UnionCase doesn't seem to be a valid target for the DefaultAugmentationAttribute ([Issue #17499](https://github.com/dotnet/fsharp/issues/17499), [PR #17502](https://github.com/dotnet/fsharp/pull/17502))
+
+### Added
+
+* Enable C# collection expression support for F# lists & sets. ([Language suggestion #1355](https://github.com/fsharp/fslang-suggestions/issues/1355), [RFC FS-1145 (PR#776)](https://github.com/fsharp/fslang-design/pull/776), [PR #17359](https://github.com/dotnet/fsharp/pull/17359))
+* Add module functions for converting between `'T option` and `'T voption`. ([PR #17436](https://github.com/dotnet/fsharp/pull/17436))
+
+### Changed
+* Change compiler default setting realsig+ when building assemblies ([Issue #17384](https://github.com/dotnet/fsharp/issues/17384), [PR #17378](https://github.com/dotnet/fsharp/pull/17385))
+* Change compiler default setting for compressedMetadata ([Issue #17379](https://github.com/dotnet/fsharp/issues/17379), [PR #17383](https://github.com/dotnet/fsharp/pull/17383))
+* Enable FSharp 9.0 Language Version ([Issue #17497](https://github.com/dotnet/fsharp/issues/17438)), [PR](https://github.com/dotnet/fsharp/pull/17500)))
+* Struct UnionCase doesn't seem to be a valid target for the DefaultAugmentationAttribute ([Issue #17499](https://github.com/dotnet/fsharp/issues/17499), [PR #17502](https://github.com/dotnet/fsharp/pull/17502))
+### Breaking Changes
+


### PR DESCRIPTION
Fixes #18245 

Nuget package has been already shipped and it points to https://github.com/dotnet/fsharp/blob/main/docs/release-notes/.FSharp.Core/9.0.101.md .

This PR adds content to the page.