### PR TITLE
Expand docstring on SynModuleDecl.Types

### DIFF
--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -1731,7 +1731,13 @@ type SynModuleDecl =
     /// An 'expr' within a module.
     | Expr of expr: SynExpr * range: range
 
-    /// One or more 'type' definitions within a module
+    /// One or more 'type' definitions within a module.
+    ///
+    /// If there is more than one SynTypeDefn in the list, this indicates a "recursive knot" of types:
+    /// 'type Foo ... and Bar ...', for example.
+    /// (By contrast, consecutively defined types which are each defined with the 'type' keyword, such as
+    /// 'type Foo ... type Bar ...', will appear in the syntax tree as multiple distinct Types nodes,
+    /// not as a single Types node with multiple definitions within.)
     | Types of typeDefns: SynTypeDefn list * range: range
 
     /// An 'exception' definition within a module


### PR DESCRIPTION
## Description

Expand the ambiguous docstring on `SynModuleDecl.Types`.

This change is in `src/Compiler`, but I really don't think it merits a release note.

Correctness: the only construction of this DU case is [in the fsyacc parser](https://github.com/dotnet/fsharp/blob/6d57e3b588b92d1d6a2c8541be4b3873a0b03366/src/Compiler/pars.fsy#L1334), and if you can decipher that then you're better than I am. But I did check with [the Fantomas tools](https://fsprojects.github.io/fantomas-tools/#/ast?data=N4KABGBEAmCmBmBLAdrAzpAXFSAacUiaAYmolmPAIYA2as%2BEkAxgPZwWQAuAngA6wwxVqzABeMACMaVABYAdZIt4CwAISoAvcVJmy8BSLAAefKsmgUuAJwCusEAF8gA).

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/release-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**