### PR TITLE
Revert back to use the wrong attribute targets for union case declarations.

### DIFF
--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -583,16 +583,15 @@ module TcRecdUnionAndEnumDeclarations =
                 Enforce union-cases AttributeTargets:
                 - AttributeTargets.Method
                     type SomeUnion =
-                    | Case1 of int // Compiles down to a static method
+                    | Case1 of int // Compiles down to a static method so the target should be AttributeTargets.Method
                 - AttributeTargets.Property
                     type SomeUnion =
-                    | Case1 // Compiles down to a static property
+                    | Case1 // Compiles down to a static property so the target should be AttributeTargets.Property
             *)
-            if g.langVersion.SupportsFeature(LanguageFeature.EnforceAttributeTargets) then
-                let target = if rfields.IsEmpty then AttributeTargets.Property else AttributeTargets.Method
-                TcAttributes cenv env target synAttrs
-            else
-                TcAttributes cenv env AttributeTargets.UnionCaseDecl synAttrs
+            // See https://github.com/dotnet/fsharp/issues/18298#issuecomment-2685481590
+            // For backward compatibility, we can't enforce the correct the attribute targets for union case declarations.
+            // In the future, we should have a dedicated `FsharpAttributeTargets` that will help us enforce F# the attribute targets.
+            TcAttributes cenv env AttributeTargets.UnionCaseDecl synAttrs
         
         Construct.NewUnionCase id rfields recordTy attrs xmlDoc vis
 


### PR DESCRIPTION
Fixes #18298

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated