### PR TITLE
Diagnostics: add extended data for 'No constructors' error

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
@@ -3,6 +3,7 @@
 * Add support for `when 'T : Enum` library-only static optimization constraint. ([PR #18546](https://github.com/dotnet/fsharp/pull/18546))
 * Add support for tail calls in computation expressions ([PR #18804](https://github.com/dotnet/fsharp/pull/18804))
 * Add `--typecheck-only` flag support for F# Interactive (FSI) scripts to type-check without execution. ([Issue #18686](https://github.com/dotnet/fsharp/issues/18686))
+* Diagnostics: add extended data for 'No constructors' error ([PR #18863](https://github.com/dotnet/fsharp/pull/18863))
 
 ### Fixed
 

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -1370,7 +1370,8 @@ module MutRecBindingChecking =
                                 try
                                    let baseTy, tpenv = TcType cenv NoNewTypars CheckCxs ItemOccurrence.Use WarnOnIWSAM.Yes envInstance tpenv synBaseTy
                                    let baseTy = baseTy |> convertToTypeWithMetadataIfPossible g
-                                   TcNewExpr cenv envInstance tpenv baseTy (Some synBaseTy.Range) true arg m
+                                   let mTcNew = unionRanges synBaseTy.Range arg.Range
+                                   TcNewExpr cenv envInstance tpenv baseTy (Some synBaseTy.Range) true arg mTcNew
                                 with RecoverableException e ->
                                     errorRecovery e m
                                     mkUnit g m, tpenv

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -38,6 +38,8 @@ open FSharp.Compiler.TypeHierarchy
 open FSharp.Compiler.TypeProviders
 #endif
 
+exception NoConstructorsAvailableForType of TType * DisplayEnv * range
+
 /// An object that captures the logical context for name resolution.
 type NameResolver(g: TcGlobals,
                   amap: Import.ImportMap,
@@ -2554,7 +2556,7 @@ let private ResolveObjectConstructorPrim (ncenv: NameResolver) edenv resInfo m a
                     [DefaultStructCtor(g, ty)]
                 else []
             if (isNil defaultStructCtorInfo && isNil ctorInfos) || (not (isAppTy g ty) && not (isAnyTupleTy g ty)) then
-                raze (Error(FSComp.SR.nrNoConstructorsAvailableForType(NicePrint.minimalStringOfType edenv ty), m))
+                raze (error(NoConstructorsAvailableForType(ty, edenv, m)))
             else
                 let ctorInfos = ctorInfos |> List.filter (IsMethInfoAccessible amap m ad)
                 let metadataTy = convertToTypeWithMetadataIfPossible g ty

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -2556,7 +2556,7 @@ let private ResolveObjectConstructorPrim (ncenv: NameResolver) edenv resInfo m a
                     [DefaultStructCtor(g, ty)]
                 else []
             if (isNil defaultStructCtorInfo && isNil ctorInfos) || (not (isAppTy g ty) && not (isAnyTupleTy g ty)) then
-                raze (error(NoConstructorsAvailableForType(ty, edenv, m)))
+                raze (NoConstructorsAvailableForType(ty, edenv, m))
             else
                 let ctorInfos = ctorInfos |> List.filter (IsMethInfoAccessible amap m ad)
                 let metadataTy = convertToTypeWithMetadataIfPossible g ty

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -14,6 +14,8 @@ open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeOps
 open FSharp.Compiler.TcGlobals
 
+exception NoConstructorsAvailableForType of TType * DisplayEnv * range
+
 /// A NameResolver is a context for name resolution. It primarily holds an InfoReader.
 type NameResolver =
 

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1019,7 +1019,6 @@ lexfltInvalidNestedConstruct,"'%s' must be defined at module level, not inside a
 1129,nrRecordDoesNotContainSuchLabel,"The record type '%s' does not contain a label '%s'."
 1130,nrInvalidFieldLabel,"Invalid field label"
 1132,nrInvalidExpression,"Invalid expression '%s'"
-1133,nrNoConstructorsAvailableForType,"No constructors are available for the type '%s'"
 1134,nrUnionTypeNeedsQualifiedAccess,"The union type for union case '%s' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('%s') in the name you are using."
 1135,nrRecordTypeNeedsQualifiedAccess,"The record type for the record field '%s' was defined with the RequireQualifiedAccessAttribute. Include the name of the record type ('%s') in the name you are using."
 1136,ilwriteErrorCreatingPdb,"Unexpected error creating debug information file '%s'"

--- a/src/Compiler/FSStrings.resx
+++ b/src/Compiler/FSStrings.resx
@@ -1152,4 +1152,7 @@
   <data name="InvalidAttributeTargetForLanguageElement2" xml:space="preserve">
     <value>This attribute is not valid for use on this language element</value>
   </data>
+  <data name="NoConstructorsAvailableForType" xml:space="preserve">
+    <value>No constructors are available for the type '{0}'</value>
+  </data>
 </root>

--- a/src/Compiler/Symbols/FSharpDiagnostic.fsi
+++ b/src/Compiler/Symbols/FSharpDiagnostic.fsi
@@ -99,6 +99,13 @@ module ExtendedData =
         /// Represents the information needed to format types
         member DisplayContext: FSharpDisplayContext
 
+    [<Class>]
+    type TypeExtendedData =
+        interface IFSharpDiagnosticExtendedData
+
+        member Type: FSharpType
+        member DisplayContext: FSharpDisplayContext
+
     /// Additional data for 'This expression is a function value, i.e. is missing arguments' diagnostic
     [<Class>]
     type ExpressionIsAFunctionExtendedData =

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Neplatný výraz {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Pro typ {0} nejsou k dispozici žádné konstruktory.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Typ sjednocení pro případ sjednocení {0} se definoval pomocí atributu RequireQualifiedAccessAttribute. Do jména, které používáte, přidejte název typu sjednocení ({1}).</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Ungültiger Ausdruck "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Für den Typ "{0}" sind keine Konstruktoren verfügbar.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Der Union-Typ für Union-Fall "{0}" wurde mit RequireQualifiedAccessAttribute definiert. Fügen Sie den Union-Typnamen ("{1}") in den verwendeten Namen ein.</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Expresión '{0}' no válida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">No hay constructores disponibles para el tipo '{0}'.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">El tipo de unión del caso de unión "{0}" se definió con el atributo RequireQualifiedAccessAttribute. Incluya el nombre del tipo de unión ("{1}") en el nombre que esté usando.</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Expression non valide '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Aucun constructeur n'est disponible pour le type '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Le type union du cas d'union '{0}' a été défini avec RequireQualifiedAccessAttribute. Incluez le nom du type union ('{1}') dans le nom que vous utilisez.</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Espressione '{0}' non valida</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Nessun costruttore disponibile per il tipo '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Il tipo di unione per il case di unione '{0}' è stato definito con RequireQualifiedAccessAttribute. Includere il nome del tipo di unione ('{1}') nel nome da usare.</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">式 '{0}' は無効です</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">型 '{0}' に使用できるコンストラクターがありません</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">共用体ケース '{0}' の共用体型が RequireQualifiedAccessAttribute によって定義されました。使用中の名前に共用体型 ('{1}') の名前を含めてください。</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">'{0}' 식이 잘못되었습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">'{0}' 형식에 대해 사용할 수 있는 생성자가 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">공용 구조체 케이스 '{0}'에 대한 공용 구조체 형식은 RequireQualifiedAccessAttribute로 정의됩니다. 사용 중인 이름에 공용 구조체 형식('{1}') 이름을 포함하세요.</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Nieprawidłowe wyrażenie „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Brak konstruktorów dostępnych dla typu „{0}”</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Typ unii dla przypadku unii „{0}” został zdefiniowany z użyciem wartości RequireQualifiedAccessAttribute. Uwzględnij nazwę typu unii („{1}”) w używanej nazwie.</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Expressão '{0}' inválida</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Nenhum construtor está disponível para o tipo '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">O tipo de união para o caso de união '{0}' foi definido com o RequireQualifiedAccessAttribute. Inclua o nome do tipo de união ('{1}') no nome que você está usando.</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Недопустимое выражение "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">Недоступны конструкторы для типа "{0}"</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">Тип объединения для ветви объединения "{0}" определен с RequireQualifiedAccessAttribute. Включите имя типа объединения ("{1}") в используемое имя.</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">Geçersiz ifade: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">'{0}' türü için kullanılabilir bir oluşturucu yok</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">{0}' birleşim durumunun birleşim türü RequireQualifiedAccessAttribute ile tanımlanmış. Kullandığınız ada birleşim türünün adını ('{1}') dahil edin.</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">表达式“{0}”无效</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">没有对类型“{0}”可用的构造函数</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">使用 RequireQualifiedAccessAttribute 定义联合用例“{0}”的联合类型。包括所使用的名称中联合类型 ('{1}') 的名称。</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -6637,11 +6637,6 @@
         <target state="translated">無效的運算式 '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="nrNoConstructorsAvailableForType">
-        <source>No constructors are available for the type '{0}'</source>
-        <target state="translated">沒有可供類型 '{0}' 使用的建構函式</target>
-        <note />
-      </trans-unit>
       <trans-unit id="nrUnionTypeNeedsQualifiedAccess">
         <source>The union type for union case '{0}' was defined with the RequireQualifiedAccessAttribute. Include the name of the union type ('{1}') in the name you are using.</source>
         <target state="translated">聯集 '{0}' 的等位型別由 RequireQualifiedAccessAttribute 定義。請在您使用的名稱中，加入等位型別 '{1}' 的名稱。</target>

--- a/src/Compiler/xlf/FSStrings.cs.xlf
+++ b/src/Compiler/xlf/FSStrings.cs.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Případy sjednocení s malými písmeny jsou povolené jenom při použití atributu RequireQualifiedAccess.</target>

--- a/src/Compiler/xlf/FSStrings.de.xlf
+++ b/src/Compiler/xlf/FSStrings.de.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Diskriminierte Union-Fälle in Kleinbuchstaben sind nur zulässig, wenn das RequireQualifiedAccess-Attribut verwendet wird.</target>

--- a/src/Compiler/xlf/FSStrings.es.xlf
+++ b/src/Compiler/xlf/FSStrings.es.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Los casos de unión discriminada en minúsculas solo se permiten cuando se usa el atributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.fr.xlf
+++ b/src/Compiler/xlf/FSStrings.fr.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Les cas d’union discriminée en minuscules sont uniquement autorisés lors de l’utilisation de l’attribut RequireQualifiedAccess.</target>

--- a/src/Compiler/xlf/FSStrings.it.xlf
+++ b/src/Compiler/xlf/FSStrings.it.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">I casi di unione discriminati minuscoli sono consentiti solo quando si usa l'attributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.ja.xlf
+++ b/src/Compiler/xlf/FSStrings.ja.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">小文字で区別される和集合のケースは、RequireQualifiedAccess 属性を使用する場合にのみ許可されます</target>

--- a/src/Compiler/xlf/FSStrings.ko.xlf
+++ b/src/Compiler/xlf/FSStrings.ko.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">소문자로 구분된 공용 구조체 케이스는 RequireQualifiedAccess 특성을 사용하는 경우에만 허용됩니다.</target>

--- a/src/Compiler/xlf/FSStrings.pl.xlf
+++ b/src/Compiler/xlf/FSStrings.pl.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Przypadki unii z dyskryminatorem z małymi literami są dozwolone tylko w przypadku używania atrybutu RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.pt-BR.xlf
+++ b/src/Compiler/xlf/FSStrings.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Os casos de união discriminados em letras minúsculas só são permitidos ao usar o atributo RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.ru.xlf
+++ b/src/Compiler/xlf/FSStrings.ru.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Размеченные в нижнем регистре случаи объединения разрешены только при использовании атрибута RequireQualifiedAccess</target>

--- a/src/Compiler/xlf/FSStrings.tr.xlf
+++ b/src/Compiler/xlf/FSStrings.tr.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">Küçük harf ayrımlı birleşim durumlarına yalnızca RequireQualifiedAccess özniteliği kullanılırken izin verilir</target>

--- a/src/Compiler/xlf/FSStrings.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSStrings.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">仅当使用 RequireQualifiedAccess 属性时才允许区分小写的联合事例</target>

--- a/src/Compiler/xlf/FSStrings.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSStrings.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoConstructorsAvailableForType">
+        <source>No constructors are available for the type '{0}'</source>
+        <target state="new">No constructors are available for the type '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotUpperCaseConstructorWithoutRQA">
         <source>Lowercase discriminated union cases are only allowed when using RequireQualifiedAccess attribute</source>
         <target state="translated">只有在使用 RequireQualifiedAccess 屬性時，才允許小寫區分聯結案例</target>

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/ExceptionDefinitions/ExceptionDefinitions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/BasicGrammarElements/ExceptionDefinitions/ExceptionDefinitions.fs
@@ -291,7 +291,7 @@ module ExceptionDefinition =
         |> shouldFail
         |> withDiagnostics [
             (Error 945, Line 9, Col 13, Line 9, Col 22, "Cannot inherit a sealed type")
-            (Error 1133, Line 9, Col 5, Line 9, Col 24, "No constructors are available for the type 'FSharpExn'")
+            (Error 1133, Line 9, Col 13, Line 9, Col 24, "No constructors are available for the type 'FSharpExn'")
         ]
 
     // SOURCE=E_MatchFailure.fsx                  SCFLAGS=--test:ErrorRanges                   # E_MatchFailure.fsx

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ApplicationExpressions/Ctor.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ApplicationExpressions/Ctor.fs
@@ -1,0 +1,14 @@
+﻿module FSharp.Compiler.ComponentTests.Conformance.Expressions.ApplicationExpressions.Ctor
+
+open FSharp.Test.Compiler
+open Xunit
+
+[<Fact>]
+let ``Nullable 01`` () =
+    FSharp """
+module Module
+
+let _ = System.Nullable()
+"""
+    |> typecheck
+    |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExtendedDiagnosticDataTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExtendedDiagnosticDataTests.fs
@@ -150,7 +150,7 @@ type R = { Field1: int }
 let f (x: R) = "" + x.Field1
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "The type 'int' does not match the type 'string'")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -164,7 +164,7 @@ let ``TypeMismatchDiagnosticExtendedData 09`` () =
 let x: string = 1
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "This expression was expected to have type\n    'string'    \nbut here has type\n    'int'    ")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -179,7 +179,7 @@ let f1 (x: outref<'T>) = 1
 let f2 (x: inref<'T>) = f1 &x
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "Type mismatch. Expecting a\n    'outref<'T>'    \nbut given a\n    'inref<'T>'    \nThe type 'ByRefKinds.Out' does not match the type 'ByRefKinds.In'")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExtendedDiagnosticDataTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/ExtendedDiagnosticDataTests.fs
@@ -7,7 +7,7 @@ open FSharp.Compiler.Diagnostics.ExtendedData
 open FSharp.Test.Compiler
 open Xunit
 
-let inline checkDiagnostic
+let inline checkDiagnosticData
     (diagnosticNumber, message)
     (check: 'a -> unit)
     (checkResults: 'b when 'b: (member Diagnostics: FSharpDiagnostic[])) =
@@ -27,7 +27,7 @@ let ``TypeMismatchDiagnosticExtendedData 01`` () =
 let x, y, z = 1, 2
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "Type mismatch. Expecting a tuple of length 3 of type\n    'a * 'b * 'c    \nbut given a tuple of length 2 of type\n    int * int    \n")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         Assert.Equal(DiagnosticContextInfo.NoContext, typeMismatch.ContextInfo)
@@ -41,7 +41,7 @@ let ``TypeMismatchDiagnosticExtendedData 02`` () =
 let x, y = 1
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "This expression was expected to have type\n    ''a * 'b'    \nbut here has type\n    'int'    ")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -55,7 +55,7 @@ let ``TypeMismatchDiagnosticExtendedData 03`` () =
 if true then 5
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "This 'if' expression is missing an 'else' branch. Because 'if' is an expression, and not a statement, add an 'else' branch which also returns a value of type 'int'.")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -69,7 +69,7 @@ let ``TypeMismatchDiagnosticExtendedData 04`` () =
 1 :> string
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (193, "Type constraint mismatch. The type \n    'int'    \nis not compatible with type\n    'string'    \n")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -85,7 +85,7 @@ match 0 with
 | 1 -> "a"
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "All branches of a pattern match expression must return values implicitly convertible to the type of the first branch, which here is 'int'. This branch returns a value of type 'string'.")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -106,7 +106,7 @@ match 0 with
     1
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "This expression was expected to have type\n    'int'    \nbut here has type\n    'string'    ")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -121,7 +121,7 @@ let _: bool =
     if true then "a" else "b"
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "The 'if' expression needs to have type 'bool' to satisfy context type requirements. It currently has type 'string'.")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -135,7 +135,7 @@ let ``TypeMismatchDiagnosticExtendedData 07`` () =
 if true then 1 else "a"
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (1, "All branches of an 'if' expression must return values implicitly convertible to the type of the first branch, which here is 'int'. This branch returns a value of type 'string'.")
        (fun (typeMismatch: TypeMismatchDiagnosticExtendedData) ->
         let displayContext = typeMismatch.DisplayContext
@@ -204,7 +204,7 @@ let f (y: int) = ()
     encodeFsi
     |> withAdditionalSourceFile encodeFs
     |> typecheckProject true useTransparentCompiler
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (3218, "The argument names in the signature 'x' and implementation 'y' do not match. The argument name from the signature file will be used. This may cause problems when debugging or profiling.")
        (fun (argsMismatch: ArgumentsInSigAndImplMismatchExtendedData) ->
         Assert.Equal("x", argsMismatch.SignatureName)
@@ -231,7 +231,7 @@ type A =
     encodeFsi
     |> withAdditionalSourceFile encodeFs
     |> typecheckProject true useTransparentCompiler
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (193, "The module contains the field\n    myStatic: int    \nbut its signature specifies\n    myStatic: int    \nthe accessibility specified in the signature is more than that specified in the implementation")
        (fun (fieldsData: FieldNotContainedDiagnosticExtendedData) ->
         Assert.True(fieldsData.SignatureField.Accessibility.IsPublic)
@@ -245,7 +245,7 @@ module Test
 id
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (193, "This expression is a function value, i.e. is missing arguments. Its type is 'a -> 'a.")
        (fun (wrongType: ExpressionIsAFunctionExtendedData) ->
         Assert.Equal("type 'a -> 'a", wrongType.ActualType.ToString()))
@@ -279,7 +279,7 @@ type  Foo = {| bar: int; x: int |}
     signature
     |> withAdditionalSourceFile implementation
     |> typecheckProject true useTransparentCompiler
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (318, "The type definitions for type 'Foo' in the signature and implementation are not compatible because the abbreviations differ:\n    {| bar: int; x: int |}\nversus\n    {| bar: int |}")
        (fun (fieldsData: DefinitionsInSigAndImplNotCompatibleAbbreviationsDifferExtendedData) ->
         assertRange (4,5) (4,8) fieldsData.SignatureRange
@@ -296,7 +296,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated. Message")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -312,7 +312,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated. Message")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -328,7 +328,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated. Message")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(None, obsoleteDiagnostic.DiagnosticId)
@@ -344,7 +344,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -376,7 +376,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated. Use something else")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -407,7 +407,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated. Use something else")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -438,7 +438,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated. Use something else")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(None, obsoleteDiagnostic.DiagnosticId)
@@ -469,7 +469,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -485,7 +485,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(None, obsoleteDiagnostic.DiagnosticId)
@@ -516,7 +516,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (44, "This construct is deprecated")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(None, obsoleteDiagnostic.DiagnosticId)
@@ -532,7 +532,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (101, "This construct is deprecated. Message")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -548,7 +548,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (101, "This construct is deprecated. Message")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -564,7 +564,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (101, "This construct is deprecated. Message")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(None, obsoleteDiagnostic.DiagnosticId)
@@ -580,7 +580,7 @@ type MyClass() = class end
 let x = MyClass()
 """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (101, "This construct is deprecated")
        (fun (obsoleteDiagnostic: ObsoleteDiagnosticExtendedData) ->
         Assert.Equal(Some "FS222", obsoleteDiagnostic.DiagnosticId)
@@ -612,7 +612,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (57, """This construct is experimental. This warning can be disabled using '--nowarn:57' or '#nowarn "57"'.""")
        (fun (experimental: ExperimentalExtendedData) ->
         Assert.Equal(Some "FS222", experimental.DiagnosticId)
@@ -645,7 +645,7 @@ let text = Class1.Test();
 
     app
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (57, """This construct is experimental. This warning can be disabled using '--nowarn:57' or '#nowarn "57"'.""")
        (fun (experimental: ExperimentalExtendedData) ->
         Assert.Equal(Some "FS222", experimental.DiagnosticId)
@@ -663,7 +663,7 @@ type Class1() =
 let text = Class1.Test();
     """
     |> typecheckResults
-    |> checkDiagnostic
+    |> checkDiagnosticData
        (57, """This construct is experimental. Use with caution. This warning can be disabled using '--nowarn:57' or '#nowarn "57"'.""")
        (fun (experimental: ExperimentalExtendedData) ->
         Assert.Equal(None, experimental.DiagnosticId)

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="Conformance\GeneratedEqualityHashingComparison\Basic\Basic.fs" />
     <Compile Include="Conformance\GeneratedEqualityHashingComparison\IComparison\IComparison.fs" />
     <Compile Include="Conformance\Expressions\ApplicationExpressions\BasicApplication\BasicApplication.fs" />
+    <Compile Include="Conformance\Expressions\ApplicationExpressions\Ctor.fs" />
     <Compile Include="Conformance\Expressions\BindingExpressions\BindingExpressions.fs" />
     <Compile Include="Conformance\Expressions\ComputationExpressions\ComputationExpressions.fs" />
     <Compile Include="Conformance\Expressions\ObjectExpressions\ObjectExpressions.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
@@ -27,7 +27,7 @@ type B() =
     inherit A()
 """
     |> typecheck
-    |> withSingleDiagnostic (Error 1133, Line 5, Col 21, Line 5, Col 31, "Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).")
+    |> withSingleDiagnostic (Error 1133, Line 5, Col 13, Line 5, Col 16, "No constructors are available for the type 'A'")
 
 [<Fact>]
 let ``Class - Inherit 02 - Data`` () =

--- a/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/TypeChecks/CheckTypeTests.fs
@@ -1,5 +1,8 @@
 ﻿module TypeChecks.CheckTypeTests
 
+open ErrorMessages.ExtendedDiagnosticData
+open FSharp.Compiler.Diagnostics.ExtendedData
+open FSharp.Test.Assert
 open Xunit
 open FSharp.Test.Compiler
 
@@ -13,3 +16,28 @@ type Other = int
 """
     |> typecheck
     |> withSingleDiagnostic (Error 3580, Line 4, Col 21, Line 4, Col 31, "Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).")
+
+
+[<Fact>]
+let ``Class - Inherit 01`` () =
+    FSharp """
+type A = class end
+
+type B() =
+    inherit A()
+"""
+    |> typecheck
+    |> withSingleDiagnostic (Error 1133, Line 5, Col 21, Line 5, Col 31, "Unexpected function type in union case field definition. If you intend the field to be a function, consider wrapping the function signature with parens, e.g. | Case of a -> b into | Case of (a -> b).")
+
+[<Fact>]
+let ``Class - Inherit 02 - Data`` () =
+    FSharp """
+type A = class end
+
+type B() =
+    inherit A()
+"""
+    |> typecheckResults
+    |> checkDiagnosticData
+        (1133, "No constructors are available for the type 'A'")
+        (fun (typeData: TypeExtendedData) -> typeData.Type.Format(typeData.DisplayContext) |> shouldEqual "A")

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.debug.bsl
@@ -2849,6 +2849,10 @@ FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microso
 FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microsoft.FSharp.Core.FSharpOption`1[System.String] UrlFormat
 FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_DiagnosticId()
 FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_UrlFormat()
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpDisplayContext DisplayContext
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpDisplayContext get_DisplayContext()
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpType Type
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpType get_Type()
 FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData: DiagnosticContextInfo ContextInfo
 FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData: DiagnosticContextInfo get_ContextInfo()
 FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData: FSharp.Compiler.Symbols.FSharpDisplayContext DisplayContext
@@ -2869,6 +2873,7 @@ FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedDa
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+FieldNotContainedDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+IFSharpDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData
+FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+ValueNotContainedDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.FSharpDiagnostic: FSharp.Compiler.Diagnostics.FSharpDiagnostic Create(FSharp.Compiler.Diagnostics.FSharpDiagnosticSeverity, System.String, Int32, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String])

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.release.bsl
@@ -2849,6 +2849,10 @@ FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microso
 FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microsoft.FSharp.Core.FSharpOption`1[System.String] UrlFormat
 FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_DiagnosticId()
 FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_UrlFormat()
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpDisplayContext DisplayContext
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpDisplayContext get_DisplayContext()
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpType Type
+FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData: FSharp.Compiler.Symbols.FSharpType get_Type()
 FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData: DiagnosticContextInfo ContextInfo
 FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData: DiagnosticContextInfo get_ContextInfo()
 FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData: FSharp.Compiler.Symbols.FSharpDisplayContext DisplayContext
@@ -2869,6 +2873,7 @@ FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedDa
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+FieldNotContainedDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+IFSharpDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+ObsoleteDiagnosticExtendedData
+FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+TypeExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+TypeMismatchDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.ExtendedData: FSharp.Compiler.Diagnostics.ExtendedData+ValueNotContainedDiagnosticExtendedData
 FSharp.Compiler.Diagnostics.FSharpDiagnostic: FSharp.Compiler.Diagnostics.FSharpDiagnostic Create(FSharp.Compiler.Diagnostics.FSharpDiagnosticSeverity, System.String, Int32, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String])

--- a/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/InheritsDeclarations/E_InheritFromGenericType01.fs
+++ b/tests/fsharpqa/Source/Conformance/ObjectOrientedTypeDefinitions/ClassTypes/InheritsDeclarations/E_InheritFromGenericType01.fs
@@ -2,7 +2,7 @@
 // Regression test for FSHARP1.0:3782
 // Make sure we do not ICE when trying to
 // inherit from a type variable.
-//<Expects id="FS0753" span="(9,19)" status="error">Cannot inherit from a variable type</Expects>
+//<Expects id="FS0753" span="(9,27)" status="error">Cannot inherit from a variable type</Expects>
 #light
 
 type X<'a>() = class


### PR DESCRIPTION
Adds the additional data for the tooling in the following error:

```fsharp
type A = class end

type B() =
    inherit A()
```