### PR TITLE
Bugfix for Array.insertManyAt returns original array for empty inserion (#18352)

### DIFF
--- a/docs/release-notes/.FSharp.Core/9.0.300.md
+++ b/docs/release-notes/.FSharp.Core/9.0.300.md
@@ -1,4 +1,5 @@
 ### Fixed
+* Modified the behavior of `Array.insertManyAt` to return a copy of the original array when inserting an empty array. ([PR #18353](https://github.com/dotnet/fsharp/pull/18353))
 
 ### Added
 * Added nullability annotations to `.Using` builder method for `async` and `task` builders ([PR #18292](https://github.com/dotnet/fsharp/pull/18292))

--- a/src/FSharp.Core/array.fs
+++ b/src/FSharp.Core/array.fs
@@ -1934,7 +1934,7 @@ module Array =
         let valuesArray = Seq.toArray values
 
         if valuesArray.Length = 0 then
-            source
+            source.Clone() :?> 'T array
         else
             let length = source.Length + valuesArray.Length
             let result = Microsoft.FSharp.Primitives.Basics.Array.zeroCreateUnchecked length

--- a/src/FSharp.Core/array.fsi
+++ b/src/FSharp.Core/array.fsi
@@ -3080,7 +3080,7 @@ module Array =
     /// <param name="values">The values to insert.</param>
     /// <param name="source">The input array.</param>
     ///
-    /// <returns>The result array.</returns>
+    /// <returns>A new array (even if values is empty).</returns>
     ///
     /// <exception cref="T:System.ArgumentException">Thrown when index is below 0 or greater than source.Length.</exception>
     ///

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule2.fs
@@ -1680,3 +1680,9 @@ type ArrayModule2() =
         Assert.AreEqual([0; 0], Array.insertManyAt 0 [0; 0] [||])
         CheckThrowsArgumentException (fun () -> Array.insertManyAt -1 [0; 0] [|1|] |> ignore)
         CheckThrowsArgumentException (fun () -> Array.insertManyAt 2 [0; 0] [|1|] |> ignore)
+        
+        // Do not return the original array when inserting an empty array
+        let originalArr = [| 1; 2; 3 |]
+        let insertionEmptyResultArr = Array.insertManyAt 3 [| |] originalArr
+        insertionEmptyResultArr[0] <- 3
+        Assert.AreEqual([| 1; 2; 3 |], originalArr)


### PR DESCRIPTION
## Description

Use `array.Clone()` to fix the bug that `Array.insertManyAt` directly returning source array when the values inserted are empty.

- Fix #18352 

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated