### PR TITLE
Update xcopy-msbuild to latest available version

### DIFF
--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.12.0"
+    "xcopy-msbuild": "17.13.0"
   },
   "native-tools": {
     "perl": "5.38.2.2"


### PR DESCRIPTION
Updated `xcopy-msbuild` in `global.json` to the latest available version on dotnet-eng

I am raising this as I made the change in [aspnetcore](https://github.com/dotnet/aspnetcore) via https://github.com/dotnet/aspnetcore/pull/60666 and spotted this repository was using the previous version also