### PR TITLE
Include FSharp pre-release packages in the SDK transport package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,6 +10,7 @@
   <!-- Version number computation -->
   <PropertyGroup>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- These have to be in sync with latest release branch -->
     <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>
@@ -40,7 +41,7 @@
     <FSharpCoreShippedPackageVersionValue>9.0.300</FSharpCoreShippedPackageVersionValue>
     <!-- -->
     <!-- The pattern for specifying the preview package -->
-    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).*</FSharpCorePreviewPackageVersionValue>
+    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration).*</FSharpCorePreviewPackageVersionValue>
     <!-- -->
     <!-- FSharp tools for Visual Studio version number -->
     <FSToolsMajorVersion>14</FSToolsMajorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,8 +9,10 @@
   </PropertyGroup>
   <!-- Version number computation -->
   <PropertyGroup>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <!-- Don't use the built in support for pre-release iteration. The nuget repack task doesn't support
+         the iteration format at the moment. https://github.com/dotnet/arcade/issues/15919 -->
+    <FSharpPreReleaseIteration>6</FSharpPreReleaseIteration>
+    <PreReleaseVersionLabel>preview$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
     <!-- These have to be in sync with latest release branch -->
     <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,7 @@
     <FSharpCoreShippedPackageVersionValue>9.0.300</FSharpCoreShippedPackageVersionValue>
     <!-- -->
     <!-- The pattern for specifying the preview package -->
-    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).$(PreReleaseVersionIteration).*</FSharpCorePreviewPackageVersionValue>
+    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).$(FSharpPreReleaseIteration).*</FSharpCorePreviewPackageVersionValue>
     <!-- -->
     <!-- FSharp tools for Visual Studio version number -->
     <FSToolsMajorVersion>14</FSToolsMajorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,7 +43,7 @@
     <FSharpCoreShippedPackageVersionValue>9.0.300</FSharpCoreShippedPackageVersionValue>
     <!-- -->
     <!-- The pattern for specifying the preview package -->
-    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).$(FSharpPreReleaseIteration).*</FSharpCorePreviewPackageVersionValue>
+    <FSharpCorePreviewPackageVersionValue>$(FSCorePackageVersionValue)-$(PreReleaseVersionLabel).*</FSharpCorePreviewPackageVersionValue>
     <!-- -->
     <!-- FSharp tools for Visual Studio version number -->
     <FSToolsMajorVersion>14</FSToolsMajorVersion>

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -55,7 +55,6 @@
     <PackageDescription>The F# Compiler Services package for F# $(FSLanguageVersion) exposes additional functionality for implementing F# language bindings, additional tools based on the compiler or refactoring tools. The package also includes F# interactive service that can be used for embedding F# scripting into your applications.  Contains code from the F# Software Foundation.</PackageDescription>
     <PackageReleaseNotes>/blob/main/docs/release-notes/.FSharp.Compiler.Service/$(FSharpLibrariesChangelogVersion).md</PackageReleaseNotes>
     <PackageTags>F#, fsharp, interactive, compiler, editor</PackageTags>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PackageIconFullPath>$(MSBuildThisFileDirectory)logo.png</PackageIconFullPath>
   </PropertyGroup>
 

--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -69,7 +69,7 @@
     </NoneSubstituteText>
     <NoneSubstituteText Include="Microsoft.FSharp.Core.NetSdk.props" CopyToOutputDirectory="PreserveNewest" Condition="'$(Configuration)' != 'Proto'">
       <TargetFileName>Microsoft.FSharp.Core.NetSdk.props</TargetFileName>
-      <SubDir>Prerelease\</SubDir>
+      <SubDir>PreRelease\</SubDir>
       <Pattern1>{{FSCorePackageVersionValue}}</Pattern1>
       <Replacement1>$(FSCorePackageVersionValue)-$(_PreReleaseLabel).final</Replacement1>
     </NoneSubstituteText>

--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -67,6 +67,12 @@
       <Pattern1>{{FSCorePackageVersionValue}}</Pattern1>
       <Replacement1>$(FSCorePackageVersionValue)-$(VersionSuffix)</Replacement1>
     </NoneSubstituteText>
+    <NoneSubstituteText Include="Microsoft.FSharp.Core.NetSdk.props" CopyToOutputDirectory="PreserveNewest" Condition="'$(Configuration)' != 'Proto'">
+      <TargetFileName>Microsoft.FSharp.Core.NetSdk.props</TargetFileName>
+      <SubDir>Prerelease\</SubDir>
+      <Pattern1>{{FSCorePackageVersionValue}}</Pattern1>
+      <Replacement1>$(FSCorePackageVersionValue)-$(_PreReleaseLabel).final</Replacement1>
+    </NoneSubstituteText>
     <None Include="Microsoft.FSharp.Overrides.NetSdk.targets" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -80,7 +80,7 @@
     <!-- Force references among packages to use exact versions (see https://github.com/NuGet/Home/issues/7213) -->
     <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="release" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Release" AllowPreReleaseDependencies="true" ExactVersions="true" />
     
-    <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="prerelease" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Prerelease" AllowPreReleaseDependencies="true" ExactVersions="true" />
+    <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="prerelease" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)PreRelease" AllowPreReleaseDependencies="true" ExactVersions="true" />
 
     <!-- Rewrite the version ranges of per-build pre-release packages (see https://github.com/NuGet/Home/issues/7213) -->
     <Microsoft.DotNet.Tools.UpdatePackageVersionTask Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Shipping" ExactVersions="true"/>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -79,6 +79,8 @@
 
     <!-- Force references among packages to use exact versions (see https://github.com/NuGet/Home/issues/7213) -->
     <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="release" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Release" AllowPreReleaseDependencies="true" ExactVersions="true" />
+    
+    <Microsoft.DotNet.Tools.UpdatePackageVersionTask VersionKind="prerelease" Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Prerelease" AllowPreReleaseDependencies="true" ExactVersions="true" />
 
     <!-- Rewrite the version ranges of per-build pre-release packages (see https://github.com/NuGet/Home/issues/7213) -->
     <Microsoft.DotNet.Tools.UpdatePackageVersionTask Packages="@(_BuiltPackages)" OutputDirectory="$(DependentPackagesDir)Shipping" ExactVersions="true"/>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -60,11 +60,14 @@
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"                           target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\Release" />
+        <file src="$artifactsPackagesDir$Dependency\Prerelease\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\Prerelease" />
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"    target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Release" />
+        <file src="$artifactsPackagesDir$Dependency\Prerelease\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Prerelease" />
 
         <file src="FSharp.Build\$configuration$\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"                                         target="contentFiles\Shipping" />
         <file src="FSharp.Build\$configuration$\netstandard2.0\Release\Microsoft.FSharp.Core.NetSdk.props"                                          target="contentFiles\Release" />
+        <file src="FSharp.Build\$configuration$\netstandard2.0\PreRelease\Microsoft.FSharp.Core.NetSdk.props"                                          target="contentFiles\PreRelease" />
     </files>
 </package>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -60,7 +60,7 @@
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Core.$fSharpCorePreviewPackageVersion$*nupkg"                           target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\Release" />
-        <file src="$artifactsPackagesDir$Dependency\Prerelease\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\Prerelease" />
+        <file src="$artifactsPackagesDir$Dependency\PreRelease\FSharp.Core.$fSharpCorePackageVersion$*nupkg"                                   target="contentFiles\PreRelease" />
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"    target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Release" />

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.nuspec
@@ -64,7 +64,7 @@
 
         <file src="$artifactsPackagesDir$Dependency\Shipping\FSharp.Compiler.Service.$fSharpCompilerServicePreviewPackageVersion$*nupkg"    target="contentFiles\Shipping" />
         <file src="$artifactsPackagesDir$Dependency\Release\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Release" />
-        <file src="$artifactsPackagesDir$Dependency\Prerelease\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\Prerelease" />
+        <file src="$artifactsPackagesDir$Dependency\PreRelease\FSharp.Compiler.Service.$fSharpCompilerServicePackageVersion$*nupkg"            target="contentFiles\PreRelease" />
 
         <file src="FSharp.Build\$configuration$\netstandard2.0\Shipping\Microsoft.FSharp.Core.NetSdk.props"                                         target="contentFiles\Shipping" />
         <file src="FSharp.Build\$configuration$\netstandard2.0\Release\Microsoft.FSharp.Core.NetSdk.props"                                          target="contentFiles\Release" />

--- a/vsintegration/shims/shims.csproj
+++ b/vsintegration/shims/shims.csproj
@@ -10,12 +10,7 @@
     <None Include="Microsoft.FSharp.Overrides.NetSdk.Shim.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.FSharp.Shim.targets" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Microsoft.Portable.FSharp.Shim.targets" CopyToOutputDirectory="PreserveNewest" />
-
-    <NoneSubstituteText Include="Microsoft.FSharp.ShimHelpers.props" CopyToOutputDirectory="PreserveNewest">
-      <TargetFileName>Microsoft.FSharp.ShimHelpers.props</TargetFileName>
-      <Pattern1>{{FSharpCorePreviewPackageVersionValue}}</Pattern1>
-      <Replacement1>$(FSharpCorePreviewPackageVersionValue)</Replacement1>
-    </NoneSubstituteText>
+    <None Include="Microsoft.FSharp.ShimHelpers.props" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Enable the SDK to publish the stable-preview packages
- Add a pre-release iteration so that previews can be differentiated.
- Remove the version substitution in the shims project. There was no replacement happening.
