### PR TITLE
make devcontainer work with unpublished sdks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 {
     "name": "F#",
-    "image": "mcr.microsoft.com/dotnet/sdk:10.0.100-preview.3",
+    "image": "mcr.microsoft.com/dotnet/sdk:9.0.304",
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.3": {},
-        "ghcr.io/devcontainers/features/git:1.3.3": {},
+        "ghcr.io/devcontainers/features/common-utils:2.5.4": {},
+        "ghcr.io/devcontainers/features/git:1.3.4": {},
         "ghcr.io/devcontainers/features/github-cli:1.0.14": {},
-        "ghcr.io/devcontainers/features/dotnet:2.2.1": {}
+        "ghcr.io/devcontainers/features/dotnet:2.3.0": {}
     },
     "hostRequirements": {
         "cpus": 2,
@@ -28,7 +28,8 @@
         }
     },
     "remoteEnv": {
-        "TARGET": "net9.0"
+        "FSHARPCORE_USE_PACKAGE": "false",
+        "PATH": "${localWorkspaceFolder}/.dotnet:${containerEnv:PATH}"
     },
-    "postCreateCommand": [ "dotnet", "build", "FSharp.Compiler.Service.sln"]
+    "postCreateCommand": [ "bash", "-c", "eng/common/dotnet.sh && cp -r .dotnet/sdk/* /usr/share/dotnet/sdk && cp -r .dotnet/shared/Microsoft.NETCore.App/* /usr/share/dotnet/shared/Microsoft.NETCore.App" ]
 }


### PR DESCRIPTION
## Description

This enables devcontainer also when global.json requests an unofficial new SDK (like we now often have).
The change is not really nice, but the only way that I found after much trying.
The issue is that the Microsoft SDK devcontainer images install dotnet in `/usr`, while `eng/common/dotnet.sh` (which is needed to get the unofficial SDK) installs into the workspace folder, and, unfortunately, this cannot be changed.
While the local version is fine for terminal use, it is not found by Ionide, that's why the copying in postCreateCommand is necessary.
Not so nice is that on creation you get a lot of error messages from Ionide. After reload, however, everything works fine.

@vzarytovskii @baronfel : Any other ideas?

Related: #18715

EDIT:
Maybe the root issue is that Ionide doesn't respect the `remoteEnv:PATH`. If I understand the devcontainer documentation correctly, it should. (?)