### PR TITLE
Keep parens around records in interpolated strings

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/9.0.300.md
@@ -16,7 +16,7 @@
 * Unsafe downcast from `obj` to generic `T` no longer requires `not null` constraint on `T`([Issue #18275](https://github.com/dotnet/fsharp/issues/18275), [PR #18343](https://github.com/dotnet/fsharp/pull/18343))
 * Fix "type inference problem too complicated" for SRTP with T:null and T:struct dummy constraint([Issue #18288](https://github.com/dotnet/fsharp/issues/18288), [PR #18345](https://github.com/dotnet/fsharp/pull/18345))
 * Fix for missing parse diagnostics in TransparentCompiler.ParseAndCheckProject ([PR #18366](https://github.com/dotnet/fsharp/pull/18366))
-* Miscellanous parentheses analyzer fixes. ([PR #18350](https://github.com/dotnet/fsharp/pull/18350))
+* Miscellanous parentheses analyzer fixes. ([PR #18350](https://github.com/dotnet/fsharp/pull/18350), [PR #18534](https://github.com/dotnet/fsharp/pull/18534))
 * Fix duplicate parse error reporting for GetBackgroundCheckResultsForFileInProject ([Issue #18379](https://github.com/dotnet/fsharp/issues/18379) [PR #18380](https://github.com/dotnet/fsharp/pull/18380))
 * Fix MethodDefNotFound when compiling code invoking delegate with option parameter ([Issue #5171](https://github.com/dotnet/fsharp/issues/5171), [PR #18385](https://github.com/dotnet/fsharp/pull/18385))
 * Fix #r nuget ..." downloads unneeded packages ([Issue #18231](https://github.com/dotnet/fsharp/issues/18231), [PR #18393](https://github.com/dotnet/fsharp/pull/18393))

--- a/src/Compiler/Service/SynExpr.fs
+++ b/src/Compiler/Service/SynExpr.fs
@@ -1078,6 +1078,8 @@ module SynExpr =
             | SynExpr.Sequential(expr1 = SynExpr.Paren(expr = Is inner); expr2 = expr2), _ when innerBindingsWouldShadowOuter inner expr2 ->
                 true
 
+            | SynExpr.InterpolatedString _, SynExpr.Record _
+            | SynExpr.InterpolatedString _, SynExpr.AnonRecd _
             | SynExpr.InterpolatedString _, SynExpr.Sequential _
             | SynExpr.InterpolatedString _, SynExpr.Tuple(isStruct = false) -> true
 

--- a/src/Compiler/Service/SynExpr.fs
+++ b/src/Compiler/Service/SynExpr.fs
@@ -1078,8 +1078,14 @@ module SynExpr =
             | SynExpr.Sequential(expr1 = SynExpr.Paren(expr = Is inner); expr2 = expr2), _ when innerBindingsWouldShadowOuter inner expr2 ->
                 true
 
+            // $"{({ A = 3 })}"
+            // $"{({| A = 3 |})}"
+            // $"{({1..10})}"
+            // $"{(();1)}"
+            // $"{(1,2)}"
             | SynExpr.InterpolatedString _, SynExpr.Record _
             | SynExpr.InterpolatedString _, SynExpr.AnonRecd _
+            | SynExpr.InterpolatedString _, SynExpr.ComputationExpr _
             | SynExpr.InterpolatedString _, SynExpr.Sequential _
             | SynExpr.InterpolatedString _, SynExpr.Tuple(isStruct = false) -> true
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -1404,6 +1404,13 @@ in x
             $"{({| A = 3 |})}"
             """
 
+            """
+            $"{({ 1..10 })}"
+            """,
+            """
+            $"{({ 1..10 })}"
+            """
+
             // LibraryOnlyILAssembly
             """(# "ldlen.multi 2 0" array : int #)""", """(# "ldlen.multi 2 0" array : int #)"""
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/RemoveUnnecessaryParenthesesTests.fs
@@ -1390,6 +1390,20 @@ in x
             $"{3 + LanguagePrimitives.GenericZero<int> :N0}"
             """
 
+            """
+            $"{({ A = 3 })}"
+            """,
+            """
+            $"{({ A = 3 })}"
+            """
+
+            """
+            $"{({| A = 3 |})}"
+            """,
+            """
+            $"{({| A = 3 |})}"
+            """
+
             // LibraryOnlyILAssembly
             """(# "ldlen.multi 2 0" array : int #)""", """(# "ldlen.multi 2 0" array : int #)"""
 


### PR DESCRIPTION
## Description

- Keep parentheses around records and `seq`-less sequence expressions in interpolated strings. Inspired by https://github.com/fsprojects/fantomas/issues/3162.

  We could alternatively add spaces as part of the code fix, but I am leaning towards not doing more of that unless I someday get around to doing something more sophisticated as described in https://github.com/dotnet/fsharp/issues/16966.

## Checklist

- [x] Test cases added.
- [x] Release notes entry updated.