### PR TITLE
Update runtime to 9.0.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "9.0.202",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "9.0.200",
+    "dotnet": "9.0.202",
     "vs": {
       "version": "17.8",
       "components": [


### PR DESCRIPTION
The goal is to make Azure pipeline tests run on 9.0.3, containing the fix for CLR crash that happens a lot in our CI.

- [x] Verified the tests run with 9.0.3 now:
`[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.3)` 
