### PR TITLE
Revert back to use the wrong attribute targets for union case declarations

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.201.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.201.md
@@ -1,0 +1,8 @@
+### Fixed
+* Revert back to use the wrong attribute targets for union case declarations.([Issue #18298](https://github.com/dotnet/fsharp/issues/18298), [PR #18346](https://github.com/dotnet/fsharp/pull/18346))
+
+### Added
+
+### Changed
+
+### Breaking Changes

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -580,19 +580,18 @@ module TcRecdUnionAndEnumDeclarations =
         let attrs =
             (*
                 The attributes of a union case decl get attached to the generated "static factory" method.
-                Enforce union-cases AttributeTargets:
-                - AttributeTargets.Method
-                    type SomeUnion =
-                    | Case1 of int // Compiles down to a static method
-                - AttributeTargets.Property
-                    type SomeUnion =
-                    | Case1 // Compiles down to a static property
-            *)
-            if g.langVersion.SupportsFeature(LanguageFeature.EnforceAttributeTargets) then
-                let target = if rfields.IsEmpty then AttributeTargets.Property else AttributeTargets.Method
-                TcAttributes cenv env target synAttrs
-            else
-                TcAttributes cenv env AttributeTargets.UnionCaseDecl synAttrs
+                 Enforce union-cases AttributeTargets:
+                 - AttributeTargets.Method
+                     type SomeUnion =
+                     | Case1 of int // Compiles down to a static method so the target should be AttributeTargets.Method
+                 - AttributeTargets.Property
+                     type SomeUnion =
+                     | Case1 // Compiles down to a static property so the target should be AttributeTargets.Property
+             *)
+             // See https://github.com/dotnet/fsharp/issues/18298
+             // For backward compatibility, we can't enforce the correct the attribute targets for union case declarations.
+             // In the future, we should have a dedicated `FsharpAttributeTargets` that will help us enforce F# the attribute targets.
+             TcAttributes cenv env AttributeTargets.UnionCaseDecl synAttrs
         
         Construct.NewUnionCase id rfields recordTy attrs xmlDoc vis
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -481,6 +481,7 @@ module CustomAttributes_AttributeUsage =
             (Error 842, Line 14, Col 5, Line 14, Col 15, "This attribute is not valid for use on this language element")
         ]
     
+    // https://github.com/dotnet/fsharp/issues/18298
     // SOURCE=E_AttributeTargetIsField03.fs	# E_AttributeTargetIsField03.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsField03.fs"|])>]
     let ``E_AttributeTargetIsField03_fs`` compilation =
@@ -490,7 +491,6 @@ module CustomAttributes_AttributeUsage =
         |> shouldFail
         |> withDiagnostics [
             (Error 842, Line 14, Col 5, Line 14, Col 15, "This attribute is not valid for use on this language element")
-            (Error 842, Line 15, Col 5, Line 15, Col 25, "This attribute is not valid for use on this language element")
         ]
         
     // SOURCE=E_AttributeTargetIsProperty01.fs	# E_AttributeTargetIsField03.fs
@@ -501,17 +501,14 @@ module CustomAttributes_AttributeUsage =
         |> verifyCompile
         |> shouldSucceed
     
+    // https://github.com/dotnet/fsharp/issues/18298
     // SOURCE=E_AttributeTargetIsProperty01.fs	# E_AttributeTargetIsField03.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsProperty01.fs"|])>]
     let ``E_AttributeTargetIsProperty01_fs`` compilation =
         compilation
         |> withLangVersion90
         |> verifyCompile
-        |> shouldFail
-        |> withDiagnostics [
-            (Error 842, Line 14, Col 5, Line 14, Col 18, "This attribute is not valid for use on this language element")
-            (Error 842, Line 15, Col 5, Line 15, Col 25, "This attribute is not valid for use on this language element")
-        ]
+        |> shouldSucceed
         
     // SOURCE=E_AttributeTargetIsCtor01.fs	# E_AttributeTargetIsCtor01.fs
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsCtor01.fs"|])>]


### PR DESCRIPTION
## Description

Fixes #18298

## Checklist

- [x] Test cases added
- [x] Release notes entry updated