### PR TITLE
Cleanup; remove XunitSetup.fs linked file that does nothing

### DIFF
--- a/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
+++ b/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
@@ -16,9 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(FSharpTestsRoot)\FSharp.Test.Utilities\XunitSetup.fs">
-      <Link>XunitSetup.fs</Link>
-    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Utilities\NullnessShims.fs"/>
     <EmbeddedText Include="$(FSharpSourcesRoot)\Compiler\Facilities\UtilsStrings.txt" />
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Facilities\CompilerLocation.fs">

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -17,9 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(FSharpTestsRoot)\FSharp.Test.Utilities\XunitSetup.fs">
-      <Link>XunitSetup.fs</Link>
-    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Utilities\NullnessShims.fs" />
     <Compile Include="AssemblyResolver.fs" />
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Utilities\InternalCollections.fsi">


### PR DESCRIPTION
Just a cleanup.
Linked `XunitSetup.fs` does nothing in the VS test projects when they're not referencing the `FSharp.Test.Utilities` project.