### PR TITLE
Tests: fix getNetCoreAppReferences output leaking

### DIFF
--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -627,8 +627,6 @@ module CompilerAssertHelpers =
         File.WriteAllText(runtimeconfigPath, runtimeconfig)
 #endif
         let rc, output, errors = Commands.executeProcess fileName arguments (Path.GetDirectoryName(outputFilePath))
-        let output = String.Join(Environment.NewLine, output)
-        let errors = String.Join(Environment.NewLine, errors)
         ExitCode rc, output, errors
 
 open CompilerAssertHelpers

--- a/tests/FSharp.Test.Utilities/ILChecker.fs
+++ b/tests/FSharp.Test.Utilities/ILChecker.fs
@@ -15,9 +15,7 @@ module ILChecker =
 
     let private exec exe args =
         let arguments = args |> String.concat " "
-        let exitCode, _output, errors = Commands.executeProcess exe arguments ""
-        let errors = errors |> String.concat Environment.NewLine
-        errors, exitCode
+        Commands.executeProcess exe arguments ""
 
     /// Filters i.e ['The system type \'System.ReadOnlySpan`1\' was required but no referenced system DLL contained this type']
     let private filterSpecialComment (text: string) =
@@ -101,7 +99,7 @@ module ILChecker =
 
         let ildasmFullArgs = [ dllFilePath; $"-out=%s{ilFilePath}"; yield! ildasmArgs  ]
 
-        let stdErr, exitCode =
+        let exitCode, _, stdErr =
             let ildasmCommandPath = Path.ChangeExtension(dllFilePath, ".ildasmCommandPath")
             File.WriteAllLines(ildasmCommandPath, [| $"{ildasmPath} {ildasmFullArgs}" |] )
             exec ildasmPath ildasmFullArgs
@@ -212,5 +210,5 @@ module ILChecker =
 
     let reassembleIL ilFilePath dllFilePath =
         let ilasmPath = config.ILASM
-        let errors, _ = exec ilasmPath [ $"%s{ilFilePath} /output=%s{dllFilePath} /dll" ]
+        let _, _, errors = exec ilasmPath [ $"%s{ilFilePath} /output=%s{dllFilePath} /dll" ]
         errors

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -165,8 +165,8 @@ open System
 let main argv = 0"""
 
         let private getNetCoreAppReferences =
-            let mutable output = [||]
-            let mutable errors = [||]
+            let mutable output = ""
+            let mutable errors = ""
             let mutable cleanUp = true
             let pathToArtifacts = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../.."))
             if Path.GetFileName(pathToArtifacts) <> "artifacts" then failwith "CompilerAssert did not find artifacts directory --- has the location changed????"
@@ -196,17 +196,15 @@ let main argv = 0"""
                         errors <- dotneterrors
                         output <- dotnetoutput
                         printfn "Output:\n=======\n"
-                        output |> Seq.iter(fun line -> printfn "STDOUT:%s\n" line)
+                        printfn "%s" dotnetoutput
                         printfn "Errors:\n=======\n"
-                        errors  |> Seq.iter(fun line -> printfn "STDERR:%s\n" line)
+                        printfn "%s" dotneterrors
                         Assert.True(false, "Errors produced generating References")
 
                     File.ReadLines(frameworkReferencesFileName) |> Seq.toArray
                 with | e ->
                     cleanUp <- false
                     let message =
-                        let output = output |> String.concat "\nSTDOUT: "
-                        let errors = errors |> String.concat "\nSTDERR: "
                         File.WriteAllText(Path.Combine(projectDirectory, "project.stdout"), output)
                         File.WriteAllText(Path.Combine(projectDirectory, "project.stderror"), errors)
                         $"""                        


### PR DESCRIPTION
Fixes random test failures like [this one](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1154368&view=logs&j=435f3a2d-942b-5f08-8f7e-dcf1279f0606&t=3298b475-d4c8-5bba-4a76-7fefacd20ca6&l=4722)

also `Commands.executeProcess` output handling is more streamlined now and no longer uses filesystem to pass around the output as files. If we want the output on disk, we can dump it to a file when needed.

