### PR TITLE
Update package Category

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <!-- Update Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage".
+       Depending on channel configuration, this means that these assets could be pushed to a different feed. -->
+  <ItemGroup>
+    <Artifact Update="@(Artifact->WithMetadataValue('Kind', 'Package'))" Category="ToolingPackage" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Update Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage". Depending on channel configuration, this means that these assets could be pushed to a different feed.