### PR TITLE
Type checker: use inner expr range in upcast constraints errors

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
@@ -24,6 +24,7 @@
 
 ### Changed
 * Use `errorR` instead of `error` in `CheckDeclarations.fs` when possible. ([PR #18645](https://github.com/dotnet/fsharp/pull/18645))
+* Type checker: use inner expr range in upcast constraints errors ([PR #18850](https://github.com/dotnet/fsharp/pull/18850))
 
 ### Breaking Changes
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ControlFlowExpressions/Type-relatedExpressions/Type-relatedExpressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ControlFlowExpressions/Type-relatedExpressions/Type-relatedExpressions.fs
@@ -74,4 +74,16 @@ module TyperelatedExpressions =
             (Warning 20, Line 9, Col 1, Line 9, Col 22, "The result of this expression has type 'obj' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
         ]
 
+    [<Fact>]
+    let ``Upcast 01`` () =
+        FSharp """
+module Module
 
+type A() =
+    class end
+
+not true :> A |> ignore
+"""
+        |> compile
+        |> shouldFail
+        |> withDiagnostics [(Error 193, Line 7, Col 1, Line 7, Col 9, "Type constraint mismatch. The type \n    'bool'    \nis not compatible with type\n    'A'    \n")]

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UpcastDowncastTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/UpcastDowncastTests.fs
@@ -17,7 +17,7 @@ let c = orig :> Dictionary<obj,obj>
         """
         |> typecheck
         |> shouldFail
-        |> withSingleDiagnostic (Error 193, Line 5, Col 9, Line 5, Col 36,
+        |> withSingleDiagnostic (Error 193, Line 5, Col 9, Line 5, Col 13,
                                  "Type constraint mismatch. The type \n    'IDictionary<obj,obj>'    \nis not compatible with type\n    'Dictionary<obj,obj>'    \n")
 
     [<Fact>]


### PR DESCRIPTION
Makes type checker use inner expression range for upcast errors. It makes it more in-line with other type constraint errors and makes it easier to distinguish cases where upcast expressions themselves do not satisfy the constraints.

Before this change the same range was used for errors about `b` not being compatible with `T2` and for `T2` not being compatible with `T1`:
```fsharp
let a: T1 =
    b :> T2
```

With this change the first error covers `b` range only.