### PR TITLE
Fix FSharpExpr documentation to reference correct module. issue #17294

### DIFF
--- a/src/Compiler/Symbols/Exprs.fsi
+++ b/src/Compiler/Symbols/Exprs.fsi
@@ -58,7 +58,7 @@ type public FSharpImplementationFileDeclaration =
     | InitAction of action: FSharpExpr
 
 /// Represents a checked and reduced expression, as seen by the F# language.  The active patterns
-/// in 'FSharp.Compiler.SourceCodeServices' can be used to analyze information about the expression.
+/// in 'FSharp.Compiler.Symbols.FSharpExprPatterns' can be used to analyze information about the expression.
 ///
 /// Pattern matching is reduced to decision trees and conditional tests. Some other
 /// constructs may be represented in reduced form.


### PR DESCRIPTION
Fixes issue #17294: Update FSharpExpr documentation to reference FSharp.Compiler.Symbols.FSharpExprPatterns instead of the nonexistent FSharp.Compiler.SourceCodeServices module.

