### PR TITLE
Fix overbuilding fsharp & define solution to build in script for VMR

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -210,7 +210,7 @@ stages:
         enableSourceBuild: 
         sourceBuildParameters:
           platforms:
-            buildArguments: --source-build
+            buildArguments: '--source-build'
         enableTelemetry: true
         helixRepo: dotnet/fsharp
         jobs:

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -207,7 +207,7 @@ stages:
         enablePublishTestResults: false
         enablePublishBuildAssets: true
         enablePublishUsingPipelines: $(_PublishUsingPipelines)
-        enableSourceBuild: 
+        enableSourceBuild: true
         sourceBuildParameters:
           platforms:
           - name: 'Managed'

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -210,6 +210,8 @@ stages:
         enableSourceBuild: 
         sourceBuildParameters:
           platforms:
+          - name: 'Managed'
+            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
             buildArguments: '--source-build'
         enableTelemetry: true
         helixRepo: dotnet/fsharp

--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -207,7 +207,10 @@ stages:
         enablePublishTestResults: false
         enablePublishBuildAssets: true
         enablePublishUsingPipelines: $(_PublishUsingPipelines)
-        enableSourceBuild: true
+        enableSourceBuild: 
+        sourceBuildParameters:
+          platforms:
+            buildArguments: --source-build
         enableTelemetry: true
         helixRepo: dotnet/fsharp
         jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,6 +103,11 @@ extends:
           enablePublishBuildAssets: true
           enablePublishUsingPipelines: $(_PublishUsingPipelines)
           enableSourceBuild: true
+          sourceBuildParameters:
+            platforms:
+            - name: 'Managed'
+              container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9'
+              buildArguments: '--source-build'
           enableTelemetry: true
           helixRepo: dotnet/fsharp
           jobs:

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -7,6 +7,18 @@
   </PropertyGroup>
 
   <!--
+    The build script passes in the full path of the sln to build.  This must be overridden in order to build
+    the cloned source in the inner build.
+  -->
+  <Target Name="ConfigureInnerBuildArg"
+          BeforeTargets="GetSourceBuildCommandConfiguration"
+          Condition="'$(DotNetBuildOrchestrator)' != 'true'">
+    <PropertyGroup>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Microsoft.FSharp.Compiler.sln"</InnerBuildArgs>
+    </PropertyGroup>
+  </Target>
+
+  <!--
     The build script bootstraps some tooling for the build.  Since the inner build is triggerred via msbuild,
     trigger the bootstrapping for the inner build.
   -->

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,22 +1,10 @@
 <!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
-
 <Project>
 
   <PropertyGroup>
     <GitHubRepositoryName>fsharp</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
-
-  <!--
-    The build script passes in the full path of the sln to build.  This must be overridden in order to build
-    the cloned source in the inner build.
-  -->
-  <Target Name="ConfigureInnerBuildArg"
-          BeforeTargets="GetSourceBuildCommandConfiguration">
-    <PropertyGroup>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Microsoft.FSharp.Compiler.sln"</InnerBuildArgs>
-    </PropertyGroup>
-  </Target>
 
   <!--
     The build script bootstraps some tooling for the build.  Since the inner build is triggerred via msbuild,
@@ -26,7 +14,6 @@
           DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
           BeforeTargets="RunInnerSourceBuildCommand"
           Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-          
     <PropertyGroup>
       <SourceBuildBootstrapTfmArg Condition="$(SourceBuildBootstrapTfm) != ''">--tfm $(SourceBuildBootstrapTfm)</SourceBuildBootstrapTfmArg>
       <DotNetBuildUseMonoRuntime Condition="'$(DotNetBuildUseMonoRuntime)' == ''">false</DotNetBuildUseMonoRuntime>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -7,18 +7,6 @@
   </PropertyGroup>
 
   <!--
-    The build script passes in the full path of the sln to build.  This must be overridden in order to build
-    the cloned source in the inner build.
-  -->
-  <Target Name="ConfigureInnerBuildArg"
-          BeforeTargets="GetSourceBuildCommandConfiguration"
-          Condition="'$(DotNetBuildOrchestrator)' != 'true'">
-    <PropertyGroup>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)\Microsoft.FSharp.Compiler.sln"</InnerBuildArgs>
-    </PropertyGroup>
-  </Target>
-
-  <!--
     The build script bootstraps some tooling for the build.  Since the inner build is triggerred via msbuild,
     trigger the bootstrapping for the inner build.
   -->

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -299,7 +299,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $source_build_args $product_build_args $properties
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $source_build_args $product_build_args $properties"
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -257,16 +257,6 @@ function BuildSolution {
     enable_analyzers=false
   fi
 
-  local source_build_args=""
-  if [[ "$source_build" == true ]]; then
-    source_build_args="/p:DotNetBuildSourceOnly=true"
-  fi
-
-  local product_build_args=""
-  if [[ "$product_build" == true ]]; then
-    product_build_args="/p:DotNetBuildRepo=true"
-  fi
-
   # NuGet often exceeds the limit of open files on Mac and Linux
   # https://github.com/NuGet/Home/issues/2163
   if [[ "$UNAME" == "Darwin" || "$UNAME" == "Linux" ]]; then
@@ -299,7 +289,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $source_build_args $product_build_args $properties"
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto /p:DotNetBuildRepo=$product_build /p:DotNetBuildSourceOnly=$source_build $properties"
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi
@@ -323,8 +313,8 @@ function BuildSolution {
       /p:QuietRestore=$quiet_restore \
       /p:QuietRestoreBinaryLog="$binary_log" \
       /p:BuildNoRealsig=$buildnorealsig \
-      $source_build_args \
-      $product_build_args \
+      /p:DotNetBuildRepo=$product_build \
+      /p:DotNetBuildSourceOnly=$source_build \
       $properties
   fi
 }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -289,7 +289,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $properties"
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $properties /p:DotNetBuildRepo=$product_build /p:DotNetBuildSourceOnly=$source_build"
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -257,6 +257,16 @@ function BuildSolution {
     enable_analyzers=false
   fi
 
+  local source_build_args=""
+  if [[ "$source_build" == true ]]; then
+    source_build_args="/p:DotNetBuildSourceOnly=true"
+  fi
+
+  local product_build_args=""
+  if [[ "$product_build" == true ]]; then
+    product_build_args="/p:DotNetBuildRepo=true"
+  fi
+
   # NuGet often exceeds the limit of open files on Mac and Linux
   # https://github.com/NuGet/Home/issues/2163
   if [[ "$UNAME" == "Darwin" || "$UNAME" == "Linux" ]]; then
@@ -289,7 +299,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $properties /p:DotNetBuildRepo=$product_build /p:DotNetBuildSourceOnly=$source_build"
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $source_build_args $product_build_args $properties
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi
@@ -304,8 +314,6 @@ function BuildSolution {
       /p:RepoRoot="$repo_root" \
       /p:Restore=$restore \
       /p:Build=$build \
-      /p:DotNetBuildRepo=$product_build \
-      /p:DotNetBuildSourceOnly=$source_build \
       /p:Rebuild=$rebuild \
       /p:Pack=$pack \
       /p:Publish=$publish \
@@ -315,6 +323,8 @@ function BuildSolution {
       /p:QuietRestore=$quiet_restore \
       /p:QuietRestoreBinaryLog="$binary_log" \
       /p:BuildNoRealsig=$buildnorealsig \
+      $source_build_args \
+      $product_build_args \
       $properties
   fi
 }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -35,7 +35,8 @@ usage()
   echo "  --skipAnalyzers                Do not run analyzers during build operations"
   echo "  --skipBuild                    Do not run the build"
   echo "  --prepareMachine               Prepare machine for CI run, clean up processes after build"
-  echo "  --sourceBuild                  Simulate building for source-build"
+  echo "  --sourceBuild                  Build the repository in source-only mode."
+  echo "  --productBuild                 Build the repository in product-build mode."
   echo "  --buildnorealsig               Build product with realsig- (default use realsig+ where necessary)"
   echo "  --tfm                          Override the default target framework"
   echo ""
@@ -73,6 +74,7 @@ skip_analyzers=false
 skip_build=false
 prepare_machine=false
 source_build=false
+product_build=false
 buildnorealsig=true
 properties=""
 
@@ -161,8 +163,12 @@ while [[ $# > 0 ]]; do
     --docker)
       docker=true
       ;;
-    --sourcebuild)
+    --sourcebuild|--source-build|-sb)
       source_build=true
+      product_build=true
+      ;;
+    --productbuild|--product-build|-pb)
+      product_build=true
       ;;
     --buildnorealsig)
       buildnorealsig=true
@@ -238,6 +244,9 @@ function BuildSolution {
   fi
 
   local projects="$repo_root/FSharp.sln"
+  if [[ "$product_build" = true ]]; then
+    projects="$repo_root/Microsoft.FSharp.Compiler.sln"
+  fi
 
   echo "$projects:"
 
@@ -246,11 +255,6 @@ function BuildSolution {
   UNAME="$(uname)"
   if [[ "$UNAME" == "Darwin" ]]; then
     enable_analyzers=false
-  fi
-  
-  local source_build_args=""
-  if [[ "$source_build" == true ]]; then
-    source_build_args="/p:DotNetBuildRepo=true /p:DotNetBuildSourceOnly=true"
   fi
 
   # NuGet often exceeds the limit of open files on Mac and Linux
@@ -285,7 +289,7 @@ function BuildSolution {
     fi
 
     BuildMessage="Error building tools"
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $source_build_args $properties"
+    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto $properties"
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
   fi
@@ -300,6 +304,8 @@ function BuildSolution {
       /p:RepoRoot="$repo_root" \
       /p:Restore=$restore \
       /p:Build=$build \
+      /p:DotNetBuildRepo=$product_build \
+      /p:DotNetBuildSourceOnly=$source_build \
       /p:Rebuild=$rebuild \
       /p:Pack=$pack \
       /p:Publish=$publish \
@@ -309,7 +315,6 @@ function BuildSolution {
       /p:QuietRestore=$quiet_restore \
       /p:QuietRestoreBinaryLog="$binary_log" \
       /p:BuildNoRealsig=$buildnorealsig \
-      $source_build_args \
       $properties
   fi
 }

--- a/eng/common/core-templates/job/source-build.yml
+++ b/eng/common/core-templates/job/source-build.yml
@@ -26,6 +26,8 @@ parameters:
   #   Specifies the build script to invoke to perform the build in the repo. The default
   #   './build.sh' should work for typical Arcade repositories, but this is customizable for
   #   difficult situations.
+  # buildArguments: ''
+  #   Specifies additional build arguments to pass to the build script.
   # jobProperties: {}
   #   A list of job properties to inject at the top level, for potential extensibility beyond
   #   container and pool.

--- a/eng/common/core-templates/steps/source-build.yml
+++ b/eng/common/core-templates/steps/source-build.yml
@@ -79,6 +79,7 @@ steps:
     ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \
       --configuration $buildConfig \
       --restore --build --pack $publishArgs -bl \
+      ${{ parameters.platform.buildArguments }} \
       $officialBuildArgs \
       $internalRuntimeDownloadArgs \
       $internalRestoreArgs \


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5005
Fixes https://github.com/dotnet/source-build/issues/5071
Contributes to https://github.com/dotnet/dotnet/pull/176

FSharp was building two solutions in the VMR on Windows which resulted in the inner-build building the same thing but in parallel. The builds each take 7-8 minutes. Fix that by introducing a productBuild switch (which is already exposed in the Arcade scripts) and condition which solution to build on it.

Remove the /p:Projects property from DotNetBuild.props.
Also delete the source-build logic from Build.ps1 as source-build isn't supported on Windows today.

VMR validation build: https://github.com/dotnet/dotnet/pull/188