### PR TITLE
Fix Packagemanager behaviour in Visual Studio

### DIFF
--- a/src/Compiler/Driver/ScriptClosure.fs
+++ b/src/Compiler/Driver/ScriptClosure.fs
@@ -327,11 +327,13 @@ module ScriptPreprocessClosure =
                     for kv in tcConfig.packageManagerLines do
                         let packageManagerKey, packageManagerLines = kv.Key, kv.Value
 
-                        match packageManagerLines |> List.filter (not << isEditorCursorInPackageLines) with
+                        let packageManagerLines =
+                            packageManagerLines |> List.filter (not << isEditorCursorInPackageLines)
+
+                        match packageManagerLines with
                         | [] -> ()
                         | packageManagerLine :: _ ->
                             let m = packageManagerLine.Range
-                            let packageManagerLines = packageManagerLines
                             yield! processPackageManagerLines m packageManagerLines scriptName packageManagerKey
             ]
 

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -139,7 +139,7 @@ type Document with
                 | hr, _, _, docData, _ when ErrorHandler.Succeeded(hr) && docData <> IntPtr.Zero ->
                     match Marshal.GetObjectForIUnknown docData with
                     | :? IVsTextBuffer as ivsTextBuffer ->
-                        match textManager.GetActiveView(1, ivsTextBuffer) with
+                        match textManager.GetActiveView(0, ivsTextBuffer) with
                         | hr, vsTextView when ErrorHandler.Succeeded(hr) -> Some vsTextView
                         | _ -> None
                     | _ -> None

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -200,13 +200,16 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
         cancellableTask {
             let! ct = CancellableTask.getCancellationToken ()
             let! fileStamp = document.GetTextVersionAsync(ct)
+            let textViewAndCaret () : (IVsTextView * Position) option = document.TryGetTextViewAndCaretPos()
 
             match singleFileCache.TryGetValue(document.Id) with
             | false, _ ->
                 let! sourceText = document.GetTextAsync(ct)
 
                 let getProjectOptionsFromScript textViewAndCaret =
-                    match textViewAndCaret with
+                    let caret = textViewAndCaret ()
+
+                    match caret with
                     | None ->
                         checker.GetProjectOptionsFromScript(
                             document.FilePath,
@@ -226,7 +229,6 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                             userOpName = userOpName
                         )
 
-                let textViewAndCaret = document.TryGetTextViewAndCaretPos()
                 let! scriptProjectOptions, _ = getProjectOptionsFromScript textViewAndCaret
                 let project = document.Project
 
@@ -266,7 +268,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
 
                 let updateProjectOptions () =
                     async {
-                        let! scriptProjectOptions, _ = getProjectOptionsFromScript None
+                        let! scriptProjectOptions, _ = getProjectOptionsFromScript textViewAndCaret
 
                         checker.NotifyFileChanged(document.FilePath, scriptProjectOptions)
                         |> Async.Start
@@ -281,7 +283,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                     match value with
                     | projectId, fileStamp, parsingOptions, projectOptions, _ ->
                         let subscription =
-                            match textViewAndCaret with
+                            match textViewAndCaret () with
                             | Some(textView, _) ->
                                 subscribeToTextViewEvents (textView, (Some onChangeCaretHandler), (Some onKillFocus), (Some onSetFocus))
                             | None -> None


### PR DESCRIPTION
The https://github.com/dotnet/fsharp/pull/18393

The issue happens when there are multiple #r "nugets: " in the script, when editing the second package management line causes the currently edited line to be submitted.

The fix is to remove the line under the caret from the submission.  All other lines should be submitted.  Additionally improve the GetTextView() to use the cached view.  Which improves the reliability of the editing PM experience.
