### PR TITLE
Fix delegate with option parameter

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -16,6 +16,7 @@
 * Fix "type inference problem too complicated" for SRTP with T:null and T:struct dummy constraint([Issue #18288](https://github.com/dotnet/fsharp/issues/18288), [PR #18345](https://github.com/dotnet/fsharp/pull/18345))
 * Fix for missing parse diagnostics in TransparentCompiler.ParseAndCheckProject ([PR #18366](https://github.com/dotnet/fsharp/pull/18366))
 * Miscellanous parentheses analyzer fixes. ([PR #18350](https://github.com/dotnet/fsharp/pull/18350))
+* Fix MethodDefNotFound when compiling code invoking delegate with option parameter ([Issue #5171](https://github.com/dotnet/fsharp/issues/5171), [PR #18385](https://github.com/dotnet/fsharp/pull/18385))
 
 ### Added
 * Added missing type constraints in FCS. ([PR #18241](https://github.com/dotnet/fsharp/pull/18241))

--- a/src/Compiler/Checking/CheckPatterns.fs
+++ b/src/Compiler/Checking/CheckPatterns.fs
@@ -58,14 +58,6 @@ let UnifyRefTupleType contextInfo (cenv: cenv) denv m ty ps =
     AddCxTypeEqualsType contextInfo denv cenv.css m ty (TType_tuple (tupInfoRef, ptys))
     ptys
 
-let inline mkOptionalParamTyBasedOnAttribute (g: TcGlobals)  tyarg attribs =
-    if g.langVersion.SupportsFeature(LanguageFeature.SupportValueOptionsAsOptionalParameters)
-        && findSynAttribute "StructAttribute" attribs
-    then
-        mkValueOptionTy g tyarg
-    else
-        mkOptionTy g tyarg
-
 let rec TryAdjustHiddenVarNameToCompGenName (cenv: cenv) env (id: Ident) altNameRefCellOpt =
     match altNameRefCellOpt with
     | Some ({contents = SynSimplePatAlternativeIdInfo.Undecided altId } as altNameRefCell) ->

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -4307,8 +4307,8 @@ and TcValSpec (cenv: cenv) env declKind newOk containerInfo memFlagsOpt thisTyOp
                             ((List.mapSquared fst curriedArgTys), valSynInfo.CurriedArgInfos)
                             ||> List.map2 (fun argTys argInfos ->
                                  (argTys, argInfos)
-                                 ||> List.map2 (fun argTy argInfo ->
-                                     if SynInfo.IsOptionalArg argInfo then mkOptionTy g argTy
+                                 ||> List.map2 (fun argTy (SynArgInfo(attribs, _, _) as argInfo) ->
+                                     if SynInfo.IsOptionalArg argInfo then mkOptionalParamTyBasedOnAttribute g argTy attribs
                                      else argTy))
                         mkIteratedFunTy g (List.map (mkRefTupledTy g) curriedArgTys) returnTy
                     else tyR

--- a/src/Compiler/Checking/Expressions/CheckExpressionsOps.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressionsOps.fs
@@ -384,3 +384,12 @@ let compileSeqExprMatchClauses (cenv: TcFileState) env inputExprMark (pat: Patte
         bindPatTy
         genInnerTy
         tclauses
+
+let inline mkOptionalParamTyBasedOnAttribute (g: TcGlobals.TcGlobals) tyarg attribs =
+    if
+        g.langVersion.SupportsFeature(LanguageFeature.SupportValueOptionsAsOptionalParameters)
+        && findSynAttribute "StructAttribute" attribs
+    then
+        mkValueOptionTy g tyarg
+    else
+        mkOptionTy g tyarg

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
@@ -46,3 +46,26 @@ namespace FSharpTest
         """
         |> compile
         |> shouldSucceed
+
+    [<Fact>]
+    let ``Delegate with optional parameter`` () =
+        FSharp """open System.Runtime.CompilerServices
+type A = delegate of [<CallerLineNumber>] ?a: int -> unit
+let f = fun (a: int option) -> defaultArg a 100 |> printfn "line: %d"
+let a = A f
+a.Invoke()"""
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> verifyOutput "line: 5"
+        
+    [<Fact>]
+    let ``Delegate with struct optional parameter`` () =
+        FSharp """open System.Runtime.CompilerServices
+type A = delegate of [<CallerLineNumber; Struct>] ?a: int -> unit
+let f = fun (a: int voption) -> defaultArg a 100 |> printfn "line: %d"
+let a = A f
+a.Invoke()"""
+        |> withLangVersionPreview
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> verifyOutput "line: 5" 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
@@ -60,11 +60,10 @@ a.Invoke()"""
         
     [<Fact>]
     let ``Delegate with struct optional parameter`` () =
-        FSharp """open System.Runtime.CompilerServices
-type A = delegate of [<CallerLineNumber; Struct>] ?a: int -> unit
+        FSharp """type A = delegate of [<Struct>] ?a: int -> unit
 let f = fun (a: int voption) -> defaultValueArg a 100 |> printf "line: %d"
 let a = A f
-a.Invoke()"""
+a.Invoke(5)"""
         |> withLangVersionPreview
         |> compileExeAndRun
         |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
@@ -62,7 +62,7 @@ a.Invoke()"""
     let ``Delegate with struct optional parameter`` () =
         FSharp """open System.Runtime.CompilerServices
 type A = delegate of [<CallerLineNumber; Struct>] ?a: int -> unit
-let f = fun (a: int voption) -> defaultArg a 100 |> printfn "line: %d"
+let f = fun (a: int voption) -> defaultValueArg a 100 |> printfn "line: %d"
 let a = A f
 a.Invoke()"""
         |> withLangVersionPreview

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/DelegateTypes/DelegateDefinition.fs
@@ -51,7 +51,7 @@ namespace FSharpTest
     let ``Delegate with optional parameter`` () =
         FSharp """open System.Runtime.CompilerServices
 type A = delegate of [<CallerLineNumber>] ?a: int -> unit
-let f = fun (a: int option) -> defaultArg a 100 |> printfn "line: %d"
+let f = fun (a: int option) -> defaultArg a 100 |> printf "line: %d"
 let a = A f
 a.Invoke()"""
         |> compileExeAndRun
@@ -62,7 +62,7 @@ a.Invoke()"""
     let ``Delegate with struct optional parameter`` () =
         FSharp """open System.Runtime.CompilerServices
 type A = delegate of [<CallerLineNumber; Struct>] ?a: int -> unit
-let f = fun (a: int voption) -> defaultValueArg a 100 |> printfn "line: %d"
+let f = fun (a: int voption) -> defaultValueArg a 100 |> printf "line: %d"
 let a = A f
 a.Invoke()"""
         |> withLangVersionPreview


### PR DESCRIPTION
## Description

Fix MethodDefNotFound when compiling code invoking delegate with option parameter

Fixes #5171

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated: