### PR TITLE
Checker: report environment before checking namespace

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
@@ -5,3 +5,4 @@
 * Allow `let!` and `use!` type annotations without requiring parentheses ([PR #18508](https://github.com/dotnet/fsharp/pull/18508))
 * Fix find all references for F# exceptions ([PR #18565](https://github.com/dotnet/fsharp/pull/18565))
 * Shorthand lambda: fix completion for chained calls and analysis for unfinished expression ([PR #18560](https://github.com/dotnet/fsharp/pull/18560))
+* Completion: fix previous namespace considered opened [PR #18609](https://github.com/dotnet/fsharp/pull/18609)

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5428,7 +5428,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
 
           let envNS = LocateEnv kind.IsModule cenv.thisCcu env enclosingNamespacePath
           let envNS = ImplicitlyOpenOwnNamespace cenv.tcSink g cenv.amap m enclosingNamespacePath envNS
-          CallEnvSink cenv.tcSink (scopem, envNS.NameEnv, env.eAccessRights)
+          CallEnvSink cenv.tcSink (m, envNS.NameEnv, env.eAccessRights)
 
           let modTyNS = envNS.eModuleOrNamespaceTypeAccumulator.Value
           let modTyRoot, modulNSs = BuildRootModuleType enclosingNamespacePath envNS.eCompPath modTyNS

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5428,6 +5428,7 @@ let rec TcModuleOrNamespaceElementNonMutRec (cenv: cenv) parent typeNames scopem
 
           let envNS = LocateEnv kind.IsModule cenv.thisCcu env enclosingNamespacePath
           let envNS = ImplicitlyOpenOwnNamespace cenv.tcSink g cenv.amap m enclosingNamespacePath envNS
+          CallEnvSink cenv.tcSink (scopem, envNS.NameEnv, env.eAccessRights)
 
           let modTyNS = envNS.eModuleOrNamespaceTypeAccumulator.Value
           let modTyRoot, modulNSs = BuildRootModuleType enclosingNamespacePath envNS.eCompPath modTyNS

--- a/tests/FSharp.Compiler.Service.Tests/Common.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Common.fs
@@ -5,9 +5,9 @@ open System
 open System.Diagnostics
 open System.IO
 open System.Collections.Generic
-open System.Threading
 open System.Threading.Tasks
 open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.EditorServices
 open FSharp.Compiler.IO
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
@@ -351,6 +351,14 @@ let getCursorPosAndPrepareSource (source: string) : string * string * pos =
     let source = source.Replace("{caret}", "")
     let lineText = lineText.Replace("{caret}", "")
     source, lineText, Position.mkPos (line + 1) (column - 1)
+
+let getPartialIdentifierAndPrepareSource source =
+    let source, lineText, pos = getCursorPosAndPrepareSource source
+    let _, column, _ = QuickParse.GetCompleteIdentifierIsland false lineText pos.Column |> Option.get
+    let pos = Position.mkPos pos.Line column
+    let plid = QuickParse.GetPartialLongNameEx(lineText, column - 1)
+    let names = plid.QualifyingIdents @ [plid.PartialIdent]
+    source, lineText, pos, plid, names
 
 let getParseResults (source: string) =
     parseSourceCode("Test.fsx", source)

--- a/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
@@ -369,6 +369,8 @@ namespace Ns1
 
 type E =
     | A = 1
+    | B = 2
+    | C = 3
 
 namespace Ns2
 

--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -4362,7 +4362,7 @@ let ``Test Project32 should be able to find impl symbols`` () =
         checker.GetBackgroundCheckResultsForFileInProject(Project32.fileName1, Project32.options)
         |> Async.RunImmediate
 
-    let implSymbolUseOpt = implBackgroundTypedParse1.GetSymbolUseAtLocation(3,5,"",["func"])
+    let implSymbolUseOpt = implBackgroundTypedParse1.GetSymbolUseAtLocation(3,5,"let func x = x + 1",["func"])
     let implSymbol = implSymbolUseOpt.Value.Symbol
 
     let usesOfImplSymbol =


### PR DESCRIPTION
A follow up for #18519.

It turns out features like the code completion relied on the own environment being reported when checking top level declarations in some cases. This is not an entirely correct approach, but it's likely that there are many similar places where things assumed _something_ close enough being reported.

#18519 has broken cases where an name resolution environment just before checking a namespace was lost (i.e. including previously checked namespaces). This PR adds reporting the environment before checking the current namespace fragment. This may break some other things but it seems it's a step in the right direction.