### PR TITLE
Use thread pool in StackGuard

### DIFF
--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -898,10 +898,7 @@ type StackGuard(maxDepth: int, name: string) =
         try
             if depth % maxDepth = 0 then
                 async {
-                    let mutable w, c = 0, 0
-                    ThreadPool.GetAvailableThreads(&w, &c)
-
-                    if w > 256 then
+                    if Environment.Is64BitProcess then
                         do! Async.SwitchToThreadPool()
                     else
                         do! Async.SwitchToNewThread()


### PR DESCRIPTION
## Description

Running the task on a thread pool thread is significantly faster than spinning up a new thread.
This could improve performance with codebases that trigger the StackGuard a lot.
