### PR TITLE
Fix checking nested fields for records

### DIFF
--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fs
@@ -156,12 +156,14 @@ let TransformAstForNestedUpdates (cenv: TcFileState) (env: TcEnv) overallTy (lid
         (accessIds, outerFieldId),
         Some(synExprRecd (recdExprCopyInfo (fields |> List.map fst) withExpr) outerFieldId rest exprBeingAssigned)
 
+let BindIdText = "bind@"
+
 /// When the original expression in copy-and-update is more complex than `{ x with ... }`, like `{ f () with ... }`,
 /// we bind it first, so that it's not evaluated multiple times during a nested update
 let BindOriginalRecdExpr (withExpr: SynExpr * BlockSeparator) mkRecdExpr =
     let originalExpr, blockSep = withExpr
     let mOrigExprSynth = originalExpr.Range.MakeSynthetic()
-    let id = mkSynId mOrigExprSynth "bind@"
+    let id = mkSynId mOrigExprSynth BindIdText
     let withExpr = SynExpr.Ident id, blockSep
 
     let binding =

--- a/src/Compiler/Checking/CheckRecordSyntaxHelpers.fsi
+++ b/src/Compiler/Checking/CheckRecordSyntaxHelpers.fsi
@@ -19,5 +19,7 @@ val TransformAstForNestedUpdates<'a> :
     withExpr: SynExpr * (range * 'a) ->
         (Ident list * Ident) * SynExpr option
 
+val BindIdText: string
+
 val BindOriginalRecdExpr:
     withExpr: SynExpr * BlockSeparator -> mkRecdExpr: ((SynExpr * BlockSeparator) option -> SynExpr) -> SynExpr

--- a/tests/FSharp.Compiler.ComponentTests/Language/CopyAndUpdateTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CopyAndUpdateTests.fs
@@ -480,3 +480,59 @@ if actual <> expected then
     |> withLangVersion80
     |> compileExeAndRun
     |> verifyOutput "once"
+
+[<Fact>]
+let ``N-Nested copy-and-update works when the starting expression is not a simple identifier``() =
+    FSharp """
+module CopyAndUpdateTests
+type SubSubTest = {
+    Z: int
+}
+
+type SubTest = {
+    Y: SubSubTest
+}
+
+type Test = {
+    X: SubTest
+}
+
+let getTest () =
+    { X = { Y = { Z = 0 } } }
+
+[<EntryPoint>]
+let main argv =
+    let a = {
+         getTest () with
+            X.Y.Z = 1 
+    }
+    printfn "%i" a.X.Y.Z |> ignore
+    0
+    """
+    |> withLangVersion80
+    |> typecheck
+    |> shouldSucceed
+    |> verifyOutput "1"
+
+[<Fact>]
+let ``N-Nested, anonymous copy-and-update works when the starting expression is not a simple identifier``() =
+    FSharp """
+module CopyAndUpdateTests
+
+let getTest () =
+    {| X = {| Y = {| Z = 0 |} |} |}
+
+[<EntryPoint>]
+let main argv =
+    let a = 1
+    let a = {|
+         getTest () with
+            X.Y.Z = 1 
+    |}
+    printfn "%i" a.X.Y.Z |> ignore
+    0
+    """
+    |> withLangVersion80
+    |> typecheck
+    |> shouldSucceed
+    |> verifyOutput "1"


### PR DESCRIPTION
Enhance the F# compiler’s type checker to correctly support and validate nested field updates (with depth > 1) for both anonymous and records. Add tests to cover these scenarios, and perform minor refactoring.

Fixes #18940