### PR TITLE
Make [<CallerMemberName; Struct>] combination work

### DIFF
--- a/src/Compiler/Checking/PostInferenceChecks.fs
+++ b/src/Compiler/Checking/PostInferenceChecks.fs
@@ -2398,13 +2398,25 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                 errorR(Error(FSComp.SR.chkCurriedMethodsCantHaveOutParams(), m))
 
             if numCurriedArgSets = 1 then
+                let inline tryDestOptionalTy g ty =
+                    if isOptionTy g ty then
+                        destOptionTy g ty |> ValueSome
+                    elif g.langVersion.SupportsFeature LanguageFeature.SupportValueOptionsAsOptionalParameters && isValueOptionTy g ty then
+                        destValueOptionTy g ty |> ValueSome
+                    else
+                        ValueNone
+
                 let errorIfNotStringTy m ty callerInfo = 
                     if not (typeEquiv g g.string_ty ty) then
                         errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv ty), m))
                         
-                let errorIfNotStringOptionTy m ty callerInfo =
-                    if not ((isOptionTy g ty) && (typeEquiv g g.string_ty (destOptionTy g ty))) then
-                        errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "string", NicePrint.minimalStringOfType cenv.denv (destOptionTy g ty)), m))
+                let errorIfNotOptional tyToCompare desiredTyName m ty callerInfo =
+
+                    match tryDestOptionalTy g ty with
+                    | ValueSome t when typeEquiv g tyToCompare t -> ()
+                    | ValueSome innerTy -> errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, desiredTyName, NicePrint.minimalStringOfType cenv.denv innerTy), m))
+                    | ValueNone -> errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, desiredTyName, NicePrint.minimalStringOfType cenv.denv ty), m))                   
+
 
                 minfo.GetParamDatas(cenv.amap, m, minfo.FormalMethodInst)
                 |> List.iterSquared (fun (ParamData(_, isInArg, _, optArgInfo, callerInfo, nameOpt, _, ty)) ->
@@ -2421,11 +2433,9 @@ let CheckEntityDefn cenv env (tycon: Entity) =
                     | CallerSide _, CallerLineNumber ->
                         if not (typeEquiv g g.int32_ty ty) then
                             errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "int", NicePrint.minimalStringOfType cenv.denv ty), m))
-                    | CalleeSide, CallerLineNumber ->
-                        if not ((isOptionTy g ty) && (typeEquiv g g.int32_ty (destOptionTy g ty))) then
-                            errorR(Error(FSComp.SR.tcCallerInfoWrongType(callerInfo |> string, "int", NicePrint.minimalStringOfType cenv.denv (destOptionTy g ty)), m))
+                    | CalleeSide, CallerLineNumber -> errorIfNotOptional g.int32_ty "int" m ty callerInfo
                     | CallerSide _, (CallerFilePath | CallerMemberName) -> errorIfNotStringTy m ty callerInfo
-                    | CalleeSide, (CallerFilePath | CallerMemberName) -> errorIfNotStringOptionTy m ty callerInfo
+                    | CalleeSide, (CallerFilePath | CallerMemberName) -> errorIfNotOptional g.string_ty "string" m ty callerInfo
                 )
 
         for pinfo in immediateProps do

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/MemberDefinitions/OptionalArguments/OptionalArguments.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/MemberDefinitions/OptionalArguments/OptionalArguments.fs
@@ -610,3 +610,40 @@ but here has type
 but here has type
     ''a voption'    "
             ]
+
+    [<Fact>]
+    let ``Struct optional args can have caller member name`` () =
+
+        let source = """module TestLib
+open System.Runtime.CompilerServices
+
+let printItOut x =
+  printf "%s" $"{x};"
+
+type Ab() =
+
+  static member aa ([<CallerMemberName; Struct>]?b: string) =
+    printItOut b
+
+  static member bb ([<CallerLineNumber; Struct>]?i: int) =
+    printItOut i
+
+[<EntryPoint>]
+let main _args =
+  Ab.aa()
+  Ab.bb()
+  Ab.aa("hello")
+  Ab.bb(42)
+  0
+"""
+
+        source
+        |> FSharp
+        |> withLangVersionPreview
+        |> withNoWarn 25
+        |> asExe
+        |> compile
+        |> ILVerifierModule.verifyPEFileWithSystemDlls
+        |> run
+        |> verifyOutputContains [|"main;18;hello;42;"|]
+    

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -1640,7 +1640,8 @@ Actual:
                 | Some (ExecutionOutput {Outcome = Failure ex }) ->
                     failwithf $"Eval or Execution has failed (expected to succeed): %A{ex}\n{diagnostics}"
                 | _ ->
-                    failwithf $"Operation failed (expected to succeed).\n{diagnostics}"
+                    
+                    failwithf $"Operation failed (expected to succeed).\n{diagnostics} \n OUTPUTs: %A{r.Output}"
 
         let shouldFail (result: CompilationResult) : CompilationResult =
             match result with


### PR DESCRIPTION
The combination of `[<CallerMemberName; Struct>]` was not working correctly.
Fixes #18386 


After fixing the typecheck failure, this later lead to invalid IL (`Some x` passed to `ValueOption` expecting methods).
This has been rectified for all 3 `Caller..`  enhancement attributes.

