### PR TITLE
Optimize Array Slicing Performance 

### DIFF
--- a/docs/release-notes/.FSharp.Core/10.0.100.md
+++ b/docs/release-notes/.FSharp.Core/10.0.100.md
@@ -10,3 +10,5 @@
 * Optimize array slicing performance. ([PR #18778](https://github.com/dotnet/fsharp/pull/18778))
 
 ### Breaking Changes
+
+* Empty 1D array slices return `[||]` instead of allocating a new array. ([PR #18778](https://github.com/dotnet/fsharp/pull/18778))

--- a/docs/release-notes/.FSharp.Core/10.0.100.md
+++ b/docs/release-notes/.FSharp.Core/10.0.100.md
@@ -7,5 +7,6 @@
 ### Changed
 
 * Random functions support for zero element chosen/sampled ([PR #18568](https://github.com/dotnet/fsharp/pull/18568))
+* Optimize array slicing performance. ([PR #18778](https://github.com/dotnet/fsharp/pull/18778))
 
 ### Breaking Changes

--- a/docs/release-notes/.FSharp.Core/10.0.100.md
+++ b/docs/release-notes/.FSharp.Core/10.0.100.md
@@ -11,4 +11,4 @@
 
 ### Breaking Changes
 
-* Empty 1D array slices return `[||]` instead of allocating a new array. ([PR #18778](https://github.com/dotnet/fsharp/pull/18778))
+* 1D array slicing now returns an empty array singleton instead of allocating a new array when the result is empty. ([PR #18778](https://github.com/dotnet/fsharp/pull/18778))

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -779,17 +779,17 @@ namespace Microsoft.FSharp.Core
 
             let inline SetArray (target: 'T array) (index:int) (value:'T) =  (# "stelem.any !0" type ('T) target index value #)  
 
-            let inline GetArraySub arr (start:int) (len:int) =
-                let len = if len < 0 then 0 else len
-                let dst = zeroCreate len   
-                for i = 0 to len - 1 do 
-                    SetArray dst i (GetArray arr (start + i))
-                dst
+            let inline GetArraySub (arr: 'a array) (start:int) (len:int) : 'a array =
+                if len <= 0 then
+                    zeroCreate 0
+                else
+                    let dst = zeroCreate len
+                    Array.Copy(arr, start, dst, 0, len)
+                    dst
 
-            let inline SetArraySub arr (start:int) (len:int) (src:_ array) =
-                for i = 0 to len - 1 do 
-                    SetArray arr (start+i) (GetArray src i)
-
+            let inline SetArraySub (arr: 'T array) (start:int) (len:int) (src: 'T array) =
+                if len > 0 then
+                    Array.Copy(src, 0, arr, start, len)
 
             let inline GetArray2D (source: 'T[,]) (index1: int) (index2: int) = (# "ldelem.multi 2 !0" type ('T) source index1 index2 : 'T #)  
 

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -781,7 +781,7 @@ namespace Microsoft.FSharp.Core
 
             let inline GetArraySub (arr: 'a array) (start:int) (len:int) : 'a array =
                 if len <= 0 then
-                    zeroCreate 0
+                    [||]
                 else
                     let dst = zeroCreate len
                     Array.Copy(arr, start, dst, 0, len)

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
@@ -1963,6 +1963,17 @@ type ArrayModule() =
 
 
     [<Fact>]
+    member _.``Slicing always creates new arrays`` () =
+        let arr = [|1;2;3;4;5;6|]
+
+        Assert.False(Object.ReferenceEquals(arr[1..3], arr[1..3]))
+        Assert.False(Object.ReferenceEquals(arr[0..], arr[0..]))
+        Assert.False(Object.ReferenceEquals(arr[..^1], arr[..^1]))
+        
+        Assert.AreEqual(arr[1..-1].Length, 0)
+        Assert.False(Object.ReferenceEquals(arr[1..-1], arr[1..-1]))
+
+    [<Fact>]
     member _.RandomShuffle() =
         let arr = [| 1..20 |]
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
@@ -1963,15 +1963,19 @@ type ArrayModule() =
 
 
     [<Fact>]
-    member _.``Slicing always creates new arrays`` () =
+    member _.``Slicing creates new non-empty arrays`` () =
         let arr = [|1;2;3;4;5;6|]
 
         Assert.False(Object.ReferenceEquals(arr[1..3], arr[1..3]))
         Assert.False(Object.ReferenceEquals(arr[0..], arr[0..]))
         Assert.False(Object.ReferenceEquals(arr[..^1], arr[..^1]))
         
+    [<Fact>]
+    member _.``Empty slices are referentially equivalent`` () =
+        let arr = [|1;2;3;4;5;6|]
+
         Assert.AreEqual(arr[1..-1].Length, 0)
-        Assert.False(Object.ReferenceEquals(arr[1..-1], arr[1..-1]))
+        Assert.True(Object.ReferenceEquals(arr[1..-1], arr[1..-1]))
 
     [<Fact>]
     member _.RandomShuffle() =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/ArrayModule.fs
@@ -1976,6 +1976,9 @@ type ArrayModule() =
 
         Assert.AreEqual(arr[1..-1].Length, 0)
         Assert.True(Object.ReferenceEquals(arr[1..-1], arr[1..-1]))
+        
+        Assert.True(Object.ReferenceEquals(arr[1..-1], ([||]: int array)))
+
 
     [<Fact>]
     member _.RandomShuffle() =

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/ArraySlicing.fs
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/ArraySlicing.fs
@@ -1,0 +1,15 @@
+module ArraySlicing
+
+open BenchmarkDotNet.Attributes
+open System
+
+[<SimpleJob(launchCount = 2, warmupCount = 1, iterationCount = 2)>]
+[<GcServer(true)>]
+[<MemoryDiagnoser>]
+[<MarkdownExporterAttribute.GitHub>]
+type ArraySlicingBenchmark() =
+    let b = [| for _ in 1 .. 100_000 -> byte DateTime.Now.Ticks |]
+
+    [<Benchmark>]
+    member _.x () =
+        b[ 20 .. 4999 ]

--- a/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/MicroPerf.fsproj
+++ b/tests/benchmarks/CompiledCodeBenchmarks/MicroPerf/MicroPerf.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="Equality\OptionsAndCo.fs" />
     <Compile Include="Equality\ExactEquals.fs" />
     <Compile Include="Async.fs" />
+    <Compile Include="ArraySlicing.fs" />
     <Compile Include="Conditions.fs" />
     <Compile Include="Collections.fs" />
     <Compile Include="Program.fs" />


### PR DESCRIPTION
## Description

Delegate array slicing to `System.Array.Copy`.

Fixes #18644

## Benchmark Results:
The MicroPerf benchmarks that are committed aren't launching on my installed version of .NET (I don't have .NET 10 Preview 7 access)

Using benchmarks from #18644:

```fsharp
[<MemoryDiagnoser; ShortRunJob>]
type Benchmarks () =
    let b = [| for _ in 1 .. 100_000 -> byte DateTime.Now.Ticks |]

    [<Benchmark>]
    member _.x () =
        b.[ 20 .. 4999 ]

    [<Benchmark>]
    member f.xx () =
        let out = GC.AllocateUninitializedArray<byte> (4980, false)
        Array.Copy (b, 20, out, 0, 4980)
        out

    [<Benchmark>]
    member gg.xxx () =
        b.AsSpan(20, 4980).ToArray ()
```

Before:
```
BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.4652/24H2/2024Update/HudsonValley)
AMD Ryzen 7 5800X, 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.100-preview.6.25358.103
  [Host]   : .NET 10.0.0 (10.0.25.35903), X64 RyuJIT AVX2 DEBUG
  ShortRun : .NET 10.0.0 (10.0.25.35903), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

| Method | Mean       | Error     | StdDev   | Gen0   | Allocated |
|------- |-----------:|----------:|---------:|-------:|----------:|
| x      | 2,514.5 ns | 690.39 ns | 37.84 ns | 0.2975 |   4.89 KB |
| xx     |   224.0 ns | 158.36 ns |  8.68 ns | 0.2983 |   4.89 KB |
| xxx    |   210.8 ns |  88.84 ns |  4.87 ns | 0.2992 |   4.89 KB |
```

After:
```
BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.4652/24H2/2024Update/HudsonValley)
AMD Ryzen 7 5800X, 1 CPU, 16 logical and 8 physical cores
.NET SDK 10.0.100-preview.6.25358.103
  [Host]   : .NET 10.0.0 (10.0.25.35903), X64 RyuJIT AVX2 DEBUG
  ShortRun : .NET 10.0.0 (10.0.25.35903), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

| Method | Mean     | Error    | StdDev   | Gen0   | Allocated |
|------- |---------:|---------:|---------:|-------:|----------:|
| x      | 238.1 ns | 108.7 ns |  5.96 ns | 0.2992 |   4.89 KB |
| xx     | 218.4 ns | 210.3 ns | 11.53 ns | 0.2983 |   4.89 KB |
| xxx    | 232.6 ns | 389.8 ns | 21.37 ns | 0.2992 |   4.89 KB |
```

90% performance improvement on my machine. An AVX-512 CPU would be even faster.

## Tests
Existing tests already cover array slicing get/set. This PR adds an additional test to verify an array returned as a slice is unique (different object) as is the existing behavior.

## Checklist

- [x] Test cases added
- [x] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated