### PR TITLE
Deal with a hanging test

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/CompilerService/AsyncMemoize.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerService/AsyncMemoize.fs
@@ -430,7 +430,7 @@ let ``Cancel running jobs with the same key`` () =
     let current = eventsWhen events (received Requested)
     Assert.Equal(0, current |> countOf Canceled)
 
-    waitUntil events (countOf Canceled >> (=) 10)
+    // waitUntil events (countOf Canceled >> (=) 10)
 
     waitUntil events (received Started)
 
@@ -442,6 +442,7 @@ let ``Cancel running jobs with the same key`` () =
 
     Assert.Equal(0, events |> countOf Failed)
 
+    // All outdated jobs should have been canceled by now.
     Assert.Equal(10, events |> countOf Canceled)
 
     Assert.Equal(1, events |> countOf Finished)


### PR DESCRIPTION
`CompilerService.AsyncMemoize.Cancel running jobs with the same key` test likes to hang sometimes:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=993075&view=logs&j=09cc464c-89cd-5758-006d-ba9e3958cfa9&t=098678ff-b2f3-5c88-44d3-4c7be2f47e75&l=9207

This should fix it or at least produce a proper test failure if it happens again.