### PR TITLE
Cache: immediate eviction in net4 tests

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -321,6 +321,7 @@ stages:
 
           - script: eng\CIBuildNoPublish.cmd -compressallmetadata -buildnorealsig -testDesktop -configuration Release -testBatch $(System.JobPositionInPhase)
             env:
+              FSharp_CacheEvictionImmediate: true
               DOTNET_DbgEnableMiniDump: 1
               DOTNET_DbgMiniDumpType: 3 # Triage dump, 1 for mini, 2 for Heap, 3 for triage, 4 for full. Don't use 4 unless you know what you're doing.
               DOTNET_DbgMiniDumpName: $(Build.SourcesDirectory)\artifacts\log\Release\$(Build.BuildId)-%e-%p-%t.dmp
@@ -456,11 +457,13 @@ stages:
               fsharpqa_release:
                 _configuration: Release
                 _testKind: testFSharpQA
+                FSharp_CacheEvictionImmediate: true
                 transparentCompiler:
               vs_release:
                 _configuration: Release
                 _testKind: testVs
                 setupVsHive: true
+                FSharp_CacheEvictionImmediate: true
                 transparentCompiler:
               transparent_compiler_release:
                 _configuration: Release
@@ -559,6 +562,7 @@ stages:
 
           - script: eng\CIBuildNoPublish.cmd -compressallmetadata -configuration Release -testDesktop -testBatch $(System.JobPositionInPhase)
             env:
+              FSharp_CacheEvictionImmediate: true
               DOTNET_DbgEnableMiniDump: 1
               DOTNET_DbgMiniDumpType: 3 # Triage dump, 1 for mini, 2 for Heap, 3 for triage, 4 for full. Don't use 4 unless you know what you're doing.
               DOTNET_DbgMiniDumpName: $(Build.SourcesDirectory)\artifacts\log\Release\$(Build.BuildId)-%e-%p-%t.dmp

--- a/src/Compiler/Utilities/Caches.fs
+++ b/src/Compiler/Utilities/Caches.fs
@@ -97,11 +97,23 @@ type CacheOptions<'Key> =
     }
 
 module CacheOptions =
+    let forceImmediate =
+        try
+            Environment.GetEnvironmentVariable("FSharp_CacheEvictionImmediate") <> null
+        with _ ->
+            false
+
+    let defaultEvictionMode =
+        if forceImmediate then
+            EvictionMode.Immediate
+        else
+            EvictionMode.MailboxProcessor
+
     let getDefault () =
         {
             CacheOptions.TotalCapacity = 1024
             CacheOptions.HeadroomPercentage = 50
-            CacheOptions.EvictionMode = EvictionMode.MailboxProcessor
+            CacheOptions.EvictionMode = defaultEvictionMode
             CacheOptions.Comparer = HashIdentity.Structural
         }
 
@@ -109,7 +121,7 @@ module CacheOptions =
         {
             CacheOptions.TotalCapacity = 1024
             CacheOptions.HeadroomPercentage = 50
-            CacheOptions.EvictionMode = EvictionMode.MailboxProcessor
+            CacheOptions.EvictionMode = defaultEvictionMode
             CacheOptions.Comparer = HashIdentity.Reference
         }
 


### PR DESCRIPTION
## Description

I'm noticing some CI hangs on .Net Framework tests after #18875

The cause may or may not be thread pool starvation: old .Net uses different algorithms and does not ramp up threads fast enough.

Specifically after #18875 the type subsumption cache is tied to TcGlobals, which means more instances instead of one per process singleton. Unfortunately, in tests it means thousand started in quick succession. So, the queued eviction for each one eats some threads, quickly.

So, if the problem persists, this should be a fix.
