### PR TITLE
CI jobs - allow preview versions of .NET

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -118,7 +118,7 @@ stages:
             inputs:
               packageType: sdk
               useGlobalJson: true
-              includePreviewVersions: false
+              includePreviewVersions: true
               workingDirectory: $(Build.SourcesDirectory)
               installationPath: $(Build.SourcesDirectory)/.dotnet
           - script: .\eng\test-determinism.cmd -configuration Debug


### PR DESCRIPTION
With the move to latest arcade, we can occassionaly be getting updates to global.json which specify a preview version of .NET.

As of now, such pushes will crash CI jobs that happen to use the `UseDotNet@2` task. The ones using build script work just fine as of now already.

This changes the config `includePreviewVersions` for the task to allow preview versions

