### PR TITLE
Remove deoptimizations in FSharp.Test.Utilities

### DIFF
--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -8,8 +8,6 @@
     <ReferenceVsAssemblies>true</ReferenceVsAssemblies>
     <OutputType>Library</OutputType>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <Optimize>false</Optimize>
-    <Tailcalls>false</Tailcalls>
     <UnitTestType>xunit</UnitTestType>
     <IsTestProject>true</IsTestProject>
     <OtherFlags>$(OtherFlags) --realsig-</OtherFlags>


### PR DESCRIPTION
Just to see if things still work. I can't think of a reason this particular project needs to disable optimizations and tailcalls.