### PR TITLE
Update F# build and package versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,21 +12,13 @@
   <PropertyGroup>
     <!-- Don't use the built in support for pre-release iteration. The nuget repack task doesn't support
          the iteration format at the moment. https://github.com/dotnet/arcade/issues/15919 -->
-    <FSharpPreReleaseIteration>2</FSharpPreReleaseIteration>
-    <PreReleaseVersionLabel>rc$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
-    <!-- These have to be in sync with latest release branch -->
+    <FSharpPreReleaseIteration>1</FSharpPreReleaseIteration>
+    <PreReleaseVersionLabel>alpha$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
     <!-- F# Version components -->
-    <FSMajorVersion>10</FSMajorVersion>
+    <FSMajorVersion>11</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>200</FSBuildVersion>
-<FSharpPreReleaseIteration>1</FSharpPreReleaseIteration>
-<PreReleaseVersionLabel>alpha$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
-<!-- These have to be in sync with latest release branch -->
-<!-- F# Version components -->
-<FSMajorVersion>11</FSMajorVersion>
-<FSMinorVersion>0</FSMinorVersion>
     <FSBuildVersion>0</FSBuildVersion>
-<FSRevisionVersion>0</FSRevisionVersion>
+    <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>


### PR DESCRIPTION
@T-Gro since main is not targeting 18.0 (and 10.0.100) anymore, bump is due, right (to accidentally not mess up nuget versions once 10.0.100 gets published)?
