### PR TITLE
Re-enable unused bindings detection

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,11 +10,6 @@
     <IgnoreMibc Condition="'$(IgnoreMibc)' == ''">$(DotNetBuildSourceOnly)</IgnoreMibc>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- TODO: These need to be removed once we merge/release the new SDK with noward and line fixes. -->
-    <NoWarn>$(NoWarn);FS0064;FS1182</NoWarn>
-  </PropertyGroup>
-
   <!--
    When developers load the FSharp.Compiler.Service solution we set FSHARPCORE_USE_PACKAGE to true if it hasn't already been set to a value.
    This option ensures that building and testing uses the specified FSharp.Core nuget package instead of the local FSharp.Core project.

--- a/FSharp.sln
+++ b/FSharp.sln
@@ -106,6 +106,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Compiler.Benchmarks"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D58BFE8B-7C85-4D3B-B5F3-9A7BB90FF1EE}"
 	ProjectSection(SolutionItems) = preProject
+		src\Compiler\default.win32manifest = src\Compiler\default.win32manifest
 		src\Compiler\FSComp.txt = src\Compiler\FSComp.txt
 		src\Compiler\FSCompCheck.fsx = src\Compiler\FSCompCheck.fsx
 	EndProjectSection

--- a/FSharpBuild.Directory.Build.props
+++ b/FSharpBuild.Directory.Build.props
@@ -27,7 +27,8 @@
     <SymStoreDirectory>$(ArtifactsDir)\SymStore</SymStoreDirectory>
     <ProtoOutputPath>$(ArtifactsDir)\Bootstrap</ProtoOutputPath>
     <ValueTupleImplicitPackageVersion>4.4.0</ValueTupleImplicitPackageVersion>
-    <WarningsAsErrors>1182;0025;$(WarningsAsErrors)</WarningsAsErrors>
+    <WarnOn>$(WarnOn);1182</WarnOn>
+    <WarningsAsErrors>0025;$(WarningsAsErrors)</WarningsAsErrors>
     <OtherFlags>$(OtherFlags) --nowarn:3384</OtherFlags>
     <OtherFlags>$(OtherFlags) --times --nowarn:75</OtherFlags>
     <OtherFlags Condition="$(AdditionalFscCmdFlags) != ''">$(OtherFlags) $(AdditionalFscCmdFlags)</OtherFlags>

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -813,7 +813,7 @@ let TcConst (cenv: cenv) (overallTy: TType) m env synConst =
             warning(Error(FSComp.SR.tcImplicitMeasureFollowingSlash(), m))
             let factor1 = ms1 |> Option.defaultValue (SynMeasure.One Range.Zero)
             Measure.Prod(tcMeasure factor1, Measure.Inv (tcMeasure ms2), ms.Range)
-        | SynMeasure.Divide(measure1 = ms1; measure2 = ms2; range= m) ->
+        | SynMeasure.Divide(measure1 = ms1; measure2 = ms2) ->
             let factor1 = ms1 |> Option.defaultValue (SynMeasure.One Range.Zero)
             Measure.Prod(tcMeasure factor1, Measure.Inv (tcMeasure ms2), ms.Range)
         | SynMeasure.Seq(mss, _) -> ProdMeasures (List.map tcMeasure mss)
@@ -10686,7 +10686,7 @@ and TcMatchClauses cenv inputTy (resultTy: OverallTy) env tpenv clauses =
     resultList,tpEnv
 
 and TcMatchClause cenv inputTy (resultTy: OverallTy) env isFirst tpenv synMatchClause =
-    let (SynMatchClause(synPat, synWhenExprOpt, synResultExpr, patm, spTgt, trivia)) = synMatchClause
+    let (SynMatchClause(synPat, synWhenExprOpt, synResultExpr, patm, spTgt, _trivia)) = synMatchClause
 
     let isTrueMatchClause =
         if synMatchClause.IsTrueMatchClause then

--- a/src/Compiler/Checking/Expressions/CheckSequenceExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckSequenceExpressions.fs
@@ -270,7 +270,7 @@ let TcSequenceExpression (cenv: TcFileState) env tpenv comp (overallTy: OverallT
 
             let tclauses, tpenv =
                 (tpenv, clauses)
-                ||> List.mapFold (fun tpenv (SynMatchClause(pat, cond, innerComp, _, sp, trivia) as clause) ->
+                ||> List.mapFold (fun tpenv (SynMatchClause(pat, cond, innerComp, _, sp, _trivia) as clause) ->
                     let isTrueMatchClause =
                         if clause.IsTrueMatchClause then
                             TcTrueMatchClause.Yes
@@ -319,7 +319,7 @@ let TcSequenceExpression (cenv: TcFileState) env tpenv comp (overallTy: OverallT
             // Compile the pattern twice, once as a filter with all succeeding targets returning "1", and once as a proper catch block.
             let clauses, tpenv =
                 (tpenv, withList)
-                ||> List.mapFold (fun tpenv (SynMatchClause(pat, cond, innerComp, m, sp, trivia) as clause) ->
+                ||> List.mapFold (fun tpenv (SynMatchClause(pat, cond, innerComp, m, sp, _trivia) as clause) ->
                     let isTrueMatchClause =
                         if clause.IsTrueMatchClause then
                             TcTrueMatchClause.Yes

--- a/src/Compiler/Checking/TailCallChecks.fs
+++ b/src/Compiler/Checking/TailCallChecks.fs
@@ -794,7 +794,7 @@ let CheckModuleBinding cenv (isRec: bool) (TBind _ as bind) =
                 | Expr.Op(args = exprs) -> exprs |> Seq.iter (checkTailCall insideSubBindingOrTry)
                 | Expr.Sequential(expr1 = expr1; expr2 = expr2) ->
                     match expr1 with
-                    | Expr.Op(args = exprs; op = TOp.IntegerForLoop _) -> checkTailCall insideSubBindingOrTry expr1
+                    | Expr.Op(op = TOp.IntegerForLoop _) -> checkTailCall insideSubBindingOrTry expr1
                     | _ -> ()
 
                     checkTailCall insideSubBindingOrTry expr2

--- a/src/Compiler/Checking/infos.fs
+++ b/src/Compiler/Checking/infos.fs
@@ -1438,10 +1438,10 @@ type MethInfo =
             match retTy with
             | Some retTy -> isTyparTy g retTy
             | None -> false
-        | MethInfoWithModifiedReturnType(_,retTy) -> false
+        | MethInfoWithModifiedReturnType _ -> false
         | DefaultStructCtor _ -> false
 #if !NO_TYPEPROVIDERS
-        | ProvidedMeth(amap, mi, _, m) -> false
+        | ProvidedMeth _ -> false
 #endif
 
     /// Get the ParamData objects for the parameters of a MethInfo

--- a/src/Compiler/CodeGen/EraseUnions.fs
+++ b/src/Compiler/CodeGen/EraseUnions.fs
@@ -1210,8 +1210,7 @@ let convAlternativeDef
 
                         let basicCtorFields =
                             basicFields
-                            |> List.map (fun fdef ->
-                                let existingAttrs = fdef.CustomAttrs.AsArray()
+                            |> List.map (fun fdef ->                             
                                 let nullableAttr = getFieldsNullability g fdef |> Option.toList
                                 fdef.Name, fdef.FieldType, nullableAttr)
 

--- a/src/Compiler/CodeGen/EraseUnions.fs
+++ b/src/Compiler/CodeGen/EraseUnions.fs
@@ -1210,7 +1210,7 @@ let convAlternativeDef
 
                         let basicCtorFields =
                             basicFields
-                            |> List.map (fun fdef ->                             
+                            |> List.map (fun fdef ->
                                 let nullableAttr = getFieldsNullability g fdef |> Option.toList
                                 fdef.Name, fdef.FieldType, nullableAttr)
 

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -678,7 +678,7 @@ type Exception with
                     showNullnessAnnotations = Some true
                 }
 
-            let t1, t2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
+            let t1, _t2, _cxs = NicePrint.minimalStringsOfTwoTypes denv ty1 ty2
 
             os.Append(ConstraintSolverNullnessWarningEquivWithTypesE().Format t1) |> ignore
 

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -10,8 +10,7 @@
     <NoWarn>$(NoWarn);75</NoWarn> <!-- InternalCommandLineOption -->
     <NoWarn>$(NoWarn);1204</NoWarn> <!-- This construct is for use in the FSharp.Core library and should not be used directly -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
-    <NoWarn>$(NoWarn);64;1182;1204</NoWarn>         <!--Temporary fix for sourcebuild -->
-    <OtherFlags>$(OtherFlags) --warnaserror-:1182</OtherFlags>         <!--Temporary fix for sourcebuild -->
+    <NoWarn>$(NoWarn);64;1204</NoWarn>         <!--Temporary fix for sourcebuild -->
     <AssemblyName>FSharp.Compiler.Service</AssemblyName>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
@@ -26,11 +25,6 @@
     <TargetFrameworks Condition=" '$(OfficialBuildId)' == '' AND '$(FSharpNetCoreProductTargetFramework)' != '' AND '$(Configuration)' != 'Proto' AND '$(SKIP_NETCURRENT_FSC_BUILD)' != 'true' ">$(FSharpNetCoreProductTargetFramework);$(TargetFrameworks)</TargetFrameworks>
     <DefineConstants Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">$(DefineConstants);FSHARPCORE_USE_PACKAGE</DefineConstants>
     <OtherFlags>$(OtherFlags) --extraoptimizationloops:1</OtherFlags>
-
-    <!-- TODO: This needs to be re-enabled once we merge/release the new SDK with noward and line fixes. -->
-    <!-- 1182: Unused variables -->
-    <OtherFlags>$(OtherFlags) --nowarn:1182</OtherFlags>
-
     <!-- 3218: ArgumentsInSigAndImplMismatch -->
     <OtherFlags>$(OtherFlags) --warnon:3218</OtherFlags>
     <!-- 3390: xmlDocBadlyFormed -->

--- a/src/Compiler/Facilities/AsyncMemoize.fs
+++ b/src/Compiler/Facilities/AsyncMemoize.fs
@@ -183,7 +183,7 @@ type internal AsyncMemoize<'TKey, 'TVersion, 'TValue
     when 'TKey: equality and 'TVersion: equality and 'TKey: not null and 'TVersion: not null>
     (?keepStrongly, ?keepWeakly, ?name: string, ?cancelUnawaitedJobs: bool, ?cancelDuplicateRunningJobs: bool) =
 
-    let name = defaultArg name "N/A"
+    let _name = defaultArg name "N/A"
     let cancelUnawaitedJobs = defaultArg cancelUnawaitedJobs true
     let cancelDuplicateRunningJobs = defaultArg cancelDuplicateRunningJobs false
 

--- a/src/Compiler/Service/TransparentCompiler.fs
+++ b/src/Compiler/Service/TransparentCompiler.fs
@@ -2355,7 +2355,7 @@ type internal TransparentCompiler
             (
                 fileName: string,
                 sourceText: ISourceTextNew,
-                caret: Position option,
+                _caret: Position option,
                 documentSource: DocumentSource,
                 previewEnabled: bool option,
                 loadedTimeStamp: DateTime option,

--- a/src/Compiler/SyntaxTree/LexerStore.fs
+++ b/src/Compiler/SyntaxTree/LexerStore.fs
@@ -32,8 +32,6 @@ let private tryGetStoreData<'T when 'T: not null> (lexbuf: Lexbuf) key =
     | true, data -> Some(data :?> 'T)
     | _ -> None
 
-let private setStoreData (lexbuf: Lexbuf) key data = lexbuf.BufferLocalStore[key] <- data
-
 //------------------------------------------------------------------------
 // A SynArgNameGenerator for the current file, used by the parser
 //------------------------------------------------------------------------

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -1024,9 +1024,9 @@ let parsedHashDirectiveArgumentsNoCheck (input: ParsedHashDirectiveArgument list
         (function
         | ParsedHashDirectiveArgument.String(s, _, _) -> s
         | ParsedHashDirectiveArgument.SourceIdentifier(_, v, _) -> v
-        | ParsedHashDirectiveArgument.Int32(n, m) -> string n
-        | ParsedHashDirectiveArgument.Ident(ident, m) -> ident.idText
-        | ParsedHashDirectiveArgument.LongIdent(ident, m) -> longIdentToString ident)
+        | ParsedHashDirectiveArgument.Int32(n, _) -> string n
+        | ParsedHashDirectiveArgument.Ident(ident, _) -> ident.idText
+        | ParsedHashDirectiveArgument.LongIdent(ident, _) -> longIdentToString ident)
         input
 
 let parsedHashDirectiveStringArguments (input: ParsedHashDirectiveArgument list) (_langVersion: LanguageVersion) =

--- a/src/Compiler/TypedTree/TypedTreeOps.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.fs
@@ -9241,7 +9241,7 @@ let GetDisallowedNullness (g:TcGlobals) (ty:TType) =
                 | None -> []
                 | Some t -> hasWithNullAnyWhere t withNull
 
-            | TType_app (tcr, tinst, nullnessOrig) -> 
+            | TType_app (tcr, tinst, _) -> 
                 let tyArgs = tinst |> List.collect (fun t -> hasWithNullAnyWhere t false)
                 
                 match alreadyWrappedInOuterWithNull, tcr.TypeAbbrev with
@@ -9260,7 +9260,7 @@ let GetDisallowedNullness (g:TcGlobals) (ty:TType) =
                 let inner = tupTypes |> List.collect (fun t -> hasWithNullAnyWhere t false)
                 if alreadyWrappedInOuterWithNull then ty :: inner else inner
 
-            | TType_anon (anon,tys) -> 
+            | TType_anon (tys=tys) -> 
                 let inner = tys |> List.collect (fun t -> hasWithNullAnyWhere t false)
                 if alreadyWrappedInOuterWithNull then ty :: inner else inner
             | TType_fun (d, r, _) ->

--- a/src/FSharp.Build/CreateFSharpManifestResourceName.fs
+++ b/src/FSharp.Build/CreateFSharpManifestResourceName.fs
@@ -18,7 +18,7 @@ type CreateFSharpManifestResourceName public () =
             linkFileName: string,
             rootNamespace: string, // may be null
             dependentUponFileName: string, // may be null
-            binaryStream: Stream // may be null
+            _binaryStream: Stream // may be null
         ) : string =
 
         // The Visual CSharp and XBuild CSharp toolchains transform resource names like this:

--- a/src/FSharp.Build/FSharpEmbedResourceText.fs
+++ b/src/FSharp.Build/FSharpEmbedResourceText.fs
@@ -447,7 +447,7 @@ open Printf
                 let lines =
                     File.ReadAllLines(fileName)
                     |> Array.mapi (fun i s -> i, s) // keep line numbers
-                    |> Array.filter (fun (i, s) -> not (s.StartsWith "#")) // filter out comments
+                    |> Array.filter (fun (_i, s) -> not (s.StartsWith "#")) // filter out comments
 
                 printMessage "Parsing %s" fileName
                 let stringInfos = lines |> Array.map (fun (i, s) -> ParseLine fileName i s)
@@ -511,7 +511,7 @@ open Printf
                 printMessage "Generating resource methods for %s" outFileName
                 // gen each resource method
                 stringInfos
-                |> Seq.iter (fun (lineNum, (optErrNum, ident), str, holes, netFormatString) ->
+                |> Seq.iter (fun (lineNum, (optErrNum, ident), str, holes, _netFormatString) ->
                     let formalArgs = new System.Text.StringBuilder()
                     let actualArgs = new System.Text.StringBuilder()
                     let mutable firstTime = true
@@ -589,7 +589,7 @@ open Printf
                 fprintfn outSignature "    static member RunStartupValidation: unit -> unit"
 
                 stringInfos
-                |> Seq.iter (fun (lineNum, (optErrNum, ident), str, holes, netFormatString) ->
+                |> Seq.iter (fun (_lineNum, (_optErrNum, ident), _str, _holes, _netFormatString) ->
                     fprintfn out "        ignore(GetString(\"%s\"))" ident)
 
                 fprintfn out "        ()" // in case there are 0 strings, we need the generated code to parse
@@ -598,7 +598,7 @@ open Printf
                 xd.LoadXml(xmlBoilerPlateString)
 
                 stringInfos
-                |> Seq.iter (fun (lineNum, (optErrNum, ident), str, holes, netFormatString) ->
+                |> Seq.iter (fun (_lineNum, (_optErrNum, ident), _str, _holes, netFormatString) ->
                     let xn = xd.CreateElement("data")
                     xn.SetAttribute("name", ident) |> ignore
                     xn.SetAttribute("xml:space", "preserve") |> ignore

--- a/src/FSharp.Build/Fsc.fs
+++ b/src/FSharp.Build/Fsc.fs
@@ -69,7 +69,6 @@ type public Fsc() as this =
     let mutable tailcalls: bool = true
     let mutable targetProfile: string MaybeNull = null
     let mutable targetType: string MaybeNull = null
-    let mutable toolExe: string = "fsc.exe"
 
     let defaultToolPath =
         let locationOfThisDll =
@@ -733,8 +732,6 @@ type public Fsc() as this =
             match host with
             | null -> base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands)
             | _ ->
-                let sources = sources |> Array.map (fun i -> i.ItemSpec)
-
                 let invokeCompiler baseCallDelegate =
                     try
                         let ret =
@@ -765,7 +762,7 @@ type public Fsc() as this =
                         ->
                         fsc.Log.LogError(tie.InnerException.Message, [||])
                         -1
-                    | e -> reraise ()
+                    | _ -> reraise ()
 
                 let baseCallDelegate =
                     Func<int>(fun () -> fsc.BaseExecuteTool(pathToTool, responseFileCommands, commandLineCommands))

--- a/src/FSharp.Build/Fsi.fs
+++ b/src/FSharp.Build/Fsi.fs
@@ -37,15 +37,12 @@ type public Fsi() as this =
     let mutable provideCommandLineArgs = false
     let mutable references: ITaskItem[] = [||]
     let mutable referencePath: string MaybeNull = null
-    let mutable resources: ITaskItem[] = [||]
     let mutable skipCompilerExecution = false
     let mutable sources: ITaskItem[] = [||]
     let mutable loadSources: ITaskItem[] = [||]
     let mutable useSources: ITaskItem[] = [||]
     let mutable tailcalls: bool = true
     let mutable targetProfile: string MaybeNull = null
-    let mutable targetType: string MaybeNull = null
-    let mutable toolExe: string = "fsi.exe"
 
     let mutable toolPath: string =
         let locationOfThisDll =

--- a/src/FSharp.Build/MapSourceRoots.fs
+++ b/src/FSharp.Build/MapSourceRoots.fs
@@ -130,7 +130,7 @@ type MapSourceRoots() =
 
                     for root in mappedSourceRoots do
                         match root.GetMetadata SourceControl with
-                        | HasValue v when isSourceControlled -> mapNestedRootIfEmpty root
+                        | HasValue _ when isSourceControlled -> mapNestedRootIfEmpty root
                         | NullOrEmpty when not isSourceControlled -> mapNestedRootIfEmpty root
                         | _ -> ()
 

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
@@ -8,7 +8,6 @@
     <AssemblyName>FSharp.DependencyManager.Nuget</AssemblyName>
     <AllowCrossTargeting>true</AllowCrossTargeting>
     <DefineConstants>$(DefineConstants);COMPILER</DefineConstants>
-    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
     <Tailcalls>true</Tailcalls> <!-- .tail annotations always emitted for this binary, even in debug mode -->
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/tests/FSharp.Build.UnitTests/MapSourceRootsTests.fs
+++ b/tests/FSharp.Build.UnitTests/MapSourceRootsTests.fs
@@ -9,6 +9,8 @@ open Xunit
 open System.Collections.Generic
 open FSharp.Test
 
+#nowarn "1182" //Unused arguments
+
 type MockEngine() =
     member val Errors = ResizeArray() with get
     member val Warnings = ResizeArray() with get

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/DependencyManagerInteractiveTests.fs
@@ -39,8 +39,6 @@ type DependencyManagerInteractiveTests() =
     let getErrors ((_value: Result<FsiValue option, exn>), (errors: FSharpDiagnostic[])) =
         errors
 
-    let ignoreValue = getValue >> ignore
-
     [<Fact>]
     member _.``SmokeTest - #r nuget``() =
         let text = """
@@ -58,7 +56,7 @@ type DependencyManagerInteractiveTests() =
 #r @"nuget:System.Collections.Immutable.DoesNotExist, version=1.5.0"
 0"""
         use script = new scriptHost()
-        let opt, errors = script.Eval(text)
+        let _opt, errors = script.Eval(text)
         Assert.Equal(errors.Length, 1)
 
 (*
@@ -152,8 +150,6 @@ type DependencyManagerInteractiveTests() =
 
     [<Fact>]
     member _.``Multiple Instances of DependencyProvider should be isolated``() =
-
-        let assemblyProbingPaths () = Seq.empty<string>
         let nativeProbingRoots () = Seq.empty<string>
 
         use dp1 = new DependencyProvider(NativeResolutionProbe(nativeProbingRoots), false)
@@ -283,7 +279,6 @@ TorchSharp.Tensor.LongTensor.From([| 0L .. 100L |]).Device
             ResolvingErrorReport (report)
 
         let mutable resolverPackageRoots = Seq.empty<string>
-        let mutable resolverPackageRoots = Seq.empty<string>
         let mutable resolverReferences = Seq.empty<string>
 
         let nativeProbingRoots () = resolverPackageRoots
@@ -383,11 +378,9 @@ printfn ""%A"" result
             ResolvingErrorReport (report)
 
         let mutable resolverPackageRoots = Seq.empty<string>
-        let mutable resolverPackageRoots = Seq.empty<string>
 
         let mutable resolverReferences = Seq.empty<string>
         let nativeProbingRoots () = resolverPackageRoots
-        let assemblyPaths () = resolverReferences
 
         // Restore packages, Get Reference dll paths and package roots
         let result =
@@ -526,10 +519,7 @@ x |> Seq.iter(fun r ->
             ResolvingErrorReport (report)
 
         let mutable resolverPackageRoots = Seq.empty<string>
-        let mutable resolverReferences = Seq.empty<string>
-
         let nativeProbingRoots () = resolverPackageRoots
-        let assemblyProbingPaths () = resolverReferences
 
         // Restore packages, Get Reference dll paths and package roots
         let result =
@@ -552,10 +542,7 @@ x |> Seq.iter(fun r ->
             ResolvingErrorReport (report)
 
         let mutable resolverPackageRoots = Seq.empty<string>
-        let mutable resolverReferences = Seq.empty<string>
-
         let nativeProbingRoots () = resolverPackageRoots
-        let assemblyProbingPaths () = resolverReferences
 
         // Restore packages, Get Reference dll paths and package roots
         let result =
@@ -740,7 +727,7 @@ x |> Seq.iter(fun r ->
         use script = new FSharpScript(quiet = false, langVersion = LangVersion.V47)
 
         use capture = new TestConsole.ExecutionCapture()
-        let opt = script.Eval("#help") |> getValue
+        let _opt = script.Eval("#help") |> getValue
 
         let output = capture.OutText
 
@@ -772,7 +759,7 @@ x |> Seq.iter(fun r ->
         use script = new FSharpScript(quiet = false, langVersion = LangVersion.Preview)
 
         use capture = new TestConsole.ExecutionCapture()
-        let opt = script.Eval("#help") |> getValue
+        let _opt = script.Eval("#help") |> getValue
 
         let output = capture.OutText
 
@@ -871,7 +858,7 @@ x |> Seq.iter(fun r ->
         let idm = dp.TryFindDependencyManagerByKey(Seq.empty, "", reportError, "nuget")
 
         // Resolve and cache the results won't time out
-        let result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"; "r", "timeout=10000"|], reportError, "net9.0", null, "", "", "", -1)           // Wait forever
+        let _result = dp.Resolve(idm, ".fsx", [|"r", "FSharp.Data,3.3.3"; "r", "timeout=10000"|], reportError, "net9.0", null, "", "", "", -1)           // Wait forever
 
         // Clear the results
         foundCorrectError <- false

--- a/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
+++ b/tests/FSharp.Compiler.Private.Scripting.UnitTests/FSharpScriptTests.fs
@@ -71,7 +71,7 @@ x
         let ce = new ControlledExecution(true)
         ce.Run(fun () ->
             use script = new FSharpScript()
-            let result, errors = 
+            let result, _errors = 
                 script.Eval("""
 open System
 let x = 1 + 2
@@ -178,7 +178,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
         Assert.Empty(errors)
         match result with
         | Ok(_) -> ()
-        | Error(ex) -> Assert.True(true, "expected no failures")
+        | Error _ -> Assert.True(true, "expected no failures")
 
     [<Theory>]
     [<InlineData("""#i""", "input.fsx (1,1)-(1,3) interactive warning Invalid directive '#i '")>]                                               // No argument
@@ -186,7 +186,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
     [<InlineData("""#i "        " """, "input.fsx (1,1)-(1,14) interactive error #i is not supported by the registered PackageManagers")>]      // whitespace only argument
     member _.``Script with #i syntax errors fail``(code, error0) =
         use script = new FSharpScript()
-        let result, errors = script.Eval(code)
+        let _result, errors = script.Eval(code)
         Assert.NotEmpty(errors)
         Assert.Equal(errors.[0].ToString(), error0)
 
@@ -196,7 +196,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
                  "input.fsx (1,1)-(1,3) interactive warning Invalid directive '#i '")>]
     member _.``Script with more #i syntax errors fail``(code, error0, error1) =
         use script = new FSharpScript()
-        let result, errors = script.Eval(code)
+        let _result, errors = script.Eval(code)
         Assert.NotEmpty(errors)
         Assert.Equal(errors.Length, 2)
         Assert.Equal(error0, errors.[0].ToString())
@@ -207,7 +207,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
                  "input.fsx (1,1)-(1,42) interactive error #i is not supported by the registered PackageManagers")>]
     member _.``Script with #i and no package manager specified``(code, error0) =
         use script = new FSharpScript()
-        let result, errors = script.Eval(code)
+        let _result, errors = script.Eval(code)
         Assert.NotEmpty(errors)
         Assert.Equal(errors.Length, 1)
         Assert.Equal(errors.[0].ToString(), error0)
@@ -217,7 +217,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
                  "input.fsx (1,1)-(1,15) interactive error Invalid URI: The format of the URI could not be determined.")>]
     member _.``Script with #i and forgot to add quotes``(code, error) =
         use script = new FSharpScript()
-        let result, errors = script.Eval(code)
+        let _result, errors = script.Eval(code)
         Assert.NotEmpty(errors)
         Assert.Equal(1, errors.Length)
         Assert.Equal(error, errors.[0].ToString())
@@ -227,7 +227,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
         let path = Path.GetTempPath()
         let code = sprintf "#i @\"nuget:%s\" " path
         use script = new FSharpScript()
-        let result, errors = script.Eval(code)
+        let _result, errors = script.Eval(code)
         Assert.Empty(errors)
         Assert.Equal(0, errors.Length)
 
@@ -239,7 +239,7 @@ System.Configuration.ConfigurationManager.AppSettings.Item "Environment" <- "LOC
         let code = sprintf "#i @\"nuget:%s\"" path
         let error = sprintf "interactive error The source directory '%s' not found" path
         use script = new FSharpScript()
-        let result, errors = script.Eval(code)
+        let _result, errors = script.Eval(code)
         Assert.NotEmpty(errors)
         Assert.Equal(1, errors.Length)
         Assert.True(errors.[0].ToString().EndsWith(error))
@@ -308,7 +308,7 @@ printfn "{@"%A"}" result
     member _.``Eval script with invalid PackageName should fail immediately``() =
         use capture = new TestConsole.ExecutionCapture()
         use script = new FSharpScript(additionalArgs=[| |])
-        let result, errors = script.Eval("""#r "nuget:FSharp.Really.Not.A.Package" """)
+        let _result, errors = script.Eval("""#r "nuget:FSharp.Really.Not.A.Package" """)
 
         let lines = capture.OutText.Split([| Environment.NewLine |], StringSplitOptions.None)
         let found = lines |> Seq.exists (fun line -> line.Contains("error NU1101:") && line.Contains("FSharp.Really.Not.A.Package"))
@@ -320,7 +320,7 @@ printfn "{@"%A"}" result
     member _.``Eval script with invalid PackageName should fail immediately and resolve one time only``() =
         use capture = new TestConsole.ExecutionCapture()
         use script = new FSharpScript(additionalArgs=[| |])
-        let result, errors =
+        let _result, errors =
             script.Eval("""
 #r "nuget:FSharp.Really.Not.A.Package"
 #r "nuget:FSharp.Really.Not.Another.Package"
@@ -526,7 +526,7 @@ let add (col:IServiceCollection) =
             Assert.Empty(errors)
             match result with
             | Ok(_) -> ()
-            | Error(ex) -> Assert.True(false, "expected no failures")
+            | Error _ -> Assert.True(false, "expected no failures")
         | false ->
             Assert.NotEmpty(errors)
             Assert.Equal(1, errors.Length)

--- a/tests/FSharp.Compiler.Service.Tests/AssemblyReaderShim.fs
+++ b/tests/FSharp.Compiler.Service.Tests/AssemblyReaderShim.fs
@@ -20,6 +20,6 @@ module M
 let x = 123
 """
 
-    let fileName, options = mkTestFileAndOptions source [| |]
+    let fileName, options = mkTestFileAndOptions [| |]
     checker.ParseAndCheckFileInProject(fileName, 0, SourceText.ofString source, options) |> Async.RunImmediate |> ignore
     gotRequest |> Assert.True

--- a/tests/FSharp.Compiler.Service.Tests/Common.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Common.fs
@@ -129,7 +129,7 @@ let mkProjectCommandLineArgsForScript (dllName, fileNames) =
      |]
 #endif
 
-let mkTestFileAndOptions source additionalArgs =
+let mkTestFileAndOptions additionalArgs =
     let fileName = Path.ChangeExtension(getTemporaryFileName (), ".fs")
     let project = getTemporaryFileName ()
     let dllName = Path.ChangeExtension(project, ".dll")
@@ -193,7 +193,7 @@ let parseSourceCode (name: string, code: string) =
     let filePath = Path.Combine(location, name)
     let dllPath = Path.Combine(location, name + ".dll")
     let args = mkProjectCommandLineArgs(dllPath, [filePath])
-    let options, errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
+    let options, _errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
     let parseResults = checker.ParseFile(filePath, SourceText.ofString code, options) |> Async.RunImmediate
     parseResults.ParseTree
 
@@ -203,7 +203,7 @@ let matchBraces (name: string, code: string) =
     let filePath = Path.Combine(location, name + ".fs")
     let dllPath = Path.Combine(location, name + ".dll")
     let args = mkProjectCommandLineArgs(dllPath, [filePath])
-    let options, errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
+    let options, _errors = checker.GetParsingOptionsFromCommandLineArgs(List.ofArray args)
     let braces = checker.MatchBraces(filePath, SourceText.ofString code, options) |> Async.RunImmediate
     braces
 
@@ -265,7 +265,7 @@ let attribsOfSymbol (symbol: FSharpSymbol) =
             if v.IsStatic then yield "static"
             if v.IsLiteral then yield sprintf "%A" v.LiteralValue.Value
             if v.IsAnonRecordField then
-                let info, tys, i = v.AnonRecordFieldDetails
+                let info, _tys, i = v.AnonRecordFieldDetails
                 yield "anon(" + string i + ", [" + info.Assembly.QualifiedName + "/" + String.concat "+" info.EnclosingCompiledTypeNames + "/" + info.CompiledName + "]" + String.concat "," info.SortedFieldNames + ")"
 
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net472;$(FSharpNetCoreProductTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix' or '$(BUILDING_USING_DOTNET)' == 'true'">$(FSharpNetCoreProductTargetFramework)</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);1182</NoWarn> <!-- suppress warning for unused values in FSharp.Compiler.Service.Tests tests, very often checker results are needed, but not used -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UnitTestType>xunit</UnitTestType>
   </PropertyGroup>

--- a/tests/FSharp.Compiler.Service.Tests/FSharpExprPatternsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/FSharpExprPatternsTests.fs
@@ -25,7 +25,7 @@ module TASTCollecting =
         | Application (funcExpr, _typeArgs, argExprs) ->
             visitExpr handler funcExpr
             visitExprs handler argExprs
-        | Call (objExprOpt, memberOrFunc, _typeArgs1, _typeArgs2, argExprs) ->
+        | Call (objExprOpt, _memberOrFunc, _typeArgs1, _typeArgs2, argExprs) ->
             visitObjArg handler objExprOpt
             visitExprs handler argExprs
         | Coerce (_targetType, inpExpr) -> visitExpr handler inpExpr
@@ -132,7 +132,7 @@ let testPatterns handler source =
         Map.tryFind fileName files |> async.Return
 
     let projectOptions =
-        let _, projectOptions = mkTestFileAndOptions "" Array.empty
+        let _, projectOptions = mkTestFileAndOptions Array.empty
 
         { projectOptions with
             SourceFiles = [| "A.fs" |]

--- a/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GeneratedCodeSymbolsTests.fs
@@ -22,10 +22,10 @@ type T () =
             for implFile in wholeProjectResults.AssemblyContents.ImplementationFiles do
                 for decl in implFile.Declarations do
                     match decl with
-                    | FSharpImplementationFileDeclaration.Entity(e,ds) ->
+                    | FSharpImplementationFileDeclaration.Entity(_e,ds) ->
                         for d in ds do
                             match d with
-                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, args, body) ->
+                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, _args, _body) ->
                                 yield mfv
                             | _ -> ()
                     | _ -> ()
@@ -51,10 +51,10 @@ type T = A | B
             for implFile in wholeProjectResults.AssemblyContents.ImplementationFiles do
                 for decl in implFile.Declarations do
                     match decl with
-                    | FSharpImplementationFileDeclaration.Entity(e,ds) ->
+                    | FSharpImplementationFileDeclaration.Entity(_e,ds) ->
                         for d in ds do
                             match d with
-                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, args, body) ->
+                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, _args, _body) ->
                                 yield mfv
                             | _ -> ()
                     | _ -> ()
@@ -84,10 +84,10 @@ type T =
             for implFile in wholeProjectResults.AssemblyContents.ImplementationFiles do
                 for decl in implFile.Declarations do
                     match decl with
-                    | FSharpImplementationFileDeclaration.Entity(e,ds) ->
+                    | FSharpImplementationFileDeclaration.Entity(_e,ds) ->
                         for d in ds do
                             match d with
-                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, args, body) ->
+                            | FSharpImplementationFileDeclaration.MemberOrFunctionOrValue (mfv, _args, _body) ->
                                 yield mfv
                             | _ -> ()
                     | _ -> ()

--- a/tests/FSharp.Compiler.Service.Tests/ModuleReaderCancellationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ModuleReaderCancellationTests.fs
@@ -102,13 +102,6 @@ type PreTypeDefData =
       CancelOnImport: bool }
 
     member this.TypeDef =
-        let name =
-            match this.Namespace with
-            | [] -> this.Name
-            | ns ->
-                let ns = ns |> String.concat "."
-                $"{ns}.{this.Name}"
-
         let methodsDefs =
             if this.HasCtor then
                 let mkCtor = runCancelFirstTime (fun _ -> [| ModuleReader.mkCtor () |])
@@ -191,7 +184,7 @@ let ``Type defs 01 - assembly import`` () =
 
     let getPreTypeDefs typeData = runCancelFirstTime (fun _ -> createPreTypeDefs typeData)
     let typeDefs = getPreTypeDefs [ { Name = "T"; Namespace = []; HasCtor = false; CancelOnImport = false } ]
-    let path, options = mkTestFileAndOptions source [||]
+    let path, options = mkTestFileAndOptions [||]
     let options = referenceReaderProject typeDefs false options
 
     // First request, should be cancelled inside getPreTypeDefs
@@ -217,7 +210,7 @@ let ``Type defs 02 - assembly import`` () =
     let source = source1
 
     let typeDefs = fun _ -> createPreTypeDefs [ { Name = "T"; Namespace = ["Ns"]; HasCtor = false; CancelOnImport = true } ]
-    let path, options = mkTestFileAndOptions source [||]
+    let path, options = mkTestFileAndOptions [||]
     let options = referenceReaderProject typeDefs false options
 
     parseAndCheck path source options |> ignore
@@ -235,7 +228,7 @@ let ``Type defs 03 - type import`` () =
     let source = source2
 
     let typeDefs = fun _ -> createPreTypeDefs [ { Name = "T"; Namespace = ["Ns1"; "Ns2"]; HasCtor = false; CancelOnImport = true } ]
-    let path, options = mkTestFileAndOptions source [||]
+    let path, options = mkTestFileAndOptions [||]
     let options = referenceReaderProject typeDefs false options
 
     // First request, should be cancelled inside GetTypeDef
@@ -260,7 +253,7 @@ let ``Type defs 04 - ctor import`` () =
     let source = source1
 
     let typeDefs = fun _ -> createPreTypeDefs [ { Name = "T"; Namespace = []; HasCtor = true; CancelOnImport = false } ]
-    let path, options = mkTestFileAndOptions source [||]
+    let path, options = mkTestFileAndOptions [||]
     let options = referenceReaderProject typeDefs false options
 
     // First request, should be cancelled inside ILMethodDefs
@@ -282,7 +275,7 @@ let ``Module def 01 - assembly import`` () =
 
     let getPreTypeDefs typeData = fun _ -> createPreTypeDefs typeData
     let typeDefs = getPreTypeDefs [ { Name = "T"; Namespace = []; HasCtor = false; CancelOnImport = false } ]
-    let path, options = mkTestFileAndOptions source [||]
+    let path, options = mkTestFileAndOptions [||]
     let options = referenceReaderProject typeDefs true options
 
     // First request, should be cancelled inside getPreTypeDefs

--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -3,6 +3,7 @@
 open System.Threading.Tasks
 
 #nowarn "57" // Experimental stuff
+#nowarn "1182" //Lot of unused results are stored in a binding, since those tests are checking how internal caching works when changes are being applied
 
 let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e ->  false
 
@@ -5460,7 +5461,7 @@ type A(i:int) =
 [<Fact>]
 let ``#4030, Incremental builder creation warnings 1`` () =
     let source = "module M"
-    let fileName, options = mkTestFileAndOptions source [||]
+    let fileName, options = mkTestFileAndOptions [||]
 
     let _, checkResults = parseAndCheckFile fileName source options
     checkResults.Diagnostics |> Array.map (fun e -> e.Severity = FSharpDiagnosticSeverity.Error) |> shouldEqual [||]
@@ -5468,7 +5469,7 @@ let ``#4030, Incremental builder creation warnings 1`` () =
 [<Fact>]
 let ``#4030, Incremental builder creation warnings 2`` () =
     let source = "module M"
-    let fileName, options = mkTestFileAndOptions source [| "--times" |]
+    let fileName, options = mkTestFileAndOptions [| "--times" |]
 
     let _, checkResults = parseAndCheckFile fileName source options
     checkResults.Diagnostics |> Array.map (fun e -> e.Severity = FSharpDiagnosticSeverity.Error) |> shouldEqual [| false |]
@@ -5476,7 +5477,7 @@ let ``#4030, Incremental builder creation warnings 2`` () =
 [<Fact>]
 let ``#4030, Incremental builder creation warnings 3`` () =
     let source = "module M"
-    let fileName, options = mkTestFileAndOptions source [| "--times"; "--nowarn:75" |]
+    let fileName, options = mkTestFileAndOptions [| "--times"; "--nowarn:75" |]
 
     let _, checkResults = parseAndCheckFile fileName source options
     checkResults.Diagnostics |> Array.map (fun e -> e.Severity = FSharpDiagnosticSeverity.Error) |> shouldEqual [||]
@@ -5484,7 +5485,7 @@ let ``#4030, Incremental builder creation warnings 3`` () =
 [<Fact>]
 let ``#4030, Incremental builder creation warnings 4`` () =
     let source = "module M"
-    let fileName, options = mkTestFileAndOptions source [| "--times"; "--warnaserror:75" |]
+    let fileName, options = mkTestFileAndOptions [| "--times"; "--warnaserror:75" |]
 
     let _, checkResults = parseAndCheckFile fileName source options
     checkResults.Diagnostics |> Array.map (fun e -> e.Severity = FSharpDiagnosticSeverity.Error) |> shouldEqual [| true |]
@@ -5492,7 +5493,7 @@ let ``#4030, Incremental builder creation warnings 4`` () =
 [<Fact>]
 let ``#4030, Incremental builder creation warnings 5`` () =
     let source = "module M"
-    let fileName, options = mkTestFileAndOptions source [| "--times"; "--warnaserror-:75"; "--warnaserror" |]
+    let fileName, options = mkTestFileAndOptions [| "--times"; "--warnaserror-:75"; "--warnaserror" |]
 
     let _, checkResults = parseAndCheckFile fileName source options
     checkResults.Diagnostics |> Array.map (fun e -> e.Severity = FSharpDiagnosticSeverity.Error) |> shouldEqual [| false |]

--- a/tests/FSharp.Compiler.Service.Tests/Symbols.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Symbols.fs
@@ -30,7 +30,7 @@ match "foo" with
 """
 
     let getCaseUsages source line =
-         let fileName, options = mkTestFileAndOptions source [| |]
+         let fileName, options = mkTestFileAndOptions [| |]
          let _, checkResults = parseAndCheckFile fileName source options
           
          checkResults.GetAllUsesOfAllSymbolsInFile()
@@ -201,7 +201,7 @@ module Mod1 =
     module Mod2 =
        let func2 () = ()
 """
-        let fileName, options = mkTestFileAndOptions source [| |]
+        let fileName, options = mkTestFileAndOptions [| |]
         let _, checkResults = parseAndCheckFile fileName source options  
 
         let mod1 = checkResults.PartialAssemblySignature.FindEntityByPath ["Ns1"; "Mod1"] |> Option.get
@@ -221,7 +221,7 @@ let val1 = 1
 module Mod2 =
     let func2 () = ()
 """
-         let fileName, options = mkTestFileAndOptions source [| |]
+         let fileName, options = mkTestFileAndOptions [| |]
          let _, checkResults = parseAndCheckFile fileName source options  
 
          let mod1 = checkResults.PartialAssemblySignature.FindEntityByPath ["Mod1"] |> Option.get
@@ -247,7 +247,7 @@ type FooAttribute() =
 [<Foo>]
 let x = 123
 """
-        let fileName, options = mkTestFileAndOptions source [| "--noconditionalerasure" |]
+        let fileName, options = mkTestFileAndOptions [| "--noconditionalerasure" |]
         let _, checkResults = parseAndCheckFile fileName source options
 
         checkResults.GetAllUsesOfAllSymbolsInFile()
@@ -370,7 +370,7 @@ type I<'T> =
         let _, checkResults = getParseAndCheckResults """
 [1] |> ignore
 """
-        let symbolUses = checkResults.GetAllUsesOfAllSymbolsInFile()
+        let _symbolUses = checkResults.GetAllUsesOfAllSymbolsInFile()
         ()
 
     [<Fact>]

--- a/tests/FSharp.Compiler.Service.Tests/TooltipTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/TooltipTests.fs
@@ -26,7 +26,7 @@ let testXmlDocFallbackToSigFileWhileInImplFile sigSource implSource line colAtEn
     let documentSource fileName = Map.tryFind fileName files |> async.Return
 
     let projectOptions =
-        let _, projectOptions = mkTestFileAndOptions "" Array.empty
+        let _, projectOptions = mkTestFileAndOptions Array.empty
 
         { projectOptions with
             SourceFiles = [| "A.fsi"; "A.fs" |] }
@@ -274,7 +274,7 @@ let testToolTipSquashing source line colAtEndOfNames lineText names tokenTag =
     let documentSource fileName = Map.tryFind fileName files |> async.Return
 
     let projectOptions =
-        let _, projectOptions = mkTestFileAndOptions "" Array.empty
+        let _, projectOptions = mkTestFileAndOptions Array.empty
 
         { projectOptions with
             SourceFiles = [| "A.fs" |] }
@@ -394,7 +394,6 @@ c.Abc
 let getCheckResults source options =
     let fileName, options =
         mkTestFileAndOptions
-            source
             options
     let _, checkResults = parseAndCheckFile fileName source options
     checkResults
@@ -455,7 +454,7 @@ let exists() = System.IO.Path.Exists(null:string)
     let checkResults = getCheckResults source [|"--checknulls+";"--langversion:preview"|]
     checkResults.GetToolTip(2, 36, "let exists() = System.IO.Path.Exists(null:string)", [ "Exists" ], FSharpTokenTag.Identifier)
     |> assertAndExtractTooltip
-    |> fun (text,xml,remarks) ->
+    |> fun (text,xml,_remarks) ->
             text |> Assert.shouldBeEquivalentTo "System.IO.Path.Exists([<NotNullWhenAttribute (true)>] path: string | null) : bool"
             match xml with
             | FSharpXmlDoc.FromXmlFile (_dll,sigPath) -> sigPath |> Assert.shouldBeEquivalentTo "M:System.IO.Path.Exists(System.String)"

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
@@ -12,6 +12,7 @@
     <PackageVersion>$(FSCoreUnitTestsPackageVersion)</PackageVersion>
     <PreRelease>true</PreRelease>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);1182</NoWarn> <!-- suppress warning for unused values in FSharp.Core tests, there are way too many of edge case scenarios tested -->
 
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UnitTestType>xunit</UnitTestType>

--- a/tests/service/data/TestTP/TestTP.fs
+++ b/tests/service/data/TestTP/TestTP.fs
@@ -5,6 +5,8 @@ open Microsoft.FSharp.Core.CompilerServices
 open System.Reflection
 open FSharp.Quotations
 
+#nowarn "1182"  // Lot of unused "args","x","y","c" around this test file
+
 module Helper =
     let doNothing() = ()
     let doNothingOneArg(x:int) = ()

--- a/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NoWarn>$(NoWarn);47;75</NoWarn>
+    <NoWarn>$(NoWarn);47;75;1182</NoWarn><!-- 1182 - unused bindings, too many of them here -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <OtherFlags>$(OtherFlags) --subsystemversion:6.00</OtherFlags>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
+++ b/vsintegration/tests/MockTypeProviders/DummyProviderForLanguageServiceTesting/DummyProviderForLanguageServiceTesting.fsproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <OtherFlags>$(OtherFlags) --nowarn:3390 --nowarn:3218</OtherFlags>
+    <OtherFlags>$(OtherFlags) --nowarn:3390 --nowarn:3218 --nowarn:1182</OtherFlags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
+++ b/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <NoWarn>$(NoWarn);44;45;47;52;58;75</NoWarn>
+    <NoWarn>$(NoWarn);44;45;47;52;58;75;1182</NoWarn><!-- 1182 - unused bindings, too many of them here -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UsePackageTargetFallbackHack>true</UsePackageTargetFallbackHack>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -6,7 +6,7 @@
     <TargetFramework>net472</TargetFramework>
     <PlatformTarget>x86</PlatformTarget>
     <OutputType>Library</OutputType>
-    <NoWarn>$(NoWarn);44;58;75;3005</NoWarn>
+    <NoWarn>$(NoWarn);44;58;75;3005;1182</NoWarn><!-- 1182 - unused bindings, too many of them here -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <UsePackageTargetFallbackHack>true</UsePackageTargetFallbackHack>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Re-enable unused binding.
Simplify how this is managed in project and directory files, centralize.

Localize exceptional cases and disable warning at lowest level possible (ideally just 1 file, worst case 1 full project - never full directory)