### PR TITLE
Tests: introduce resolve and code completion contexts

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/Checker.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Checker.fs
@@ -1,0 +1,105 @@
+namespace FSharp.Compiler.Service.Tests
+
+open System
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.EditorServices
+open FSharp.Compiler.Text
+open FSharp.Compiler.Tokenization
+
+type SourceContext =
+    { Source: string
+      LineText: string
+      CaretPos: pos }
+
+type ResolveContext =
+    { SourceContext: SourceContext
+      Pos: pos
+      Names: string list }
+
+    member this.Source = this.SourceContext.Source
+    member this.LineText = this.SourceContext.LineText
+
+type CodeCompletionContext =
+    { SourceContext: SourceContext
+      Pos: pos
+      PartialIdentifier: PartialLongName }
+
+    member this.Source = this.SourceContext.Source
+    member this.LineText = this.SourceContext.LineText
+
+[<RequireQualifiedAccess>]
+module SourceContext =
+    let fromMarkedSource (markedSource: string) : SourceContext =
+        let lines = markedSource.Split([|"\r\n"; "\n"|], StringSplitOptions.None)
+        let line = lines |> Seq.findIndex _.Contains("{caret}")
+        let lineText = lines[line]
+        let column = lineText.IndexOf("{caret}")
+
+        let source = markedSource.Replace("{caret}", "")
+        let pos = Position.mkPos (line + 1) (column - 1)
+        let lineText = lineText.Replace("{caret}", "")
+        { Source = source; CaretPos = pos; LineText = lineText }
+
+
+[<AutoOpen>]
+module CheckResultsExtensions =
+    type FSharpCheckFileResults with
+        member this.GetSymbolUses(context: ResolveContext) =
+            this.GetSymbolUsesAtLocation(context.Pos.Line, context.Pos.Column, context.LineText, context.Names)
+
+        member this.GetSymbolUse(context: ResolveContext) =
+            this.GetSymbolUses(context) |> List.exactlyOne
+    
+        member this.GetTooltip(context: ResolveContext) =
+            this.GetToolTip(context.Pos.Line, context.Pos.Column, context.LineText, context.Names, FSharpTokenTag.Identifier)
+
+        member this.GetTooltip(context: ResolveContext, width) =
+            this.GetToolTip(context.Pos.Line, context.Pos.Column, context.LineText, context.Names, FSharpTokenTag.Identifier, width)
+
+        member this.GetCodeCompletionSuggestions(context: CodeCompletionContext, parseResults: FSharpParseFileResults) =
+            this.GetDeclarationListInfo(Some parseResults, context.Pos.Line, context.LineText, context.PartialIdentifier)
+
+[<RequireQualifiedAccess>]
+module Checker =
+    let getResolveContext (markedSource: string) =
+        let context = SourceContext.fromMarkedSource markedSource
+        let pos =
+            match QuickParse.GetCompleteIdentifierIsland false context.LineText context.CaretPos.Column with
+            | Some(_, column, _) -> Position.mkPos context.CaretPos.Line column
+            | _ -> context.CaretPos
+
+        let plid = QuickParse.GetPartialLongNameEx(context.LineText, pos.Column - 1)
+        let names = plid.QualifyingIdents @ [plid.PartialIdent]
+        { SourceContext = context; Pos = pos; Names = names }
+
+    let getCompletionContext (markedSource: string) =
+        let context = SourceContext.fromMarkedSource markedSource
+        let plid = QuickParse.GetPartialLongNameEx(context.LineText, context.CaretPos.Column)
+        let names = plid.QualifyingIdents @ [plid.PartialIdent]
+        { SourceContext = context; Pos = context.CaretPos; PartialIdentifier = plid }
+
+    let getCheckedResolveContext (markedSource: string) =
+        let context = getResolveContext markedSource
+        let _, checkResults = getParseAndCheckResults context.Source
+        context, checkResults
+
+    let getCompletionInfo (markedSource: string) =
+        let context = getCompletionContext markedSource
+        let parseResults, checkResults = getParseAndCheckResults context.Source
+        checkResults.GetCodeCompletionSuggestions(context, parseResults)
+
+    let getSymbolUses (markedSource: string) =
+        let context, checkResults = getCheckedResolveContext markedSource
+        checkResults.GetSymbolUses(context)
+
+    let getSymbolUse (markedSource: string) =
+        let symbolUses = getSymbolUses markedSource
+        symbolUses |> List.exactlyOne
+
+    let getTooltipWithOptions (options: string array) (markedSource: string) =
+        let context = getResolveContext markedSource
+        let _, checkResults = getParseAndCheckResultsWithOptions options context.Source
+        checkResults.GetToolTip(context.Pos.Line, context.Pos.Column, context.LineText, context.Names, FSharpTokenTag.Identifier)
+
+    let getTooltip (markedSource: string) =
+        getTooltipWithOptions [||] markedSource

--- a/tests/FSharp.Compiler.Service.Tests/Common.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Common.fs
@@ -342,24 +342,6 @@ let rec allSymbolsInEntities compGen (entities: IList<FSharpEntity>) =
           yield! allSymbolsInEntities compGen entity.NestedEntities ]
 
 
-let getCursorPosAndPrepareSource (source: string) : string * string * pos =
-    let lines = source.Split([|"\r\n"; "\n"|], StringSplitOptions.None)
-    let line = lines |> Seq.findIndex _.Contains("{caret}")
-    let lineText = lines[line]
-    let column = lineText.IndexOf("{caret}")
-
-    let source = source.Replace("{caret}", "")
-    let lineText = lineText.Replace("{caret}", "")
-    source, lineText, Position.mkPos (line + 1) (column - 1)
-
-let getPartialIdentifierAndPrepareSource source =
-    let source, lineText, pos = getCursorPosAndPrepareSource source
-    let _, column, _ = QuickParse.GetCompleteIdentifierIsland false lineText pos.Column |> Option.get
-    let pos = Position.mkPos pos.Line column
-    let plid = QuickParse.GetPartialLongNameEx(lineText, column - 1)
-    let names = plid.QualifyingIdents @ [plid.PartialIdent]
-    source, lineText, pos, plid, names
-
 let getParseResults (source: string) =
     parseSourceCode("Test.fsx", source)
 
@@ -368,6 +350,9 @@ let getParseResultsOfSignatureFile (source: string) =
 
 let getParseAndCheckResults (source: string) =
     parseAndCheckScript("Test.fsx", source)
+
+let getParseAndCheckResultsWithOptions options source =
+    parseAndCheckScriptWithOptions ("Test.fsx", source, options)
 
 let getParseAndCheckResultsOfSignatureFile (source: string) =
     parseAndCheckScript("Test.fsi", source)

--- a/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
@@ -1,20 +1,10 @@
 ﻿module FSharp.Compiler.Service.Tests.CompletionTests
 
-open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.EditorServices
 open Xunit
 
-let getCompletionInfo source =
-    let source, lineText, pos = getCursorPosAndPrepareSource source
-    let parseResults, checkResults = getParseAndCheckResultsPreview source
-    let plid = QuickParse.GetPartialLongNameEx(lineText, pos.Column)
-    checkResults.GetDeclarationListInfo(Some parseResults, pos.Line, lineText, plid)
-
-let getCompletionItemNames (completionInfo: DeclarationListInfo) =
-    completionInfo.Items |> Array.map (fun item -> item.NameInCode)
-
 let private assertItemsWithNames contains names (completionInfo: DeclarationListInfo) =
-    let itemNames = getCompletionItemNames completionInfo |> set
+    let itemNames = completionInfo.Items |> Array.map _.NameInCode |> set
 
     for name in names do
         Assert.True(Set.contains name itemNames = contains)
@@ -27,7 +17,7 @@ let assertHasNoItemsWithNames names (completionInfo: DeclarationListInfo) =
 
 [<Fact>]
 let ``Expr - After record decl 01`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: int }
 
 { Fi{caret} }
@@ -36,7 +26,7 @@ type Record = { Field: int }
 
 [<Fact>]
 let ``Expr - After record decl 02`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: int }
 
 {caret}
@@ -45,7 +35,7 @@ type Record = { Field: int }
 
 [<Fact>]
 let ``Expr - record - field 01 - anon module`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: int }
 
 { Fi{caret} }
@@ -54,7 +44,7 @@ type Record = { Field: int }
 
 [<Fact>]
 let ``Expr - record - field 02 - anon module`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: int }
 
 let record = { Field = 1 }
@@ -65,7 +55,7 @@ let record = { Field = 1 }
 
 [<Fact>]
 let ``Expr - record - empty 01`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: int }
 
 { {caret} }
@@ -74,7 +64,7 @@ type Record = { Field: int }
 
 [<Fact>]
 let ``Expr - record - empty 02`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: int }
 
 let record = { Field = 1 }
@@ -85,56 +75,56 @@ let record = { Field = 1 }
 
 [<Fact>]
 let ``Underscore dot lambda - completion 01`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Len{caret}"""
 
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 02`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 System.DateTime.Now |> _.TimeOfDay.Mill{caret}"""
 
     assertHasItemWithNames ["Milliseconds"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 03`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.ToString().Len{caret}"""
 
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 04`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Len{caret}gth.ToString()"""
 
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 05`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Length.ToString().Chars("".Len{caret})"""
 
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 06`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Chars(System.DateTime.UtcNow.Tic{caret}).ToString()"""
 
     assertHasItemWithNames ["Ticks"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 07`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Length.ToString().Len{caret}"""
 
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 08`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 System.DateTime.Now |> _.TimeOfDay
                         .Mill{caret}"""
 
@@ -142,21 +132,21 @@ System.DateTime.Now |> _.TimeOfDay
 
 [<Fact>]
 let ``Underscore dot lambda - completion 09`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Length.ToSt{caret}.Length"""
 
     assertHasItemWithNames ["ToString"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 10`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Chars(0).ToStr{caret}.Length"""
 
     assertHasItemWithNames ["ToString"] info
 
 [<Fact>]
 let ``Underscore dot lambda - completion 11`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 open System.Linq
 
 [[""]] |> _.Select(_.Head.ToL{caret})"""
@@ -165,7 +155,7 @@ open System.Linq
 
 [<Fact>]
 let ``Underscore dot lambda - completion 12`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 open System.Linq
 
 [[[""]]] |> _.Head.Select(_.Head.ToL{caret})"""
@@ -174,7 +164,7 @@ open System.Linq
 
 [<Fact>]
 let ``Underscore dot lambda - completion 13`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let myFancyFunc (x:string) =
     x
     |> _.ToL{caret}"""
@@ -182,7 +172,7 @@ let myFancyFunc (x:string) =
 
 [<Fact>]
 let ``Underscore dot lambda - completion 14`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let myFancyFunc (x:System.DateTime) =
     x
     |> _.TimeOfDay.Mill{caret}
@@ -191,14 +181,14 @@ let myFancyFunc (x:System.DateTime) =
 
 [<Fact>]
 let ``Underscore dot lambda - completion 15`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let _a = 5
 "" |> _{caret}.Length.ToString() """
     assertHasItemWithNames ["_a"] info
 
 [<Fact>]
 let ``Underscore dot lambda - No prefix 01`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let s = ""
 [s] |> List.map _.{caret}
 """
@@ -206,21 +196,21 @@ let s = ""
 
 [<Fact>]
 let ``Underscore dot lambda - No prefix 02`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 System.DateTime.Now |> _.TimeOfDay.{caret}"""
 
     assertHasItemWithNames ["Milliseconds"] info
 
 [<Fact>]
 let ``Underscore dot lambda - No prefix 03`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 "" |> _.Length.ToString().{caret}"""
 
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Type decl - Record - Field type 01`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type Record = { Field: {caret} }
 """
     assertHasItemWithNames ["string"] info
@@ -228,7 +218,7 @@ type Record = { Field: {caret} }
 
 [<Fact>]
 let ``Expr - Qualifier 01`` () =
-    let info = getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let f (s: string) =
     s.Trim().{caret}
     s.Trim()
@@ -239,8 +229,7 @@ let f (s: string) =
 
 [<Fact>]
 let ``Expr - Qualifier 02`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let f (s: string) =
     s.Trim()
     s.Trim().{caret}
@@ -251,8 +240,7 @@ let f (s: string) =
 
 [<Fact>]
 let ``Expr - Qualifier 03`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 let f (s: string) =
     s.Trim()
     s.Trim()
@@ -263,8 +251,7 @@ let f (s: string) =
 
 [<Fact>]
 let ``Expr - Qualifier 04`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type T() =
     do
         System.String.Empty.ToString().L{caret}
@@ -273,24 +260,21 @@ type T() =
 
 [<Fact>]
 let ``Expr - Qualifier 05`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 System.String.Empty.ToString().{caret}
 """
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Expr - Qualifier 06`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 System.String.Empty.ToString().L{caret}
 """
     assertHasItemWithNames ["Length"] info
 
 [<Fact>]
 let ``Expr - Qualifier 07`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 type T() =
     do
         System.String.Empty.ToString().L{caret}
@@ -300,8 +284,7 @@ type T() =
 
 [<Fact>]
 let ``Import - Ns 01`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 namespace Ns
 
 type Rec1 = { F: int }
@@ -321,8 +304,7 @@ module M =
 
 [<Fact>]
 let ``Import - Ns 02 - Rec`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 namespace Ns
 
 type Rec1 = { F: int }
@@ -342,8 +324,7 @@ module M =
 
 [<Fact>]
 let ``Import - Ns 03 - Rec`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 namespace Ns
 
 type Rec1 = { F: int }
@@ -363,8 +344,7 @@ module rec M =
 
 [<Fact>]
 let ``Not in scope 01`` () =
-    let info =
-        getCompletionInfo """
+    let info = Checker.getCompletionInfo """
 namespace Ns1
 
 type E =

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -25,6 +25,7 @@
       <Link>XunitSetup.fs</Link>
     </Compile>
     <Compile Include="Common.fs" />
+    <Compile Include="Checker.fs" />
     <Compile Include="TypeChecker\TypeCheckerRecoveryTests.fs" />
     <Compile Include="GeneratedCodeSymbolsTests.fs" />
     <Compile Include="AssemblyReaderShim.fs" />


### PR DESCRIPTION
This PR replaces manual context creation with locating a `{caret}` mark in the source in more tests. It makes it much easier to write new editor-related tests and should also prevent mistakes that are easy to make when providing the context by hand. It continues the work started in #18524 and #18609.

To make it easier to use the FCS APIs it introduces several new types:
* `SourceContext`: contains info about the cursor position and the line text
* `ResolveContext`: contains data needed for resolve-related features (getting a symbol, tooltip, overloads, etc)
* `CodeCompletionContext`: similar to `ResolveContext` but has code completion-specific differences

It also introduces new `Checker` module that provides test helpers for working with these new contexts. We may evolve these helpers into a newer FCS API in future, as it makes it significantly easier to work with these contexts than to provide things like the cursor coordinates separately.