### PR TITLE
Tooltips: fix `null` annotation highlighting

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -23,6 +23,7 @@
 * Fix checking bug in unpickling [PR #18430](https://github.com/dotnet/fsharp/pull/18430)
 * Reenable β-reduction and subsequent reoptimization of immediately-invoked F#-defined generic delegates. ([PR #18401](https://github.com/dotnet/fsharp/pull/18401))
 * Fixed [#18433](https://github.com/dotnet/fsharp/issues/18433), a rare case of an internal error in xml comment processing. ([PR #18436](https://github.com/dotnet/fsharp/pull/18436))
+* Fix missing `null` highlighting in tooltips ([PR #18457](https://github.com/dotnet/fsharp/pull/18457))
 
 ### Added
 * Added missing type constraints in FCS. ([PR #18241](https://github.com/dotnet/fsharp/pull/18241))

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -944,7 +944,7 @@ module PrintTypes =
         // Show nullness annotations unless explicitly turned off
         if denv.showNullnessAnnotations <> Some false then
             match nullness.Evaluate() with
-            | NullnessInfo.WithNull -> part2 ^^ wordL (tagText "| null")
+            | NullnessInfo.WithNull -> part2 ^^ wordL (tagPunctuation "|") ^^ wordL (tagKeyword "null") 
             | NullnessInfo.WithoutNull -> part2
             | NullnessInfo.AmbivalentToNull -> part2 //^^ wordL (tagText "__maybenull")
         else


### PR DESCRIPTION
Fixes missing `null` highlighting in the tooltips:

<img width="408" alt="Screenshot 2025-04-08 at 16 25 58" src="https://github.com/user-attachments/assets/203913d2-5944-4e45-a285-02f248eed242" />
