### PR TITLE
Type subsumption cache, fix keys to reduce memory use

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -457,13 +457,11 @@ stages:
                 _configuration: Release
                 _testKind: testFSharpQA
                 transparentCompiler:
-                FSHARP_CACHE_OVERRIDE: 256
               vs_release:
                 _configuration: Release
                 _testKind: testVs
                 setupVsHive: true
                 transparentCompiler:
-                FSHARP_CACHE_OVERRIDE: 256
               transparent_compiler_release:
                 _configuration: Release
                 _testKind: testCoreclr

--- a/src/Compiler/Checking/TypeRelations.fs
+++ b/src/Compiler/Checking/TypeRelations.fs
@@ -28,7 +28,7 @@ type CanCoerce =
 [<Struct; NoComparison>]
 type TTypeCacheKey =
     | TTypeCacheKey of TypeStructure * TypeStructure * CanCoerce
-    static member Create(ty1, ty2, canCoerce) =
+    static member FromStrippedTypes(ty1, ty2, canCoerce) =
         TTypeCacheKey(getTypeStructure ty1, getTypeStructure ty2, canCoerce)
 
 let getTypeSubsumptionCache =
@@ -157,7 +157,7 @@ let rec TypeFeasiblySubsumesType ndeep (g: TcGlobals) (amap: ImportMap) m (ty1: 
                     List.exists (TypeFeasiblySubsumesType (ndeep + 1) g amap m ty1 NoCoerce) interfaces
 
     if g.langVersion.SupportsFeature LanguageFeature.UseTypeSubsumptionCache then
-        let key = TTypeCacheKey.Create(ty1, ty2, canCoerce)
+        let key = TTypeCacheKey.FromStrippedTypes(ty1, ty2, canCoerce)
         (getTypeSubsumptionCache g).GetOrAdd(key, fun _ -> checkSubsumes ty1 ty2)
     else
         checkSubsumes ty1 ty2

--- a/src/Compiler/Checking/TypeRelations.fs
+++ b/src/Compiler/Checking/TypeRelations.fs
@@ -7,6 +7,7 @@ module internal FSharp.Compiler.TypeRelations
 open FSharp.Compiler.Features
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
+open Internal.Utilities.TypeHashing.StructuralUtilities
 
 open FSharp.Compiler.DiagnosticsLogger
 open FSharp.Compiler.TcGlobals
@@ -18,6 +19,26 @@ open FSharp.Compiler.TypeHierarchy
 open Import
 
 #nowarn "3391"
+
+[<Struct; NoComparison>]
+type CanCoerce =
+    | CanCoerce
+    | NoCoerce
+
+[<Struct; NoComparison>]
+type TTypeCacheKey =
+    | TTypeCacheKey of TypeStructure * TypeStructure * CanCoerce
+    static member Create(ty1, ty2, canCoerce) =
+        TTypeCacheKey(getTypeStructure ty1, getTypeStructure ty2, canCoerce)
+
+let getTypeSubsumptionCache =
+    let factory (g: TcGlobals) =
+        let options =
+            match g.compilationMode with
+            | CompilationMode.OneOff -> Caches.CacheOptions.getDefault() |> Caches.CacheOptions.withNoEviction
+            | _ -> { Caches.CacheOptions.getDefault() with TotalCapacity = 65536; HeadroomPercentage = 75 }
+        new Caches.Cache<TTypeCacheKey, bool>(options, "typeSubsumptionCache")
+    Extras.WeakMap.getOrCreate factory     
 
 /// Implements a :> b without coercion based on finalized (no type variable) types
 // Note: This relation is approximate and not part of the language specification.
@@ -136,14 +157,8 @@ let rec TypeFeasiblySubsumesType ndeep (g: TcGlobals) (amap: ImportMap) m (ty1: 
                     List.exists (TypeFeasiblySubsumesType (ndeep + 1) g amap m ty1 NoCoerce) interfaces
 
     if g.langVersion.SupportsFeature LanguageFeature.UseTypeSubsumptionCache then
-        let key = TTypeCacheKey.FromStrippedTypes (ty1, ty2, canCoerce)
-
-        match amap.TypeSubsumptionCache.TryGetValue(key) with
-        | true, subsumes -> subsumes
-        | false, _ ->
-            let subsumes = checkSubsumes ty1 ty2
-            amap.TypeSubsumptionCache.TryAdd(key, subsumes) |> ignore
-            subsumes
+        let key = TTypeCacheKey.Create(ty1, ty2, canCoerce)
+        (getTypeSubsumptionCache g).GetOrAdd(key, fun _ -> checkSubsumes ty1 ty2)
     else
         checkSubsumes ty1 ty2
 

--- a/src/Compiler/Checking/TypeRelations.fsi
+++ b/src/Compiler/Checking/TypeRelations.fsi
@@ -9,6 +9,11 @@ open FSharp.Compiler.TcGlobals
 open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 
+[<Struct; NoComparison>]
+type CanCoerce =
+    | CanCoerce
+    | NoCoerce
+
 /// Implements a :> b without coercion based on finalized (no type variable) types
 val TypeDefinitelySubsumesTypeNoCoercion:
     ndeep: int -> g: TcGlobals -> amap: ImportMap -> m: range -> ty1: TType -> ty2: TType -> bool

--- a/src/Compiler/Checking/import.fsi
+++ b/src/Compiler/Checking/import.fsi
@@ -36,24 +36,6 @@ type AssemblyLoader =
     abstract RecordGeneratedTypeRoot: ProviderGeneratedType -> unit
 #endif
 
-[<Struct; NoComparison>]
-type CanCoerce =
-    | CanCoerce
-    | NoCoerce
-
-[<Struct; NoComparison; CustomEquality>]
-type TTypeCacheKey =
-    interface System.IEquatable<TTypeCacheKey>
-    private new: ty1: TType * ty2: TType * canCoerce: CanCoerce -> TTypeCacheKey
-
-    static member FromStrippedTypes: ty1: TType * ty2: TType * canCoerce: CanCoerce -> TTypeCacheKey
-
-    val ty1: TType
-    val ty2: TType
-    val canCoerce: CanCoerce
-
-    override GetHashCode: unit -> int
-
 /// Represents a context used for converting AbstractIL .NET and provided types to F# internal compiler data structures.
 /// Also cache the conversion of AbstractIL ILTypeRef nodes, based on hashes of these.
 ///
@@ -69,9 +51,6 @@ type ImportMap =
 
     /// The TcGlobals for the import context
     member g: TcGlobals
-
-    /// Type subsumption cache
-    member TypeSubsumptionCache: Cache<TTypeCacheKey, bool>
 
 module Nullness =
 

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -538,7 +538,7 @@ type internal TypeCheckInfo
                         // check that type of value is the same or subtype of tcref
                         // yes - allow access to protected members
                         // no - strip ability to access protected members
-                        if TypeRelations.TypeFeasiblySubsumesType 0 g amap m thisTy Import.CanCoerce ty then
+                        if TypeRelations.TypeFeasiblySubsumesType 0 g amap m thisTy TypeRelations.CanCoerce ty then
                             ad
                         else
                             AccessibleFrom(paths, None)

--- a/src/Compiler/Utilities/Caches.fs
+++ b/src/Compiler/Utilities/Caches.fs
@@ -118,21 +118,6 @@ module CacheOptions =
             CacheOptions.EvictionMode = EvictionMode.NoEviction
         }
 
-module Cache =
-    // During testing a lot of compilations are started in app domains and subprocesses.
-    // This is a reliable way to pass the override to all of them.
-    [<Literal>]
-    let private overrideVariable = "FSHARP_CACHE_OVERRIDE"
-
-    /// Use for testing purposes to reduce memory consumption in testhost and its subprocesses.
-    let OverrideCapacityForTesting () =
-        Environment.SetEnvironmentVariable(overrideVariable, "4096", EnvironmentVariableTarget.Process)
-
-    let applyOverride (options: CacheOptions<_>) =
-        match Int32.TryParse(Environment.GetEnvironmentVariable(overrideVariable)) with
-        | true, n when options.TotalCapacity > n -> { options with TotalCapacity = n }
-        | _ -> options
-
 // It is important that this is not a struct, because LinkedListNode holds a reference to it,
 // and it holds the reference to that Node, in a circular way.
 [<Sealed; NoComparison; NoEquality>]
@@ -175,8 +160,6 @@ type Cache<'Key, 'Value when 'Key: not null> internal (options: CacheOptions<'Ke
 
         if options.HeadroomPercentage < 0 then
             invalidArg "HeadroomPercentage" "HeadroomPercentage must be positive"
-
-    let options = Cache.applyOverride options
 
     let name = defaultArg name (Guid.NewGuid().ToString())
 

--- a/src/Compiler/Utilities/Caches.fsi
+++ b/src/Compiler/Utilities/Caches.fsi
@@ -49,10 +49,6 @@ module internal CacheOptions =
     /// Set eviction mode to NoEviction.
     val withNoEviction: CacheOptions<'Key> -> CacheOptions<'Key>
 
-module internal Cache =
-    /// Use for testing purposes to reduce memory consumption in testhost and its subprocesses.
-    val OverrideCapacityForTesting: unit -> unit
-
 [<Sealed; NoComparison; NoEquality>]
 type internal Cache<'Key, 'Value when 'Key: not null> =
     new: options: CacheOptions<'Key> * ?name: string -> Cache<'Key, 'Value>

--- a/src/Compiler/Utilities/TypeHashing.fs
+++ b/src/Compiler/Utilities/TypeHashing.fs
@@ -365,6 +365,7 @@ module StructuralUtilities =
         struct
             interface System.IEquatable<NeverEqual> with
                 member _.Equals _ = false
+
             override _.Equals _ = false
             override _.GetHashCode() = 0
         end
@@ -400,17 +401,13 @@ module StructuralUtilities =
 
     let rec private accumulateMeasure (tokens: ResizeArray<TypeToken>) (m: Measure) =
         match m with
-        | Measure.Var mv ->
-            tokens.Add(TypeToken.Stamp mv.Stamp)
-        | Measure.Const(tcref, _) ->
-            tokens.Add(TypeToken.Stamp tcref.Stamp)
+        | Measure.Var mv -> tokens.Add(TypeToken.Stamp mv.Stamp)
+        | Measure.Const(tcref, _) -> tokens.Add(TypeToken.Stamp tcref.Stamp)
         | Measure.Prod(m1, m2, _) ->
             accumulateMeasure tokens m1
             accumulateMeasure tokens m2
-        | Measure.Inv m1 ->
-            accumulateMeasure tokens m1
-        | Measure.One _ ->
-            tokens.Add(TypeToken.MeasureOne)
+        | Measure.Inv m1 -> accumulateMeasure tokens m1
+        | Measure.One _ -> tokens.Add(TypeToken.MeasureOne)
         | Measure.RationalPower(m1, r) ->
             accumulateMeasure tokens m1
             tokens.Add(TypeToken.MeasureRational r)
@@ -419,24 +416,29 @@ module StructuralUtilities =
         match ty with
         | TType_ucase(u, tinst) ->
             tokens.Add(TypeToken.UCase u.CaseName)
+
             for arg in tinst do
                 accumulateTType tokens arg
         | TType_app(tcref, tinst, n) ->
             tokens.Add(TypeToken.Stamp tcref.Stamp)
             tokens.Add(TypeToken.Nullness(toNullnessToken n))
+
             for arg in tinst do
                 accumulateTType tokens arg
         | TType_anon(info, tys) ->
             tokens.Add(TypeToken.Stamp info.Stamp)
+
             for arg in tys do
                 accumulateTType tokens arg
         | TType_tuple(tupInfo, tys) ->
             tokens.Add(TypeToken.TupInfo(evalTupInfoIsStruct tupInfo))
+
             for arg in tys do
                 accumulateTType tokens arg
         | TType_forall(tps, tau) ->
             for tp in tps do
                 tokens.Add(TypeToken.Stamp tp.Stamp)
+
             accumulateTType tokens tau
         | TType_fun(d, r, n) ->
             accumulateTType tokens d
@@ -445,10 +447,9 @@ module StructuralUtilities =
         | TType_var(r, n) ->
             tokens.Add(TypeToken.Stamp r.Stamp)
             tokens.Add(TypeToken.Nullness(toNullnessToken n))
-        | TType_measure m ->
-            accumulateMeasure tokens m
+        | TType_measure m -> accumulateMeasure tokens m
 
-    /// Get the full structure of a type as a sequence of tokens, suitable for equality 
+    /// Get the full structure of a type as a sequence of tokens, suitable for equality
     let getTypeStructure ty =
         let tokens = ResizeArray<TypeToken>(initialTokenCapacity)
         accumulateTType tokens ty

--- a/src/Compiler/Utilities/TypeHashing.fs
+++ b/src/Compiler/Utilities/TypeHashing.fs
@@ -8,6 +8,7 @@ open FSharp.Compiler.Text
 open FSharp.Compiler.TypedTree
 open FSharp.Compiler.TypedTreeBasics
 open FSharp.Compiler.TypedTreeOps
+open System.Collections.Immutable
 
 type ObserverVisibility =
     | PublicOnly
@@ -357,68 +358,98 @@ module HashTastMemberOrVals =
             hashNonMemberVal (g, obs) (tps, vref.Deref, tau, cxs)
         | Some _ -> hashMember (g, obs) emptyTyparInst vref.Deref
 
-/// Practical TType comparer strictly for the use with cache keys.
-module HashStamps =
-    let rec typeInstStampsEqual (tys1: TypeInst) (tys2: TypeInst) =
-        tys1.Length = tys2.Length && (tys1, tys2) ||> Seq.forall2 stampEquals
+/// Lossless accumulation of TType structure
+module StructuralUtilities =
+    [<Struct; CustomEquality; NoComparison>]
+    type NeverEqual =
+        struct
+            interface System.IEquatable<NeverEqual> with
+                member _.Equals _ = false
+            override _.Equals _ = false
+            override _.GetHashCode() = 0
+        end
 
-    and inline typarStampEquals (t1: Typar) (t2: Typar) = t1.Stamp = t2.Stamp
+    [<Struct; NoComparison; RequireQualifiedAccess>]
+    type NullnessToken =
+        | Known of info: NullnessInfo
+        | Variable of never: NeverEqual
+        | Absent
 
-    and typarsStampsEqual (tps1: Typars) (tps2: Typars) =
-        tps1.Length = tps2.Length && (tps1, tps2) ||> Seq.forall2 typarStampEquals
+    [<Struct; NoComparison; RequireQualifiedAccess>]
+    type TypeToken =
+        | Stamp of stamp: Stamp
+        | UCase of name: string
+        | Nullness of nullness: NullnessToken
+        | TupInfo of b: bool
+        | MeasureOne
+        | MeasureRational of rational: Rational
 
-    and measureStampEquals (m1: Measure) (m2: Measure) =
-        match m1, m2 with
-        | Measure.Var(mv1), Measure.Var(mv2) -> mv1.Stamp = mv2.Stamp
-        | Measure.Const(t1, _), Measure.Const(t2, _) -> t1.Stamp = t2.Stamp
-        | Measure.Prod(m1, m2, _), Measure.Prod(m3, m4, _) -> measureStampEquals m1 m3 && measureStampEquals m2 m4
-        | Measure.Inv m1, Measure.Inv m2 -> measureStampEquals m1 m2
-        | Measure.One _, Measure.One _ -> true
-        | Measure.RationalPower(m1, r1), Measure.RationalPower(m2, r2) -> r1 = r2 && measureStampEquals m1 m2
-        | _ -> false
+    type TypeStructure = TypeToken[]
 
-    and nullnessEquals (n1: Nullness) (n2: Nullness) =
-        match n1, n2 with
-        | Nullness.Known k1, Nullness.Known k2 -> k1 = k2
-        | Nullness.Variable _, Nullness.Variable _ -> true
-        | _ -> false
+    [<Literal>]
+    let private initialTokenCapacity = 4
 
-    and stampEquals ty1 ty2 =
-        match ty1, ty2 with
-        | TType_ucase(u, tys1), TType_ucase(v, tys2) -> u.CaseName = v.CaseName && typeInstStampsEqual tys1 tys2
-        | TType_app(tcref1, tinst1, n1), TType_app(tcref2, tinst2, n2) ->
-            tcref1.Stamp = tcref2.Stamp
-            && nullnessEquals n1 n2
-            && typeInstStampsEqual tinst1 tinst2
-        | TType_anon(info1, tys1), TType_anon(info2, tys2) -> info1.Stamp = info2.Stamp && typeInstStampsEqual tys1 tys2
-        | TType_tuple(c1, tys1), TType_tuple(c2, tys2) -> c1 = c2 && typeInstStampsEqual tys1 tys2
-        | TType_forall(tps1, tau1), TType_forall(tps2, tau2) -> stampEquals tau1 tau2 && typarsStampsEqual tps1 tps2
-        | TType_var(r1, n1), TType_var(r2, n2) -> r1.Stamp = r2.Stamp && nullnessEquals n1 n2
-        | TType_measure m1, TType_measure m2 -> measureStampEquals m1 m2
-        | _ -> false
+    // Single reusable token for Nullness.Variable
+    let private neverEqual = NullnessToken.Variable(NeverEqual())
 
-    let inline hashStamp (x: Stamp) : Hash = uint x * 2654435761u |> int
+    let inline toNullnessToken (n: Nullness) =
+        match n with
+        | Nullness.Known k -> NullnessToken.Known k
+        // If nullness is not known we must treat the types as not equal for caching purposes.
+        | Nullness.Variable _ -> neverEqual
 
-    // The idea is to keep the illusion of immutability of TType.
-    // This hash must be stable during compilation, otherwise we won't be able to find keys or evict from the cache.
-    let rec hashTType ty : Hash =
+    let rec private accumulateMeasure (tokens: ResizeArray<TypeToken>) (m: Measure) =
+        match m with
+        | Measure.Var mv ->
+            tokens.Add(TypeToken.Stamp mv.Stamp)
+        | Measure.Const(tcref, _) ->
+            tokens.Add(TypeToken.Stamp tcref.Stamp)
+        | Measure.Prod(m1, m2, _) ->
+            accumulateMeasure tokens m1
+            accumulateMeasure tokens m2
+        | Measure.Inv m1 ->
+            accumulateMeasure tokens m1
+        | Measure.One _ ->
+            tokens.Add(TypeToken.MeasureOne)
+        | Measure.RationalPower(m1, r) ->
+            accumulateMeasure tokens m1
+            tokens.Add(TypeToken.MeasureRational r)
+
+    let rec private accumulateTType (tokens: ResizeArray<TypeToken>) (ty: TType) =
         match ty with
-        | TType_ucase(u, tinst) -> tinst |> hashListOrderMatters (hashTType) |> pipeToHash (hash u.CaseName)
-        | TType_app(tcref, tinst, Nullness.Known n) ->
-            tinst
-            |> hashListOrderMatters (hashTType)
-            |> pipeToHash (hashStamp tcref.Stamp)
-            |> pipeToHash (hash n)
-        | TType_app(tcref, tinst, Nullness.Variable _) -> tinst |> hashListOrderMatters (hashTType) |> pipeToHash (hashStamp tcref.Stamp)
-        | TType_anon(info, tys) -> tys |> hashListOrderMatters (hashTType) |> pipeToHash (hashStamp info.Stamp)
-        | TType_tuple(c, tys) -> tys |> hashListOrderMatters (hashTType) |> pipeToHash (hash c)
+        | TType_ucase(u, tinst) ->
+            tokens.Add(TypeToken.UCase u.CaseName)
+            for arg in tinst do
+                accumulateTType tokens arg
+        | TType_app(tcref, tinst, n) ->
+            tokens.Add(TypeToken.Stamp tcref.Stamp)
+            tokens.Add(TypeToken.Nullness(toNullnessToken n))
+            for arg in tinst do
+                accumulateTType tokens arg
+        | TType_anon(info, tys) ->
+            tokens.Add(TypeToken.Stamp info.Stamp)
+            for arg in tys do
+                accumulateTType tokens arg
+        | TType_tuple(tupInfo, tys) ->
+            tokens.Add(TypeToken.TupInfo(evalTupInfoIsStruct tupInfo))
+            for arg in tys do
+                accumulateTType tokens arg
         | TType_forall(tps, tau) ->
-            tps
-            |> Seq.map _.Stamp
-            |> hashListOrderMatters (hashStamp)
-            |> pipeToHash (hashTType tau)
-        | TType_fun(d, r, Nullness.Known n) -> hashTType d |> pipeToHash (hashTType r) |> pipeToHash (hash n)
-        | TType_fun(d, r, Nullness.Variable _) -> hashTType d |> pipeToHash (hashTType r)
-        | TType_var(r, Nullness.Known n) -> hashStamp r.Stamp |> pipeToHash (hash n)
-        | TType_var(r, Nullness.Variable _) -> hashStamp r.Stamp
-        | TType_measure _ -> 0
+            for tp in tps do
+                tokens.Add(TypeToken.Stamp tp.Stamp)
+            accumulateTType tokens tau
+        | TType_fun(d, r, n) ->
+            accumulateTType tokens d
+            accumulateTType tokens r
+            tokens.Add(TypeToken.Nullness(toNullnessToken n))
+        | TType_var(r, n) ->
+            tokens.Add(TypeToken.Stamp r.Stamp)
+            tokens.Add(TypeToken.Nullness(toNullnessToken n))
+        | TType_measure m ->
+            accumulateMeasure tokens m
+
+    /// Get the full structure of a type as a sequence of tokens, suitable for equality 
+    let getTypeStructure ty =
+        let tokens = ResizeArray<TypeToken>(initialTokenCapacity)
+        accumulateTType tokens ty
+        tokens.ToArray()

--- a/src/Compiler/Utilities/TypeHashing.fs
+++ b/src/Compiler/Utilities/TypeHashing.fs
@@ -387,6 +387,7 @@ module StructuralUtilities =
             override _.Equals _ = false
             override _.GetHashCode() = 0
         end
+
         static member Singleton = NeverEqual()
 
     [<Struct; NoComparison; RequireQualifiedAccess>]

--- a/src/Compiler/Utilities/TypeHashing.fs
+++ b/src/Compiler/Utilities/TypeHashing.fs
@@ -406,10 +406,9 @@ module StructuralUtilities =
     let private initialTokenCapacity = 4
 
     let inline toNullnessToken (n: Nullness) =
-        match n with
-        | Nullness.Known k -> TypeToken.Nullness k
-        // If nullness is not known we must treat the types as not equal for caching purposes.
-        | Nullness.Variable _ -> TypeToken.NeverEqual NeverEqual.Singleton
+        match n.TryEvaluate() with
+        | ValueSome k -> TypeToken.Nullness k
+        | _ -> TypeToken.NeverEqual NeverEqual.Singleton
 
     let rec private accumulateMeasure (tokens: ResizeArray<TypeToken>) (m: Measure) =
         match m with

--- a/src/Compiler/Utilities/lib.fsi
+++ b/src/Compiler/Utilities/lib.fsi
@@ -295,3 +295,15 @@ module ListParallel =
 [<RequireQualifiedAccess>]
 module Async =
     val map: ('T -> 'U) -> Async<'T> -> Async<'U>
+
+module internal WeakMap =
+    /// Provides association of lazily-created values with arbitrary key objects.
+    /// The associated value is created on first request and kept alive only while the key
+    /// is strongly referenced elsewhere (backed by ConditionalWeakTable).
+    ///
+    /// Usage:
+    ///   let getValueFor = WeakMap.getOrCreate (fun key -> expensiveInit key)
+    ///   let v = getValueFor someKey
+    val internal getOrCreate:
+        valueFactory: ('Key -> 'Value) -> ('Key -> 'Value)
+            when 'Key: not struct and 'Key: not null and 'Value: not struct

--- a/tests/FSharp.Test.Utilities/XunitHelpers.fs
+++ b/tests/FSharp.Test.Utilities/XunitHelpers.fs
@@ -202,8 +202,6 @@ module OneTimeSetup =
         log "Adding AssemblyResolver"
         AssemblyResolver.addResolver ()
     #endif
-        log "Overriding cache capacity"
-        Cache.OverrideCapacityForTesting()
         log "Installing TestConsole redirection"
         TestConsole.install()
 

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -17,6 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(FSharpTestsRoot)\FSharp.Test.Utilities\XunitSetup.fs">
+        <Link>XunitSetup.fs</Link>
+    </Compile>
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Utilities\NullnessShims.fs" />
     <Compile Include="AssemblyResolver.fs" />
     <Compile Include="$(FSharpSourcesRoot)\Compiler\Utilities\InternalCollections.fsi">
@@ -79,6 +82,7 @@
     <ProjectReference Include="..\..\src\FSharp.Editor\FSharp.Editor.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.LanguageService\FSharp.LanguageService.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.ProjectSystem.FSharp\FSharp.ProjectSystem.FSharp.fsproj" />
+    <ProjectReference Include="..\..\..\tests\FSharp.Test.Utilities\FSharp.Test.Utilities.fsproj" />
   </ItemGroup>
 
   <!-- assemblies used during tests -->


### PR DESCRIPTION
The type subsumption cache was causing problems with the legacy 32 bit test projects.

This was swept under a rug for a few months, using a cache capacity override in tests.
In the course of https://github.com/dotnet/fsharp/pull/18872 I had to revisit this because it showed up again.

I captured a memory snapshot during tests to see what's going on.
Turns out the `TType` objects used as cache keys were the problem.
They can reference a lot of additional lazy initialized data, including ginormous circular references. Now when we put them as cache keys, that can extend their life well beyond their natural lifespan. This was not a big problem memory wise in normal use, but somehow 32 bit tests couldn't handle it and had hard time GCing this.
For example If I weakly attached the cache to `TcGlobals`. This was correctly GC'd in other test projects but never collected in VS tests.

Anyway, the fix is to use a synthetic key, created as a slim structural representation of `TType` in such a way as to guarantee equality soundness.

I checked (by capturing telemetry from the test run) that the cache still works, hit ratio is still good and evictions happen ok.
