### PR TITLE
Cache: support reference identity

### DIFF
--- a/src/Compiler/Checking/CheckBasics.fs
+++ b/src/Compiler/Checking/CheckBasics.fs
@@ -243,11 +243,7 @@ type TcEnv =
       eLambdaArgInfos: ArgReprInfo list list
 
       // Do we lay down an implicit debug point?
-      eIsControlFlow: bool
-      
-      // In order to avoid checking implicit-yield expressions multiple times, we cache the resulting checked expressions.
-      // This avoids exponential behavior in the type checker when nesting implicit-yield expressions.
-      eCachedImplicitYieldExpressions : HashMultiMap<range, SynExpr * TType * Expr>
+      eIsControlFlow: bool     
     }
 
     member tenv.DisplayEnv = tenv.eNameResEnv.DisplayEnv

--- a/src/Compiler/Checking/CheckBasics.fsi
+++ b/src/Compiler/Checking/CheckBasics.fsi
@@ -130,9 +130,6 @@ type TcEnv =
 
         eIsControlFlow: bool
 
-        // In order to avoid checking implicit-yield expressions multiple times, we cache the resulting checked expressions.
-        // This avoids exponential behavior in the type checker when nesting implicit-yield expressions.
-        eCachedImplicitYieldExpressions: HashMultiMap<range, SynExpr * TType * Expr>
     }
 
     member DisplayEnv: DisplayEnv

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5620,8 +5620,7 @@ let emptyTcEnv g =
       eCtorInfo = None
       eCallerMemberName = None 
       eLambdaArgInfos = []
-      eIsControlFlow = false
-      eCachedImplicitYieldExpressions = HashMultiMap(HashIdentity.Structural, useConcurrentDictionary = true) }
+      eIsControlFlow = false }
 
 let CreateInitialTcEnv(g, amap, scopem, assemblyName, ccus) =
     (emptyTcEnv g, ccus) ||> List.collectFold (fun env (ccu, autoOpens, internalsVisible) -> 

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -4052,6 +4052,10 @@ type ImplicitlyBoundTyparsAllowed =
     | NewTyparsOK
     | NoNewTypars
 
+// In order to avoid checking implicit-yield expressions multiple times, we cache the resulting checked expressions.
+// This avoids exponential behavior in the type checker when nesting implicit-yield expressions.
+let CachedImplicitYieldExpressions = Caches.Cache<SynExpr, _>.Create(Caches.CacheOptions.Default, HashIdentity.Reference)
+
 //-------------------------------------------------------------------------
 // Checking types and type constraints
 //-------------------------------------------------------------------------
@@ -5504,18 +5508,11 @@ and CheckForAdjacentListExpression (cenv: cenv) synExpr hpa isInfix delayed (arg
 and TcExprThen (cenv: cenv) overallTy env tpenv isArg synExpr delayed =
     let g = cenv.g
 
-    let cachedExpression =
-        env.eCachedImplicitYieldExpressions.FindAll synExpr.Range
-        |> List.tryPick (fun (se, ty, e) ->
-            if obj.ReferenceEquals(se, synExpr) then Some (ty, e) else None
-        )
-
-    match cachedExpression with
-    | Some (ty, expr) ->
+    match CachedImplicitYieldExpressions.TryGetValue(synExpr) with
+    | true, (ty, expr) ->
         UnifyOverallType cenv env synExpr.Range overallTy ty
         expr, tpenv
     | _ ->
-
 
         match synExpr with
 
@@ -6379,9 +6376,8 @@ and TcExprSequentialOrImplicitYield (cenv: cenv) overallTy env tpenv (sp, synExp
             | Expr.DebugPoint(_,e) -> e
             | _ -> expr1
 
-        env.eCachedImplicitYieldExpressions.Add(synExpr1.Range, (synExpr1, expr1Ty, cachedExpr))
-        try TcExpr cenv overallTy env tpenv otherExpr
-        finally env.eCachedImplicitYieldExpressions.Remove synExpr1.Range
+        CachedImplicitYieldExpressions.AddOrUpdate(synExpr1, (expr1Ty, cachedExpr))
+        TcExpr cenv overallTy env tpenv otherExpr
 
 and TcExprStaticOptimization (cenv: cenv) overallTy env tpenv (constraints, synExpr2, expr3, m) =
     let constraintsR, tpenv = List.mapFold (TcStaticOptimizationConstraint cenv env) tpenv constraints

--- a/src/Compiler/Checking/TypeRelations.fs
+++ b/src/Compiler/Checking/TypeRelations.fs
@@ -137,13 +137,7 @@ let rec TypeFeasiblySubsumesType ndeep (g: TcGlobals) (amap: ImportMap) m (ty1: 
 
     if g.langVersion.SupportsFeature LanguageFeature.UseTypeSubsumptionCache then
         let key = TTypeCacheKey.FromStrippedTypes (ty1, ty2, canCoerce)
-
-        match amap.TypeSubsumptionCache.TryGetValue(key) with
-        | true, subsumes -> subsumes
-        | false, _ ->
-            let subsumes = checkSubsumes ty1 ty2
-            amap.TypeSubsumptionCache.TryAdd(key, subsumes) |> ignore
-            subsumes
+        amap.TypeSubsumptionCache.GetOrAdd(key, fun key -> checkSubsumes key.ty1 key.ty2)
     else
         checkSubsumes ty1 ty2
 

--- a/src/Compiler/Utilities/Caches.fs
+++ b/src/Compiler/Utilities/Caches.fs
@@ -42,9 +42,11 @@ type CachedEntity<'Key, 'Value> =
     member this.Key = this.key
     member this.Value = this.value
 
+    member this.UpdateValue(value: 'Value) = this.value <- value
+
     static member Create(key: 'Key, value: 'Value) =
         let entity = CachedEntity(key, value)
-        // The contract is that each CachedEntity produced by the EntityPool always has Node referencing itself.
+        // The contract is that each CachedEntity always has a LinkedListNode referencing itself.
         entity.node <- LinkedListNode(entity)
         entity
 
@@ -57,20 +59,13 @@ type CacheMetrics(cacheId: string) =
     static let meter = new Meter("FSharp.Compiler.Cache")
     static let observedCaches = ConcurrentDictionary<string, CacheMetrics>()
 
-    let created = meter.CreateCounter<int64>("created", "count", cacheId)
     let hits = meter.CreateCounter<int64>("hits", "count", cacheId)
     let misses = meter.CreateCounter<int64>("misses", "count", cacheId)
     let evictions = meter.CreateCounter<int64>("evictions", "count", cacheId)
     let evictionFails = meter.CreateCounter<int64>("eviction-fails", "count", cacheId)
-    let allCouinters = [ created; hits; misses; evictions; evictionFails ]
+    let allCounters = [ hits; misses; evictions; evictionFails ]
 
-    let totals =
-        let builder = ImmutableDictionary.CreateBuilder<Instrument, int64 ref>()
-
-        for counter in allCouinters do
-            builder.Add(counter, ref 0L)
-
-        builder.ToImmutable()
+    let totals = Map [ for counter in allCounters -> counter.Name, ref 0L ]
 
     let incr key v =
         Interlocked.Add(totals[key], v) |> ignore
@@ -80,23 +75,22 @@ type CacheMetrics(cacheId: string) =
     let mutable ratio = Double.NaN
 
     let updateRatio () =
-        ratio <- float (total hits) / float (total hits + total misses)
+        ratio <- float (total hits.Name) / float (total hits.Name + total misses.Name)
 
     let listener = new MeterListener()
 
     let startListening () =
-        for i in allCouinters do
+        for i in allCounters do
             listener.EnableMeasurementEvents i
 
         listener.SetMeasurementEventCallback(fun instrument v _ _ ->
-            incr instrument v
+            incr instrument.Name v
 
             if instrument = hits || instrument = misses then
                 updateRatio ())
 
         listener.Start()
 
-    member val Created = created
     member val Hits = hits
     member val Misses = misses
     member val Evictions = evictions
@@ -111,7 +105,7 @@ type CacheMetrics(cacheId: string) =
         listener.Dispose()
 
     member _.GetInstanceTotals() =
-        [ for k in totals.Keys -> k.Name, total k ] |> Map.ofList
+        [ for k in totals.Keys -> k, total k ] |> Map.ofList
 
     member _.GetInstanceStats() = [ "hit-ratio", ratio ] |> Map.ofList
 
@@ -145,7 +139,7 @@ type EvictionQueueMessage<'Key, 'Value> =
 
 [<Sealed; NoComparison; NoEquality>]
 [<DebuggerDisplay("{GetStats()}")>]
-type Cache<'Key, 'Value when 'Key: not null and 'Key: equality> internal (totalCapacity, headroom, name, listen) =
+type Cache<'Key, 'Value when 'Key: not null> internal (totalCapacity: int, headroom, comparer, name, listen) =
 
     let metrics = new CacheMetrics(name)
 
@@ -154,7 +148,7 @@ type Cache<'Key, 'Value when 'Key: not null and 'Key: equality> internal (totalC
             metrics.ObserveMetrics()
 
     let store =
-        ConcurrentDictionary<'Key, CachedEntity<'Key, 'Value>>(Environment.ProcessorCount, totalCapacity)
+        ConcurrentDictionary<'Key, CachedEntity<'Key, 'Value>>(Environment.ProcessorCount, totalCapacity, comparer)
 
     let evictionQueue = LinkedList<CachedEntity<'Key, 'Value>>()
 
@@ -229,6 +223,40 @@ type Cache<'Key, 'Value when 'Key: not null and 'Key: equality> internal (totalC
 
         added
 
+    member _.GetOrAdd(key, valueFactory) =
+        let mutable wasMiss = false
+
+        let makeEntity key =
+            wasMiss <- true
+            let entity = CachedEntity.Create(key, valueFactory key)
+            evictionProcessor.Post(EvictionQueueMessage.Add entity)
+            entity
+
+        let result = store.GetOrAdd(key, makeEntity)
+
+        if wasMiss then
+            metrics.Misses.Add 1L
+        else
+            metrics.Hits.Add 1L
+
+        evictionProcessor.Post(EvictionQueueMessage.Update result)
+        result.Value
+
+    member _.AddOrUpdate(key, value) =
+        let addValue = CachedEntity.Create(key, value)
+
+        let updateValue _ (oldEntity: CachedEntity<_, _>) =
+            oldEntity.UpdateValue(value)
+            oldEntity
+
+        let result = store.AddOrUpdate(key, addValue, updateValue)
+
+        // Returned value tells us if the entity was added or updated.
+        if Object.ReferenceEquals(addValue, result) then
+            evictionProcessor.Post(EvictionQueueMessage.Add addValue)
+        else
+            evictionProcessor.Post(EvictionQueueMessage.Update result)
+
     interface IDisposable with
         member this.Dispose() =
             cts.Cancel()
@@ -239,7 +267,7 @@ type Cache<'Key, 'Value when 'Key: not null and 'Key: equality> internal (totalC
 
     member this.Dispose() = (this :> IDisposable).Dispose()
 
-    static member Create<'Key, 'Value>(options: CacheOptions, ?name, ?observeMetrics) =
+    static member Create<'Key, 'Value>(options: CacheOptions, ?comparer: IEqualityComparer<'Key>, ?name, ?observeMetrics) =
         if options.TotalCapacity < 0 then
             invalidArg "Capacity" "Capacity must be positive"
 
@@ -253,7 +281,9 @@ type Cache<'Key, 'Value when 'Key: not null and 'Key: equality> internal (totalC
 
         let name = defaultArg name (Guid.NewGuid().ToString())
         let observeMetrics = defaultArg observeMetrics false
+        let comparer = defaultArg comparer EqualityComparer<'Key>.Default
 
-        let cache = new Cache<_, _>(totalCapacity, headroom, name, observeMetrics)
+        let cache =
+            new Cache<'Key, 'Value>(totalCapacity, headroom, comparer, name, observeMetrics)
 
         cache

--- a/src/Compiler/Utilities/Caches.fsi
+++ b/src/Compiler/Utilities/Caches.fsi
@@ -1,8 +1,8 @@
 namespace FSharp.Compiler.Caches
 
 open System
+open System.Collections.Generic
 open System.Diagnostics.Metrics
-open System.Threading
 
 [<Struct; RequireQualifiedAccess; NoComparison; NoEquality>]
 type internal CacheOptions =
@@ -20,9 +20,11 @@ module internal Cache =
     val OverrideCapacityForTesting: unit -> unit
 
 [<Sealed; NoComparison; NoEquality>]
-type internal Cache<'Key, 'Value when 'Key: not null and 'Key: equality> =
+type internal Cache<'Key, 'Value when 'Key: not null> =
     member TryGetValue: key: 'Key * value: outref<'Value> -> bool
     member TryAdd: key: 'Key * value: 'Value -> bool
+    member GetOrAdd: key: 'Key * valueFactory: ('Key -> 'Value) -> 'Value
+    member AddOrUpdate: key: 'Key * value: 'Value -> unit
     /// Cancels the background eviction task.
     member Dispose: unit -> unit
 
@@ -33,7 +35,8 @@ type internal Cache<'Key, 'Value when 'Key: not null and 'Key: equality> =
     member EvictionFailed: IEvent<unit>
 
     static member Create<'Key, 'Value> :
-        options: CacheOptions * ?name: string * ?observeMetrics: bool -> Cache<'Key, 'Value>
+        options: CacheOptions * ?comparer: IEqualityComparer<'Key> * ?name: string * ?observeMetrics: bool ->
+            Cache<'Key, 'Value>
 
 [<Class>]
 type internal CacheMetrics =

--- a/tests/FSharp.Compiler.ComponentTests/CompilerService/Caches.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerService/Caches.fs
@@ -5,6 +5,7 @@ open Xunit
 open FSharp.Test.Assert
 open System.Threading.Tasks
 open System.Diagnostics
+open Microsoft.FSharp.Collections
 
 #if DEBUG
 let shouldNeverTimeout = 15_000
@@ -128,3 +129,105 @@ let ``Metrics can be retrieved`` () =
 
     stats.["hit-ratio"] |> shouldEqual 1.0
     totals.["evictions"] |> shouldEqual 1L
+
+[<Fact>]
+let ``GetOrAdd basic usage`` () =
+    let cacheName = "GetOrAdd_basic_usage"
+    use cache = Cache.Create<string, int>(CacheOptions.Default, name = cacheName, observeMetrics = true)
+    let mutable factoryCalls = 0
+    let factory k = factoryCalls <- factoryCalls + 1; String.length k
+    let v1 = cache.GetOrAdd("abc", factory)
+    v1 |> shouldEqual 3
+    let v2 = cache.GetOrAdd("abc", factory)
+    v2 |> shouldEqual 3
+    factoryCalls |> shouldEqual 1
+    let v3 = cache.GetOrAdd("defg", factory)
+    v3 |> shouldEqual 4
+    factoryCalls |> shouldEqual 2
+    // Metrics assertions
+    let stats = CacheMetrics.GetStats(cacheName)
+    let totals = CacheMetrics.GetTotals(cacheName)
+    totals.["hits"] |> shouldEqual 1L
+    totals.["misses"] |> shouldEqual 2L
+    stats.["hit-ratio"] |> shouldEqual (1.0/3.0)
+
+[<Fact>]
+let ``AddOrUpdate basic usage`` () =
+    let cacheName = "AddOrUpdate_basic_usage"
+    use cache = Cache.Create<string, int>(CacheOptions.Default, name = cacheName, observeMetrics = true)
+    cache.AddOrUpdate("x", 1)
+    let mutable value = 0
+    cache.TryGetValue("x", &value) |> shouldBeTrue
+    value |> shouldEqual 1
+    cache.AddOrUpdate("x", 42)
+    cache.TryGetValue("x", &value) |> shouldBeTrue
+    value |> shouldEqual 42
+    cache.AddOrUpdate("y", 99)
+    cache.TryGetValue("y", &value) |> shouldBeTrue
+    value |> shouldEqual 99
+    // Metrics assertions
+    let stats = CacheMetrics.GetStats(cacheName)
+    let totals = CacheMetrics.GetTotals(cacheName)
+    totals.["hits"] |> shouldEqual 3L // 3 cache hits
+    totals.["misses"] |> shouldEqual 0L // 0 cache misses
+    stats.["hit-ratio"] |> shouldEqual 1.0
+
+[<Fact>]
+let ``GetOrAdd with reference identity`` () =
+    let cacheName = "GetOrAdd_with_Reference"
+    use cache = Cache.Create<int * int, int>(CacheOptions.Default, HashIdentity.Reference, cacheName, observeMetrics = true)
+    let t1 = box (1, 2)
+    let t2 = box (1, 2)
+    let t3 = box (1, 2)
+    let mutable createdCOunter = 0
+    let factory _ = 
+            createdCOunter <- createdCOunter + 1
+            createdCOunter
+
+    let v1 = cache.GetOrAdd(t1, factory) // miss
+    let v2 = cache.GetOrAdd(t2, factory) // miss (different reference)
+    v1 |> shouldEqual 1
+    v2 |> shouldEqual 2
+    // Reference comparer: t1 and t2 are different keys
+    t1 = t2 |> shouldBeTrue // value equality
+    obj.ReferenceEquals(t1, t2) |> shouldBeFalse // reference inequality
+    let mutable v1' = 0
+    let mutable v2' = 0
+    let mutable v3' = 0
+    cache.TryGetValue(t1, &v1') |> shouldBeTrue // hit
+    cache.TryGetValue(t2, &v2') |> shouldBeTrue // hit
+    cache.TryGetValue(t3, &v3') |> shouldBeFalse // miss
+    let v1'' = cache.GetOrAdd(t1, factory) // hit
+    let v2'' = cache.GetOrAdd(t2, factory) // hit
+    v1'' |> shouldEqual v1'
+    v2'' |> shouldEqual v2'
+    // Metrics assertions
+    let stats = CacheMetrics.GetStats(cacheName)
+    let totals = CacheMetrics.GetTotals(cacheName)
+    totals.["hits"] |> shouldEqual 4L
+    totals.["misses"] |> shouldEqual 3L
+    stats.["hit-ratio"] |> shouldEqual (4.0 / 7.0)
+
+[<Fact>]
+let ``AddOrUpdate with reference identity`` () =
+    let cacheName = "AddOrUpdate_with_Reference"
+    let comparer = HashIdentity.Reference<obj>
+    use cache = Cache.Create<obj, int>(CacheOptions.Default, comparer = comparer, name = cacheName, observeMetrics = true)
+    let t1 = box (3, 4)
+    let t2 = box (3, 4)
+    cache.AddOrUpdate(t1, 7)
+    let mutable value1 = 0
+    cache.TryGetValue(t1, &value1) |> shouldBeTrue
+    value1 |> shouldEqual 7
+    cache.AddOrUpdate(t2, 8)
+    let mutable value2 = 0
+    cache.TryGetValue(t2, &value2) |> shouldBeTrue
+    value2 |> shouldEqual 8
+    // t1 and t2 are different keys under reference equality
+    obj.ReferenceEquals(t1, t2) |> shouldBeFalse
+    // Metrics assertions
+    let stats = CacheMetrics.GetStats(cacheName)
+    let totals = CacheMetrics.GetTotals(cacheName)
+    totals.["hits"] |> shouldEqual 2L // 2 cache hits
+    totals.["misses"] |> shouldEqual 0L // 0 cache misses
+    stats.["hit-ratio"] |> shouldEqual 1.0


### PR DESCRIPTION
WIP

Add reference identity support to the cache. Use it instead of `HashMultiMap` for caching implicit yield expressions.


