### PR TITLE
Test-TP: Reference assembly loading fixes

### DIFF
--- a/tests/service/data/TestTP/ProvidedTypes.fs
+++ b/tests/service/data/TestTP/ProvidedTypes.fs
@@ -8907,6 +8907,7 @@ namespace ProviderImplementation.ProvidedTypes
         let enqueueReferencedAssemblies(asm: Assembly) = 
             do sourceAssembliesQueue.Add (fun () -> 
                 [| for referencedAssemblyName  in asm.GetReferencedAssemblies() do
+                    if not (sourceAssembliesTable_.ContainsKey referencedAssemblyName.Name) then
                       let referencedAssembly = try Assembly.Load(referencedAssemblyName) with _ -> null
                       if not (isNull referencedAssembly) then
                           yield referencedAssembly |])
@@ -8920,12 +8921,12 @@ namespace ProviderImplementation.ProvidedTypes
                 for q in qs do 
                     for asm in q() do 
                         let simpleName = asm.GetName().Name
-                        if not (sourceAssembliesTable_.ContainsKey(simpleName)) then 
-                            sourceAssembliesTable_[simpleName] <- asm
+                        sourceAssembliesTable_.GetOrAdd(simpleName, fun k ->
                             sourceAssemblies_.Add asm
                             // Find the transitive closure of all referenced assemblies
                             enqueueReferencedAssemblies asm
-
+                            asm
+                        ) |> ignore
             sourceAssemblies_
 
         /// When translating quotations, Expr.Var's are translated to new variable respecting reference equality.


### PR DESCRIPTION
I noticed that with the current reference loading of TypeProviders, if I had 139 reference assemblies (in a solution memory), I ended up calling the Assembly.Load for 897 times. This is because so many assemblies have the same references like System.Memory, System.Xml, System.Buffers, System.Threading.Tasks.Extensions, ... And the code said "load all reference assemblies". Simple fix: Check already loaded reference assemblies before trying to call the slow Assembly.Load again.

The sourceAssembliesTable_ is a ConcurrentDictionary to ensure thread-safety. However, instead of code using it in thread-safe way, it was used by double-lookup. So that is fixed to actually use it properly. (It's role is to be used as a guard to sourceAssemblies_ array, which is manually lazy-loaded from the queue.)

These changes match the FSharp.TypeProvider.SDK merged PR.
