### PR TITLE
Remove feature/lsp merge from branch-merge.yml

### DIFF
--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -16,7 +16,3 @@ jobs:
     uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
     with:
       configuration_file_path: '.config/service-branch-merge.json'
-  feature-lsp-flow:
-    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
-    with:
-      configuration_file_path: '.config/feature-lsp-branch-merge.json'


### PR DESCRIPTION
Cleaning up, since we've merged feature/lsp to main some time ago, `feature-lsp-branch-mege.json` has been removed already