### PR TITLE
Revert "Parser: Capture multiple block separators (#18899)"

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.100.md
@@ -42,7 +42,6 @@
 * Parser: Capture named fields block separators. ([PR #18857](https://github.com/dotnet/fsharp/pull/18857))
 * Type checker: use inner expr range in upcast constraints errors ([PR #18850](https://github.com/dotnet/fsharp/pull/18850))
 * Import `IEnumerable` as `seq`. ([PR #18865](https://github.com/dotnet/fsharp/pull/18865))
-* Parser: Capture multiple block separators ([PR #18899](https://github.com/dotnet/fsharp/pull/18899))
 
 ### Breaking Changes
 

--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
@@ -90,14 +90,19 @@ let TransformAstForNestedUpdates (cenv: TcFileState) (env: TcEnv) overallTy (lid
         let totalRange (origId: Ident) (id: Ident) =
             withStartEnd origId.idRange.End id.idRange.Start origId.idRange
 
-        match withExpr with
-        | SynExpr.Ident origId, (blockSep: BlockSeparator) ->
-            let lid, rng = upToId blockSep.Range id (origId :: ids)
+        let rangeOfBlockSeparator (id: Ident) =
+            let idEnd = id.idRange.End
+            let blockSeparatorStartCol = idEnd.Column
+            let blockSeparatorEndCol = blockSeparatorStartCol + 4
+            let blockSeparatorStartPos = mkPos idEnd.Line blockSeparatorStartCol
+            let blockSeparatorEndPos = mkPos idEnd.Line blockSeparatorEndCol
 
-            Some(
-                SynExpr.LongIdent(false, LongIdentWithDots(lid, rng), None, totalRange origId id),
-                BlockSeparator.Offside(blockSep.Range, None)
-            )
+            withStartEnd blockSeparatorStartPos blockSeparatorEndPos id.idRange
+
+        match withExpr with
+        | SynExpr.Ident origId, (sepRange, _) ->
+            let lid, rng = upToId sepRange id (origId :: ids)
+            Some(SynExpr.LongIdent(false, LongIdentWithDots(lid, rng), None, totalRange origId id), (rangeOfBlockSeparator id, None))
         | _ -> None
 
     let rec synExprRecd copyInfo (outerFieldId: Ident) innerFields exprBeingAssigned =

--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fsi
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fsi
@@ -10,13 +10,13 @@ open FSharp.Compiler.TypedTree
 val GroupUpdatesToNestedFields:
     fields: ((Ident list * Ident) * SynExpr option) list -> ((Ident list * Ident) * SynExpr option) list
 
-val TransformAstForNestedUpdates:
+val TransformAstForNestedUpdates<'a> :
     cenv: TcFileState ->
     env: TcEnv ->
     overallTy: TType ->
     lid: LongIdent ->
     exprBeingAssigned: SynExpr ->
-    withExpr: SynExpr * BlockSeparator ->
+    withExpr: SynExpr * (range * 'a) ->
         (Ident list * Ident) * SynExpr option
 
 val BindOriginalRecdExpr:

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -7763,7 +7763,7 @@ and TcRecdExpr cenv overallTy env tpenv (inherits, withExprOpt, synRecdFields, m
 
                 match withExprOpt, synLongId.LongIdent, exprBeingAssigned with
                 | _, [ id ], _ -> ([], id), exprBeingAssigned
-                | Some (origExpr, blockSep), lid, Some exprBeingAssigned -> TransformAstForNestedUpdates cenv env overallTy lid exprBeingAssigned (origExpr, blockSep)
+                | Some withExpr, lid, Some exprBeingAssigned -> TransformAstForNestedUpdates cenv env overallTy lid exprBeingAssigned withExpr
                 | _ -> List.frontAndBack synLongId.LongIdent, exprBeingAssigned)
 
         let flds = if hasOrigExpr then GroupUpdatesToNestedFields flds else flds

--- a/src/Compiler/Service/ServiceParseTreeWalk.fs
+++ b/src/Compiler/Service/ServiceParseTreeWalk.fs
@@ -445,12 +445,12 @@ module SyntaxTraversal =
                 | SynExpr.AnonRecd(copyInfo = copyOpt; recordFields = fields) ->
                     [
                         match copyOpt with
-                        | Some(expr, blockSep) ->
+                        | Some(expr, (withRange, _)) ->
                             yield dive expr expr.Range traverseSynExpr
 
                             yield
-                                dive () blockSep.Range (fun () ->
-                                    if posGeq pos blockSep.Range.End then
+                                dive () withRange (fun () ->
+                                    if posGeq pos withRange.End then
                                         // special case: caret is after WITH
                                         // { x with $ }
                                         visitor.VisitRecordField(path, Some expr, None)
@@ -498,24 +498,24 @@ module SyntaxTraversal =
                                         traverseSynExpr expr)
 
                             match sepOpt with
-                            | Some blockSep ->
+                            | Some(sep, scPosOpt) ->
                                 yield
-                                    dive () blockSep.Range (fun () ->
+                                    dive () sep (fun () ->
                                         // special case: caret is below 'inherit' + one or more fields are already defined
                                         // inherit A()
                                         // $
                                         // field1 = 5
-                                        diveIntoSeparator inheritRange.StartColumn blockSep.Position None)
+                                        diveIntoSeparator inheritRange.StartColumn scPosOpt None)
                             | None -> ()
                         | _ -> ()
 
                         match copyOpt with
-                        | Some(expr, blockSep) ->
+                        | Some(expr, (withRange, _)) ->
                             yield dive expr expr.Range traverseSynExpr
 
                             yield
-                                dive () blockSep.Range (fun () ->
-                                    if posGeq pos blockSep.Range.End then
+                                dive () withRange (fun () ->
+                                    if posGeq pos withRange.End then
                                         // special case: caret is after WITH
                                         // { x with $ }
                                         visitor.VisitRecordField(path, Some expr, None)
@@ -556,14 +556,14 @@ module SyntaxTraversal =
                             | None -> ()
 
                             match sepOpt with
-                            | Some blockSep ->
+                            | Some(sep, scPosOpt) ->
                                 yield
-                                    dive () blockSep.Range (fun () ->
+                                    dive () sep (fun () ->
                                         // special case: caret is between field bindings
                                         // field1 = 5
                                         // $
                                         // field2 = 5
-                                        diveIntoSeparator offsideColumn blockSep.Position copyOpt)
+                                        diveIntoSeparator offsideColumn scPosOpt copyOpt)
                             | _ -> ()
 
                     ]

--- a/src/Compiler/SyntaxTree/SyntaxTree.fs
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fs
@@ -306,23 +306,7 @@ type DebugPointAtBinding =
 
 type SeqExprOnly = SeqExprOnly of bool
 
-[<NoEquality; NoComparison; RequireQualifiedAccess>]
-type BlockSeparator =
-    | Semicolon of range: range * position: pos option
-    | Comma of range: range * position: pos option
-    | Offside of range: range * position: pos option
-
-    member this.Range =
-        match this with
-        | Semicolon(range = m)
-        | Comma(range = m)
-        | Offside(range = m) -> m
-
-    member this.Position =
-        match this with
-        | Semicolon(position = p)
-        | Comma(position = p)
-        | Offside(position = p) -> p
+type BlockSeparator = range * pos option
 
 type RecordFieldName = SynLongIdent * bool
 

--- a/src/Compiler/SyntaxTree/SyntaxTree.fsi
+++ b/src/Compiler/SyntaxTree/SyntaxTree.fsi
@@ -354,26 +354,9 @@ type SeqExprOnly =
     /// Indicates if a for loop is 'for x in e1 -> e2', only valid in sequence expressions
     | SeqExprOnly of bool
 
-/// Represents the location of the separator block and optional position of the semicolon (used for tooling support)
-[<NoEquality; NoComparison; RequireQualifiedAccess>]
-type BlockSeparator =
-    /// A separator consisting of a semicolon ';'
-    /// range is the range of the semicolon
-    /// position is the position of the semicolon (if available)
-    | Semicolon of range: range * position: pos option
-    /// A separator consisting of a comma ','
-    /// range is the range of the comma
-    /// position is the position of the comma (if available)
-    | Comma of range: range * position: pos option
-
-    // A separator consisting of a newline
-    /// range is the range of the newline
-    /// position is the position of the newline (if available)
-    | Offside of range: range * position: pos option
-
-    member Range: range
-
-    member Position: pos option
+/// Represents the location of the separator block + optional position
+/// of the semicolon (used for tooling support)
+type BlockSeparator = range * pos option
 
 /// Represents a record field name plus a flag indicating if given record field name is syntactically
 /// correct and can be used in name resolution.

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5709,7 +5709,7 @@ recdExprCore:
   | appExpr
     { let mExpr = rhs parseState 1
       reportParseErrorAt mExpr (FSComp.SR.parsFieldBinding ())
-      Some($1, BlockSeparator.Offside(mExpr.EndRange, None)), [] }
+      Some($1, (mExpr.EndRange, None)), [] }
 
 /*
     handles cases when identifier can start from the underscore
@@ -5743,15 +5743,15 @@ recdExprCore:
   | appExpr WITH recdBinding recdExprBindings opt_seps_block
      { let l = List.rev $4
        let l = rebindRanges $3 l $5
-       (Some($1, BlockSeparator.Offside(rhs parseState 2, None)), l) }
+       (Some($1, (rhs parseState 2, None)), l) }
 
   | appExpr OWITH opt_seps_block OEND
-     { (Some($1, BlockSeparator.Offside(rhs parseState 2, None)), []) }
+     { (Some($1, (rhs parseState 2, None)), []) }
 
   | appExpr OWITH recdBinding recdExprBindings opt_seps_block OEND
      { let l = List.rev $4
        let l = rebindRanges $3 l $5
-       (Some($1, BlockSeparator.Offside(rhs parseState 2, None)), l) }
+       (Some($1, (rhs parseState 2, None)), l) }
 
 opt_seps_block:
   | seps_block
@@ -5762,17 +5762,17 @@ opt_seps_block:
 
 seps_block:
   | OBLOCKSEP
-     { BlockSeparator.Offside((rhs parseState 1), None) }
+     { (rhs parseState 1), None }
 
   | SEMICOLON
      { let m = (rhs parseState 1)
-       BlockSeparator.Semicolon(m, Some m.End) }
+       m, Some m.End }
 
   | SEMICOLON OBLOCKSEP
-     { BlockSeparator.Semicolon((rhs2 parseState 1 2), Some (rhs parseState 1).End) }
+     { (rhs2 parseState 1 2), Some (rhs parseState 1).End }
 
   | OBLOCKSEP SEMICOLON
-     { BlockSeparator.Semicolon((rhs2 parseState 1 2), Some (rhs parseState 2).End) }
+     { (rhs2 parseState 1 2), Some (rhs parseState 2).End }
 
 
 /* identifier can start from the underscore */

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
@@ -5921,41 +5921,6 @@ FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 GetHashCode(System.Collections.IEqua
 FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 Tag
 FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 get_Tag()
 FSharp.Compiler.Symbols.FSharpXmlDoc: System.String ToString()
-FSharp.Compiler.Syntax.BlockSeparator+Comma: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.BlockSeparator+Comma: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.BlockSeparator+Comma: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] get_position()
-FSharp.Compiler.Syntax.BlockSeparator+Comma: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] position
-FSharp.Compiler.Syntax.BlockSeparator+Offside: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.BlockSeparator+Offside: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.BlockSeparator+Offside: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] get_position()
-FSharp.Compiler.Syntax.BlockSeparator+Offside: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] position
-FSharp.Compiler.Syntax.BlockSeparator+Semicolon: FSharp.Compiler.Text.Range get_range()
-FSharp.Compiler.Syntax.BlockSeparator+Semicolon: FSharp.Compiler.Text.Range range
-FSharp.Compiler.Syntax.BlockSeparator+Semicolon: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] get_position()
-FSharp.Compiler.Syntax.BlockSeparator+Semicolon: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] position
-FSharp.Compiler.Syntax.BlockSeparator+Tags: Int32 Comma
-FSharp.Compiler.Syntax.BlockSeparator+Tags: Int32 Offside
-FSharp.Compiler.Syntax.BlockSeparator+Tags: Int32 Semicolon
-FSharp.Compiler.Syntax.BlockSeparator: Boolean IsComma
-FSharp.Compiler.Syntax.BlockSeparator: Boolean IsOffside
-FSharp.Compiler.Syntax.BlockSeparator: Boolean IsSemicolon
-FSharp.Compiler.Syntax.BlockSeparator: Boolean get_IsComma()
-FSharp.Compiler.Syntax.BlockSeparator: Boolean get_IsOffside()
-FSharp.Compiler.Syntax.BlockSeparator: Boolean get_IsSemicolon()
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator NewComma(FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position])
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator NewOffside(FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position])
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator NewSemicolon(FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position])
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator+Comma
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator+Offside
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator+Semicolon
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Syntax.BlockSeparator+Tags
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Text.Range Range
-FSharp.Compiler.Syntax.BlockSeparator: FSharp.Compiler.Text.Range get_Range()
-FSharp.Compiler.Syntax.BlockSeparator: Int32 Tag
-FSharp.Compiler.Syntax.BlockSeparator: Int32 get_Tag()
-FSharp.Compiler.Syntax.BlockSeparator: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] Position
-FSharp.Compiler.Syntax.BlockSeparator: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position] get_Position()
-FSharp.Compiler.Syntax.BlockSeparator: System.String ToString()
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtDo
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtInvisible
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtLet
@@ -6203,7 +6168,7 @@ FSharp.Compiler.Syntax.Ident: System.String ToString()
 FSharp.Compiler.Syntax.Ident: System.String get_idText()
 FSharp.Compiler.Syntax.Ident: System.String idText
 FSharp.Compiler.Syntax.Ident: Void .ctor(System.String, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Syntax.NamePatPairField NewNamePatPairField(FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator])
+FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Syntax.NamePatPairField NewNamePatPairField(FSharp.Compiler.Syntax.SynLongIdent, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range, FSharp.Compiler.Syntax.SynPat, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]])
 FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Syntax.SynLongIdent FieldName
 FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Syntax.SynLongIdent fieldName
 FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Syntax.SynLongIdent get_FieldName()
@@ -6218,10 +6183,10 @@ FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.NamePatPairField: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.NamePatPairField: Int32 Tag
 FSharp.Compiler.Syntax.NamePatPairField: Int32 get_Tag()
-FSharp.Compiler.Syntax.NamePatPairField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator] blockSeparator
-FSharp.Compiler.Syntax.NamePatPairField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator] get_blockSeparator()
 FSharp.Compiler.Syntax.NamePatPairField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] equalsRange
 FSharp.Compiler.Syntax.NamePatPairField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_equalsRange()
+FSharp.Compiler.Syntax.NamePatPairField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] blockSeparator
+FSharp.Compiler.Syntax.NamePatPairField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] get_blockSeparator()
 FSharp.Compiler.Syntax.NamePatPairField: System.String ToString()
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Syntax.ParsedHashDirective NewParsedHashDirective(System.String, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.ParsedHashDirectiveArgument], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.ParsedHashDirective: FSharp.Compiler.Text.Range get_range()
@@ -7026,8 +6991,8 @@ FSharp.Compiler.Syntax.SynExpr+AnonRecd: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynLongIdent,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]] get_recordFields()
 FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynLongIdent,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]] recordFields
-FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Syntax.BlockSeparator]] copyInfo
-FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Syntax.BlockSeparator]] get_copyInfo()
+FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]] copyInfo
+FSharp.Compiler.Syntax.SynExpr+AnonRecd: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]] get_copyInfo()
 FSharp.Compiler.Syntax.SynExpr+App: Boolean get_isInfix()
 FSharp.Compiler.Syntax.SynExpr+App: Boolean isInfix
 FSharp.Compiler.Syntax.SynExpr+App: FSharp.Compiler.Syntax.ExprAtomicFlag flag
@@ -7424,10 +7389,10 @@ FSharp.Compiler.Syntax.SynExpr+Record: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExpr+Record: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField] get_recordFields()
 FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField] recordFields
-FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Syntax.BlockSeparator]] copyInfo
-FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Syntax.BlockSeparator]] get_copyInfo()
-FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator],FSharp.Compiler.Text.Range]] baseInfo
-FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator],FSharp.Compiler.Text.Range]] get_baseInfo()
+FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]] copyInfo
+FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]] get_copyInfo()
+FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]],FSharp.Compiler.Text.Range]] baseInfo
+FSharp.Compiler.Syntax.SynExpr+Record: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]],FSharp.Compiler.Text.Range]] get_baseInfo()
 FSharp.Compiler.Syntax.SynExpr+Sequential: Boolean get_isTrueSeq()
 FSharp.Compiler.Syntax.SynExpr+Sequential: Boolean isTrueSeq
 FSharp.Compiler.Syntax.SynExpr+Sequential: FSharp.Compiler.Syntax.DebugPointAtSequential debugPoint
@@ -7774,7 +7739,7 @@ FSharp.Compiler.Syntax.SynExpr: Boolean get_IsWhileBang()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsYieldOrReturn()
 FSharp.Compiler.Syntax.SynExpr: Boolean get_IsYieldOrReturnFrom()
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewAddressOf(Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewAnonRecd(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Syntax.BlockSeparator]], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynLongIdent,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprAnonRecdTrivia)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewAnonRecd(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[System.Tuple`3[FSharp.Compiler.Syntax.SynLongIdent,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range],FSharp.Compiler.Syntax.SynExpr]], FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprAnonRecdTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewApp(FSharp.Compiler.Syntax.ExprAtomicFlag, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewArbitraryAfterError(System.String, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewArrayOrList(Boolean, Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Text.Range)
@@ -7825,7 +7790,7 @@ FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewNull(FSharp.Co
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewObjExpr(FSharp.Compiler.Syntax.SynType, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.Ident]]], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynBinding], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynMemberDefn], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynInterfaceImpl], FSharp.Compiler.Text.Range, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewParen(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewQuote(FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Syntax.SynExpr, Boolean, FSharp.Compiler.Text.Range)
-FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewRecord(Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator],FSharp.Compiler.Text.Range]], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Syntax.BlockSeparator]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField], FSharp.Compiler.Text.Range)
+FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewRecord(Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`5[FSharp.Compiler.Syntax.SynType,FSharp.Compiler.Syntax.SynExpr,FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]],FSharp.Compiler.Text.Range]], Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Syntax.SynExpr,System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]]], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SynExprRecordField], FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewSequential(FSharp.Compiler.Syntax.DebugPointAtSequential, Boolean, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range, FSharp.Compiler.SyntaxTrivia.SynExprSequentialTrivia)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewSequentialOrImplicitYield(FSharp.Compiler.Syntax.DebugPointAtSequential, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
 FSharp.Compiler.Syntax.SynExpr: FSharp.Compiler.Syntax.SynExpr NewSet(FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Syntax.SynExpr, FSharp.Compiler.Text.Range)
@@ -7922,17 +7887,17 @@ FSharp.Compiler.Syntax.SynExpr: Int32 Tag
 FSharp.Compiler.Syntax.SynExpr: Int32 get_Tag()
 FSharp.Compiler.Syntax.SynExpr: System.String ToString()
 FSharp.Compiler.Syntax.SynExprModule: Boolean shouldBeParenthesizedInContext(Microsoft.FSharp.Core.FSharpFunc`2[System.Int32,System.String], Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Syntax.SyntaxNode], FSharp.Compiler.Syntax.SynExpr)
-FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Syntax.SynExprRecordField NewSynExprRecordField(System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator])
+FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Syntax.SynExprRecordField NewSynExprRecordField(System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range], Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr], FSharp.Compiler.Text.Range, Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]])
 FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Text.Range get_range()
 FSharp.Compiler.Syntax.SynExprRecordField: FSharp.Compiler.Text.Range range
 FSharp.Compiler.Syntax.SynExprRecordField: Int32 Tag
 FSharp.Compiler.Syntax.SynExprRecordField: Int32 get_Tag()
-FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator] blockSeparator
-FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.BlockSeparator] get_blockSeparator()
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] expr
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Syntax.SynExpr] get_expr()
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] equalsRange
 FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] get_equalsRange()
+FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] blockSeparator
+FSharp.Compiler.Syntax.SynExprRecordField: Microsoft.FSharp.Core.FSharpOption`1[System.Tuple`2[FSharp.Compiler.Text.Range,Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Position]]] get_blockSeparator()
 FSharp.Compiler.Syntax.SynExprRecordField: System.String ToString()
 FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean] fieldName
 FSharp.Compiler.Syntax.SynExprRecordField: System.Tuple`2[FSharp.Compiler.Syntax.SynLongIdent,System.Boolean] get_fieldName()

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-01.fs.bsl
@@ -26,17 +26,16 @@ ImplFile
               (4,0--4,12));
            Expr
              (AnonRecd
-                (false, Some (Null (5,3--5,7), Offside ((5,7--5,7), None)), [],
+                (false, Some (Null (5,3--5,7), ((5,7--5,7), None)), [],
                  (5,0--5,10), { OpeningBraceRange = (5,0--5,2) }), (5,0--5,10));
            Expr
              (AnonRecd
-                (true, Some (Null (6,10--6,14), Offside ((6,14--6,14), None)),
-                 [], (6,0--6,17), { OpeningBraceRange = (6,7--6,9) }),
-              (6,0--6,17))], PreXmlDocEmpty, [], None, (1,0--6,17),
-          { LeadingKeyword = None })], (true, true),
-      { ConditionalDirectives = []
-        WarnDirectives = []
-        CodeComments = [] }, set []))
+                (true, Some (Null (6,10--6,14), ((6,14--6,14), None)), [],
+                 (6,0--6,17), { OpeningBraceRange = (6,7--6,9) }), (6,0--6,17))],
+          PreXmlDocEmpty, [], None, (1,0--6,17), { LeadingKeyword = None })],
+      (true, true), { ConditionalDirectives = []
+                      WarnDirectives = []
+                      CodeComments = [] }, set []))
 
 (5,3)-(5,7) parse error Field bindings must have the form 'id = expr;'
 (6,10)-(6,14) parse error Field bindings must have the form 'id = expr;'

--- a/tests/service/data/SyntaxTree/Expression/AnonymousRecords-06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/AnonymousRecords-06.fs.bsl
@@ -19,7 +19,7 @@ ImplFile
                      Pats [Named (SynIdent (x, None), false, None, (1,6--1,7))],
                      None, (1,4--1,7)), None,
                   AnonRecd
-                    (false, Some (Ident x, Offside ((1,15--1,19), None)),
+                    (false, Some (Ident x, ((1,15--1,19), None)),
                      [(SynLongIdent ([R; D], [(1,21--1,22)], [None; None]),
                        Some (1,24--1,25),
                        Const (String ("s", Regular, (1,26--1,29)), (1,26--1,29)));

--- a/tests/service/data/SyntaxTree/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/CopySynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
@@ -9,7 +9,7 @@ ImplFile
           false, AnonModule,
           [Expr
              (Record
-                (None, Some (Ident foo, Offside ((2,6--2,10), None)),
+                (None, Some (Ident foo, ((2,6--2,10), None)),
                  [SynExprRecordField
                     ((SynLongIdent ([X], [], [None]), true), Some (4,12--4,13),
                      Some (Const (Int32 12, (5,16--5,18))), (3,8--5,18), None)],

--- a/tests/service/data/SyntaxTree/Expression/InheritRecord - Field 1.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/InheritRecord - Field 1.fs.bsl
@@ -40,11 +40,11 @@ ImplFile
                             (String ("message", Regular, (6,4--6,13)),
                              (6,4--6,13)), (4,4--6,13)), (3,19--3,20),
                        Some (7,2--7,3), (3,19--7,3)), (3,10--7,3),
-                    Some (Offside ((7,4--8,2), None)), (3,2--3,9)), None,
+                    Some ((7,4--8,2), None), (3,2--3,9)), None,
                  [SynExprRecordField
                     ((SynLongIdent ([X], [], [None]), true), Some (8,4--8,5),
                      Some (Const (Int32 42, (8,6--8,8))), (8,2--8,8),
-                     Some (Offside ((8,9--9,2), None)));
+                     Some ((8,9--9,2), None));
                   SynExprRecordField
                     ((SynLongIdent ([Y], [], [None]), true), Some (9,4--9,5),
                      Some

--- a/tests/service/data/SyntaxTree/Expression/InheritRecord - Field 2.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/InheritRecord - Field 2.fs.bsl
@@ -12,19 +12,18 @@ ImplFile
                       (Const
                          (String ("test", Regular, (4,22--4,28)), (4,22--4,28)),
                        (4,21--4,22), Some (4,28--4,29), (4,21--4,29)),
-                    (4,12--4,29), Some (Offside ((4,30--5,4), None)),
-                    (4,4--4,11)), None,
+                    (4,12--4,29), Some ((4,30--5,4), None), (4,4--4,11)), None,
                  [SynExprRecordField
                     ((SynLongIdent ([Field1], [], [None]), true),
                      Some (5,11--5,12), Some (Const (Int32 1, (5,13--5,14))),
-                     (5,4--5,14), Some (Offside ((5,15--6,4), None)));
+                     (5,4--5,14), Some ((5,15--6,4), None));
                   SynExprRecordField
                     ((SynLongIdent ([Field2], [], [None]), true),
                      Some (6,11--6,12),
                      Some
                        (Const
                           (String ("two", Regular, (6,13--6,18)), (6,13--6,18))),
-                     (6,4--6,18), Some (Offside ((6,19--7,4), None)));
+                     (6,4--6,18), Some ((6,19--7,4), None));
                   SynExprRecordField
                     ((SynLongIdent ([Field3], [], [None]), true),
                      Some (7,11--7,12), Some (Const (Double 3.0, (7,13--7,16))),

--- a/tests/service/data/SyntaxTree/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/InheritSynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
@@ -14,12 +14,12 @@ ImplFile
                    (LongIdent (SynLongIdent ([Exception], [], [None])),
                     Paren
                       (Ident msg, (2,19--2,20), Some (2,23--2,24), (2,19--2,24)),
-                    (2,10--2,24), Some (Semicolon ((2,24--2,25), Some (2,25))),
-                    (2,2--2,9)), None,
+                    (2,10--2,24), Some ((2,24--2,25), Some (2,25)), (2,2--2,9)),
+                 None,
                  [SynExprRecordField
                     ((SynLongIdent ([X], [], [None]), true), Some (2,28--2,29),
                      Some (Const (Int32 1, (2,30--2,31))), (2,26--2,31),
-                     Some (Semicolon ((2,31--2,32), Some (2,32))))], (2,0--2,34)),
+                     Some ((2,31--2,32), Some (2,32)))], (2,0--2,34)),
               (2,0--2,34))], PreXmlDocEmpty, [], None, (2,0--2,34),
           { LeadingKeyword = None })], (true, true),
       { ConditionalDirectives = []

--- a/tests/service/data/SyntaxTree/Expression/Record - Anon 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Anon 03.fs.bsl
@@ -6,8 +6,8 @@ ImplFile
          ([Module], false, NamedModule,
           [Expr
              (AnonRecd
-                (false, Some (Ident F, Offside ((3,4--3,4), None)), [],
-                 (3,0--3,7), { OpeningBraceRange = (3,0--3,2) }), (3,0--3,7))],
+                (false, Some (Ident F, ((3,4--3,4), None)), [], (3,0--3,7),
+                 { OpeningBraceRange = (3,0--3,2) }), (3,0--3,7))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--3,7), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
       { ConditionalDirectives = []

--- a/tests/service/data/SyntaxTree/Expression/Record - Anon 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Anon 04.fs.bsl
@@ -10,7 +10,7 @@ ImplFile
                  Some
                    (App
                       (Atomic, false, Ident f, Const (Unit, (3,4--3,6)),
-                       (3,3--3,6)), Offside ((3,6--3,6), None)), [], (3,0--3,9),
+                       (3,3--3,6)), ((3,6--3,6), None)), [], (3,0--3,9),
                  { OpeningBraceRange = (3,0--3,2) }), (3,0--3,9))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--3,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Expression/Record - Anon 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Anon 05.fs.bsl
@@ -12,7 +12,7 @@ ImplFile
                       (App
                          (Atomic, false, Ident f, Const (Unit, (3,4--3,6)),
                           (3,3--3,6)), (3,6--3,7), (3,3--3,7)),
-                    Offside ((3,10--3,10), None)), [], (3,0--3,10),
+                    ((3,10--3,10), None)), [], (3,0--3,10),
                  { OpeningBraceRange = (3,0--3,2) }), (3,0--3,10))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--3,10), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Expression/Record - Anon 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Anon 06.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                          (Atomic, false, Ident f, Const (Unit, (3,4--3,6)),
                           (3,3--3,6)), (3,6--3,7),
                        SynLongIdent ([F], [], [None]), (3,3--3,8)),
-                    Offside ((3,8--3,8), None)), [], (3,0--3,11),
+                    ((3,8--3,8), None)), [], (3,0--3,11),
                  { OpeningBraceRange = (3,0--3,2) }), (3,0--3,11))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--3,11), { LeadingKeyword = Module (1,0--1,6) })], (true, true),

--- a/tests/service/data/SyntaxTree/Expression/Record - Anon 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Anon 12.fs.bsl
@@ -6,8 +6,8 @@ ImplFile
          ([Module], false, NamedModule,
           [Expr
              (AnonRecd
-                (false, Some (Ident F1, Offside ((3,5--3,5), None)), [],
-                 (3,0--3,5), { OpeningBraceRange = (3,0--3,2) }), (3,0--3,5));
+                (false, Some (Ident F1, ((3,5--3,5), None)), [], (3,0--3,5),
+                 { OpeningBraceRange = (3,0--3,2) }), (3,0--3,5));
            Expr
              (App
                 (NonAtomic, false,

--- a/tests/service/data/SyntaxTree/Expression/Record - Field 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Field 08.fs.bsl
@@ -10,7 +10,7 @@ ImplFile
                  [SynExprRecordField
                     ((SynLongIdent ([A], [], [None]), true), Some (3,4--3,5),
                      Some (Const (Int32 1, (3,6--3,7))), (3,2--3,7),
-                     Some (Offside ((3,8--4,2), None)));
+                     Some ((3,8--4,2), None));
                   SynExprRecordField
                     ((SynLongIdent ([B], [(4,3--4,4)], [None]), true), None,
                      None, (4,2--4,4), None)], (3,0--4,6)), (3,0--4,6))],

--- a/tests/service/data/SyntaxTree/Expression/Record - Field 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Field 09.fs.bsl
@@ -10,7 +10,7 @@ ImplFile
                  [SynExprRecordField
                     ((SynLongIdent ([A], [], [None]), true), Some (3,4--3,5),
                      Some (Const (Int32 1, (3,6--3,7))), (3,2--3,7),
-                     Some (Offside ((3,8--4,2), None)));
+                     Some ((3,8--4,2), None));
                   SynExprRecordField
                     ((SynLongIdent ([B], [], [None]), true), None, None,
                      (4,2--4,3), None)], (3,0--4,5)), (3,0--4,5))],

--- a/tests/service/data/SyntaxTree/Expression/Record - Field 13.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Field 13.fs.bsl
@@ -10,7 +10,7 @@ ImplFile
                  [SynExprRecordField
                     ((SynLongIdent ([F1], [], [None]), true), Some (3,5--3,6),
                      Some (Const (Int32 1, (3,7--3,8))), (3,2--3,8),
-                     Some (Offside ((3,9--4,2), None)));
+                     Some ((3,9--4,2), None));
                   SynExprRecordField
                     ((SynLongIdent ([F2], [], [None]), true), Some (4,5--4,6),
                      None, (4,2--4,6), None)], (3,0--4,8)), (3,0--4,8))],

--- a/tests/service/data/SyntaxTree/Expression/Record - Field 14.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Record - Field 14.fs.bsl
@@ -10,7 +10,7 @@ ImplFile
                  [SynExprRecordField
                     ((SynLongIdent ([F1], [], [None]), true), Some (3,5--3,6),
                      Some (Const (Int32 1, (3,7--3,8))), (3,2--3,8),
-                     Some (Offside ((3,9--4,2), None)));
+                     Some ((3,9--4,2), None));
                   SynExprRecordField
                     ((SynLongIdent ([F2], [], [None]), true), Some (4,5--4,6),
                      Some

--- a/tests/service/data/SyntaxTree/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/SynExprRecordContainsTheRangeOfTheEqualsSignInSynExprRecordField.fs.bsl
@@ -12,8 +12,7 @@ ImplFile
                 (None, None,
                  [SynExprRecordField
                     ((SynLongIdent ([V], [], [None]), true), Some (2,4--2,5),
-                     Some (Ident v), (2,2--2,7),
-                     Some (Offside ((2,8--3,2), None)));
+                     Some (Ident v), (2,2--2,7), Some ((2,8--3,2), None));
                   SynExprRecordField
                     ((SynLongIdent ([X], [], [None]), true), Some (3,9--3,10),
                      Some

--- a/tests/service/data/SyntaxTree/Pattern/Named field 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 01.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                           ([NamePatPairField
                               (SynLongIdent ([a], [], [None]), Some (4,6--4,7),
                                (4,4--4,9), Wild (4,8--4,9),
-                               Some (Semicolon ((4,9--4,10), Some (4,10))));
+                               Some ((4,9--4,10), Some (4,10)));
                             NamePatPairField
                               (SynLongIdent ([b], [], [None]), Some (4,13--4,14),
                                (4,11--4,16), Wild (4,15--4,16), None)],

--- a/tests/service/data/SyntaxTree/Pattern/Named field 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 02.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                           ([NamePatPairField
                               (SynLongIdent ([a], [], [None]), Some (4,6--4,7),
                                (4,4--4,9), Wild (4,8--4,9),
-                               Some (Semicolon ((4,9--4,10), Some (4,10))));
+                               Some ((4,9--4,10), Some (4,10)));
                             NamePatPairField
                               (SynLongIdent ([b], [], [None]), Some (4,13--4,14),
                                (4,11--4,14),

--- a/tests/service/data/SyntaxTree/Pattern/Named field 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 03.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                           ([NamePatPairField
                               (SynLongIdent ([a], [], [None]), Some (4,6--4,7),
                                (4,4--4,9), Wild (4,8--4,9),
-                               Some (Semicolon ((4,9--4,10), Some (4,10))));
+                               Some ((4,9--4,10), Some (4,10)));
                             NamePatPairField
                               (SynLongIdent ([b], [], [None]), None,
                                (4,11--4,12),

--- a/tests/service/data/SyntaxTree/Pattern/Named field 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 04.fs.bsl
@@ -13,13 +13,13 @@ ImplFile
                           ([NamePatPairField
                               (SynLongIdent ([a], [], [None]), Some (4,6--4,7),
                                (4,4--4,9), Wild (4,8--4,9),
-                               Some (Semicolon ((4,9--4,10), Some (4,10))))],
-                           (4,4--4,10), { ParenRange = (4,3--4,11) }), None,
-                        (4,2--4,11)), None, Const (Int32 2, (4,15--4,16)),
-                     (4,2--4,16), Yes, { ArrowRange = Some (4,12--4,14)
-                                         BarRange = Some (4,0--4,1) })],
-                 (3,0--4,16), { MatchKeyword = (3,0--3,5)
-                                WithKeyword = (3,8--3,12) }), (3,0--4,16))],
+                               Some ((4,9--4,10), Some (4,10)))], (4,4--4,10),
+                           { ParenRange = (4,3--4,11) }), None, (4,2--4,11)),
+                     None, Const (Int32 2, (4,15--4,16)), (4,2--4,16), Yes,
+                     { ArrowRange = Some (4,12--4,14)
+                       BarRange = Some (4,0--4,1) })], (3,0--4,16),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,8--3,12) }), (3,0--4,16))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--4,16), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
       { ConditionalDirectives = []

--- a/tests/service/data/SyntaxTree/Pattern/Named field 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 05.fs.bsl
@@ -13,7 +13,7 @@ ImplFile
                           ([NamePatPairField
                               (SynLongIdent ([a], [], [None]), Some (4,6--4,7),
                                (4,4--4,9), Wild (4,8--4,9),
-                               Some (Semicolon ((4,9--4,10), Some (4,10))));
+                               Some ((4,9--4,10), Some (4,10)));
                             NamePatPairField
                               (SynLongIdent ([c], [], [None]), Some (4,15--4,16),
                                (4,13--4,18), Wild (4,17--4,18), None)],

--- a/tests/service/data/SyntaxTree/Pattern/Named field 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 06.fs.bsl
@@ -15,13 +15,13 @@ ImplFile
                                (4,4--4,9),
                                Named
                                  (SynIdent (a, None), false, None, (4,8--4,9)),
-                               Some (Semicolon ((4,9--4,10), Some (4,10))));
+                               Some ((4,9--4,10), Some (4,10)));
                             NamePatPairField
                               (SynLongIdent ([b], [], [None]), Some (4,13--4,14),
                                (4,11--4,16),
                                Named
                                  (SynIdent (b, None), false, None, (4,15--4,16)),
-                               Some (Semicolon ((4,16--4,17), Some (4,17))));
+                               Some ((4,16--4,17), Some (4,17)));
                             NamePatPairField
                               (SynLongIdent ([c], [], [None]), Some (4,20--4,21),
                                (4,18--4,23),

--- a/tests/service/data/SyntaxTree/Pattern/Named field 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 07.fs.bsl
@@ -19,11 +19,11 @@ ImplFile
                               ([Foo; Bar; A], [(4,7--4,8); (4,11--4,12)],
                                [None; None; None]), Some (4,14--4,15),
                             (4,4--4,17), Const (Int32 1, (4,16--4,17)),
-                            Some (Semicolon ((4,17--4,18), Some (4,18))));
+                            Some ((4,17--4,18), Some (4,18)));
                          NamePatPairField
                            (SynLongIdent ([B], [], [None]), Some (4,21--4,22),
                             (4,19--4,24), Const (Int32 2, (4,23--4,24)),
-                            Some (Semicolon ((4,24--4,25), Some (4,25))));
+                            Some ((4,24--4,25), Some (4,25)));
                          NamePatPairField
                            (SynLongIdent ([C], [], [None]), Some (4,28--4,29),
                             (4,26--4,31), Const (Int32 3, (4,30--4,31)), None)],

--- a/tests/service/data/SyntaxTree/Pattern/Named field 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Named field 08.fs.bsl
@@ -17,7 +17,7 @@ ImplFile
                        ([NamePatPairField
                            (SynLongIdent ([A], [], [None]), None, (4,4--4,5),
                             FromParseError (Wild (4,5--4,5), (4,5--4,5)),
-                            Some (Semicolon ((4,6--4,7), Some (4,7))));
+                            Some ((4,6--4,7), Some (4,7)));
                          NamePatPairField
                            (SynLongIdent ([B], [], [None]), Some (4,10--4,11),
                             (4,8--4,13), Const (Int32 3, (4,12--4,13)), None)],

--- a/tests/service/data/SyntaxTree/Pattern/Record 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Record 02.fs.bsl
@@ -11,7 +11,7 @@ ImplFile
                        ([NamePatPairField
                            (SynLongIdent ([A], [], [None]), Some (4,6--4,7),
                             (4,4--4,9), Wild (4,8--4,9),
-                            Some (Semicolon ((4,9--4,10), Some (4,10))));
+                            Some ((4,9--4,10), Some (4,10)));
                          NamePatPairField
                            (SynLongIdent ([B], [], [None]), Some (4,13--4,14),
                             (4,11--4,16), Wild (4,15--4,16), None)], (4,2--4,18)),

--- a/tests/service/data/SyntaxTree/Pattern/Record 07.fs.bsl
+++ b/tests/service/data/SyntaxTree/Pattern/Record 07.fs.bsl
@@ -11,11 +11,11 @@ ImplFile
                        ([NamePatPairField
                            (SynLongIdent ([A], [], [None]), Some (4,6--4,7),
                             (4,4--4,9), Const (Int32 1, (4,8--4,9)),
-                            Some (Semicolon ((4,9--4,10), Some (4,10))));
+                            Some ((4,9--4,10), Some (4,10)));
                          NamePatPairField
                            (SynLongIdent ([B], [], [None]), Some (4,13--4,14),
                             (4,11--4,16), Const (Int32 2, (4,15--4,16)),
-                            Some (Semicolon ((4,16--4,17), Some (4,17))));
+                            Some ((4,16--4,17), Some (4,17)));
                          NamePatPairField
                            (SynLongIdent ([C], [], [None]), Some (4,20--4,21),
                             (4,18--4,23), Const (Int32 3, (4,22--4,23)), None)],

--- a/tests/service/data/SyntaxTree/SynType/Typed LetBang AndBang 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Typed LetBang AndBang 03.fs.bsl
@@ -26,8 +26,7 @@ ImplFile
                                         Named
                                           (SynIdent (name, None), false, None,
                                            (4,19--4,23)),
-                                        Some
-                                          (Semicolon ((4,23--4,24), Some (4,24))));
+                                        Some ((4,23--4,24), Some (4,24)));
                                      NamePatPairField
                                        (SynLongIdent ([Age], [], [None]),
                                         Some (4,29--4,30), (4,25--4,34),

--- a/tests/service/data/SyntaxTree/SynType/Typed LetBang AndBang 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Typed LetBang AndBang 04.fs.bsl
@@ -25,8 +25,7 @@ ImplFile
                                      Named
                                        (SynIdent (name, None), false, None,
                                         (4,18--4,22)),
-                                     Some
-                                       (Semicolon ((4,22--4,23), Some (4,23))));
+                                     Some ((4,22--4,23), Some (4,23)));
                                   NamePatPairField
                                     (SynLongIdent ([Age], [], [None]),
                                      Some (4,28--4,29), (4,24--4,33),

--- a/tests/service/data/SyntaxTree/SynType/Typed LetBang AndBang 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/SynType/Typed LetBang AndBang 05.fs.bsl
@@ -26,8 +26,7 @@ ImplFile
                                         Named
                                           (SynIdent (name, None), false, None,
                                            (4,19--4,23)),
-                                        Some
-                                          (Semicolon ((4,23--4,24), Some (4,24))));
+                                        Some ((4,23--4,24), Some (4,24)));
                                      NamePatPairField
                                        (SynLongIdent ([Age], [], [None]),
                                         Some (4,29--4,30), (4,25--4,34),


### PR DESCRIPTION
This reverts commit a276808a77c84e72c66893d9e25019773371a6c6.

# Conflicts:
#	docs/release-notes/.FSharp.Compiler.Service/10.0.100.md

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue, if applicable)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated: