### PR TITLE
Tests: fix runFsi not picking up source from file

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/resources/tests/Conformance/Printing/WidthForAFormatter.fs
+++ b/tests/FSharp.Compiler.ComponentTests/resources/tests/Conformance/Printing/WidthForAFormatter.fs
@@ -6,7 +6,7 @@
 let test = 
     sprintf "%1A" [1..5] = "[1;\n 2;\n 3;\n 4;\n 5]" &&
     sprintf "%13A" [|1..5|] = "[|1; 2; 3; 4;\n  5|]" &&
-    sprintf "%3.1A" {1..3} = "seq\n  [1;\n   ...]"
+    sprintf "%3.1A"  (seq {1..3}) = "seq\n  [1;\n   ...]"
 
 match test with
 | false -> raise (new System.Exception("LazyValues03 failed - this should never be forced"))

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -1191,7 +1191,7 @@ module rec Compiler =
     let runFsi (cUnit: CompilationUnit) : CompilationResult =
         match cUnit with
         | FS fs ->
-            let source = fs.Source.GetSourceText |> Option.defaultValue ""
+            let source = fs.Source.GetSourceText |> Option.defaultWith fs.Source.LoadSourceText
             let name = fs.Name |> Option.defaultValue "unnamed"
             let options = fs.Options |> Array.ofList
             let outputDirectory =

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -136,6 +136,8 @@ type SourceCodeFileKind =
         | Fsi s -> s.FileName
         | Cs s -> s.FileName
 
+    member this.LoadSourceText() = FileSystem.OpenFileForReadShim(this.GetSourceFileName).ReadAllText()
+
     member this.GetSourceText =
         match this with
         | Fs s -> s.SourceText


### PR DESCRIPTION
Some tests were silently skipped because of this.