### PR TITLE
Handle active patterns with inferred function ty & unsolved range typar

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
@@ -11,6 +11,7 @@
 * Fix find all references for F# exceptions ([PR #18565](https://github.com/dotnet/fsharp/pull/18565))
 * Shorthand lambda: fix completion for chained calls and analysis for unfinished expression ([PR #18560](https://github.com/dotnet/fsharp/pull/18560))
 * Completion: fix previous namespace considered opened [PR #18609](https://github.com/dotnet/fsharp/pull/18609)
+* Fix active pattern typechecking regression. ([Issue #18638](https://github.com/dotnet/fsharp/issues/18638), [PR #18642](https://github.com/dotnet/fsharp/pull/18642))
 
 ### Added
 

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ActivePatternArgCountMismatchTest.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ActivePatternArgCountMismatchTest.fs
@@ -761,6 +761,26 @@ match 1 with P expr2 pat -> ()
             |> typecheck
             |> shouldSucceed
 
+    module ``Recursive active pattern definition with and`` =
+        /// See https://github.com/dotnet/fsharp/issues/18638
+        [<Fact>]
+        let ``match expr1 with P expr2 pat -> …`` () =
+            FSharp """
+let rec parse p =
+    function
+    | IsSomething p v -> Some v
+    | _ -> None
+
+and (|IsSomething|_|) p =
+    function
+    | "nested" -> parse p "42"
+    | "42" -> Some 42
+    | _ -> None
+            """
+            |> withNoWarn IncompletePatternMatches
+            |> typecheck
+            |> shouldSucceed
+
     module ``int → int → int voption`` =
         // Normal usage; pat is int.
         [<Fact>]


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/fsharp/issues/18638, originally introduced in https://github.com/dotnet/fsharp/pull/16846 (I [think](https://github.com/dotnet/fsharp/blame/c8ee77c756f71e25a1e99ce21393f92327e312d2/src/Compiler/Checking/CheckExpressions.fs#L5184-L5186)?).

- Treat `(|P|) : 'a -> 'b` similarly to `(|P|) : 'a`.

   That is, for an active pattern whose type is known to be a function type but whose range type is not yet solved, assume that it _could_ be solved to, e.g., another function type. This can show up in, e.g., an active pattern that is defined mutually-recursively with `and`, has no type annotations, and returns a lambda with `fun` or `function`.

## Checklist

- [x] Test cases added.
- [x] Release notes entry updated.