### PR TITLE
Update System versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,17 +17,17 @@
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>c192adbb5252264481e8c046a8e0694f7fc7855b</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="8.0.0">
+    <Dependency Name="System.Reflection.Metadata" Version="9.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
+      <Sha>9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3</Sha>
     </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="8.0.0">
+    <Dependency Name="System.Collections.Immutable" Version="9.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
+      <Sha>9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Tasks.Dataflow" Version="8.0.0">
+    <Dependency Name="System.Threading.Tasks.Dataflow" Version="9.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
+      <Sha>9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Build" Version="17.13.26">
+    <Dependency Name="Microsoft.Build" Version="17.15.0-preview-25276-10">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>c192adbb5252264481e8c046a8e0694f7fc7855b</Sha>
+      <Sha>15d19b96cf826b99925c8e5fd75575f46c60dd4a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Framework" Version="17.13.26">
+    <Dependency Name="Microsoft.Build.Framework" Version="17.15.0-preview-25276-10">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>c192adbb5252264481e8c046a8e0694f7fc7855b</Sha>
+      <Sha>15d19b96cf826b99925c8e5fd75575f46c60dd4a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.13.26">
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.15.0-preview-25276-10">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>c192adbb5252264481e8c046a8e0694f7fc7855b</Sha>
+      <Sha>15d19b96cf826b99925c8e5fd75575f46c60dd4a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.13.26">
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.15.0-preview-25276-10">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>c192adbb5252264481e8c046a8e0694f7fc7855b</Sha>
+      <Sha>15d19b96cf826b99925c8e5fd75575f46c60dd4a</Sha>
     </Dependency>
     <Dependency Name="System.Reflection.Metadata" Version="9.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,6 +29,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3</Sha>
     </Dependency>
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="9.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="9.0.0-beta.25271.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -99,9 +99,9 @@
     <!-- Versions for package groups -->
     <RoslynVersion>4.15.0-1.25171.14</RoslynVersion>
     <VisualStudioEditorPackagesVersion>17.14.188</VisualStudioEditorPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.14.39473</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.14.40268</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.14.79</VisualStudioProjectSystemPackagesVersion>
-    <VisualStudioShellProjectsPackages>17.14.39490</VisualStudioShellProjectsPackages>
+    <VisualStudioShellProjectsPackages>17.14.40254</VisualStudioShellProjectsPackages>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.14.15</MicrosoftVisualStudioThreadingPackagesVersion>
     <MicrosoftBuildVersion>17.15.0-preview-25276-10</MicrosoftBuildVersion>
     <!-- Roslyn packages -->
@@ -196,8 +196,8 @@
     <MicrosoftNETTestSdkVersion>17.11.1</MicrosoftNETTestSdkVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
-    <StreamJsonRpcVersion>2.21.66</StreamJsonRpcVersion>
-    <NerdbankStreamsVersion>2.11.90</NerdbankStreamsVersion>
+    <StreamJsonRpcVersion>2.22.11</StreamJsonRpcVersion>
+    <NerdbankStreamsVersion>2.12.87</NerdbankStreamsVersion>
     <XUnitVersion>2.9.0</XUnitVersion>
     <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>
     <XunitXmlTestLoggerVersion>3.1.17</XunitXmlTestLoggerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,7 +97,7 @@
     <SystemThreadingTasksDataflow>$(SystemPackageVersionVersion)</SystemThreadingTasksDataflow>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <!-- Versions for package groups -->
-    <RoslynVersion>4.11.0-2.24264.2</RoslynVersion>
+    <RoslynVersion>4.14.0</RoslynVersion>
     <VisualStudioEditorPackagesVersion>17.10.191</VisualStudioEditorPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.10.40152</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.10.526-pre-g1b474069f5</VisualStudioProjectSystemPackagesVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -131,9 +131,9 @@
     <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
     <MicrosoftVisualStudioProjectAggregatorVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioProjectAggregatorVersion>
     <MicrosoftVisualStudioGraphModelVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioGraphModelVersion>
-    <MicrosoftVisualStudioImagingVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImagingVersion>
+    <MicrosoftVisualStudioImagingVersion>17.14.40270</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
-    <MicrosoftVisualStudioUtilitiesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioUtilitiesVersion>
+    <MicrosoftVisualStudioUtilitiesVersion>17.14.40270</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioShellImmutable100Version>10.0.30319</MicrosoftVisualStudioShellImmutable100Version>
     <MicrosoftVisualStudioShellImmutable110Version>11.0.50727</MicrosoftVisualStudioShellImmutable110Version>
     <MicrosoftVisualStudioShellImmutable150Version>15.0.25123-Dev15Preview</MicrosoftVisualStudioShellImmutable150Version>
@@ -169,7 +169,7 @@
     <!-- -->
     <!-- Misc. Visual Studio packages -->
     <MicrosoftVSSDKBuildToolsVersion>17.10.2179</MicrosoftVSSDKBuildToolsVersion>
-    <MicrosoftVisualStudioRpcContractsVersion>17.14.18</MicrosoftVisualStudioRpcContractsVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.14.20</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioValidationVersion>17.8.8</MicrosoftVisualStudioValidationVersion>
     <VSSDKDebuggerVisualizersVersion>12.0.4</VSSDKDebuggerVisualizersVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,14 +80,14 @@
   <!-- Dependencies from maintenance-packages, everything else -->
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <SystemBuffersVersion>4.6.0</SystemBuffersVersion>
-    <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
+    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- System.* packages -->
     <!-- If a System.* package is stuck on version 4.3.x, targets .NET Standard 1.x and hasn't been
     updated in years, you most likely DON'T need it, please exercise caution when adding it to the list. -->
-    <SystemPackageVersionVersion>8.0.0</SystemPackageVersionVersion>
+    <SystemPackageVersionVersion>9.0.0</SystemPackageVersionVersion>
     <SystemCollectionsImmutableVersion>$(SystemPackageVersionVersion)</SystemCollectionsImmutableVersion>
     <SystemComponentModelCompositionVersion>$(SystemPackageVersionVersion)</SystemComponentModelCompositionVersion>
     <SystemCompositionVersion>$(SystemPackageVersionVersion)</SystemCompositionVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,11 +97,11 @@
     <SystemThreadingTasksDataflow>$(SystemPackageVersionVersion)</SystemThreadingTasksDataflow>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <!-- Versions for package groups -->
-    <RoslynVersion>4.14.0</RoslynVersion>
-    <VisualStudioEditorPackagesVersion>17.10.191</VisualStudioEditorPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.10.40152</MicrosoftVisualStudioShellPackagesVersion>
-    <VisualStudioProjectSystemPackagesVersion>17.10.526-pre-g1b474069f5</VisualStudioProjectSystemPackagesVersion>
-    <MicrosoftVisualStudioThreadingPackagesVersion>17.10.41</MicrosoftVisualStudioThreadingPackagesVersion>
+    <RoslynVersion>4.15.0</RoslynVersion>
+    <VisualStudioEditorPackagesVersion>17.14.15</VisualStudioEditorPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.14.15</MicrosoftVisualStudioShellPackagesVersion>
+    <VisualStudioProjectSystemPackagesVersion>17.14.15</VisualStudioProjectSystemPackagesVersion>
+    <MicrosoftVisualStudioThreadingPackagesVersion>17.14.15</MicrosoftVisualStudioThreadingPackagesVersion>
     <MicrosoftBuildVersion>17.13.26</MicrosoftBuildVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,16 +97,17 @@
     <SystemThreadingTasksDataflow>$(SystemPackageVersionVersion)</SystemThreadingTasksDataflow>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <!-- Versions for package groups -->
-    <RoslynVersion>4.14.0</RoslynVersion>
+    <RoslynVersion>4.15.0-1.25171.14</RoslynVersion>
     <VisualStudioEditorPackagesVersion>17.14.188</VisualStudioEditorPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.14.39341</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.14.39473</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.14.79</VisualStudioProjectSystemPackagesVersion>
+    <VisualStudioShellProjectsPackages>17.14.39490</VisualStudioShellProjectsPackages>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.14.15</MicrosoftVisualStudioThreadingPackagesVersion>
     <MicrosoftBuildVersion>17.15.0-preview-25276-10</MicrosoftBuildVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesTextVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfVersion>4.15.0</MicrosoftCodeAnalysisEditorFeaturesWpfVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesWpfVersion>
     <MicrosoftCodeAnalysisExternalAccessFSharpVersion>$(RoslynVersion)</MicrosoftCodeAnalysisExternalAccessFSharpVersion>
     <MicrosoftCodeAnalysisVersion>$(RoslynVersion)</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpVersion>$(RoslynVersion)</MicrosoftCodeAnalysisCSharpVersion>
@@ -117,7 +118,7 @@
     <!-- Visual Studio Shell packages -->
     <MicrosoftVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropVersion>
     <MicrosoftInternalVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropVersion>
-    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
+    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftVisualStudioImageCatalogVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImageCatalogVersion>
     <MicrosoftVisualStudioShellInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellInteropVersion>
     <MicrosoftVisualStudioTextManagerInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioTextManagerInteropVersion>
@@ -127,8 +128,8 @@
     <MicrosoftVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioPackageLanguageService150Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioPackageLanguageService150Version>
-    <MicrosoftVisualStudioManagedInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioManagedInterfacesVersion>
-    <MicrosoftVisualStudioProjectAggregatorVersion>17.14.39383</MicrosoftVisualStudioProjectAggregatorVersion>
+    <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
+    <MicrosoftVisualStudioProjectAggregatorVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioProjectAggregatorVersion>
     <MicrosoftVisualStudioGraphModelVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImagingVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
@@ -153,7 +154,7 @@
     <MicrosoftVisualStudioTextUIWpfVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextUIWpfVersion>
     <MicrosoftVisualStudioTextDataVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextDataVersion>
     <MicrosoftVisualStudioTextInternalVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextInternalVersion>
-    <MicrosoftVisualStudioComponentModelHostVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVisualStudioComponentModelHostVersion>17.14.106</MicrosoftVisualStudioComponentModelHostVersion>
     <NuGetSolutionRestoreManagerInteropVersion>5.6.0</NuGetSolutionRestoreManagerInteropVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.169-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>
@@ -168,7 +169,7 @@
     <!-- -->
     <!-- Misc. Visual Studio packages -->
     <MicrosoftVSSDKBuildToolsVersion>17.10.2179</MicrosoftVSSDKBuildToolsVersion>
-    <MicrosoftVisualStudioRpcContractsVersion>17.13.7</MicrosoftVisualStudioRpcContractsVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.14.18</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioValidationVersion>17.8.8</MicrosoftVisualStudioValidationVersion>
     <VSSDKDebuggerVisualizersVersion>12.0.4</VSSDKDebuggerVisualizersVersion>
@@ -195,7 +196,7 @@
     <MicrosoftNETTestSdkVersion>17.11.1</MicrosoftNETTestSdkVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
-    <StreamJsonRpcVersion>2.21.10</StreamJsonRpcVersion>
+    <StreamJsonRpcVersion>2.21.66</StreamJsonRpcVersion>
     <NerdbankStreamsVersion>2.11.90</NerdbankStreamsVersion>
     <XUnitVersion>2.9.0</XUnitVersion>
     <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,7 +97,7 @@
     <SystemThreadingTasksDataflow>$(SystemPackageVersionVersion)</SystemThreadingTasksDataflow>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <!-- Versions for package groups -->
-    <RoslynVersion>4.15.0</RoslynVersion>
+    <RoslynVersion>4.14.0</RoslynVersion>
     <VisualStudioEditorPackagesVersion>17.14.15</VisualStudioEditorPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.14.15</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>17.14.15</VisualStudioProjectSystemPackagesVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -128,7 +128,7 @@
     <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioPackageLanguageService150Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioPackageLanguageService150Version>
     <MicrosoftVisualStudioManagedInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioManagedInterfacesVersion>
-    <MicrosoftVisualStudioProjectAggregatorVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioProjectAggregatorVersion>
+    <MicrosoftVisualStudioProjectAggregatorVersion>17.14.39383</MicrosoftVisualStudioProjectAggregatorVersion>
     <MicrosoftVisualStudioGraphModelVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioGraphModelVersion>
     <MicrosoftVisualStudioImagingVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioImagingVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
@@ -196,7 +196,7 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
     <StreamJsonRpcVersion>2.21.10</StreamJsonRpcVersion>
-    <NerdbankStreamsVersion>2.11.86</NerdbankStreamsVersion>
+    <NerdbankStreamsVersion>2.11.90</NerdbankStreamsVersion>
     <XUnitVersion>2.9.0</XUnitVersion>
     <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>
     <XunitXmlTestLoggerVersion>3.1.17</XunitXmlTestLoggerVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -98,15 +98,15 @@
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <!-- Versions for package groups -->
     <RoslynVersion>4.14.0</RoslynVersion>
-    <VisualStudioEditorPackagesVersion>17.14.15</VisualStudioEditorPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.14.15</MicrosoftVisualStudioShellPackagesVersion>
-    <VisualStudioProjectSystemPackagesVersion>17.14.15</VisualStudioProjectSystemPackagesVersion>
+    <VisualStudioEditorPackagesVersion>17.14.188</VisualStudioEditorPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.14.39341</MicrosoftVisualStudioShellPackagesVersion>
+    <VisualStudioProjectSystemPackagesVersion>17.14.79</VisualStudioProjectSystemPackagesVersion>
     <MicrosoftVisualStudioThreadingPackagesVersion>17.14.15</MicrosoftVisualStudioThreadingPackagesVersion>
-    <MicrosoftBuildVersion>17.13.26</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>17.15.0-preview-25276-10</MicrosoftBuildVersion>
     <!-- Roslyn packages -->
     <MicrosoftCodeAnalysisEditorFeaturesVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesVersion>
     <MicrosoftCodeAnalysisEditorFeaturesTextVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesTextVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfVersion>$(RoslynVersion)</MicrosoftCodeAnalysisEditorFeaturesWpfVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfVersion>4.15.0</MicrosoftCodeAnalysisEditorFeaturesWpfVersion>
     <MicrosoftCodeAnalysisExternalAccessFSharpVersion>$(RoslynVersion)</MicrosoftCodeAnalysisExternalAccessFSharpVersion>
     <MicrosoftCodeAnalysisVersion>$(RoslynVersion)</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisCSharpVersion>$(RoslynVersion)</MicrosoftCodeAnalysisCSharpVersion>
@@ -138,9 +138,9 @@
     <MicrosoftVisualStudioShellImmutable150Version>15.0.25123-Dev15Preview</MicrosoftVisualStudioShellImmutable150Version>
     <!-- -->
     <!-- Microsoft Build packages -->
-    <MicrosoftBuildFrameworkVersion>17.13.26</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildTasksCoreVersion>17.13.26</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>17.13.26</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildFrameworkVersion>17.15.0-preview-25276-10</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildTasksCoreVersion>17.15.0-preview-25276-10</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.15.0-preview-25276-10</MicrosoftBuildUtilitiesCoreVersion>
     <!-- -->
     <!-- Visual Studio Editor packages -->
     <MicrosoftVisualStudioCoreUtilityVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioCoreUtilityVersion>
@@ -168,7 +168,7 @@
     <!-- -->
     <!-- Misc. Visual Studio packages -->
     <MicrosoftVSSDKBuildToolsVersion>17.10.2179</MicrosoftVSSDKBuildToolsVersion>
-    <MicrosoftVisualStudioRpcContractsVersion>17.10.21</MicrosoftVisualStudioRpcContractsVersion>
+    <MicrosoftVisualStudioRpcContractsVersion>17.13.7</MicrosoftVisualStudioRpcContractsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
     <MicrosoftVisualStudioValidationVersion>17.8.8</MicrosoftVisualStudioValidationVersion>
     <VSSDKDebuggerVisualizersVersion>12.0.4</VSSDKDebuggerVisualizersVersion>
@@ -195,8 +195,8 @@
     <MicrosoftNETTestSdkVersion>17.11.1</MicrosoftNETTestSdkVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
-    <StreamJsonRpcVersion>2.18.48</StreamJsonRpcVersion>
-    <NerdbankStreamsVersion>2.10.69</NerdbankStreamsVersion>
+    <StreamJsonRpcVersion>2.21.10</StreamJsonRpcVersion>
+    <NerdbankStreamsVersion>2.11.86</NerdbankStreamsVersion>
     <XUnitVersion>2.9.0</XUnitVersion>
     <XUnitRunnerVersion>2.8.2</XUnitRunnerVersion>
     <XunitXmlTestLoggerVersion>3.1.17</XunitXmlTestLoggerVersion>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -355,64 +355,62 @@ type internal FSharpPackage() as this =
             flushTelemetry ()
 #endif
 
-    override this.InitializeAsync(cancellationToken: CancellationToken, progress: IProgress<ServiceProgressData>) : Tasks.Task =
-        // `base.` methods can't be called in the `async` builder, so we have to cache it
-        let baseInitializeAsync = base.InitializeAsync(cancellationToken, progress)
+    override this.RegisterInitializationWork (packageRegistrationTasks: PackageRegistrationTasks): unit = 
+        base.RegisterInitializationWork(packageRegistrationTasks: PackageRegistrationTasks)
+        packageRegistrationTasks.AddTask(true, (fun progress _tasks cancellationToken -> 
+            foregroundCancellableTask{
+                let! commandService = this.GetServiceAsync(typeof<IMenuCommandService>)
+                let commandService = commandService :?> OleMenuCommandService
 
-        foregroundCancellableTask {
-            do! baseInitializeAsync
+                // Switch to UI thread
+                do! this.JoinableTaskFactory.SwitchToMainThreadAsync()
 
-            let! commandService = this.GetServiceAsync(typeof<IMenuCommandService>)
-            let commandService = commandService :?> OleMenuCommandService
+                // FSI-LINKAGE-POINT: sited init
+                FSharp.Interactive.Hooks.fsiConsoleWindowPackageInitializeSited (this :> Package) commandService
 
-            // Switch to UI thread
-            do! this.JoinableTaskFactory.SwitchToMainThreadAsync()
+                // FSI-LINKAGE-POINT: private method GetDialogPage forces fsi options to be loaded
+                let _fsiPropertyPage =
+                    this.GetDialogPage(typeof<FSharp.Interactive.FsiPropertyPage>)
 
-            // FSI-LINKAGE-POINT: sited init
-            FSharp.Interactive.Hooks.fsiConsoleWindowPackageInitializeSited (this :> Package) commandService
+                let workspace = this.ComponentModel.GetService<VisualStudioWorkspace>()
 
-            // FSI-LINKAGE-POINT: private method GetDialogPage forces fsi options to be loaded
-            let _fsiPropertyPage =
-                this.GetDialogPage(typeof<FSharp.Interactive.FsiPropertyPage>)
+                let _ =
+                    this.ComponentModel.DefaultExportProvider.GetExport<HackCpsCommandLineChanges>()
 
-            let workspace = this.ComponentModel.GetService<VisualStudioWorkspace>()
+                let optionsManager =
+                    workspace.Services.GetService<IFSharpWorkspaceService>().FSharpProjectOptionsManager
 
-            let _ =
-                this.ComponentModel.DefaultExportProvider.GetExport<HackCpsCommandLineChanges>()
+                let metadataAsSource =
+                    this.ComponentModel.DefaultExportProvider.GetExport<FSharpMetadataAsSourceService>().Value
 
-            let optionsManager =
-                workspace.Services.GetService<IFSharpWorkspaceService>().FSharpProjectOptionsManager
+                let! solution = this.GetServiceAsync(typeof<SVsSolution>)
+                let solution = solution :?> IVsSolution
 
-            let metadataAsSource =
-                this.ComponentModel.DefaultExportProvider.GetExport<FSharpMetadataAsSourceService>().Value
+                let solutionEvents = FSharpSolutionEvents(optionsManager, metadataAsSource)
 
-            let! solution = this.GetServiceAsync(typeof<SVsSolution>)
-            let solution = solution :?> IVsSolution
+                let! rdt = this.GetServiceAsync(typeof<SVsRunningDocumentTable>)
+                let rdt = rdt :?> IVsRunningDocumentTable
 
-            let solutionEvents = FSharpSolutionEvents(optionsManager, metadataAsSource)
+                solutionEventsOpt <- Some(solutionEvents)
+                solution.AdviseSolutionEvents(solutionEvents) |> ignore
 
-            let! rdt = this.GetServiceAsync(typeof<SVsRunningDocumentTable>)
-            let rdt = rdt :?> IVsRunningDocumentTable
+                let projectContextFactory =
+                    this.ComponentModel.GetService<FSharpWorkspaceProjectContextFactory>()
 
-            solutionEventsOpt <- Some(solutionEvents)
-            solution.AdviseSolutionEvents(solutionEvents) |> ignore
+                let miscFilesWorkspace =
+                    this.ComponentModel.GetService<MiscellaneousFilesWorkspace>()
 
-            let projectContextFactory =
-                this.ComponentModel.GetService<FSharpWorkspaceProjectContextFactory>()
+                do
+                    SingleFileWorkspaceMap(FSharpMiscellaneousFileService(workspace, miscFilesWorkspace, projectContextFactory), rdt)
+                    |> ignore
 
-            let miscFilesWorkspace =
-                this.ComponentModel.GetService<MiscellaneousFilesWorkspace>()
+                do
+                    LegacyProjectWorkspaceMap(solution, optionsManager, projectContextFactory)
+                    |> ignore
 
-            do
-                SingleFileWorkspaceMap(FSharpMiscellaneousFileService(workspace, miscFilesWorkspace, projectContextFactory), rdt)
-                |> ignore
+            } 
+            |> CancellableTask.startAsTask cancellationToken))
 
-            do
-                LegacyProjectWorkspaceMap(solution, optionsManager, projectContextFactory)
-                |> ignore
-
-        }
-        |> CancellableTask.startAsTask cancellationToken
 
     override _.RoslynLanguageName = FSharpConstants.FSharpLanguageName
     (*override this.CreateWorkspace() = this.ComponentModel.GetService<VisualStudioWorkspaceImpl>() *)

--- a/vsintegration/src/FSharp.LanguageService.Base/FSharp.LanguageService.Base.csproj
+++ b/vsintegration/src/FSharp.LanguageService.Base/FSharp.LanguageService.Base.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />

--- a/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
@@ -57,6 +57,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Nerdbank.Streams" Version="$(NerdbankStreamsVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.Composition" Version="$(MicrosoftCompositionVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="System.ComponentModel.Composition" Version="$(SystemComponentModelCompositionVersion)" />

--- a/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
@@ -171,7 +171,7 @@ type TestHostWorkspaceServices(hostServices: HostServices, workspace: Workspace)
         |> System.Collections.Concurrent.ConcurrentDictionary
 
     let langServices =
-        TestHostLanguageServices(this, LanguageNames.FSharp, exportProvider)
+        new TestHostLanguageServices(this, LanguageNames.FSharp, exportProvider)
 
     override _.Workspace = workspace
 
@@ -199,7 +199,7 @@ type TestHostServices() =
     inherit HostServices()
 
     override this.CreateWorkspaceServices(workspace) =
-        TestHostWorkspaceServices(this, workspace)
+        new TestHostWorkspaceServices(this, workspace)
 
 [<AbstractClass; Sealed>]
 type RoslynTestHelpers private () =

--- a/vsintegration/tests/UnitTests/Tests.RoslynHelpers.fs
+++ b/vsintegration/tests/UnitTests/Tests.RoslynHelpers.fs
@@ -160,7 +160,7 @@ type TestHostWorkspaceServices(hostServices: HostServices, workspace: Workspace)
         |> Seq.distinctBy (fun x -> x.Key)
         |> System.Collections.Concurrent.ConcurrentDictionary
 
-    let langServices = TestHostLanguageServices(this, LanguageNames.FSharp, exportProvider)
+    let langServices = new TestHostLanguageServices(this, LanguageNames.FSharp, exportProvider)
 
     override _.Workspace = workspace
 
@@ -191,7 +191,7 @@ type TestHostServices() =
     inherit HostServices()
 
     override this.CreateWorkspaceServices(workspace) =
-        TestHostWorkspaceServices(this, workspace) :> HostWorkspaceServices
+        new TestHostWorkspaceServices(this, workspace) :> HostWorkspaceServices
 
 [<AbstractClass;Sealed>]
 type RoslynTestHelpers private () =


### PR DESCRIPTION
Updating:

- System versions
- msbuild
- Roslyn
- VS packages

This initially started as system-only updates, but nuget warnings about package verison incompabilities eventually lead me to updating most of the above.

The VS packages do not exist in the feed under the same version, so I had to split a unified setting for some of the packages and introduce some deviations in the build number of a version.

Right now, all nuget warnings are resolved.