### PR TITLE
Collect metrics from MemoizationTables

### DIFF
--- a/src/Compiler/Checking/InfoReader.fs
+++ b/src/Compiler/Checking/InfoReader.fs
@@ -727,9 +727,9 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
     /// Make a cache for function 'f' keyed by type (plus some additional 'flags') that only 
     /// caches computations for monomorphic types.
 
-    let MakeInfoCache f (flagsEq : IEqualityComparer<_>) = 
+    let MakeInfoCache name f (flagsEq : IEqualityComparer<_>) = 
         MemoizationTable<_, _>
-             (compute=f,
+             (name, compute=f,
               // Only cache closed, monomorphic types (closed = all members for the type
               // have been processed). Generic type instantiations could be processed if we had 
               // a decent hash function for these.
@@ -803,18 +803,18 @@ type InfoReader(g: TcGlobals, amap: Import.ImportMap) as this =
                member _.GetHashCode((ad, nm)) = AccessorDomain.CustomGetHashCode ad + hash nm
                member _.Equals((ad1, nm1), (ad2, nm2)) = AccessorDomain.CustomEquals(g, ad1, ad2) && (nm1 = nm2) }
                          
-    let methodInfoCache = MakeInfoCache GetIntrinsicMethodSetsUncached hashFlags0
-    let propertyInfoCache = MakeInfoCache GetIntrinsicPropertySetsUncached hashFlags0
-    let recdOrClassFieldInfoCache =  MakeInfoCache GetIntrinsicRecdOrClassFieldInfosUncached hashFlags1
-    let ilFieldInfoCache = MakeInfoCache GetIntrinsicILFieldInfosUncached hashFlags1
-    let eventInfoCache = MakeInfoCache GetIntrinsicEventInfosUncached hashFlags1
-    let namedItemsCache = MakeInfoCache GetIntrinsicNamedItemsUncached hashFlags2
-    let mostSpecificOverrideMethodInfoCache = MakeInfoCache GetIntrinsicMostSpecificOverrideMethodSetsUncached hashFlags0
+    let methodInfoCache = MakeInfoCache "methodInfoCache" GetIntrinsicMethodSetsUncached hashFlags0
+    let propertyInfoCache = MakeInfoCache "propertyInfoCache" GetIntrinsicPropertySetsUncached hashFlags0
+    let recdOrClassFieldInfoCache =  MakeInfoCache "recdOrClassFieldInfoCache" GetIntrinsicRecdOrClassFieldInfosUncached hashFlags1
+    let ilFieldInfoCache = MakeInfoCache "ilFieldInfoCache" GetIntrinsicILFieldInfosUncached hashFlags1
+    let eventInfoCache = MakeInfoCache "eventInfoCache" GetIntrinsicEventInfosUncached hashFlags1
+    let namedItemsCache = MakeInfoCache "namedItemsCache" GetIntrinsicNamedItemsUncached hashFlags2
+    let mostSpecificOverrideMethodInfoCache = MakeInfoCache "mostSpecificOverrideMethodInfoCache" GetIntrinsicMostSpecificOverrideMethodSetsUncached hashFlags0
 
-    let entireTypeHierarchyCache = MakeInfoCache GetEntireTypeHierarchyUncached HashIdentity.Structural
-    let primaryTypeHierarchyCache = MakeInfoCache GetPrimaryTypeHierarchyUncached HashIdentity.Structural
-    let implicitConversionCache = MakeInfoCache FindImplicitConversionsUncached hashFlags3
-    let isInterfaceWithStaticAbstractMethodCache = MakeInfoCache IsInterfaceTypeWithMatchingStaticAbstractMemberUncached hashFlags4
+    let entireTypeHierarchyCache = MakeInfoCache "entireTypeHierarchyCache" GetEntireTypeHierarchyUncached HashIdentity.Structural
+    let primaryTypeHierarchyCache = MakeInfoCache "primaryTypeHierarchyCache" GetPrimaryTypeHierarchyUncached HashIdentity.Structural
+    let implicitConversionCache = MakeInfoCache "implicitConversionCache" FindImplicitConversionsUncached hashFlags3
+    let isInterfaceWithStaticAbstractMethodCache = MakeInfoCache "isInterfaceWithStaticAbstractMethodCache" IsInterfaceTypeWithMatchingStaticAbstractMemberUncached hashFlags4
 
     // Runtime feature support
 

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -2334,6 +2334,7 @@ and AssemblyBuilder(cenv: cenv, anonTypeTable: AnonTypeGenerationTable) as mgbuf
     // A memoization table for generating value types for big constant arrays
     let rawDataValueTypeGenerator =
         MemoizationTable<CompileLocation * int, ILTypeSpec>(
+            "rawDataValueTypeGenerator",
             (fun (cloc, size) ->
                 let name =
                     CompilerGeneratedName("T" + string (newUnique ()) + "_" + string size + "Bytes") // Type names ending ...$T<unique>_37Bytes

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -114,6 +114,8 @@
     </EmbeddedResource>
     <Compile Include="Utilities\Activity.fsi" />
     <Compile Include="Utilities\Activity.fs" />
+	<Compile Include="Utilities\Caches.fsi" />
+    <Compile Include="Utilities\Caches.fs" />
     <Compile Include="Utilities\illib.fsi" />
     <Compile Include="Utilities\illib.fs" />
     <Compile Include="Utilities\sformat.fsi" />
@@ -147,8 +149,6 @@
     <Compile Include="Utilities\lib.fsi" />
     <Compile Include="Utilities\lib.fs" />
     <Compile Include="Utilities\DependencyGraph.fs" />
-    <Compile Include="Utilities\Caches.fsi" />
-    <Compile Include="Utilities\Caches.fs" />
     <Compile Include="Utilities\LruCache.fsi" />
     <Compile Include="Utilities\LruCache.fs" />
     <Compile Include="Utilities\ImmutableArray.fsi" />

--- a/src/Compiler/TypedTree/TcGlobals.fs
+++ b/src/Compiler/TypedTree/TcGlobals.fs
@@ -687,7 +687,7 @@ type TcGlobals(
 
   // Build the memoization table for files
   let v_memoize_file =
-      MemoizationTable<int, ILSourceDocument>(compute, keyComparer = HashIdentity.Structural)
+      MemoizationTable<int, ILSourceDocument>("v_memoize_file", compute, keyComparer = HashIdentity.Structural)
 
   let v_and_info =                   makeIntrinsicValRef(fslib_MFIntrinsicOperators_nleref,                    CompileOpName "&"                      , None                 , None          , [],         mk_rel_sig v_bool_ty)
   let v_addrof_info =                makeIntrinsicValRef(fslib_MFIntrinsicOperators_nleref,                    CompileOpName "~&"                     , None                 , None          , [vara],     ([[varaTy]], mkByrefTy varaTy))

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -386,7 +386,8 @@ type internal UniqueStampGenerator<'T when 'T: equality and 'T: not null> =
 type internal MemoizationTable<'T, 'U when 'T: not null> =
 
     new:
-        compute: ('T -> 'U) * keyComparer: IEqualityComparer<'T> * ?canMemoize: ('T -> bool) -> MemoizationTable<'T, 'U>
+        name: string * compute: ('T -> 'U) * keyComparer: IEqualityComparer<'T> * ?canMemoize: ('T -> bool) ->
+            MemoizationTable<'T, 'U>
 
     member Apply: x: 'T -> 'U
 


### PR DESCRIPTION
## Description

`MemoizationTables` use `ConcurrentDictionary` as a backing store. If we use named `Cache` instances with no eviction instead, we can collect and see their metrics with `--times` option:

```
    ----------------------------------------------------------------------------------------------------------------------------
    | Cache name                          | hit-ratio |     adds |  updates |     hits |   misses | evictions | eviction-fails |
    |-------------------------------------|-----------|----------|----------|----------|----------|-----------|----------------|
    | mostSpecificOverrideMethodInfoCache |    73.26% |      365 |        0 |     1000 |      365 |         0 |              0 |
    |                typeSubsumptionCache |    69.27% |   129308 |        0 |   291450 |   129308 |         0 |              0 |
    |           rawDataValueTypeGenerator |    96.40% |       39 |        0 |     1045 |       39 |         0 |              0 |
    |           primaryTypeHierarchyCache |    50.00% |       14 |        0 |       14 |       14 |         0 |              0 |
    |             implicitConversionCache |    92.71% |     1367 |        0 |    17385 |     1367 |         0 |              0 |
    |                     namedItemsCache |    56.65% |    15841 |        0 |    20697 |    15841 |         0 |              0 |
    |                      v_memoize_file |    99.90% |      380 |        0 |   385340 |      380 |         0 |              0 |
    |                   propertyInfoCache |    38.71% |     1762 |        0 |     1113 |     1762 |         0 |              0 |
    |                     methodInfoCache |    76.99% |     5621 |        0 |    18809 |     5621 |         0 |              0 |
    |                    ilFieldInfoCache |    75.19% |       32 |        0 |       97 |       32 |         0 |              0 |
    |            entireTypeHierarchyCache |    90.04% |     3428 |        0 |    30992 |     3428 |         0 |              0 |
    |           recdOrClassFieldInfoCache |    46.21% |      795 |        0 |      683 |      795 |         0 |              0 |
    |                      eventInfoCache |     0.00% |        1 |        0 |        0 |        1 |         0 |              0 |
    ----------------------------------------------------------------------------------------------------------------------------

```

In cases where there are many instances with the same name, the above data is accumulated by name.

possible TODOs: Identify other uses of `ConcurrentDictionary` that may be also instrumented like this. Maybe collect some more useful data, currently hit ratio is computed, the rest are just raw event counts as they come from the Cache.