### PR TITLE
Fix code completion for types previously defined in own namespace

### DIFF
--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -384,7 +384,7 @@ type internal TypeCheckInfo
             if rangeContainsPos mPossible cursorPos then
                 match bestSoFar with
                 | Some(bestm, _, _) ->
-                    if rangeContainsRange bestm mPossible then
+                    if rangeContainsRange bestm mPossible && not (equals bestm mPossible) then
                         bestSoFar <- Some(mPossible, env, ad)
                 | None -> bestSoFar <- Some(mPossible, env, ad))
 

--- a/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
@@ -134,3 +134,25 @@ let f (s: string) =
     ()
 """
     assertHasItemWithNames ["Length"] info
+
+
+[<Fact>]
+let ``Import - Ns 01`` () =
+    let info =
+        getCompletionInfo "let _: R " (14, 12) """
+namespace Ns
+
+type Rec1 = { F: int }
+
+
+namespace Ns
+
+type Rec2 = { F: int }
+
+module M =
+
+    type Rec3 = { F: int }
+
+    let _: R = ()
+"""
+    assertHasItemWithNames ["Rec1"; "Rec2"; "Rec3"] info


### PR DESCRIPTION
Consider this code:

```fsharp
namespace Ns

type Rec = { F: int }

namespace Ns

module M =
    let _: R{caret}
```

The two `Ns` fragments are analyzed sequentially and types from the first fragment are available in the second one. While checking the code, various intermediate name resolution environments are captured, so the IDE features could reuse them later. The code completion feature picks a dubious environment where `Rec` type is missing for some reason.

This PR introduces a hack that doesn't let it pick this environment, but it doesn't look correct to me (at least for now). I'm still opening this PR to see if any tests fail.

The main question further is where this environment is created and why doesn't it include the type?