### PR TITLE
fix line directive application for caller info

### DIFF
--- a/src/Compiler/Utilities/range.fs
+++ b/src/Compiler/Utilities/range.fs
@@ -270,8 +270,7 @@ module internal LineDirectives =
     let mutable store: Map<FileIndex, (int * (FileIndex * int)) list> = Map.empty
 
     let add originalFileIndex lineDirectives =
-        lock lineDirectives
-        <| fun () -> store <- store.Add(originalFileIndex, lineDirectives)
+        lock store <| fun () -> store <- store.Add(originalFileIndex, lineDirectives)
 
 [<Struct; CustomEquality; NoComparison>]
 [<System.Diagnostics.DebuggerDisplay("({StartLine},{StartColumn}-{EndLine},{EndColumn}) {ShortFileName} -> {DebugCode}")>]


### PR DESCRIPTION
## Description

This fixes the regression regarding caller info with line directives that was reported [here](https://github.com/dotnet/fsharp/issues/18553#issuecomment-3162073208).

So, this adds a 6th place to [this list](https://github.com/dotnet/fsharp/pull/18699#issue-3156656888) of applications of line directives.

## Checklist

- [X] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes not needed
