### PR TITLE
Checker: fix declaring type for abbreviated types extensions

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
@@ -26,6 +26,7 @@
 * Fix nullable types formatting in `FSharpType.Format` and tooltips to include parentheses. ([PR #18842](https://github.com/dotnet/fsharp/pull/18842))
 * TypeMismatchDiagnosticExtendedData: fix expected and actual types calculation. ([Issue ](https://github.com/dotnet/fsharp/pull/18851))
 * Parser: fix range for computed binding expressions ([PR #18903](https://github.com/dotnet/fsharp/pull/18903))
+* Checker: fix declaring type for abbreviated types extensions ([PR #18909](https://github.com/dotnet/fsharp/pull/18909))
 
 ### Changed
 * Use `errorR` instead of `error` in `CheckDeclarations.fs` when possible. ([PR #18645](https://github.com/dotnet/fsharp/pull/18645))

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -4253,12 +4253,6 @@ module TcDeclarations =
         if isAtOriginalTyconDefn then
             ModuleOrMemberBinding, tcref, reqTypars
         else
-            match tcref.TypeAbbrev |> Option.toValueOption |> ValueOption.bind (tryTcrefOfAppTy g) with
-            | ValueSome abbrTcref ->
-                errorR (Error(FSComp.SR.tcTypeAbbreviationsCannotHaveAugmentations(), m))
-                ExtrinsicExtensionBinding, abbrTcref, abbrTcref.TyparsNoRange
-            | _ ->
-
             let isInSameModuleOrNamespace = 
                  match envForDecls.eModuleOrNamespaceTypeAccumulator.Value.TypesByMangledName.TryGetValue tcref.LogicalName with 
                  | true, tycon -> tyconOrder.Compare(tcref.Deref, tycon) = 0
@@ -4273,6 +4267,11 @@ module TcDeclarations =
             let envForTycon = AddDeclaredTypars CheckForDuplicateTypars declaredTypars envForDecls
             let _tpenv = TcTyparConstraints cenv NoNewTypars CheckCxs ItemOccurrence.UseInType envForTycon emptyUnscopedTyparEnv synTyparCxs
             declaredTypars |> List.iter (SetTyparRigid envForDecls.DisplayEnv m)
+
+            if tcref.TypeAbbrev.IsSome then
+                errorR (Error(FSComp.SR.tcTypeAbbreviationsCannotHaveAugmentations(), m))
+                ExtrinsicExtensionBinding, tcref, declaredTypars
+            else
 
             if isInSameModuleOrNamespace && not isInterfaceOrDelegateOrEnum then 
                 // For historical reasons we only give a warning for incorrect type parameters on intrinsic extensions

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -4269,11 +4269,8 @@ module TcDeclarations =
             declaredTypars |> List.iter (SetTyparRigid envForDecls.DisplayEnv m)
 
             if tcref.TypeAbbrev.IsSome then
-                errorR (Error(FSComp.SR.tcTypeAbbreviationsCannotHaveAugmentations(), m))
                 ExtrinsicExtensionBinding, tcref, declaredTypars
-            else
-
-            if isInSameModuleOrNamespace && not isInterfaceOrDelegateOrEnum then 
+            elif isInSameModuleOrNamespace && not isInterfaceOrDelegateOrEnum then 
                 // For historical reasons we only give a warning for incorrect type parameters on intrinsic extensions
                 if nReqTypars <> synTypars.Length then 
                     errorR(Error(FSComp.SR.tcDeclaredTypeParametersForExtensionDoNotMatchOriginal(tcref.DisplayNameWithStaticParametersAndUnderscoreTypars), m))
@@ -4608,6 +4605,9 @@ module TcDeclarations =
                 if (declKind = ExtrinsicExtensionBinding) && isByrefTyconRef g tcref then 
                     error(Error(FSComp.SR.tcByrefsMayNotHaveTypeExtensions(), tyDeclRange))
 
+                if not (isNil members) && tcref.IsTypeAbbrev then 
+                    errorR(Error(FSComp.SR.tcTypeAbbreviationsCannotHaveAugmentations(), tyDeclRange))
+                
                 let (SynComponentInfo (attributes, _, _, _, _, _, _, _)) = synTyconInfo
                 if not (List.isEmpty attributes) && (declKind = ExtrinsicExtensionBinding || declKind = IntrinsicExtensionBinding) then
                     let attributeRange = (List.head attributes).Range

--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/AbbreviationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/AbbreviationTests.fs
@@ -55,6 +55,23 @@ type FloatAlias with
         ]
 
 [<Fact>]
+let ``Members 04 - Error in expr`` () =
+    Fsx """
+type StringAlias = string
+
+type StringAlias with
+    member x.Length = x.Length + ""
+        """
+        |> typecheck
+        |> shouldFail
+        |> withDiagnostics [
+            (Error 964, Line 4, Col 6, Line 4, Col 17, "Type abbreviations cannot have augmentations")
+            (Error 895, Line 5, Col 5, Line 5, Col 36, "Type abbreviations cannot have members")
+            (Error 1, Line 5, Col 34, Line 5, Col 36, "The type 'string' does not match the type 'int'")
+            (Error 43, Line 5, Col 32, Line 5, Col 33, "The type 'string' does not match the type 'int'")
+        ]
+
+[<Fact>]
 let ``Multiple types 01`` () =
     Fsx """
 type ListAlias = int list


### PR DESCRIPTION
Continuation of https://github.com/dotnet/fsharp/pull/18645. Fixes `DeclaringEntity` for members defined in an abbreviated type extension:

```fsharp
module Module

type d = System.Collections.Generic.IDictionary<int, int>

type d{caret} with
    member x.P = 1
```

Since these members are now being analyzed due to the added recovery, it gets to a state that was never explicitly supported and tested, and there are places that are not ready for it.

The problem I've encountered in the Rider plugin tests is `P` member above assumes it's defined in the actual `IDicitionary` type, not in `Module`.