### PR TITLE
revert attributes feature

### DIFF
--- a/buildtools/checkpackages/FSharp.Core_notshipped.fsproj
+++ b/buildtools/checkpackages/FSharp.Core_notshipped.fsproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildProjectDirectory)\..\..\eng\Versions.props" />
 
   <PropertyGroup>
-    <TargetFramework>ne87.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.200.md
@@ -52,7 +52,8 @@
 * Better ranges for #nowarn error reporting; bring back #nowarn warnings for --langVersion:80; add warnings under feature flag ([PR #17871](https://github.com/dotnet/fsharp/pull/17871))
 * CheckAndThrow can be invoked only from within Cancellable context ([PR #18037](https://github.com/dotnet/fsharp/pull/18037))
 * Make ILTypeDef base type calculation lazy. ([PR #18005](https://github.com/dotnet/fsharp/pull/18005))
+* Revert EnforceAttributeTargets Feature. ([PR #18005](https://github.com/dotnet/fsharp/pull/18005))
 
 ### Breaking Changes
 
-* Aliasing `StructAttribute` will now produce a warning (part of [Language suggestion #1136](https://github.com/fsharp/fslang-suggestions/issues/1136), [PR #18098](https://github.com/dotnet/fsharp/pull/18098))
+* Aliasing `StructAttribute` will now produce a warning (part of [Language suggestion #18298](https://github.com/fsharp/fslang-suggestions/issues/18298), [PR #18355](https://github.com/dotnet/fsharp/pull/18355))

--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.202.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.202.md
@@ -52,6 +52,7 @@
 * Better ranges for #nowarn error reporting; bring back #nowarn warnings for --langVersion:80; add warnings under feature flag ([PR #17871](https://github.com/dotnet/fsharp/pull/17871))
 * CheckAndThrow can be invoked only from within Cancellable context ([PR #18037](https://github.com/dotnet/fsharp/pull/18037))
 * Make ILTypeDef base type calculation lazy. ([PR #18005](https://github.com/dotnet/fsharp/pull/18005))
+* Revert EnforceAttributeTargets Feature. ([PR #18005](https://github.com/dotnet/fsharp/pull/18005))
 
 ### Breaking Changes
 

--- a/docs/release-notes/.Language/9.0.md
+++ b/docs/release-notes/.Language/9.0.md
@@ -21,6 +21,7 @@
 * Enforce AttributeTargets on implicit constructors. ([PR #16845](https://github.com/dotnet/fsharp/pull/16845/))
 * Enforce AttributeTargets on structs and classes ([PR #16790](https://github.com/dotnet/fsharp/pull/16790))
 * Ensure consistent interaction between ``#line` and `#nowarn` directives ([PR #17649](https://github.com/dotnet/fsharp/pull/17649))
+* Revert EnforceAttributeTargets Feature. ([PR #18005](https://github.com/dotnet/fsharp/pull/18005))
 
 
 ### Changed

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>9</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>201</FSBuildVersion>
+    <FSBuildVersion>202</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->
@@ -37,7 +37,7 @@
     <FSharpLibrariesChangelogVersion>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSharpLibrariesChangelogVersion>
     <!-- -->
     <!-- The current published nuget package -->
-    <FSharpCoreShippedPackageVersionValue>9.0.100</FSharpCoreShippedPackageVersionValue>
+    <FSharpCoreShippedPackageVersionValue>9.0.201</FSharpCoreShippedPackageVersionValue>
     <!-- -->
     <!-- The pattern for specifying the preview package -->
     <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).*</FSharpCorePreviewPackageVersionValue>

--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -216,9 +216,9 @@ type LanguageVersion(versionText) =
                 LanguageFeature.LowerSimpleMappingsInComprehensionsToFastLoops, languageVersion90
                 LanguageFeature.ParsedHashDirectiveArgumentNonQuotes, languageVersion90
                 LanguageFeature.EmptyBodiedComputationExpressions, languageVersion90
-                LanguageFeature.EnforceAttributeTargets, languageVersion90
 
                 // F# preview
+                LanguageFeature.EnforceAttributeTargets, previewVersion // Not enabled due to a number of external library dependencies on unenforced attributes
                 LanguageFeature.UseTypeSubsumptionCache, previewVersion
                 LanguageFeature.UnmanagedConstraintCsharpInterop, previewVersion // not enabled because: https://github.com/dotnet/fsharp/issues/17509
                 LanguageFeature.FromEndSlicing, previewVersion // Unfinished features --- needs work

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/CustomAttributes/AttributeUsage/AttributeUsage.fs
@@ -98,7 +98,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargets01.fs"|])>]
     let ``E_AttributeTargets01_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -134,7 +134,7 @@ module CustomAttributes_AttributeUsage =
     let ``E_AttributeTargetIsField01_fs`` compilation =
         compilation
         |> withOptions ["--nowarn:25"]
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -187,7 +187,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsMethod02.fs"|])>]
     let ``E_AttributeTargetIsMethod02_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> withOptions ["--nowarn:25"]
         |> verifyCompile
         |> shouldFail
@@ -218,7 +218,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsMethod03.fs"|])>]
     let ``E_AttributeTargetIsMethod03_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> withOptions ["--nowarn:25"]
         |> verifyCompile
         |> shouldFail
@@ -336,7 +336,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsStruct.fs"|])>]
     let ``E_AttributeTargetIsStruct_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -366,7 +366,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsClass.fs"|])>]
     let ``E_AttributeTargetIsClass_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -387,7 +387,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsClass01.fs"|])>]
     let ``E_AttributeTargetIsClass01_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -485,7 +485,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsField03.fs"|])>]
     let ``E_AttributeTargetIsField03_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -505,7 +505,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsProperty01.fs"|])>]
     let ``E_AttributeTargetIsProperty01_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -525,7 +525,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsCtor01.fs"|])>]
     let ``E_AttributeTargetIsCtor01_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -562,7 +562,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsEnum01.fs"|])>]
     let ``E_AttributeTargetIsEnum01_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -599,7 +599,7 @@ module CustomAttributes_AttributeUsage =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsDelegate01.fs"|])>]
     let ``E_AttributeTargetsIsDelegate01_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -648,7 +648,7 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsInterface.fs"|])>]
     let ``E_AttributeTargetIsInterface_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [
@@ -670,7 +670,7 @@ type InterruptibleLazy<'T> private (valueFactory: unit -> 'T) =
     [<Theory; Directory(__SOURCE_DIRECTORY__, Includes=[|"E_AttributeTargetIsClass02.fs"|])>]
     let ``E_AttributeTargetIsClass02_fs`` compilation =
         compilation
-        |> withLangVersion90
+        |> withLangVersionPreview
         |> verifyCompile
         |> shouldFail
         |> withDiagnostics [


### PR DESCRIPTION
Revert EnforceAttributeTargets to preview.

There were some libraries that relied on a relaxed enforcement of attribute targets, particularly on Union types.  This caused F# 9.0  the apps that relied on these libraries.

In order to reduce the number of times we have to fix bugs related to this, we will reset the feature back to preview mode.  Allowing us to re-evaluate how we want this to work in the future, we can re-enable the feature when we have a better unsderstood design.


Update, fsharp.core and fsharp.compiler service package version numbers.

/cc @baronfel /cc @T-Gro 