### PR TITLE
Include FSharp pre-release packages in the SDK transport package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,6 +10,7 @@
   <!-- Version number computation -->
   <PropertyGroup>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- These have to be in sync with latest release branch -->
     <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>
@@ -40,7 +41,7 @@
     <FSharpCoreShippedPackageVersionValue>9.0.300</FSharpCoreShippedPackageVersionValue>
     <!-- -->
     <!-- The pattern for specifying the preview package -->
-    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).*</FSharpCorePreviewPackageVersionValue>
+    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration).*</FSharpCorePreviewPackageVersionValue>
     <!-- -->
     <!-- FSharp tools for Visual Studio version number -->
     <FSToolsMajorVersion>14</FSToolsMajorVersion>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -79,6 +79,8 @@
 
     <!-- Force references among packages to use exact versions (see https://github.com/NuGet/Home/issues/7213) -->
     <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="release" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Release" AllowPreReleaseDependencies="true" ExactVersions="true" />
+    
+    <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="prerelease" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Prerelease" AllowPreReleaseDependencies="true" ExactVersions="true" />
 
     <!-- Rewrite the version ranges of per-build pre-release packages (see https://github.com/NuGet/Home/issues/7213) -->
     <Microsoft.DotNet.Tools.UpdatePackageVersionTask Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Shipping" ExactVersions="true"/>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -60,9 +60,11 @@
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"                           target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\Release" />
+        <file src="$artifactsPackagesDir$Dependency\Prerelease\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\Prerelease" />
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"    target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Release" />
+        <file src="$artifactsPackagesDir$Dependency\Prerelease\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Prerelease" />
 
         <file src="FSharp.Build\$configuration$\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"                                         target="contentFiles\Shipping" />
         <file src="FSharp.Build\$configuration$\netstandard2.0\Release\Microsoft.FSharp.Core.NetSdk.props"                                          target="contentFiles\Release" />

--- a/vsintegration/shims/shims.csproj
+++ b/vsintegration/shims/shims.csproj
@@ -10,12 +10,7 @@
     <None Include="Microsoft.FSharp.Overrides.NetSdk.Shim.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.FSharp.Shim.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.Portable.FSharp.Shim.targets" CopyToOutputDirectory="PreserveNewest" />
-
-    <NoneSubstituteText Include="Microsoft.FSharp.ShimHelpers.props" CopyToOutputDirectory="PreserveNewest">
-      <TargetFileName>Microsoft.FSharp.ShimHelpers.props</TargetFileName>
-      <Pattern1>{{FSharpCorePreviewPackageVersionValue}}</Pattern1>
-      <Replacement1>$(FSharpCorePreviewPackageVersionValue)</Replacement1>
-    </NoneSubstituteText>
+    <None Include="Microsoft.FSharp.ShimHelpers.props" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Enable the SDK to publish the stable-preview packages
- Add a pre-release iteration so that previews can be differentiated.
- Remove the version substitution in the shims project. There was no replacement happening.
