### PR TITLE
Adjust caller info attribute error message range

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -33,6 +33,7 @@
 * Added nullability annotations to `.Using` builder method for `async`, `task` and compiler-internal builders ([PR #18292](https://github.com/dotnet/fsharp/pull/18292))
 * Warn when `unit` is passed to an `obj`-typed argument  ([PR #18330](https://github.com/dotnet/fsharp/pull/18330))
 * Warning for "useless null handling" works with piped syntax constructs now ([PR #18331](https://github.com/dotnet/fsharp/pull/18331))
+* Adjust caller info attribute error message range ([PR #18388](https://github.com/dotnet/fsharp/pull/18388))
 
 ### Breaking Changes
 * Struct unions with overlapping fields now generate mappings needed for reading via reflection ([Issue #18121](https://github.com/dotnet/fsharp/issues/17797), [PR #18274](https://github.com/dotnet/fsharp/pull/17877))

--- a/src/Compiler/Checking/PostInferenceChecks.fs
+++ b/src/Compiler/Checking/PostInferenceChecks.fs
@@ -2398,9 +2398,23 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                 errorR(Error(FSComp.SR.chkCurriedMethodsCantHaveOutParams(), m))
 
             if numCurriedArgSets = 1 then
+                let errorIfNotStringTy m ty callerInfo = 
+                    if not (typeEquiv g g.string_ty ty) then
+                        errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv ty), m))
+                        
+                let errorIfNotStringOptionTy m ty callerInfo =
+                    if not ((isOptionTy g ty) && (typeEquiv g g.string_ty (destOptionTy g ty))) then
+                        errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv (destOptionTy g ty)), m))
+
                 minfo.GetParamDatas(cenv.amap, m, minfo.FormalMethodInst)
-                |> List.iterSquared (fun (ParamData(_, isInArg, _, optArgInfo, callerInfo, _, _, ty)) ->
+                |> List.iterSquared (fun (ParamData(_, isInArg, _, optArgInfo, callerInfo, nameOpt, _, ty)) ->
                     ignore isInArg
+
+                    let m =
+                        match nameOpt with
+                        | Some name -> name.idRange
+                        | None -> m
+
                     match (optArgInfo, callerInfo) with
                     | _, NoCallerInfo -> ()
                     | NotOptional, _ -> errorR(Error(FSComp.SR.tcCallerInfoNotOptional(callerInfo |> string), m))
@@ -2410,18 +2424,9 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                     | CalleeSide, CallerLineNumber ->
                         if not ((isOptionTy g ty) && (typeEquiv g g.int32_ty (destOptionTy g ty))) then
                             errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "int", NicePrint.minimalStringOfType cenv.denv (destOptionTy g ty)), m))
-                    | CallerSide _, CallerFilePath ->
-                        if not (typeEquiv g g.string_ty ty) then
-                            errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv ty), m))
-                    | CalleeSide, CallerFilePath ->
-                        if not ((isOptionTy g ty) && (typeEquiv g g.string_ty (destOptionTy g ty))) then
-                            errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv (destOptionTy g ty)), m))
-                    | CallerSide _, CallerMemberName ->
-                        if not (typeEquiv g g.string_ty ty) then
-                            errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv ty), m))
-                    | CalleeSide, CallerMemberName ->
-                        if not ((isOptionTy g ty) && (typeEquiv g g.string_ty (destOptionTy g ty))) then
-                            errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv (destOptionTy g ty)), m)))
+                    | CallerSide _, (CallerFilePath | CallerMemberName) -> errorIfNotStringTy m ty callerInfo
+                    | CalleeSide, (CallerFilePath | CallerMemberName) -> errorIfNotStringOptionTy m ty callerInfo
+                )
 
         for pinfo in immediateProps do
             let nm = pinfo.PropertyName

--- a/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_CallerFilePath.fs
+++ b/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_CallerFilePath.fs
@@ -1,6 +1,6 @@
-//<Expects id="FS1246" span="(9,19-9,45)" status="error">'CallerFilePath' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
-//<Expects id="FS1247" span="(12,19-12,47)" status="error">'CallerFilePath' can only be applied to optional arguments</Expects>
-//<Expects id="FS1247" span="(15,19-15,47)" status="error">'CallerFilePath' can only be applied to optional arguments</Expects>
+//<Expects id="FS1246" span="(9,66-9,70)" status="error">'CallerFilePath' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
+//<Expects id="FS1247" span="(12,67-12,71)" status="error">'CallerFilePath' can only be applied to optional arguments</Expects>
+//<Expects id="FS1247" span="(15,67-15,71)" status="error">'CallerFilePath' can only be applied to optional arguments</Expects>
 namespace Test
 
 open System.Runtime.CompilerServices

--- a/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_CallerLineNumber.fs
+++ b/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_CallerLineNumber.fs
@@ -1,6 +1,6 @@
-//<Expects id="FS1246" span="(9,19-9,44)" status="error">'CallerLineNumber' must be applied to an argument of type 'int', but has been applied to an argument of type 'string'</Expects>
-//<Expects id="FS1247" span="(12,19-12,49)" status="error">'CallerLineNumber' can only be applied to optional arguments</Expects>
-//<Expects id="FS1247" span="(15,19-15,49)" status="error">'CallerLineNumber' can only be applied to optional arguments</Expects>
+//<Expects id="FS1246" span="(9,67-9,71)" status="error">'CallerLineNumber' must be applied to an argument of type 'int', but has been applied to an argument of type 'string'</Expects>
+//<Expects id="FS1247" span="(12,71-12,75)" status="error">'CallerLineNumber' can only be applied to optional arguments</Expects>
+//<Expects id="FS1247" span="(15,71-15,75)" status="error">'CallerLineNumber' can only be applied to optional arguments</Expects>
 namespace Test
 
 open System.Runtime.CompilerServices

--- a/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_CallerMemberName.fs
+++ b/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_CallerMemberName.fs
@@ -1,6 +1,6 @@
-//<Expects id="FS1246" span="(9,19-9,47)" status="error">'CallerMemberName' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
-//<Expects id="FS1247" span="(12,19-12,49)" status="error">'CallerMemberName' can only be applied to optional arguments</Expects>
-//<Expects id="FS1247" span="(15,19-15,49)" status="error">'CallerMemberName' can only be applied to optional arguments</Expects>
+//<Expects id="FS1246" span="(9,70-9,74)" status="error">'CallerMemberName' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
+//<Expects id="FS1247" span="(12,71-12,75)" status="error">'CallerMemberName' can only be applied to optional arguments</Expects>
+//<Expects id="FS1247" span="(15,71-15,75)" status="error">'CallerMemberName' can only be applied to optional arguments</Expects>
 namespace Test
 
 open System.Runtime.CompilerServices

--- a/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_MultipleAttrs.fs
+++ b/tests/fsharpqa/Source/Conformance/SpecialAttributesAndTypes/Imported/CallerInfo/E_MultipleAttrs.fs
@@ -1,7 +1,7 @@
-//<Expects id="FS1246" span="(11,19-11,20)" status="error">'CallerFilePath' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
-//<Expects id="FS1246" span="(14,19-14,20)" status="error">'CallerFilePath' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
-//<Expects id="FS1246" span="(17,19-17,20)" status="error">'CallerLineNumber' must be applied to an argument of type 'int', but has been applied to an argument of type 'string'</Expects>
-//<Expects id="FS1246" span="(20,19-20,20)" status="error">'CallerLineNumber' must be applied to an argument of type 'int', but has been applied to an argument of type 'string'</Expects>
+//<Expects id="FS1246" span="(11,62-11,63)" status="error">'CallerFilePath' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
+//<Expects id="FS1246" span="(14,62-14,63)" status="error">'CallerFilePath' must be applied to an argument of type 'string', but has been applied to an argument of type 'int'</Expects>
+//<Expects id="FS1246" span="(17,62-17,63)" status="error">'CallerLineNumber' must be applied to an argument of type 'int', but has been applied to an argument of type 'string'</Expects>
+//<Expects id="FS1246" span="(20,62-20,63)" status="error">'CallerLineNumber' must be applied to an argument of type 'int', but has been applied to an argument of type 'string'</Expects>
 
 namespace Test
 


### PR DESCRIPTION
## Description

Adjust caller info attribute error message range

Before: The range is of the method name

![图片](https://github.com/user-attachments/assets/65f503a1-b696-4527-89a3-fb97d41128ef)

After: The range is of the parameter name

![图片](https://github.com/user-attachments/assets/ad09c295-39b3-41ff-8d62-cc6e07678c1a)

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated: