### PR TITLE
Ensure test console always works in VS test explorer

### DIFF
--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -59,8 +59,6 @@ module AssemblyResolver =
             match found() with
             | None -> Unchecked.defaultof<Assembly>
             | Some name -> Assembly.Load(name) )
-
-    do addResolver()
 #endif
 
 type ExecutionOutcome = 

--- a/tests/FSharp.Test.Utilities/XunitHelpers.fs
+++ b/tests/FSharp.Test.Utilities/XunitHelpers.fs
@@ -190,6 +190,23 @@ type OpenTelemetryExport(testRunName, enable) =
         member this.Dispose() =
             for p in providers do p.Dispose()
 
+// In some situations, VS can invoke CreateExecutor and RunTestCases many times during testhost lifetime.
+// For example when executing "run until failure" command in Test Explorer.
+// However, we want to ensure that OneTimeSetup is called only once per test run.
+module OneTimeSetup =
+    do
+    #if !NETCOREAPP
+        // We need AssemblyResolver already here, because OpenTelemetry loads some assemblies dynamically.
+        log "Adding AssemblyResolver"
+        AssemblyResolver.addResolver ()
+    #endif
+        log "Overriding cache capacity"
+        Cache.OverrideCapacityForTesting()
+        log "Installing TestConsole redirection"
+        TestConsole.install()
+
+        logConfig initialConfig
+
 /// `XunitTestFramework` providing parallel console support and conditionally enabling optional xUnit customizations.
 type FSharpXunitFramework(sink: IMessageSink) =
     inherit XunitTestFramework(sink)
@@ -198,25 +215,12 @@ type FSharpXunitFramework(sink: IMessageSink) =
         { new XunitTestFrameworkExecutor(assemblyName, this.SourceInformationProvider, this.DiagnosticMessageSink) with
             
             // Because xUnit v2 lacks assembly fixture, this is a good place to ensure things get called right at the start of the test run.
-            // This gets executed once per test assembly.
             override x.RunTestCases(testCases, executionMessageSink, executionOptions) =
-
-            #if !NETCOREAPP
-                // We need AssemblyResolver already here, because OpenTelemetry loads some assemblies dynamically.
-                AssemblyResolver.addResolver ()
-            #endif
-
-                // Override cache capacity to reduce memory usage in CI.
-                Cache.OverrideCapacityForTesting()
 
                 let testRunName = $"RunTests_{assemblyName.Name} {Runtime.InteropServices.RuntimeInformation.FrameworkDescription}"
 
-                use _ = new OpenTelemetryExport(testRunName, Environment.GetEnvironmentVariable("FSHARP_OTEL_EXPORT") <> null)   
-                
-                logConfig initialConfig
-                log "Installing TestConsole redirection"
-                TestConsole.install()
-              
+                use _ = new OpenTelemetryExport(testRunName, Environment.GetEnvironmentVariable("FSHARP_OTEL_EXPORT") <> null)                 
+  
                 begin
                     use _ = Activity.startNoTags testRunName
                     // We can't just call base.RunTestCases here, because it's implementation is async void.

--- a/tests/fsharp/single-test.fs
+++ b/tests/fsharp/single-test.fs
@@ -9,6 +9,8 @@ open FSharp.Compiler.IO
 
 let testConfig = testConfig __SOURCE_DIRECTORY__
 
+let log = printfn
+
 type Permutation =
 #if NETCOREAPP
     | FSC_NETCORE of optimized: bool * buildOnly: bool

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -27,6 +27,8 @@ let FSI = FSI_NETFX
 #endif
 // ^^^^^^^^^^^^ To run these tests in F# Interactive , 'build net40', then send this chunk, then evaluate body of a test ^^^^^^^^^^^^
 
+let log = printfn
+
 module CoreTests =
 
 

--- a/tests/scripts/scriptlib.fsx
+++ b/tests/scripts/scriptlib.fsx
@@ -75,9 +75,12 @@ module Scripting =
 
     let deleteDirectory output =
         if Directory.Exists output then 
-            Directory.Delete(output, true) 
-
-    let log format = printfn format
+            Directory.Delete(output, true)
+            
+    // Capture the original stdout for logging.
+    let private originalOut = stdout
+    // When used during test run, log will always output to the original stdout of the testhost, instead of the test output.
+    let log format = fprintfn originalOut format
 
     type FilePath = string
 


### PR DESCRIPTION
I noticed that the testhost fails catastrophically when executing some selected tests with "run until failure" in VS.

The reason is that apparently VS can keep alive the testhost and execute xUnit's `CreateExecutor` and `RunTestCases` many times, but we did some one-time initialisation there. In effect TestConsole redirectors returned null, bringing everything down.

This moves the initialization again to a safer place. Also adds some defenses to never return null when a redirected stream is expected.
