### PR TITLE
Reenable β-reduction of immediately-invoked F#-defined generic delegates

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -20,6 +20,7 @@
 * Fix duplicate parse error reporting for GetBackgroundCheckResultsForFileInProject ([Issue #18379](https://github.com/dotnet/fsharp/issues/18379) [PR #18380](https://github.com/dotnet/fsharp/pull/18380))
 * Fix MethodDefNotFound when compiling code invoking delegate with option parameter ([Issue #5171](https://github.com/dotnet/fsharp/issues/5171), [PR #18385](https://github.com/dotnet/fsharp/pull/18385))
 * Fix #r nuget ..." downloads unneeded packages ([Issue #18231](https://github.com/dotnet/fsharp/issues/18231), [PR #18393](https://github.com/dotnet/fsharp/pull/18393))
+* Reenable β-reduction and subsequent reoptimization of immediately-invoked F#-defined generic delegates. ([PR #18401](https://github.com/dotnet/fsharp/pull/18401))
 
 ### Added
 * Added missing type constraints in FCS. ([PR #18241](https://github.com/dotnet/fsharp/pull/18241))

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -8476,9 +8476,9 @@ let (|NewDelegateExpr|_|) g expr =
 [<return: Struct>]
 let (|DelegateInvokeExpr|_|) g expr =
     match expr with
-    | Expr.App ((Expr.Val (invokeRef, _, _)) as delInvokeRef, delInvokeTy, [], [delExpr;delInvokeArg], m) 
+    | Expr.App ((Expr.Val (invokeRef, _, _)) as delInvokeRef, delInvokeTy, tyargs, [delExpr;delInvokeArg], m) 
         when invokeRef.LogicalName = "Invoke" && isFSharpDelegateTy g (tyOfExpr g delExpr) -> 
-            ValueSome(delInvokeRef, delInvokeTy, delExpr, delInvokeArg, m)
+            ValueSome(delInvokeRef, delInvokeTy, tyargs, delExpr, delInvokeArg, m)
     | _ -> ValueNone
 
 [<return: Struct>]
@@ -8505,17 +8505,17 @@ let (|OpPipeRight3|_|) g expr =
             ValueSome(resType, arg1, arg2, arg3, fExpr, m)
     | _ -> ValueNone
 
-let rec MakeFSharpDelegateInvokeAndTryBetaReduce g (delInvokeRef, delExpr, delInvokeTy, delInvokeArg, m) =
+let rec MakeFSharpDelegateInvokeAndTryBetaReduce g (delInvokeRef, delExpr, delInvokeTy, tyargs, delInvokeArg, m) =
     match delExpr with 
     | Expr.Let (bind, body, mLet, _) ->
-        mkLetBind mLet bind (MakeFSharpDelegateInvokeAndTryBetaReduce g (delInvokeRef, body, delInvokeTy, delInvokeArg, m))
-    | NewDelegateExpr g (_, argvs, body, m, _) when argvs.Length > 0 -> 
+        mkLetBind mLet bind (MakeFSharpDelegateInvokeAndTryBetaReduce g (delInvokeRef, body, delInvokeTy, tyargs, delInvokeArg, m))
+    | NewDelegateExpr g (_, argvs & _ :: _, body, m, _) ->
         let pairs, body = MultiLambdaToTupledLambdaIfNeeded g (argvs, delInvokeArg) body
         let argvs2, args2 = List.unzip pairs
         mkLetsBind m (mkCompGenBinds argvs2 args2) body
     | _ -> 
         // Remake the delegate invoke
-        Expr.App (delInvokeRef, delInvokeTy, [], [delExpr; delInvokeArg], m) 
+        Expr.App (delInvokeRef, delInvokeTy, tyargs, [delExpr; delInvokeArg], m) 
       
 //---------------------------------------------------------------------------
 // Adjust for expected usage

--- a/src/Compiler/TypedTree/TypedTreeOps.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.fsi
@@ -1438,7 +1438,9 @@ val MakeApplicationAndBetaReduce: TcGlobals -> Expr * TType * TypeInst list * Ex
 /// Make a delegate invoke expression for an F# delegate type, doing beta reduction by introducing let-bindings
 /// if the delegate expression is a construction of a delegate.
 val MakeFSharpDelegateInvokeAndTryBetaReduce:
-    TcGlobals -> delInvokeRef: Expr * delExpr: Expr * delInvokeTy: TType * delInvokeArg: Expr * m: range -> Expr
+    TcGlobals ->
+    delInvokeRef: Expr * delExpr: Expr * delInvokeTy: TType * tyargs: TypeInst * delInvokeArg: Expr * m: range ->
+        Expr
 
 /// Combine two static-resolution requirements on a type parameter
 val JoinTyparStaticReq: TyparStaticReq -> TyparStaticReq -> TyparStaticReq
@@ -2751,7 +2753,7 @@ val (|NewDelegateExpr|_|): TcGlobals -> Expr -> (Unique * Val list * Expr * rang
 
 /// Match a .Invoke on a delegate
 [<return: Struct>]
-val (|DelegateInvokeExpr|_|): TcGlobals -> Expr -> (Expr * TType * Expr * Expr * range) voption
+val (|DelegateInvokeExpr|_|): TcGlobals -> Expr -> (Expr * TType * TypeInst * Expr * Expr * range) voption
 
 /// Match 'if __useResumableCode then ... else ...' expressions
 [<return: Struct>]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/ComputationExpressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/ComputationExpressions.fs
@@ -73,3 +73,16 @@ module ComputationExpressions =
         compilation
         |> getCompilation
         |> verifyCompilation 
+
+    [<Theory; FileInlineData("CustomCollectionBuilderComputationExpr.fs", Optimize=BooleanOptions.Both)>]
+    let ``CustomCollectionBuilderComputationExpr_fs_OptimizeOff`` compilation =
+        compilation
+        |> getCompilation
+        |> asExe
+        |> withReferences [
+            FsFromPath (Path.Combine (__SOURCE_DIRECTORY__,  "CustomCollectionBuilderComputationExprLibrary.fs"))
+            |> withName "CustomCollectionBuilderComputationExprLibrary"
+        ]
+        |> withEmbeddedPdb
+        |> withEmbedAllSource
+        |> verifyILBaseline

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExpr.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExpr.fs
@@ -1,0 +1,14 @@
+module ComputationExpressions.Program
+
+let f0 () =
+    let xs = ResizeArray ()
+    xs.Add 1
+    xs.Add 2
+    xs.Add 3
+    xs
+
+let xs = f0 ()
+
+let f1 () = resizeArray { 1; 2; 3 }
+let f2 () = resizeArray { yield! xs }
+let f3 () = resizeArray { for x in xs -> x * x }

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExpr.fs.Optimize.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExpr.fs.Optimize.il.bsl
@@ -1,0 +1,228 @@
+
+
+
+
+
+.assembly extern runtime { }
+.assembly extern FSharp.Core { }
+.assembly extern assemblyLibrary
+{
+  .ver 0:0:0:0
+}
+.assembly assembly
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  
+  
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module assembly.exe
+
+.imagebase {value}
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       
+.corflags 0x00000001    
+
+
+
+
+
+.class public abstract auto ansi sealed ComputationExpressions.Program
+       extends [runtime]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .field static assembly class [runtime]System.Collections.Generic.List`1<int32> xs@10
+  .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f0() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [runtime]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.2
+    IL_000f:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0014:  ldloc.0
+    IL_0015:  ldc.i4.3
+    IL_0016:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001b:  ldloc.0
+    IL_001c:  ret
+  } 
+
+  .method public specialname static class [runtime]System.Collections.Generic.List`1<int32> get_xs() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldsfld     class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::xs@10
+    IL_0005:  ret
+  } 
+
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f1() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_0,
+             class [runtime]System.Collections.Generic.List`1<int32> V_1,
+             class [runtime]System.Collections.Generic.List`1<int32>& V_2)
+    IL_0000:  call       class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<!0> class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>::get_Instance()
+    IL_0005:  stloc.0
+    IL_0006:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000b:  stloc.1
+    IL_000c:  ldloca.s   V_1
+    IL_000e:  stloc.2
+    IL_000f:  ldloc.2
+    IL_0010:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+    IL_0015:  ldc.i4.1
+    IL_0016:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001b:  ldloca.s   V_1
+    IL_001d:  stloc.2
+    IL_001e:  ldloc.2
+    IL_001f:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+    IL_0024:  ldc.i4.2
+    IL_0025:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_002a:  ldloca.s   V_1
+    IL_002c:  stloc.2
+    IL_002d:  ldloc.2
+    IL_002e:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+    IL_0033:  ldc.i4.3
+    IL_0034:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0039:  ldloc.1
+    IL_003a:  ret
+  } 
+
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f2() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_0,
+             class [runtime]System.Collections.Generic.List`1<int32> V_1,
+             class [runtime]System.Collections.Generic.List`1<int32>& V_2)
+    IL_0000:  call       class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<!0> class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>::get_Instance()
+    IL_0005:  stloc.0
+    IL_0006:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000b:  stloc.1
+    IL_000c:  ldloca.s   V_1
+    IL_000e:  stloc.2
+    IL_000f:  ldloc.2
+    IL_0010:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+    IL_0015:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+    IL_001a:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::AddRange(class [runtime]System.Collections.Generic.IEnumerable`1<!0>)
+    IL_001f:  ldloc.1
+    IL_0020:  ret
+  } 
+
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f3() cil managed
+  {
+    
+    .maxstack  5
+    .locals init (class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_0,
+             class [runtime]System.Collections.Generic.List`1<int32> V_1,
+             int32 V_2,
+             int32 V_3,
+             int32 V_4,
+             int32 V_5,
+             class [runtime]System.Collections.Generic.List`1<int32>& V_6)
+    IL_0000:  call       class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<!0> class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>::get_Instance()
+    IL_0005:  stloc.0
+    IL_0006:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000b:  stloc.1
+    IL_000c:  ldc.i4.0
+    IL_000d:  stloc.3
+    IL_000e:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+    IL_0013:  callvirt   instance int32 class [runtime]System.Collections.Generic.List`1<int32>::get_Count()
+    IL_0018:  ldc.i4.1
+    IL_0019:  sub
+    IL_001a:  stloc.2
+    IL_001b:  ldloc.2
+    IL_001c:  ldloc.3
+    IL_001d:  blt.s      IL_004f
+
+    IL_001f:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+    IL_0024:  ldloc.3
+    IL_0025:  callvirt   instance !0 class [runtime]System.Collections.Generic.List`1<int32>::get_Item(int32)
+    IL_002a:  stloc.s    V_4
+    IL_002c:  ldloc.s    V_4
+    IL_002e:  ldloc.s    V_4
+    IL_0030:  mul
+    IL_0031:  stloc.s    V_5
+    IL_0033:  ldloca.s   V_1
+    IL_0035:  stloc.s    V_6
+    IL_0037:  ldloc.s    V_6
+    IL_0039:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+    IL_003e:  ldloc.s    V_5
+    IL_0040:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0045:  ldloc.3
+    IL_0046:  ldc.i4.1
+    IL_0047:  add
+    IL_0048:  stloc.3
+    IL_0049:  ldloc.3
+    IL_004a:  ldloc.2
+    IL_004b:  ldc.i4.1
+    IL_004c:  add
+    IL_004d:  bne.un.s   IL_001f
+
+    IL_004f:  ldloc.1
+    IL_0050:  ret
+  } 
+
+  .method private specialname rtspecialname static void  .cctor() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldc.i4.0
+    IL_0001:  stsfld     int32 '<StartupCode$assembly>.$ComputationExpressions'.Program::init@
+    IL_0006:  ldsfld     int32 '<StartupCode$assembly>.$ComputationExpressions'.Program::init@
+    IL_000b:  pop
+    IL_000c:  ret
+  } 
+
+  .method assembly specialname static void staticInitialization@() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::f0()
+    IL_0005:  stsfld     class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::xs@10
+    IL_000a:  ret
+  } 
+
+  .property class [runtime]System.Collections.Generic.List`1<int32>
+          xs()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+  } 
+} 
+
+.class private abstract auto ansi sealed '<StartupCode$assembly>.$ComputationExpressions'.Program
+       extends [runtime]System.Object
+{
+  .field static assembly int32 init@
+  .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    
+    .maxstack  8
+    IL_0000:  call       void ComputationExpressions.Program::staticInitialization@()
+    IL_0005:  ret
+  } 
+
+} 
+
+
+
+
+
+

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExpr.fs.OptimizeOff.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExpr.fs.OptimizeOff.il.bsl
@@ -1,0 +1,593 @@
+
+
+
+
+
+.assembly extern runtime { }
+.assembly extern FSharp.Core { }
+.assembly extern assemblyLibrary
+{
+  .ver 0:0:0:0
+}
+.assembly assembly
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  
+  
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module assembly.exe
+
+.imagebase {value}
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       
+.corflags 0x00000001    
+
+
+
+
+
+.class public abstract auto ansi sealed ComputationExpressions.Program
+       extends [runtime]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'f1@12-1'
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public int32 x
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(int32 x) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ComputationExpressions.Program/'f1@12-1'::x
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+      IL_0006:  ldarg.0
+      IL_0007:  ldfld      int32 ComputationExpressions.Program/'f1@12-1'::x
+      IL_000c:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+      IL_0011:  ret
+    } 
+
+  } 
+
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'f1@12-3'
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public int32 x
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(int32 x) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ComputationExpressions.Program/'f1@12-3'::x
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+      IL_0006:  ldarg.0
+      IL_0007:  ldfld      int32 ComputationExpressions.Program/'f1@12-3'::x
+      IL_000c:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+      IL_0011:  ret
+    } 
+
+  } 
+
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'f1@12-4'
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-4'::builder@
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  6
+      .locals init (class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_0,
+               int32 V_1,
+               class [runtime]System.Collections.Generic.List`1<int32>& V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-4'::builder@
+      IL_0006:  stloc.0
+      IL_0007:  ldc.i4.3
+      IL_0008:  stloc.1
+      IL_0009:  ldarg.1
+      IL_000a:  stloc.2
+      IL_000b:  ldloc.2
+      IL_000c:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+      IL_0011:  ldloc.1
+      IL_0012:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+      IL_0017:  ret
+    } 
+
+  } 
+
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname 'f1@12-2'
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-2'::builder@
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  6
+      .locals init (class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_0,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_1,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_2,
+               int32 V_3,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_4,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_5,
+               class [runtime]System.Collections.Generic.List`1<int32>& V_6)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-2'::builder@
+      IL_0006:  stloc.0
+      IL_0007:  ldarg.0
+      IL_0008:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-2'::builder@
+      IL_000d:  stloc.2
+      IL_000e:  ldc.i4.2
+      IL_000f:  stloc.3
+      IL_0010:  ldloc.3
+      IL_0011:  newobj     instance void ComputationExpressions.Program/'f1@12-3'::.ctor(int32)
+      IL_0016:  ldftn      instance void ComputationExpressions.Program/'f1@12-3'::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+      IL_001c:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                      native int)
+      IL_0021:  stloc.1
+      IL_0022:  ldarg.0
+      IL_0023:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-2'::builder@
+      IL_0028:  stloc.s    V_5
+      IL_002a:  ldarg.0
+      IL_002b:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/'f1@12-2'::builder@
+      IL_0030:  newobj     instance void ComputationExpressions.Program/'f1@12-4'::.ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>)
+      IL_0035:  ldftn      instance void ComputationExpressions.Program/'f1@12-4'::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+      IL_003b:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                      native int)
+      IL_0040:  stloc.s    V_4
+      IL_0042:  ldarg.1
+      IL_0043:  stloc.s    V_6
+      IL_0045:  ldloc.1
+      IL_0046:  ldloc.s    V_6
+      IL_0048:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+      IL_004d:  nop
+      IL_004e:  ldloc.s    V_4
+      IL_0050:  ldloc.s    V_6
+      IL_0052:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+      IL_0057:  nop
+      IL_0058:  ret
+    } 
+
+  } 
+
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname f1@12
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f1@12::builder@
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  6
+      .locals init (class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_0,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_1,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_2,
+               int32 V_3,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_4,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_5,
+               class [runtime]System.Collections.Generic.List`1<int32>& V_6)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f1@12::builder@
+      IL_0006:  stloc.0
+      IL_0007:  ldarg.0
+      IL_0008:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f1@12::builder@
+      IL_000d:  stloc.2
+      IL_000e:  ldc.i4.1
+      IL_000f:  stloc.3
+      IL_0010:  ldloc.3
+      IL_0011:  newobj     instance void ComputationExpressions.Program/'f1@12-1'::.ctor(int32)
+      IL_0016:  ldftn      instance void ComputationExpressions.Program/'f1@12-1'::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+      IL_001c:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                      native int)
+      IL_0021:  stloc.1
+      IL_0022:  ldarg.0
+      IL_0023:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f1@12::builder@
+      IL_0028:  stloc.s    V_5
+      IL_002a:  ldarg.0
+      IL_002b:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f1@12::builder@
+      IL_0030:  newobj     instance void ComputationExpressions.Program/'f1@12-2'::.ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>)
+      IL_0035:  ldftn      instance void ComputationExpressions.Program/'f1@12-2'::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+      IL_003b:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                      native int)
+      IL_0040:  stloc.s    V_4
+      IL_0042:  ldarg.1
+      IL_0043:  stloc.s    V_6
+      IL_0045:  ldloc.1
+      IL_0046:  ldloc.s    V_6
+      IL_0048:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+      IL_004d:  nop
+      IL_004e:  ldloc.s    V_4
+      IL_0050:  ldloc.s    V_6
+      IL_0052:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+      IL_0057:  nop
+      IL_0058:  ret
+    } 
+
+  } 
+
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname f2@13
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f2@13::builder@
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  6
+      .locals init (class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_0,
+               class [runtime]System.Collections.Generic.List`1<int32> V_1,
+               class [runtime]System.Collections.Generic.List`1<int32>& V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f2@13::builder@
+      IL_0006:  stloc.0
+      IL_0007:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+      IL_000c:  stloc.1
+      IL_000d:  ldarg.1
+      IL_000e:  stloc.2
+      IL_000f:  ldloc.2
+      IL_0010:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+      IL_0015:  ldloc.1
+      IL_0016:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::AddRange(class [runtime]System.Collections.Generic.IEnumerable`1<!0>)
+      IL_001b:  ret
+    } 
+
+  } 
+
+  .class auto autochar serializable sealed nested assembly beforefieldinit specialname f3@14
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+    .field public class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@
+    .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public specialname rtspecialname instance void  .ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> builder@) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f3@14::builder@
+      IL_0007:  ldarg.0
+      IL_0008:  call       instance void [runtime]System.Object::.ctor()
+      IL_000d:  ret
+    } 
+
+    .method assembly hidebysig instance void Invoke(class [runtime]System.Collections.Generic.List`1<int32>& sm) cil managed
+    {
+      
+      .maxstack  7
+      .locals init (class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_0,
+               class [runtime]System.Collections.Generic.List`1<int32> V_1,
+               class [runtime]System.Collections.Generic.List`1<int32>& V_2,
+               int32 V_3,
+               int32 V_4,
+               int32 V_5,
+               int32 V_6,
+               class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_7,
+               int32 V_8,
+               class [runtime]System.Collections.Generic.List`1<int32>& V_9)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f3@14::builder@
+      IL_0006:  stloc.0
+      IL_0007:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+      IL_000c:  stloc.1
+      IL_000d:  ldarg.1
+      IL_000e:  stloc.2
+      IL_000f:  ldc.i4.0
+      IL_0010:  stloc.s    V_4
+      IL_0012:  ldloc.1
+      IL_0013:  callvirt   instance int32 class [runtime]System.Collections.Generic.List`1<int32>::get_Count()
+      IL_0018:  ldc.i4.1
+      IL_0019:  sub
+      IL_001a:  stloc.3
+      IL_001b:  ldloc.3
+      IL_001c:  ldloc.s    V_4
+      IL_001e:  blt.s      IL_005b
+
+      IL_0020:  ldloc.1
+      IL_0021:  ldloc.s    V_4
+      IL_0023:  callvirt   instance !0 class [runtime]System.Collections.Generic.List`1<int32>::get_Item(int32)
+      IL_0028:  stloc.s    V_5
+      IL_002a:  ldloc.s    V_5
+      IL_002c:  stloc.s    V_6
+      IL_002e:  ldarg.0
+      IL_002f:  ldfld      class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> ComputationExpressions.Program/f3@14::builder@
+      IL_0034:  stloc.s    V_7
+      IL_0036:  ldloc.s    V_6
+      IL_0038:  ldloc.s    V_6
+      IL_003a:  mul
+      IL_003b:  stloc.s    V_8
+      IL_003d:  ldloc.2
+      IL_003e:  stloc.s    V_9
+      IL_0040:  ldloc.s    V_9
+      IL_0042:  ldobj      class [runtime]System.Collections.Generic.List`1<int32>
+      IL_0047:  ldloc.s    V_8
+      IL_0049:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+      IL_004e:  ldloc.s    V_4
+      IL_0050:  ldc.i4.1
+      IL_0051:  add
+      IL_0052:  stloc.s    V_4
+      IL_0054:  ldloc.s    V_4
+      IL_0056:  ldloc.3
+      IL_0057:  ldc.i4.1
+      IL_0058:  add
+      IL_0059:  bne.un.s   IL_0020
+
+      IL_005b:  ret
+    } 
+
+  } 
+
+  .field static assembly class [runtime]System.Collections.Generic.List`1<int32> xs@10
+  .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f0() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [runtime]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.2
+    IL_000f:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0014:  ldloc.0
+    IL_0015:  ldc.i4.3
+    IL_0016:  callvirt   instance void class [runtime]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001b:  ldloc.0
+    IL_001c:  ret
+  } 
+
+  .method public specialname static class [runtime]System.Collections.Generic.List`1<int32> get_xs() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldsfld     class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::xs@10
+    IL_0005:  ret
+  } 
+
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f1() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_0,
+             class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_1,
+             class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_2,
+             class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_3,
+             class [runtime]System.Collections.Generic.List`1<int32> V_4)
+    IL_0000:  call       class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<!!0> [assemblyLibrary]ComputationExpressions.Library::resizeArray<int32>()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  stloc.1
+    IL_0008:  ldloc.0
+    IL_0009:  stloc.3
+    IL_000a:  ldloc.0
+    IL_000b:  newobj     instance void ComputationExpressions.Program/f1@12::.ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>)
+    IL_0010:  ldftn      instance void ComputationExpressions.Program/f1@12::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+    IL_0016:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                    native int)
+    IL_001b:  stloc.2
+    IL_001c:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0021:  stloc.s    V_4
+    IL_0023:  ldloc.2
+    IL_0024:  ldloca.s   V_4
+    IL_0026:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+    IL_002b:  nop
+    IL_002c:  ldloc.s    V_4
+    IL_002e:  ret
+  } 
+
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f2() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_0,
+             class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_1,
+             class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_2,
+             class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_3,
+             class [runtime]System.Collections.Generic.List`1<int32> V_4)
+    IL_0000:  call       class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<!!0> [assemblyLibrary]ComputationExpressions.Library::resizeArray<int32>()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  stloc.1
+    IL_0008:  ldloc.0
+    IL_0009:  stloc.3
+    IL_000a:  ldloc.0
+    IL_000b:  newobj     instance void ComputationExpressions.Program/f2@13::.ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>)
+    IL_0010:  ldftn      instance void ComputationExpressions.Program/f2@13::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+    IL_0016:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                    native int)
+    IL_001b:  stloc.2
+    IL_001c:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0021:  stloc.s    V_4
+    IL_0023:  ldloc.2
+    IL_0024:  ldloca.s   V_4
+    IL_0026:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+    IL_002b:  nop
+    IL_002c:  ldloc.s    V_4
+    IL_002e:  ret
+  } 
+
+  .method public static class [runtime]System.Collections.Generic.List`1<int32> f3() cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_0,
+             class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32> V_1,
+             class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>> V_2,
+             class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilder V_3,
+             class [runtime]System.Collections.Generic.List`1<int32> V_4)
+    IL_0000:  call       class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<!!0> [assemblyLibrary]ComputationExpressions.Library::resizeArray<int32>()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  stloc.1
+    IL_0008:  ldloc.0
+    IL_0009:  stloc.3
+    IL_000a:  ldloc.0
+    IL_000b:  newobj     instance void ComputationExpressions.Program/f3@14::.ctor(class [assemblyLibrary]ComputationExpressions.Library/ResizeArrayBuilder`1<int32>)
+    IL_0010:  ldftn      instance void ComputationExpressions.Program/f3@14::Invoke(class [runtime]System.Collections.Generic.List`1<int32>&)
+    IL_0016:  newobj     instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::.ctor(object,
+                                                                                                                                                                                                                    native int)
+    IL_001b:  stloc.2
+    IL_001c:  newobj     instance void class [runtime]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0021:  stloc.s    V_4
+    IL_0023:  ldloc.2
+    IL_0024:  ldloca.s   V_4
+    IL_0026:  callvirt   instance void class [assemblyLibrary]ComputationExpressions.Library/CollectionBuilderCode`1<class [runtime]System.Collections.Generic.List`1<int32>>::Invoke(!0&)
+    IL_002b:  nop
+    IL_002c:  ldloc.s    V_4
+    IL_002e:  ret
+  } 
+
+  .method private specialname rtspecialname static void  .cctor() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldc.i4.0
+    IL_0001:  stsfld     int32 '<StartupCode$assembly>.$ComputationExpressions'.Program::init@
+    IL_0006:  ldsfld     int32 '<StartupCode$assembly>.$ComputationExpressions'.Program::init@
+    IL_000b:  pop
+    IL_000c:  ret
+  } 
+
+  .method assembly specialname static void staticInitialization@() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  call       class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::f0()
+    IL_0005:  stsfld     class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::xs@10
+    IL_000a:  ret
+  } 
+
+  .property class [runtime]System.Collections.Generic.List`1<int32>
+          xs()
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
+    .get class [runtime]System.Collections.Generic.List`1<int32> ComputationExpressions.Program::get_xs()
+  } 
+} 
+
+.class private abstract auto ansi sealed '<StartupCode$assembly>.$ComputationExpressions'.Program
+       extends [runtime]System.Object
+{
+  .field static assembly int32 init@
+  .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+  .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    
+    .maxstack  8
+    IL_0000:  call       void ComputationExpressions.Program::staticInitialization@()
+    IL_0005:  ret
+  } 
+
+} 
+
+
+
+
+
+

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExprLibrary.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/ComputationExpressions/CustomCollectionBuilderComputationExprLibrary.fs
@@ -1,0 +1,59 @@
+namespace ComputationExpressions
+
+#nowarn 77
+
+open System
+
+[<AutoOpen>]
+module Library =
+    type CollectionBuilderCode<'T> = delegate of byref<'T> -> unit
+
+    type CollectionBuilder () =
+        member inline _.Combine ([<InlineIfLambda>] f1 : CollectionBuilderCode<_>, [<InlineIfLambda>] f2 : CollectionBuilderCode<_>) =
+            CollectionBuilderCode (fun sm -> f1.Invoke &sm; f2.Invoke &sm)
+
+        member inline _.Delay ([<InlineIfLambda>] f : unit -> CollectionBuilderCode<_>) =
+            CollectionBuilderCode (fun sm -> (f ()).Invoke &sm)
+
+        member inline _.Zero () = CollectionBuilderCode (fun _ -> ())
+
+        member inline _.While ([<InlineIfLambda>] condition : unit -> bool, [<InlineIfLambda>] body : CollectionBuilderCode<_>) =
+            CollectionBuilderCode (fun sm ->
+                while condition () do
+                    body.Invoke &sm)
+
+        member inline _.TryWith ([<InlineIfLambda>] body : CollectionBuilderCode<_>, [<InlineIfLambda>] handle : exn -> CollectionBuilderCode<_>) =
+            CollectionBuilderCode (fun sm ->
+                try body.Invoke &sm
+                with e -> (handle e).Invoke &sm)
+
+        member inline _.TryFinally ([<InlineIfLambda>] body : CollectionBuilderCode<_>, compensation : unit -> unit) =
+            CollectionBuilderCode (fun sm ->
+                try body.Invoke &sm
+                with _ ->
+                    compensation ()
+                    reraise ()
+                compensation ())
+
+        member inline builder.Using (disposable : #IDisposable, [<InlineIfLambda>] body : #IDisposable -> CollectionBuilderCode<_>) =
+            builder.TryFinally ((fun sm -> (body disposable).Invoke &sm), (fun () -> if not (isNull (box disposable)) then disposable.Dispose ()))
+
+        member inline _.For (resizeArray : ResizeArray<_>, [<InlineIfLambda>] body : _ -> CollectionBuilderCode<_>) =
+            CollectionBuilderCode (fun sm ->
+                for i in 0 .. resizeArray.Count - 1 do
+                    (body resizeArray[i]).Invoke &sm)
+
+        member inline _.Yield x = CollectionBuilderCode (fun sm -> ignore (^a : (member Add : ^b -> _) (sm, x)))
+
+        member inline builder.YieldFrom xs = CollectionBuilderCode (fun sm -> ignore (^a : (member AddRange : ^b -> _) (sm, xs)))
+
+    [<Sealed>]
+    type ResizeArrayBuilder<'T> () =
+        inherit CollectionBuilder ()
+        static member val Instance = ResizeArrayBuilder<'T> ()
+        member inline _.Run ([<InlineIfLambda>] f : CollectionBuilderCode<_>) =
+            let mutable sm = ResizeArray<'T> ()
+            f.Invoke &sm
+            sm
+
+    let resizeArray<'T> = ResizeArrayBuilder<'T>.Instance

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/FSharpDelegateBetaReduction.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/FSharpDelegateBetaReduction.fs
@@ -1,0 +1,25 @@
+module Program
+
+module DelegateImmediateInvoke1 =
+    type Foo = delegate of unit -> unit
+
+    let f () =
+        let f1 = Foo ignore
+        f1.Invoke ()
+
+module DelegateImmediateInvoke2 =
+    type Foo = delegate of unit -> unit
+
+    let f () = Foo(ignore).Invoke()
+
+module DelegateImmediateInvoke3 =
+    type Foo<'T> = delegate of 'T -> unit
+
+    let f () =
+        let f1 = Foo<unit> ignore
+        f1.Invoke(())
+
+module DelegateImmediateInvoke4 =
+    type Foo<'T> = delegate of 'T -> unit
+
+    let f () = Foo<unit>(ignore).Invoke(())

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/FSharpDelegateBetaReduction.fs.RealInternalSignature.Optimize.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/FSharpDelegateBetaReduction.fs.RealInternalSignature.Optimize.il.bsl
@@ -1,0 +1,247 @@
+
+
+
+
+
+.assembly extern runtime { }
+.assembly extern FSharp.Core { }
+.assembly assembly
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  
+  
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module assembly.exe
+
+.imagebase {value}
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       
+.corflags 0x00000001    
+
+
+
+
+
+.class public abstract auto ansi sealed Program
+       extends [runtime]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke4
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo`1<T>
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke(!T A_1) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(!T A_1,
+                          class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ret
+    } 
+
+  } 
+
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke3
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo`1<T>
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke(!T A_1) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(!T A_1,
+                          class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ret
+    } 
+
+  } 
+
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke2
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke() runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname 'f@13-1'
+           extends [runtime]System.Object
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+      .method assembly static void  Invoke() cil managed
+      {
+        
+        .maxstack  8
+        IL_0000:  ret
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ldftn      void Program/DelegateImmediateInvoke2/'f@13-1'::Invoke()
+      IL_0007:  newobj     instance void Program/DelegateImmediateInvoke2/Foo::.ctor(object,
+                                                                                     native int)
+      IL_000c:  tail.
+      IL_000e:  callvirt   instance void Program/DelegateImmediateInvoke2/Foo::Invoke()
+      IL_0013:  ret
+    } 
+
+  } 
+
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke1
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke() runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname f@7
+           extends [runtime]System.Object
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+      .method assembly static void  Invoke() cil managed
+      {
+        
+        .maxstack  8
+        IL_0000:  ret
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ldftn      void Program/DelegateImmediateInvoke1/f@7::Invoke()
+      IL_0007:  newobj     instance void Program/DelegateImmediateInvoke1/Foo::.ctor(object,
+                                                                                     native int)
+      IL_000c:  tail.
+      IL_000e:  callvirt   instance void Program/DelegateImmediateInvoke1/Foo::Invoke()
+      IL_0013:  ret
+    } 
+
+  } 
+
+} 
+
+.class private abstract auto ansi sealed '<StartupCode$assembly>'.$Program
+       extends [runtime]System.Object
+{
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    
+    .maxstack  8
+    IL_0000:  ret
+  } 
+
+} 
+
+
+
+
+
+

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/FSharpDelegateBetaReduction.fs.RealInternalSignature.OptimizeOff.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/FSharpDelegateBetaReduction.fs.RealInternalSignature.OptimizeOff.il.bsl
@@ -1,0 +1,277 @@
+
+
+
+
+
+.assembly extern runtime { }
+.assembly extern FSharp.Core { }
+.assembly assembly
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32,
+                                                                                                      int32,
+                                                                                                      int32) = ( 01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
+
+  
+  
+
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module assembly.exe
+
+.imagebase {value}
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       
+.corflags 0x00000001    
+
+
+
+
+
+.class public abstract auto ansi sealed Program
+       extends [runtime]System.Object
+{
+  .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke4
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo`1<T>
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke(!T A_1) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(!T A_1,
+                          class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  pop
+      IL_0002:  ret
+    } 
+
+  } 
+
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke3
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo`1<T>
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke(!T A_1) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(!T A_1,
+                          class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname 'f1@19-1'
+           extends [runtime]System.Object
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+      .method assembly static void  Invoke(class [FSharp.Core]Microsoft.FSharp.Core.Unit delegateArg0) cil managed
+      {
+        
+        .maxstack  8
+        IL_0000:  ldarg.0
+        IL_0001:  pop
+        IL_0002:  ret
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  4
+      .locals init (class Program/DelegateImmediateInvoke3/Foo`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit> V_0)
+      IL_0000:  ldnull
+      IL_0001:  ldftn      void Program/DelegateImmediateInvoke3/'f1@19-1'::Invoke(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+      IL_0007:  newobj     instance void class Program/DelegateImmediateInvoke3/Foo`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(object,
+                                                                                                                                            native int)
+      IL_000c:  stloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  ldnull
+      IL_000f:  tail.
+      IL_0011:  callvirt   instance void class Program/DelegateImmediateInvoke3/Foo`1<class [FSharp.Core]Microsoft.FSharp.Core.Unit>::Invoke(!0)
+      IL_0016:  ret
+    } 
+
+  } 
+
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke2
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke() runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname f@13
+           extends [runtime]System.Object
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+      .method assembly static void  Invoke() cil managed
+      {
+        
+        .maxstack  8
+        IL_0000:  ret
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ldftn      void Program/DelegateImmediateInvoke2/f@13::Invoke()
+      IL_0007:  newobj     instance void Program/DelegateImmediateInvoke2/Foo::.ctor(object,
+                                                                                     native int)
+      IL_000c:  tail.
+      IL_000e:  callvirt   instance void Program/DelegateImmediateInvoke2/Foo::Invoke()
+      IL_0013:  ret
+    } 
+
+  } 
+
+  .class abstract auto ansi sealed nested public DelegateImmediateInvoke1
+         extends [runtime]System.Object
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+    .class auto ansi serializable sealed nested public Foo
+           extends [runtime]System.MulticastDelegate
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 03 00 00 00 00 00 ) 
+      .method public hidebysig specialname rtspecialname instance void  .ctor(object 'object', native int 'method') runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  Invoke() runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual 
+              instance class [runtime]System.IAsyncResult 
+              BeginInvoke(class [runtime]System.AsyncCallback callback,
+                          object objects) runtime managed
+      {
+      } 
+
+      .method public hidebysig strict virtual instance void  EndInvoke(class [runtime]System.IAsyncResult result) runtime managed
+      {
+      } 
+
+    } 
+
+    .class abstract auto autochar serializable sealed nested assembly beforefieldinit specialname f1@7
+           extends [runtime]System.Object
+    {
+      .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 06 00 00 00 00 00 ) 
+      .method assembly static void  Invoke() cil managed
+      {
+        
+        .maxstack  8
+        IL_0000:  ret
+      } 
+
+    } 
+
+    .method public static void  f() cil managed
+    {
+      
+      .maxstack  4
+      .locals init (class Program/DelegateImmediateInvoke1/Foo V_0)
+      IL_0000:  ldnull
+      IL_0001:  ldftn      void Program/DelegateImmediateInvoke1/f1@7::Invoke()
+      IL_0007:  newobj     instance void Program/DelegateImmediateInvoke1/Foo::.ctor(object,
+                                                                                     native int)
+      IL_000c:  stloc.0
+      IL_000d:  ldloc.0
+      IL_000e:  tail.
+      IL_0010:  callvirt   instance void Program/DelegateImmediateInvoke1/Foo::Invoke()
+      IL_0015:  ret
+    } 
+
+  } 
+
+} 
+
+.class private abstract auto ansi sealed '<StartupCode$assembly>'.$Program
+       extends [runtime]System.Object
+{
+  .method public static void  main@() cil managed
+  {
+    .entrypoint
+    
+    .maxstack  8
+    IL_0000:  ret
+  } 
+
+} 
+
+
+
+
+
+

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Inlining.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Inlining.fs
@@ -41,6 +41,17 @@ module Inlining =
         |> getCompilation
         |> verifyCompilation
 
+    [<Theory; FileInlineData("FSharpDelegateBetaReduction.fs", Realsig=BooleanOptions.True, Optimize=BooleanOptions.Both)>]
+    let ``FSharpDelegateBetaReduction_fs`` compilation =
+        compilation
+        |> getCompilation
+        |> withOptions [ "--test:EmitFeeFeeAs100001" ]
+        |> asExe
+        |> withEmbeddedPdb
+        |> withEmbedAllSource
+        |> ignoreWarnings
+        |> verifyILBaseline
+
     [<Fact>]
     let ``List contains inlining`` () =
         Fsx """module Test

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -60,8 +60,9 @@ module ILChecker =
 
         let unifyRuntimeAssemblyName ilCode =
             List.fold replace ilCode [
-                "\[System\.Runtime\]|\[System\.Console\]|\[System\.Runtime\.Extensions\]|\[mscorlib\]|\[System\.Memory\]", "[runtime]"
+                "\[System\.Runtime\]|\[System\.Console\]|\[System\.Runtime\.Extensions\]|\[mscorlib\]|\[System\.Memory\]|\[System\.Collections\]", "[runtime]"
                 "(\.assembly extern (System\.Runtime|System\.Console|System\.Runtime\.Extensions|mscorlib|System\.Memory)){1}([^\}]*)\}", ".assembly extern runtime { }"
+                "(\.assembly extern (System\.Collections)){1}([^\}]*)\}\\s+", ""
                 "(\.assembly extern (FSharp.Core)){1}([^\}]*)\}", ".assembly extern FSharp.Core { }" ]
 
         let unifyImageBase ilCode = replace ilCode ("\.imagebase\s*0x\d*", ".imagebase {value}")


### PR DESCRIPTION
## Description

- Reenable β-reduction and subsequent reoptimization of immediately-invoked F#-defined generic delegates.

  This optimization was added as part of https://github.com/fsharp/fslang-design/blob/main/tooling/FST-1034-lambda-optimizations.md in #6811. It originally applied to both generic and non-generic delegates.

  I made use of this optimization when writing https://github.com/fsprojects/FSharp.Collections.Builders — but it turns out that the optimization has no longer been applied to code like that since .NET 7.

  #12920 (1b39cdea4d85bb63c2e919dbb21e87686c1d2be1) effectively restricted the optimization to non-generic delegates here:

  ```diff
  let (|DelegateInvokeExpr|_|) g expr =
      match expr with
  -   | Expr.App ((Expr.Val (invokeRef, _, _)) as iref, fty, tyargs, (f :: args), m) 
  -       when invokeRef.LogicalName = "Invoke" && isFSharpDelegateTy g (tyOfExpr g f) -> 
  -           Some(iref, fty, tyargs, f, args, m)
  +   | Expr.App ((Expr.Val (invokeRef, _, _)) as delInvokeRef, delInvokeTy, [], [delExpr;delInvokeArg], m) 
  +       when invokeRef.LogicalName = "Invoke" && isFSharpDelegateTy g (tyOfExpr g delExpr) -> 
  +           Some(delInvokeRef, delInvokeTy, delExpr, delInvokeArg, m)
      | _ -> None
  ```

  I.e., before, `(|DelegateInvokeExpr|_|)` would match delegates with type arguments; after, it would not.

  It does not seem like that change was essential to the fix for #5607. I added the tests from #12920 as emitted IL tests here, and they:
  - Compile (which was the problem in #5607)
  - Show that the optimization is applied to both non-generic and generic delegates.


## Checklist

- [x] Test cases added.
- [x] Release notes entry updated.