### PR TITLE
Fix for #18433 (internal error during xml comment processing)

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -21,6 +21,7 @@
 * Fix MethodDefNotFound when compiling code invoking delegate with option parameter ([Issue #5171](https://github.com/dotnet/fsharp/issues/5171), [PR #18385](https://github.com/dotnet/fsharp/pull/18385))
 * Fix #r nuget ..." downloads unneeded packages ([Issue #18231](https://github.com/dotnet/fsharp/issues/18231), [PR #18393](https://github.com/dotnet/fsharp/pull/18393))
 * Reenable β-reduction and subsequent reoptimization of immediately-invoked F#-defined generic delegates. ([PR #18401](https://github.com/dotnet/fsharp/pull/18401))
+* Fixed [#18433](https://github.com/dotnet/fsharp/issues/18433), a rare case of an internal error in xml comment processing. ([PR #18436](https://github.com/dotnet/fsharp/pull/18436))
 
 ### Added
 * Added missing type constraints in FCS. ([PR #18241](https://github.com/dotnet/fsharp/pull/18241))

--- a/src/Compiler/SyntaxTree/XmlDoc.fs
+++ b/src/Compiler/SyntaxTree/XmlDoc.fs
@@ -139,7 +139,8 @@ type XmlDocCollector() =
             let xmlDocBlock =
                 struct (savedLines.Count - currentGrabPointCommentsCount, savedLines.Count - 1, false)
 
-            savedGrabPoints.Add(pos, xmlDocBlock)
+            // silently override duplicate grab points (which happen only when preceded by nonsensical line directives)
+            savedGrabPoints[pos] <- xmlDocBlock
             currentGrabPointCommentsCount <- 0
             delayedGrabPoint <- ValueNone
 

--- a/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/XmlComments.fs
@@ -242,3 +242,19 @@ module M =
          |> withXmlCommentChecking
          |> compile
          |> withDiagnostics [ ]
+
+    // regression test for #18433
+    [<Fact>]
+    let OverrideXmlCommentsWithSameRange () =
+        Fs"""
+        module A
+        # 1
+        /// A is int
+        type A = {a: int}
+        # 1
+        /// B is int
+        type B = {b: int}
+        """
+        |> withXmlCommentChecking
+        |> compile
+        |> shouldSucceed


### PR DESCRIPTION
## Description

Fixes #18433

### Remarks

Initially, I wanted to replace the internal error by a warning.
However, the internal error only occurs
- in situations like the one described in #18433, where you are not interested in the xml comment, or
- if you have multiple line directives that point to the same line and are followed by xml comments.

So, I settled for just ignoring the repeated xml comments for the same line.
Note that an xml comment will be lost only if it is (according to the line directives) on the same line as another one AND it is different from the other one. Which really does not make sense for any of the scenarios that line directives are meant for.
(Also, implemention-wise, getting to the range for a warning would have been quite complicated.)


## Checklist

- [X] Test cases added
- [X] Release notes entry updated
