### PR TITLE
Update CODEOWNERS - keep fsharp-team-msft

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @dotnet/fsharp-team-msft
-/eng/DotNetBuild.props @dotnet/product-construction
-/eng/SourceBuild* @dotnet/source-build


### PR DESCRIPTION
@dotnet/product-construction removed
@dotnet/source-build removed


```
/eng/DotNetBuild.props @dotnet/product-construction
/eng/SourceBuild* @dotnet/source-build
```