### PR TITLE
Tests: Reduce memory use in ComponentTests

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -226,7 +226,7 @@ function Test() {
   projectname="${projectname%.*}"
   testlogpath="$artifacts_dir/TestResults/$configuration/${projectname}_$targetframework.xml"
   args="test \"$testproject\" --no-restore --no-build -c $configuration -f $targetframework --test-adapter-path . --logger \"xunit;LogFilePath=$testlogpath\" --blame-hang-timeout 5minutes --results-directory $artifacts_dir/TestResults/$configuration -p:vstestusemsbuildoutput=false"
-  args+=" -- xUnit.MaxParallelThreads=1"
+
   "$DOTNET_INSTALL_DIR/dotnet" $args || exit $?
 }
 

--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedCoreTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedCoreTests.fs
@@ -352,13 +352,13 @@ let ``subtype-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/subtype" FSC_OPTI
 let ``subtype-FSI`` () = singleTestBuildAndRun "core/subtype" FSI
 
 [<Fact>]
-let ``syntax-FSC_DEBUG`` () = singleTestBuildAndRun "core/syntax" FSC_DEBUG
+let ``syntax-FSC_DEBUG`` () = singleTestBuildAndRunIsolated "core/syntax" FSC_DEBUG
 
 [<Fact>]
-let ``syntax-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/syntax" FSC_OPTIMIZED
+let ``syntax-FSC_OPTIMIZED`` () = singleTestBuildAndRunIsolated "core/syntax" FSC_OPTIMIZED
 
 [<Fact>]
-let ``syntax-FSI`` () = singleTestBuildAndRun "core/syntax" FSI
+let ``syntax-FSI`` () = singleTestBuildAndRunIsolated "core/syntax" FSI
 
 [<Fact>]
 let ``test int32-FSC_DEBUG`` () = singleTestBuildAndRun "core/int32" FSC_DEBUG
@@ -453,10 +453,10 @@ let ``fsi_load-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/fsi-load" FSC_OP
 let ``fsi_load-FSI`` () = singleTestBuildAndRun "core/fsi-load" FSI
 
 [<Fact>]
-let ``reflect-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/reflect" FSC_OPTIMIZED
+let ``reflect-FSC_OPTIMIZED`` () = singleTestBuildAndRunIsolated "core/reflect" FSC_OPTIMIZED
 
 [<Fact>]
-let ``reflect-FSI`` () = singleTestBuildAndRun "core/reflect" FSI
+let ``reflect-FSI`` () = singleTestBuildAndRunIsolated "core/reflect" FSI
 
 let isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 

--- a/tests/FSharp.Test.Utilities/ScriptHelpers.fs
+++ b/tests/FSharp.Test.Utilities/ScriptHelpers.fs
@@ -64,7 +64,10 @@ type FSharpScript(?additionalArgs: string[], ?quiet: bool, ?langVersion: LangVer
         Thread.CurrentThread.CurrentCulture <- Option.defaultValue Globalization.CultureInfo.InvariantCulture desiredCulture
 
         let cancellationToken = defaultArg cancellationToken CancellationToken.None
-        let ch, errors = fsi.EvalInteractionNonThrowing(code, cancellationToken)
+        let ch, errors =
+            // lock, because For memory conservation in CI FSharpScripts may be reused between tests
+            lock fsi <| fun () ->
+                fsi.EvalInteractionNonThrowing(code, cancellationToken)
 
         Thread.CurrentThread.CurrentCulture <- originalCulture
 

--- a/tests/FSharp.Test.Utilities/XunitHelpers.fs
+++ b/tests/FSharp.Test.Utilities/XunitHelpers.fs
@@ -12,9 +12,9 @@ open TestFramework
 
 open FSharp.Compiler.Diagnostics
 
-open OpenTelemetry
 open OpenTelemetry.Resources
 open OpenTelemetry.Trace
+open OpenTelemetry.Metrics
 
 /// Disables custom internal parallelization added with XUNIT_EXTRAS.
 /// Execute test cases in a class or a module one by one instead of all at once. Allow other collections to run simultaneously.
@@ -130,6 +130,45 @@ type CustomTheoryTestCase =
 
 #endif
 
+
+type OpenTelemetryExport(testRunName, enable) =
+    // On Windows forwarding localhost to wsl2 docker container sometimes does not work. Use IP address instead.
+    let otlpEndpoint = Uri("http://127.0.0.1:4317")
+    
+    // Configure OpenTelemetry export. 
+    let providers : IDisposable list =
+        if not enable then [] else
+            [
+            // Configure OpenTelemetry tracing export. Traces can be viewed in Jaeger or other compatible tools.
+            OpenTelemetry.Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivityNames.FscSourceName)
+                .ConfigureResource(fun r -> r.AddService("F#") |> ignore)
+                .AddOtlpExporter(fun o ->
+                    o.Endpoint <- otlpEndpoint
+                    o.Protocol <- OpenTelemetry.Exporter.OtlpExportProtocol.Grpc
+                    // Empirical values to ensure no traces are lost and no significant delay at the end of test run.
+                    o.TimeoutMilliseconds <- 200
+                    o.BatchExportProcessorOptions.MaxQueueSize <- 16384
+                    o.BatchExportProcessorOptions.ScheduledDelayMilliseconds <- 100
+                )
+                .Build()
+
+            // Configure OpenTelemetry metrics export. Metrics can be viewed in Prometheus or other compatible tools.
+            OpenTelemetry.Sdk.CreateMeterProviderBuilder()
+                .AddMeter("System.Runtime")
+                .ConfigureResource(fun r -> r.AddService(testRunName) |> ignore)
+                .AddOtlpExporter(fun e m ->
+                    e.Endpoint <- otlpEndpoint
+                    e.Protocol <- OpenTelemetry.Exporter.OtlpExportProtocol.Grpc
+                    m.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds <- 1000
+                )
+                .Build()
+            ]
+
+    interface IDisposable with
+        member this.Dispose() =
+            for p in providers do p.Dispose()
+
 /// `XunitTestFramework` providing parallel console support and conditionally enabling optional xUnit customizations.
 type FSharpXunitFramework(sink: IMessageSink) =
     inherit XunitTestFramework(sink)
@@ -145,32 +184,21 @@ type FSharpXunitFramework(sink: IMessageSink) =
                 // We need AssemblyResolver already here, because OpenTelemetry loads some assemblies dynamically.
                 AssemblyResolver.addResolver ()
             #endif
-                
-                // Configure OpenTelemetry export. Traces can be viewed in Jaeger or other compatible tools.
-                use tracerProvider =
-                    OpenTelemetry.Sdk.CreateTracerProviderBuilder()
-                        .AddSource(ActivityNames.FscSourceName)
-                        .ConfigureResource(fun r -> r.AddService("F#") |> ignore)
-                        .AddOtlpExporter(fun o ->
-                            // Empirical values to ensure no traces are lost and no significant delay at the end of test run.
-                            o.TimeoutMilliseconds <- 200
-                            o.BatchExportProcessorOptions.MaxQueueSize <- 16384
-                            o.BatchExportProcessorOptions.ScheduledDelayMilliseconds <- 100
-                        )
-                        .Build()
 
+                let testRunName = $"RunTests_{assemblyName.Name} {Runtime.InteropServices.RuntimeInformation.FrameworkDescription}"
+
+                use _ = new OpenTelemetryExport(testRunName, Environment.GetEnvironmentVariable("FSHARP_OTEL_EXPORT") <> null)   
+                
                 logConfig initialConfig
                 log "Installing TestConsole redirection"
                 TestConsole.install()
               
                 begin
-                    use _ = Activity.startNoTags $"RunTests_{assemblyName.Name} {Runtime.InteropServices.RuntimeInformation.FrameworkDescription}"
+                    use _ = Activity.startNoTags testRunName
                     // We can't just call base.RunTestCases here, because it's implementation is async void.
                     use runner = new XunitTestAssemblyRunner (x.TestAssembly, testCases, x.DiagnosticMessageSink, executionMessageSink, executionOptions)
                     runner.RunAsync().Wait()
                 end
-
-                tracerProvider.ForceFlush() |> ignore
 
                 cleanUpTemporaryDirectoryOfThisTestRun ()
         }


### PR DESCRIPTION
ComponentTests allocate a lot, and the Linux CI instance can barely take it:
![image](https://github.com/user-attachments/assets/f63a26f9-9173-4d7e-910c-b33394d3210f)



A lot of fsi sessions are created to run script tests, that's one reason.
We can cache and reuse them, on practical basis, i.e. it's not always possible and some tests must be excluded from it, but most are fine. To exclude any test that is not cooperating, just run it with `singleTestBuildAndRunIsolated`.

I also added metrics telemetry export in tests. OTEL export is now generally enabled by setting `FSHARP_OTEL_EXPORT` env var.


Before, after:
![image](https://github.com/user-attachments/assets/ad6d73f5-9903-4ed8-9366-442530520601)




I need this to unblock #18499.
