### PR TITLE
Static parameters of type provider completion

### DIFF
--- a/src/Compiler/Service/ServiceParamInfoLocations.fs
+++ b/src/Compiler/Service/ServiceParamInfoLocations.fs
@@ -59,15 +59,6 @@ type ParameterLocations
 [<AutoOpen>]
 module internal ParameterLocationsImpl =
 
-    let isStaticArg (StripParenTypes synType) =
-        match synType with
-        | SynType.StaticConstant _
-        | SynType.StaticConstantNull _
-        | SynType.StaticConstantExpr _
-        | SynType.StaticConstantNamed _ -> true
-        | SynType.LongIdent _ -> true // NOTE: this is not a static constant, but it is a prefix of incomplete code, e.g. "TP<42, Arg3" is a prefix of "TP<42, Arg3=6>" and Arg3 shows up as a LongId
-        | _ -> false
-
     /// Dig out an identifier from an expression that used in an application
     let rec digOutIdentFromFuncExpr synExpr =
         // we found it, dig out ident

--- a/src/Compiler/Service/ServiceParsedInputOps.fsi
+++ b/src/Compiler/Service/ServiceParsedInputOps.fsi
@@ -92,6 +92,9 @@ type public CompletionContext =
         hasThis: bool *
         isStatic: bool *
         spacesBeforeEnclosingDefinition: int
+        
+    /// Completing static named parameters of a type provider. `NonProviderType<$>` will also match this.
+    | TypeProviderStaticArgumentList of typeNameEndPos: pos * assignedParams: HashSet<string>
 
 type public ModuleKind =
     { IsAutoOpen: bool

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fs
@@ -586,6 +586,15 @@ let rec stripParenTypes synType =
 
 let (|StripParenTypes|) synType = stripParenTypes synType
 
+let isStaticArg (StripParenTypes synType) =
+    match synType with
+    | SynType.StaticConstant _
+    | SynType.StaticConstantNull _
+    | SynType.StaticConstantExpr _
+    | SynType.StaticConstantNamed _ -> true
+    | SynType.LongIdent _ -> true // NOTE: this is not a static constant, but it is a prefix of incomplete code, e.g. "TP<42, Arg3" is a prefix of "TP<42, Arg3=6>" and Arg3 shows up as a LongId
+    | _ -> false
+
 /// Operations related to the syntactic analysis of arguments of value, function and member definitions and signatures.
 module SynInfo =
 

--- a/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTreeOps.fsi
@@ -198,6 +198,8 @@ val stripParenTypes: synType: SynType -> SynType
 
 val (|StripParenTypes|): synType: SynType -> SynType
 
+val isStaticArg: SynType -> bool
+
 /// Operations related to the syntactic analysis of arguments of value, function and member definitions and signatures.
 module SynInfo =
     /// The argument information for an argument without a name


### PR DESCRIPTION
## Description

Add completion for static parameters of type provider. It's surprising that we don't have this before.

![图片](https://github.com/user-attachments/assets/0896484b-7366-468b-8d38-e1bc67c67c0b)
![图片](https://github.com/user-attachments/assets/16375033-53b5-45a4-98cd-80fff1cd1611)

Note: 
1. The completion only works when there is space between the `< >`.
2. The completion for method style type provider (like `FSharp.Data.JsonProvider< >.`) only works when there is a dot after the `< >`.

This does not affect the type argument completion for non type provider.

![图片](https://github.com/user-attachments/assets/c0c82ef3-5ce8-4ec7-912e-68ac4059930e)
![图片](https://github.com/user-attachments/assets/a6016b6b-7252-44da-a36e-afd26127ef7e)


## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated: