### PR TITLE
Fix duplicate parse errors for GetBackgroundCheckResultsForFileInProject

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -16,6 +16,7 @@
 * Fix "type inference problem too complicated" for SRTP with T:null and T:struct dummy constraint([Issue #18288](https://github.com/dotnet/fsharp/issues/18288), [PR #18345](https://github.com/dotnet/fsharp/pull/18345))
 * Fix for missing parse diagnostics in TransparentCompiler.ParseAndCheckProject ([PR #18366](https://github.com/dotnet/fsharp/pull/18366))
 * Miscellanous parentheses analyzer fixes. ([PR #18350](https://github.com/dotnet/fsharp/pull/18350))
+* Fix duplicate parse error reporting for GetBackgroundCheckResultsForFileInProject ([Issue #18379](https://github.com/dotnet/fsharp/issues/18379) [PR #18380](https://github.com/dotnet/fsharp/pull/18380))
 
 ### Added
 * Added missing type constraints in FCS. ([PR #18241](https://github.com/dotnet/fsharp/pull/18241))

--- a/src/Compiler/Service/BackgroundCompiler.fs
+++ b/src/Compiler/Service/BackgroundCompiler.fs
@@ -1071,7 +1071,7 @@ type internal BackgroundCompiler
                         Some options,
                         Array.ofList tcDependencyFiles,
                         creationDiags,
-                        parseResults.Diagnostics,
+                        [||],
                         tcDiagnostics,
                         keepAssemblyContents,
                         Option.get latestCcuSigForFile,

--- a/tests/FSharp.Compiler.Service.Tests/ExprTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ExprTests.fs
@@ -3526,19 +3526,29 @@ let ``Test NoWarn HashDirective`` () =
 
     wholeProjectResults.Diagnostics.Length |> shouldEqual 0
 
-module internal SourceForTrcParseErrors =
-
-    let fileSource1 = """
+let private sourceForParseError = """
 module N.M
 #nowarn 0xy
 ()
 """
     
 [<Fact>]
-let ``TrcParseErrors`` () =
-    let options = createProjectOptions [SourceForTrcParseErrors.fileSource1] []
+let ``RegressionTestForMissingParseError(TransparentCompiler)`` () =
+    let options = createProjectOptions [sourceForParseError] []
     let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=CompilerAssertHelpers.UseTransparentCompiler)
     let wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
     wholeProjectResults.Diagnostics.Length |> shouldEqual 1
     wholeProjectResults.Diagnostics.[0].ErrorNumber |> shouldEqual 1156
     wholeProjectResults.Diagnostics.[0].Range.StartLine |> shouldEqual 3
+
+[<Fact>]
+let ``RegressionTestForDuplicateParseError(BackgroundCompiler)`` () =
+    let options = createProjectOptions [sourceForParseError] []
+    let exprChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=CompilerAssertHelpers.UseTransparentCompiler)
+    let sourceName = options.SourceFiles[0]
+    let _wholeProjectResults = exprChecker.ParseAndCheckProject(options) |> Async.RunImmediate
+    let _, checkResults = exprChecker.GetBackgroundCheckResultsForFileInProject(sourceName, options) |> Async.RunImmediate
+    checkResults.Diagnostics.Length |> shouldEqual 1
+    checkResults.Diagnostics.[0].ErrorNumber |> shouldEqual 1156
+    checkResults.Diagnostics.[0].Range.StartLine |> shouldEqual 3
+


### PR DESCRIPTION
## Description

Fixes #18379

## Checklist

- [X] Test cases added
- [x] Release notes entry updated