### PR TITLE
Enable parallel compilation features by default

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.0.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.0.md
@@ -8,4 +8,6 @@
 
 ### Changed
 
+* Parallel compilation stabilised and enabled by default ([PR #18998](https://github.com/dotnet/fsharp/pull/18998))
+
 ### Breaking Changes

--- a/src/Compiler/Driver/CompilerConfig.fs
+++ b/src/Compiler/Driver/CompilerConfig.fs
@@ -805,18 +805,11 @@ type TcConfigBuilder =
             doTLR = false
             doFinalSimplify = false
             optsOn = false
-            optSettings =
-                { OptimizationSettings.Defaults with
-                    processingMode =
-                        if FSharpExperimentalFeaturesEnabledAutomatically then
-                            OptimizationProcessingMode.Parallel
-                        else
-                            OptimizationProcessingMode.Sequential
-                }
+            optSettings = OptimizationSettings.Defaults
             emitTailcalls = true
             deterministic = false
             parallelParsing = true
-            parallelIlxGen = FSharpExperimentalFeaturesEnabledAutomatically
+            parallelIlxGen = true
             emitMetadataAssembly = MetadataAssemblyGeneration.None
             preferredUiLang = None
             lcid = None
@@ -858,15 +851,11 @@ type TcConfigBuilder =
             sdkDirOverride = sdkDirOverride
             xmlDocInfoLoader = None
             exiter = QuitProcessExiter
-            parallelReferenceResolution = ParallelReferenceResolution.Off
+            parallelReferenceResolution = ParallelReferenceResolution.On
             captureIdentifiersWhenParsing = false
             typeCheckingConfig =
                 {
-                    TypeCheckingConfig.Mode =
-                        if FSharpExperimentalFeaturesEnabledAutomatically then
-                            TypeCheckingMode.Graph
-                        else
-                            TypeCheckingMode.Sequential
+                    TypeCheckingConfig.Mode = TypeCheckingMode.Graph
                     DumpGraph = false
                 }
             dumpSignatureData = false

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2341,6 +2341,7 @@ and [<Sealed>] TcImports
             fixupOrphanCcus ()
 
             let! ccuinfos = phase2s |> runMethod
+
             if importsBase.IsSome then
                 importsBase.Value.CcuTable.Values |> Seq.iter addConstraintSources
                 ccuTable.Values |> Seq.iter addConstraintSources

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -1586,8 +1586,10 @@ and [<Sealed>] TcImports
 
 #if !NO_TYPEPROVIDERS
     member private tcImports.AttachDisposeTypeProviderAction action =
-        CheckDisposed()
-        disposeTypeProviderActions.Add action
+        tciLock.AcquireLock(fun tcitok ->
+            CheckDisposed()
+            RequireTcImportsLock(tcitok, disposeTypeProviderActions)
+            disposeTypeProviderActions.Add action)
 #endif
 
     // Note: the returned binary reader is associated with the tcImports, i.e. when the tcImports are closed

--- a/src/Compiler/Driver/CompilerImports.fs
+++ b/src/Compiler/Driver/CompilerImports.fs
@@ -2247,110 +2247,99 @@ and [<Sealed>] TcImports
         phase2
 
     // NOTE: When used in the Language Service this can cause the transitive checking of projects. Hence it must be cancellable.
-    member tcImports.TryRegisterAndPrepareToImportReferencedDll
-        (ctok, r: AssemblyResolution)
-        : Async<(_ * (unit -> AvailableImportedAssembly list)) option> =
-        async {
-            CheckDisposed()
-            let m = r.originalReference.Range
-            let fileName = r.resolvedPath
+    member tcImports.RegisterAndImportReferencedAssemblies(ctok, nms: AssemblyResolution list) =
+        let tryGetAssemblyData (r: AssemblyResolution) =
+            async {
+                CheckDisposed()
+                let m = r.originalReference.Range
+                let fileName = r.resolvedPath
 
-            let! contentsOpt =
-                async {
-                    match r.ProjectReference with
-                    | Some ilb -> return! ilb.EvaluateRawContents()
-                    | None -> return ProjectAssemblyDataResult.Unavailable true
-                }
+                try
 
-            // If we have a project reference but did not get any valid contents,
-            //     just return None and do not attempt to read elsewhere.
-            match contentsOpt with
-            | ProjectAssemblyDataResult.Unavailable false -> return None
-            | _ ->
-
-                let assemblyData =
-                    match contentsOpt with
-                    | ProjectAssemblyDataResult.Available ilb -> ilb
-                    | ProjectAssemblyDataResult.Unavailable _ ->
-                        let ilModule, ilAssemblyRefs = tcImports.OpenILBinaryModule(ctok, fileName, m)
-                        RawFSharpAssemblyDataBackedByFileOnDisk(ilModule, ilAssemblyRefs) :> IRawFSharpAssemblyData
-
-                let ilShortAssemName = assemblyData.ShortAssemblyName
-                let ilScopeRef = assemblyData.ILScopeRef
-
-                if tcImports.IsAlreadyRegistered ilShortAssemName then
-                    let dllinfo = tcImports.FindDllInfo(ctok, m, ilShortAssemName)
-
-                    let phase2 () =
-                        [ tcImports.FindCcuInfo(ctok, m, ilShortAssemName, lookupOnly = true) ]
-
-                    return Some(dllinfo, phase2)
-                else
-                    let dllinfo =
-                        {
-                            RawMetadata = assemblyData
-                            FileName = fileName
-#if !NO_TYPEPROVIDERS
-                            ProviderGeneratedAssembly = None
-                            IsProviderGenerated = false
-                            ProviderGeneratedStaticLinkMap = None
-#endif
-                            ILScopeRef = ilScopeRef
-                            ILAssemblyRefs = assemblyData.ILAssemblyRefs
+                    let! contentsOpt =
+                        async {
+                            match r.ProjectReference with
+                            | Some ilb -> return! ilb.EvaluateRawContents()
+                            | None -> return ProjectAssemblyDataResult.Unavailable true
                         }
 
-                    tcImports.RegisterDll dllinfo
+                    // If we have a project reference but did not get any valid contents,
+                    //     just return None and do not attempt to read elsewhere.
+                    match contentsOpt with
+                    | ProjectAssemblyDataResult.Unavailable false -> return None
+                    | _ ->
 
-                    let phase2 =
-                        if assemblyData.HasAnyFSharpSignatureDataAttribute then
-                            if not assemblyData.HasMatchingFSharpSignatureDataAttribute then
-                                errorR (Error(FSComp.SR.buildDifferentVersionMustRecompile fileName, m))
-                                tcImports.PrepareToImportReferencedILAssembly(ctok, m, fileName, dllinfo)
-                            else
-                                try
-                                    tcImports.PrepareToImportReferencedFSharpAssembly(ctok, m, fileName, dllinfo)
-                                with e ->
-                                    error (Error(FSComp.SR.buildErrorOpeningBinaryFile (fileName, e.Message), m))
-                        else
+                        match contentsOpt with
+                        | ProjectAssemblyDataResult.Available ilb -> return Some(r, ilb)
+                        | ProjectAssemblyDataResult.Unavailable _ ->
+                            let ilModule, ilAssemblyRefs = tcImports.OpenILBinaryModule(ctok, fileName, m)
+                            return Some(r, RawFSharpAssemblyDataBackedByFileOnDisk(ilModule, ilAssemblyRefs))
+
+                with e ->
+                    errorR (Error(FSComp.SR.buildProblemReadingAssembly (fileName, e.Message), m))
+                    return None
+            }
+
+        let registerDll (r: AssemblyResolution, assemblyData: IRawFSharpAssemblyData) =
+            let m = r.originalReference.Range
+            let fileName = r.resolvedPath
+            let ilShortAssemName = assemblyData.ShortAssemblyName
+            let ilScopeRef = assemblyData.ILScopeRef
+
+            if tcImports.IsAlreadyRegistered ilShortAssemName then
+
+                let phase2 () =
+                    [ tcImports.FindCcuInfo(ctok, m, ilShortAssemName, lookupOnly = true) ]
+
+                async { return phase2 () }
+            else
+                let dllinfo =
+                    {
+                        RawMetadata = assemblyData
+                        FileName = fileName
+#if !NO_TYPEPROVIDERS
+                        ProviderGeneratedAssembly = None
+                        IsProviderGenerated = false
+                        ProviderGeneratedStaticLinkMap = None
+#endif
+                        ILScopeRef = ilScopeRef
+                        ILAssemblyRefs = assemblyData.ILAssemblyRefs
+                    }
+
+                tcImports.RegisterDll dllinfo
+
+                let phase2 =
+                    if assemblyData.HasAnyFSharpSignatureDataAttribute then
+                        if not assemblyData.HasMatchingFSharpSignatureDataAttribute then
+                            errorR (Error(FSComp.SR.buildDifferentVersionMustRecompile fileName, m))
                             tcImports.PrepareToImportReferencedILAssembly(ctok, m, fileName, dllinfo)
+                        else
+                            try
+                                tcImports.PrepareToImportReferencedFSharpAssembly(ctok, m, fileName, dllinfo)
+                            with e ->
+                                error (Error(FSComp.SR.buildErrorOpeningBinaryFile (fileName, e.Message), m))
+                    else
+                        tcImports.PrepareToImportReferencedILAssembly(ctok, m, fileName, dllinfo)
 
-                    return Some(dllinfo, phase2)
-        }
+                async { return phase2 () }
 
-    // NOTE: When used in the Language Service this can cause the transitive checking of projects. Hence it must be cancellable.
-    member tcImports.RegisterAndImportReferencedAssemblies(ctok, nms: AssemblyResolution list) =
         async {
             CheckDisposed()
 
-            let tcConfig = tcConfigP.Get ctok
+            let! assemblyData = nms |> List.map tryGetAssemblyData |> MultipleDiagnosticsLoggers.Parallel
 
-            let runMethod =
-                match tcConfig.parallelReferenceResolution with
-                | ParallelReferenceResolution.On -> MultipleDiagnosticsLoggers.Parallel
-                | ParallelReferenceResolution.Off -> MultipleDiagnosticsLoggers.Sequential
+            // Preserve determinicstic order of references, because types from later assemblies may shadow earlier ones.
+            let phase2s = assemblyData |> Seq.choose id |> Seq.map registerDll |> List.ofSeq
 
-            let! results =
-                nms
-                |> List.map (fun nm ->
-                    async {
-                        try
-                            use _ = new CompilationGlobalsScope()
-                            return! tcImports.TryRegisterAndPrepareToImportReferencedDll(ctok, nm)
-                        with e ->
-                            errorR (Error(FSComp.SR.buildProblemReadingAssembly (nm.resolvedPath, e.Message), nm.originalReference.Range))
-                            return None
-                    })
-                |> runMethod
-
-            let _dllinfos, phase2s = results |> Array.choose id |> List.ofArray |> List.unzip
             fixupOrphanCcus ()
-            let ccuinfos = List.collect (fun phase2 -> phase2 ()) phase2s
+
+            let! ccuinfos = phase2s |> MultipleDiagnosticsLoggers.Parallel
 
             if importsBase.IsSome then
                 importsBase.Value.CcuTable.Values |> Seq.iter addConstraintSources
                 ccuTable.Values |> Seq.iter addConstraintSources
 
-            return ccuinfos
+            return ccuinfos |> List.concat
         }
 
     /// Note that implicit loading is not used for compilations from MSBuild, which passes ``--noframework``
@@ -2376,7 +2365,7 @@ and [<Sealed>] TcImports
                     ReportWarnings warns
 
                     tcImports.RegisterAndImportReferencedAssemblies(ctok, res)
-                    |> Async.RunImmediate
+                    |> Async.RunSynchronously
                     |> ignore
 
                     true
@@ -2684,7 +2673,7 @@ let RequireReferences (ctok, tcImports: TcImports, tcEnv, thisAssemblyName, reso
 
     let ccuinfos =
         tcImports.RegisterAndImportReferencedAssemblies(ctok, resolutions)
-        |> Async.RunImmediate
+        |> Async.RunSynchronously
 
     let asms =
         ccuinfos

--- a/src/Compiler/Driver/CompilerOptions.fs
+++ b/src/Compiler/Driver/CompilerOptions.fs
@@ -625,10 +625,12 @@ let callVirtSwitch (tcConfigB: TcConfigBuilder) switch =
 let callParallelCompilationSwitch (tcConfigB: TcConfigBuilder) switch =
     tcConfigB.parallelIlxGen <- switch = OptionSwitch.On
 
-    let (graphCheckingMode, optMode) =
+    let (graphCheckingMode, optMode, parallelReferenceResolution) =
         match switch with
-        | OptionSwitch.On -> TypeCheckingMode.Graph, OptimizationProcessingMode.Parallel
-        | OptionSwitch.Off -> TypeCheckingMode.Sequential, OptimizationProcessingMode.Sequential
+        | OptionSwitch.On -> TypeCheckingMode.Graph, OptimizationProcessingMode.Parallel, ParallelReferenceResolution.On
+        | OptionSwitch.Off -> TypeCheckingMode.Sequential, OptimizationProcessingMode.Sequential, ParallelReferenceResolution.Off
+
+    tcConfigB.parallelReferenceResolution <- parallelReferenceResolution
 
     if tcConfigB.typeCheckingConfig.Mode <> graphCheckingMode then
         tcConfigB.typeCheckingConfig <-

--- a/src/Compiler/Driver/GraphChecking/DependencyResolution.fs
+++ b/src/Compiler/Driver/GraphChecking/DependencyResolution.fs
@@ -237,12 +237,9 @@ let mkGraph (filePairs: FilePairMap) (files: FileInProject array) : Graph<FileIn
                 | Some sigIdx -> Array.singleton sigIdx
 
             let wrongOrderSignature =
-                if file.ParsedInput.IsSigFile then
-                    match filePairs.TryGetWrongOrderSignatureToImplementationIndex file.Idx with
-                    | Some idx -> Array.singleton idx
-                    | None -> Array.empty
-                else
-                    Array.empty
+                match filePairs.TryGetWrongOrderSignatureToImplementationIndex file.Idx with
+                | None -> Array.empty
+                | Some idx -> Array.singleton idx
 
             let allDependencies =
                 [|

--- a/src/Compiler/Driver/GraphChecking/DependencyResolution.fs
+++ b/src/Compiler/Driver/GraphChecking/DependencyResolution.fs
@@ -206,6 +206,7 @@ let mkGraph (filePairs: FilePairMap) (files: FileInProject array) : Graph<FileIn
         if file.Idx = 0 then
             // First file cannot have any dependencies.
             Array.empty
+
         else
             let fileContent = fileContents[file.Idx]
 
@@ -235,20 +236,50 @@ let mkGraph (filePairs: FilePairMap) (files: FileInProject array) : Graph<FileIn
                 | None -> Array.empty
                 | Some sigIdx -> Array.singleton sigIdx
 
+            let wrongOrderSignature =
+                if file.ParsedInput.IsSigFile then
+                    match filePairs.TryGetWrongOrderSignatureToImplementationIndex file.Idx with
+                    | Some idx -> Array.singleton idx
+                    | None -> Array.empty
+                else
+                    Array.empty
+
             let allDependencies =
                 [|
                     yield! depsResult.FoundDependencies
                     yield! ghostDependencies
                     yield! signatureDependency
+                    yield! wrongOrderSignature
                 |]
                 |> Array.distinct
 
             allDependencies
 
-    let graph =
+    // If there is a script in the project, we just process sequentially all the files that may have been added as part of the script closure.
+    // That means all files up to the last script file.
+    let scriptCompilationLength =
         files
+        |> Array.tryFindIndexBack (fun f -> f.IsScript)
+        |> Option.map (fun idx -> idx + 1)
+        |> Option.defaultValue 0
+
+    let sequentialPartForScriptCompilation =
+        files
+        |> Array.take scriptCompilationLength
+        |> Array.map (fun file ->
+            file.Idx,
+            [|
+                if file.Idx > 0 then
+                    file.Idx - 1
+            |])
+
+    let normalPart =
+        files
+        |> Array.skip scriptCompilationLength
         |> Array.Parallel.map (fun file -> file.Idx, findDependencies file)
-        |> readOnlyDict
+
+    let graph =
+        Array.append sequentialPartForScriptCompilation normalPart |> readOnlyDict
 
     let trie = trie |> Array.last |> snd
 

--- a/src/Compiler/Driver/GraphChecking/Types.fs
+++ b/src/Compiler/Driver/GraphChecking/Types.fs
@@ -151,20 +151,25 @@ type internal QueryTrie = LongIdentifier -> QueryTrieNodeResult
 
 /// Helper class to help map signature files to implementation files and vice versa.
 type internal FilePairMap(files: FileInProject array) =
+    let sigFiles = files |> Array.filter _.ParsedInput.IsSigFile
+    let implFiles = files |> Array.filter _.ParsedInput.IsImplFile
+
     let buildBiDirectionalMaps pairs =
         Map.ofArray pairs, Map.ofArray (pairs |> Array.map (fun (a, b) -> (b, a)))
 
-    let implToSig, sigToImpl =
-        files
-        |> Array.choose (fun f ->
-            match f.ParsedInput with
-            | ParsedInput.SigFile _ ->
-                files
-                |> Array.skip (f.Idx + 1)
-                |> Array.tryFind (fun (implFile: FileInProject) -> $"{implFile.FileName}i" = f.FileName)
-                |> Option.map (fun (implFile: FileInProject) -> (implFile.Idx, f.Idx))
-            | ParsedInput.ImplFile _ -> None)
-        |> buildBiDirectionalMaps
+    let pairs =
+        sigFiles
+        |> Array.map (fun sigFile ->
+            implFiles
+            |> Array.tryFind (fun (implFile: FileInProject) -> $"{implFile.FileName}i" = sigFile.FileName)
+            |> Option.map (fun (implFile: FileInProject) -> (sigFile.Idx, implFile.Idx)))
+        |> Array.choose id
+
+    let goodPairs, wrongOrderPairs =
+        pairs |> Array.partition (fun (sigIdx, implIdx) -> sigIdx < implIdx)
+
+    let sigToImpl, implToSig = buildBiDirectionalMaps goodPairs
+    let wrongOrder = wrongOrderPairs |> Map.ofArray
 
     member x.GetSignatureIndex(implementationIndex: FileIndex) = Map.find implementationIndex implToSig
     member x.GetImplementationIndex(signatureIndex: FileIndex) = Map.find signatureIndex sigToImpl
@@ -180,14 +185,7 @@ type internal FilePairMap(files: FileInProject array) =
 
     member x.IsSignature(index: FileIndex) = Map.containsKey index sigToImpl
 
-    member x.TryGetWrongOrderSignatureToImplementationIndex(index: FileIndex) =
-        let input = files[index].ParsedInput
-
-        files
-        |> Array.truncate index
-        |> Array.tryFindIndex (fun f ->
-            f.ParsedInput.IsImplFile
-            && f.ParsedInput.QualifiedName.Text = input.QualifiedName.Text)
+    member x.TryGetWrongOrderSignatureToImplementationIndex(index: FileIndex) = wrongOrder |> Map.tryFind index
 
 /// Callback that returns a previously calculated 'Result and updates 'State accordingly.
 type internal Finisher<'Node, 'State, 'Result> = Finisher of node: 'Node * finisher: ('State -> 'Result * 'State)

--- a/src/Compiler/Driver/GraphChecking/Types.fs
+++ b/src/Compiler/Driver/GraphChecking/Types.fs
@@ -2,6 +2,7 @@
 
 open System.Collections.Immutable
 open FSharp.Compiler.Syntax
+open System
 
 /// The index of a file inside a project.
 type internal FileIndex = int
@@ -157,11 +158,15 @@ type internal FilePairMap(files: FileInProject array) =
     let buildBiDirectionalMaps pairs =
         Map.ofArray pairs, Map.ofArray (pairs |> Array.map (fun (a, b) -> (b, a)))
 
+    let matchFileNames (sigFile: FileInProject) (implFile: FileInProject) =
+        implFile.FileName.Length = sigFile.FileName.Length - 1
+        && sigFile.FileName.StartsWith(implFile.FileName, StringComparison.Ordinal)
+
     let pairs =
         sigFiles
         |> Array.map (fun sigFile ->
             implFiles
-            |> Array.tryFind (fun (implFile: FileInProject) -> $"{implFile.FileName}i" = sigFile.FileName)
+            |> Array.tryFind (matchFileNames sigFile)
             |> Option.map (fun (implFile: FileInProject) -> (sigFile.Idx, implFile.Idx)))
         |> Array.choose id
 

--- a/src/Compiler/Driver/GraphChecking/Types.fs
+++ b/src/Compiler/Driver/GraphChecking/Types.fs
@@ -25,6 +25,11 @@ type internal FileInProject =
         ParsedInput: ParsedInput
     }
 
+    member x.IsScript =
+        match x.ParsedInput with
+        | ParsedInput.ImplFile impl -> impl.IsScript
+        | _ -> false
+
 /// There is a subtle difference between a module and namespace.
 /// A namespace does not necessarily expose a set of dependent files.
 /// Only when the namespace exposes types that could later be inferred.
@@ -174,6 +179,15 @@ type internal FilePairMap(files: FileInProject array) =
             None
 
     member x.IsSignature(index: FileIndex) = Map.containsKey index sigToImpl
+
+    member x.TryGetWrongOrderSignatureToImplementationIndex(index: FileIndex) =
+        let input = files[index].ParsedInput
+
+        files
+        |> Array.truncate index
+        |> Array.tryFindIndex (fun f ->
+            f.ParsedInput.IsImplFile
+            && f.ParsedInput.QualifiedName.Text = input.QualifiedName.Text)
 
 /// Callback that returns a previously calculated 'Result and updates 'State accordingly.
 type internal Finisher<'Node, 'State, 'Result> = Finisher of node: 'Node * finisher: ('State -> 'Result * 'State)

--- a/src/Compiler/Driver/GraphChecking/Types.fsi
+++ b/src/Compiler/Driver/GraphChecking/Types.fsi
@@ -23,6 +23,8 @@ type internal FileInProject =
       FileName: FileName
       ParsedInput: ParsedInput }
 
+    member IsScript: bool
+
 /// There is a subtle difference between a module and namespace.
 /// A namespace does not necessarily expose a set of dependent files.
 /// Only when the namespace exposes types that could later be inferred.
@@ -115,6 +117,7 @@ type internal FilePairMap =
     member HasSignature: implementationIndex: FileIndex -> bool
     member TryGetSignatureIndex: implementationIndex: FileIndex -> FileIndex option
     member IsSignature: index: FileIndex -> bool
+    member TryGetWrongOrderSignatureToImplementationIndex: index: FileIndex -> FileIndex option
 
 /// Callback that returns a previously calculated 'Result and updates 'State accordingly.
 type internal Finisher<'Node, 'State, 'Result> = Finisher of node: 'Node * finisher: ('State -> 'Result * 'State)

--- a/src/Compiler/Driver/OptimizeInputs.fs
+++ b/src/Compiler/Driver/OptimizeInputs.fs
@@ -510,15 +510,14 @@ let ApplyAllOptimizations
     let phases = phases.ToArray()
 
     let results, optEnvFirstLoop =
-        match tcConfig.optSettings.processingMode with
         // Parallel optimization breaks determinism - turn it off in deterministic builds.
-        | Optimizer.OptimizationProcessingMode.Parallel when (not tcConfig.deterministic) ->
+        if tcConfig.deterministic then
+            optimizeFilesSequentially optEnv phases implFiles
+        else
             let results, optEnvFirstPhase =
                 ParallelOptimization.optimizeFilesInParallel optEnv phases implFiles
 
             results |> Array.toList, optEnvFirstPhase
-        | Optimizer.OptimizationProcessingMode.Parallel
-        | Optimizer.OptimizationProcessingMode.Sequential -> optimizeFilesSequentially optEnv phases implFiles
 
 #if DEBUG
     if tcConfig.showOptimizationData then
@@ -578,7 +577,7 @@ let GenerateIlxCode
             isInteractive = tcConfig.isInteractive
             isInteractiveItExpr = isInteractiveItExpr
             alwaysCallVirt = tcConfig.alwaysCallVirt
-            parallelIlxGenEnabled = tcConfig.parallelIlxGen && not tcConfig.deterministic
+            parallelIlxGenEnabled = not tcConfig.deterministic
         }
 
     ilxGenerator.GenerateCode(ilxGenOpts, optimizedImpls, topAttrs.assemblyAttrs, topAttrs.netModuleAttrs)

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1880,11 +1880,8 @@ let CheckMultipleInputsUsingGraphMode
 let CheckClosedInputSet (ctok, checkForErrors, tcConfig: TcConfig, tcImports, tcGlobals, prefixPathOpt, tcState, eagerFormat, inputs) =
     // tcEnvAtEndOfLastFile is the environment required by fsi.exe when incrementally adding definitions
     let results, tcState =
-        if
-            not tcConfig.deterministic
-            && not tcConfig.isInteractive
-            && not tcConfig.compilingFSharpCore
-        then
+        match tcConfig.typeCheckingConfig.Mode with
+        | TypeCheckingMode.Graph when (not tcConfig.isInteractive && not tcConfig.compilingFSharpCore) ->
             CheckMultipleInputsUsingGraphMode(
                 ctok,
                 checkForErrors,
@@ -1896,8 +1893,7 @@ let CheckClosedInputSet (ctok, checkForErrors, tcConfig: TcConfig, tcImports, tc
                 eagerFormat,
                 inputs
             )
-        else
-            CheckMultipleInputsSequential(ctok, checkForErrors, tcConfig, tcImports, tcGlobals, prefixPathOpt, tcState, inputs)
+        | _ -> CheckMultipleInputsSequential(ctok, checkForErrors, tcConfig, tcImports, tcGlobals, prefixPathOpt, tcState, inputs)
 
     let (tcEnvAtEndOfLastFile, topAttrs, implFiles, _), tcState =
         CheckMultipleInputsFinish(results, tcState)

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1881,7 +1881,11 @@ let CheckClosedInputSet (ctok, checkForErrors, tcConfig: TcConfig, tcImports, tc
     // tcEnvAtEndOfLastFile is the environment required by fsi.exe when incrementally adding definitions
     let results, tcState =
         match tcConfig.typeCheckingConfig.Mode with
-        | TypeCheckingMode.Graph when (not tcConfig.isInteractive && not tcConfig.compilingFSharpCore) ->
+        | TypeCheckingMode.Graph when
+            (not tcConfig.isInteractive
+             && not tcConfig.compilingFSharpCore
+             && not tcConfig.deterministic)
+            ->
             CheckMultipleInputsUsingGraphMode(
                 ctok,
                 checkForErrors,

--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -345,7 +345,7 @@ type OptimizationSettings =
           reportFunctionSizes = false
           reportHasEffect = false
           reportTotalSizes = false
-          processingMode = OptimizationProcessingMode.Sequential
+          processingMode = OptimizationProcessingMode.Parallel
         }
 
     /// Determines if JIT optimizations are enabled

--- a/src/FSharp.Build/Fsc.fs
+++ b/src/FSharp.Build/Fsc.fs
@@ -508,7 +508,7 @@ type public Fsc() as this =
         and set (s) = outputRefAssembly <- s
 
     member _.ParallelCompilation
-        with get () = parallelCompilation |> Option.defaultValue false
+        with get () = parallelCompilation |> Option.defaultValue true
         and set (p) = parallelCompilation <- Some p
 
     // --pathmap <string>: Paths to rewrite when producing deterministic builds

--- a/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
+++ b/src/FSharp.Build/Microsoft.FSharp.NetSdk.props
@@ -50,7 +50,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <UseStandardResourceNames Condition=" '$(UseStandardResourceNames)' == '' ">true</UseStandardResourceNames>
     <FsiExec Condition=" '$(FsiExec)' == '' ">true</FsiExec>
     <ReflectionFree Condition=" '$(ReflectionFree)' == '' ">false</ReflectionFree>
-    <ParallelCompilation Condition=" '$(ParallelCompilation)' == '' and '$(LangVersion)' == 'preview' "></ParallelCompilation>                       <!-- Default to parallel compilation for preview language users before it is rolled out to everyone -->
+    <ParallelCompilation Condition=" '$(ParallelCompilation)' == '' ">true</ParallelCompilation>
   </PropertyGroup>
 
   <!-- BinaryFormatter is disabled (warning is treated as error) by default in .NET8+, this mirroring the change in SDK (https://github.com/dotnet/sdk/pull/31591) -->

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.RealInternalSignatureOff.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.RealInternalSignatureOff.il.net472.release.bsl
@@ -29,15 +29,15 @@
 
 
 
-.class public abstract auto ansi sealed Match01
+.class public abstract auto ansi sealed assembly
        extends [runtime]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class abstract auto autochar serializable nested public beforefieldinit Test1
          extends [runtime]System.Object
-         implements class [runtime]System.IEquatable`1<class Match01/Test1>,
+         implements class [runtime]System.IEquatable`1<class assembly/Test1>,
                     [runtime]System.Collections.IStructuralEquatable,
-                    class [runtime]System.IComparable`1<class Match01/Test1>,
+                    class [runtime]System.IComparable`1<class assembly/Test1>,
                     [runtime]System.IComparable,
                     [runtime]System.Collections.IStructuralComparable
   {
@@ -54,7 +54,7 @@
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X11
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                             2B 58 31 31 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -76,10 +76,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.0
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X11::item
+        IL_0009:  stfld      int32 assembly/Test1/X11::item
         IL_000e:  ret
       } 
 
@@ -90,7 +90,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X11::item
+        IL_0001:  ldfld      int32 assembly/Test1/X11::item
         IL_0006:  ret
       } 
 
@@ -101,12 +101,12 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X11::get_Item()
+        .get instance int32 assembly/Test1/X11::get_Item()
       } 
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X12
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                             2B 58 31 32 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -128,10 +128,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.1
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X12::item
+        IL_0009:  stfld      int32 assembly/Test1/X12::item
         IL_000e:  ret
       } 
 
@@ -142,7 +142,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X12::item
+        IL_0001:  ldfld      int32 assembly/Test1/X12::item
         IL_0006:  ret
       } 
 
@@ -153,12 +153,12 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X12::get_Item()
+        .get instance int32 assembly/Test1/X12::get_Item()
       } 
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X13
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                             2B 58 31 33 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -180,10 +180,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.2
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X13::item
+        IL_0009:  stfld      int32 assembly/Test1/X13::item
         IL_000e:  ret
       } 
 
@@ -194,7 +194,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X13::item
+        IL_0001:  ldfld      int32 assembly/Test1/X13::item
         IL_0006:  ret
       } 
 
@@ -205,12 +205,12 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 02 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X13::get_Item()
+        .get instance int32 assembly/Test1/X13::get_Item()
       } 
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X14
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                             2B 58 31 34 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -232,10 +232,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.3
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X14::item
+        IL_0009:  stfld      int32 assembly/Test1/X14::item
         IL_000e:  ret
       } 
 
@@ -246,7 +246,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X14::item
+        IL_0001:  ldfld      int32 assembly/Test1/X14::item
         IL_0006:  ret
       } 
 
@@ -257,18 +257,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 03 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X14::get_Item()
+        .get instance int32 assembly/Test1/X14::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X11@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X11 _obj
+      .field assembly class assembly/Test1/X11 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X11 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X11 obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -281,7 +281,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X11 Match01/Test1/X11@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X11 assembly/Test1/X11@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -292,8 +292,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X11 Match01/Test1/X11@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X11::item
+        IL_0001:  ldfld      class assembly/Test1/X11 assembly/Test1/X11@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X11::item
         IL_000b:  ret
       } 
 
@@ -304,18 +304,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X11@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X11@DebugTypeProxy::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X12@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X12 _obj
+      .field assembly class assembly/Test1/X12 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X12 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X12 obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -328,7 +328,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X12 Match01/Test1/X12@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X12 assembly/Test1/X12@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -339,8 +339,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X12 Match01/Test1/X12@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X12::item
+        IL_0001:  ldfld      class assembly/Test1/X12 assembly/Test1/X12@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X12::item
         IL_000b:  ret
       } 
 
@@ -351,18 +351,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X12@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X12@DebugTypeProxy::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X13@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X13 _obj
+      .field assembly class assembly/Test1/X13 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X13 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X13 obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -375,7 +375,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X13 Match01/Test1/X13@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X13 assembly/Test1/X13@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -386,8 +386,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X13 Match01/Test1/X13@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X13::item
+        IL_0001:  ldfld      class assembly/Test1/X13 assembly/Test1/X13@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X13::item
         IL_000b:  ret
       } 
 
@@ -398,18 +398,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 02 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X13@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X13@DebugTypeProxy::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X14@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X14 _obj
+      .field assembly class assembly/Test1/X14 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X14 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X14 obj) cil managed
       {
         .custom instance void System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -422,7 +422,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X14 Match01/Test1/X14@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X14 assembly/Test1/X14@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -433,8 +433,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X14 Match01/Test1/X14@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X14::item
+        IL_0001:  ldfld      class assembly/Test1/X14 assembly/Test1/X14@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X14::item
         IL_000b:  ret
       } 
 
@@ -445,7 +445,7 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 03 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X14@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X14@DebugTypeProxy::get_Item()
       } 
     } 
 
@@ -466,11 +466,11 @@
       IL_0001:  call       instance void [runtime]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
-      IL_0008:  stfld      int32 Match01/Test1::_tag
+      IL_0008:  stfld      int32 assembly/Test1::_tag
       IL_000d:  ret
     } 
 
-    .method public static class Match01/Test1 NewX11(int32 item) cil managed
+    .method public static class assembly/Test1 NewX11(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -479,7 +479,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X11::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X11::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -490,13 +490,13 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.0
       IL_0007:  ceq
       IL_0009:  ret
     } 
 
-    .method public static class Match01/Test1 NewX12(int32 item) cil managed
+    .method public static class assembly/Test1 NewX12(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 01 00 00 00 00 00 ) 
@@ -505,7 +505,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X12::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X12::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -516,13 +516,13 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.1
       IL_0007:  ceq
       IL_0009:  ret
     } 
 
-    .method public static class Match01/Test1 NewX13(int32 item) cil managed
+    .method public static class assembly/Test1 NewX13(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 02 00 00 00 00 00 ) 
@@ -531,7 +531,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X13::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X13::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -542,13 +542,13 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.2
       IL_0007:  ceq
       IL_0009:  ret
     } 
 
-    .method public static class Match01/Test1 NewX14(int32 item) cil managed
+    .method public static class assembly/Test1 NewX14(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 03 00 00 00 00 00 ) 
@@ -557,7 +557,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X14::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X14::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -568,7 +568,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.3
       IL_0007:  ceq
       IL_0009:  ret
@@ -581,7 +581,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  ldfld      int32 Match01/Test1::_tag
+      IL_0001:  ldfld      int32 assembly/Test1::_tag
       IL_0006:  ret
     } 
 
@@ -592,10 +592,10 @@
       
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
-      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,string>::.ctor(string)
-      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,string>::.ctor(string)
+      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
       IL_000f:  ldarg.0
-      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>::Invoke(!0)
+      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>::Invoke(!0)
       IL_0015:  ret
     } 
 
@@ -605,14 +605,14 @@
       
       .maxstack  8
       IL_0000:  ldstr      "%+A"
-      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class Match01/Test1>::.ctor(string)
-      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class assembly/Test1>::.ctor(string)
+      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
       IL_000f:  ldarg.0
-      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>::Invoke(!0)
+      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>::Invoke(!0)
       IL_0015:  ret
     } 
 
-    .method public hidebysig virtual final instance int32  CompareTo(class Match01/Test1 obj) cil managed
+    .method public hidebysig virtual final instance int32  CompareTo(class assembly/Test1 obj) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
@@ -626,8 +626,8 @@
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  ldnull
-      IL_0009:  call       int32 Match01::CompareTo$cont@4(class Match01/Test1,
-                                                           class Match01/Test1,
+      IL_0009:  call       int32 assembly::CompareTo$cont@4(class assembly/Test1,
+                                                           class assembly/Test1,
                                                            class [FSharp.Core]Microsoft.FSharp.Core.Unit)
       IL_000e:  ret
 
@@ -651,8 +651,8 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
-      IL_0002:  unbox.any  Match01/Test1
-      IL_0007:  callvirt   instance int32 Match01/Test1::CompareTo(class Match01/Test1)
+      IL_0002:  unbox.any  assembly/Test1
+      IL_0007:  callvirt   instance int32 assembly/Test1::CompareTo(class assembly/Test1)
       IL_000c:  ret
     } 
 
@@ -661,9 +661,9 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  6
-      .locals init (class Match01/Test1 V_0)
+      .locals init (class assembly/Test1 V_0)
       IL_0000:  ldarg.1
-      IL_0001:  unbox.any  Match01/Test1
+      IL_0001:  unbox.any  assembly/Test1
       IL_0006:  stloc.0
       IL_0007:  ldarg.0
       IL_0008:  brfalse.s  IL_0014
@@ -672,14 +672,14 @@
       IL_000b:  ldarg.1
       IL_000c:  ldloc.0
       IL_000d:  ldnull
-      IL_000e:  call       int32 Match01::'CompareTo$cont@4-1'(class Match01/Test1,
+      IL_000e:  call       int32 assembly::'CompareTo$cont@4-1'(class assembly/Test1,
                                                                object,
-                                                               class Match01/Test1,
+                                                               class assembly/Test1,
                                                                class [FSharp.Core]Microsoft.FSharp.Core.Unit)
       IL_0013:  ret
 
       IL_0014:  ldarg.1
-      IL_0015:  unbox.any  Match01/Test1
+      IL_0015:  unbox.any  assembly/Test1
       IL_001a:  brfalse.s  IL_001e
 
       IL_001c:  ldc.i4.m1
@@ -695,30 +695,30 @@
       
       .maxstack  7
       .locals init (int32 V_0,
-               class Match01/Test1/X11 V_1,
-               class Match01/Test1/X12 V_2,
-               class Match01/Test1/X13 V_3,
-               class Match01/Test1/X14 V_4)
+               class assembly/Test1/X11 V_1,
+               class assembly/Test1/X12 V_2,
+               class assembly/Test1/X13 V_3,
+               class assembly/Test1/X14 V_4)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_00a5
 
       IL_0006:  ldc.i4.0
       IL_0007:  stloc.0
       IL_0008:  ldarg.0
-      IL_0009:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0009:  call       instance int32 assembly/Test1::get_Tag()
       IL_000e:  switch     ( 
                             IL_0023,
                             IL_0043,
                             IL_0063,
                             IL_0083)
       IL_0023:  ldarg.0
-      IL_0024:  castclass  Match01/Test1/X11
+      IL_0024:  castclass  assembly/Test1/X11
       IL_0029:  stloc.1
       IL_002a:  ldc.i4.0
       IL_002b:  stloc.0
       IL_002c:  ldc.i4     0x9e3779b9
       IL_0031:  ldloc.1
-      IL_0032:  ldfld      int32 Match01/Test1/X11::item
+      IL_0032:  ldfld      int32 assembly/Test1/X11::item
       IL_0037:  ldloc.0
       IL_0038:  ldc.i4.6
       IL_0039:  shl
@@ -733,13 +733,13 @@
       IL_0042:  ret
 
       IL_0043:  ldarg.0
-      IL_0044:  castclass  Match01/Test1/X12
+      IL_0044:  castclass  assembly/Test1/X12
       IL_0049:  stloc.2
       IL_004a:  ldc.i4.1
       IL_004b:  stloc.0
       IL_004c:  ldc.i4     0x9e3779b9
       IL_0051:  ldloc.2
-      IL_0052:  ldfld      int32 Match01/Test1/X12::item
+      IL_0052:  ldfld      int32 assembly/Test1/X12::item
       IL_0057:  ldloc.0
       IL_0058:  ldc.i4.6
       IL_0059:  shl
@@ -754,13 +754,13 @@
       IL_0062:  ret
 
       IL_0063:  ldarg.0
-      IL_0064:  castclass  Match01/Test1/X13
+      IL_0064:  castclass  assembly/Test1/X13
       IL_0069:  stloc.3
       IL_006a:  ldc.i4.2
       IL_006b:  stloc.0
       IL_006c:  ldc.i4     0x9e3779b9
       IL_0071:  ldloc.3
-      IL_0072:  ldfld      int32 Match01/Test1/X13::item
+      IL_0072:  ldfld      int32 assembly/Test1/X13::item
       IL_0077:  ldloc.0
       IL_0078:  ldc.i4.6
       IL_0079:  shl
@@ -775,13 +775,13 @@
       IL_0082:  ret
 
       IL_0083:  ldarg.0
-      IL_0084:  castclass  Match01/Test1/X14
+      IL_0084:  castclass  assembly/Test1/X14
       IL_0089:  stloc.s    V_4
       IL_008b:  ldc.i4.3
       IL_008c:  stloc.0
       IL_008d:  ldc.i4     0x9e3779b9
       IL_0092:  ldloc.s    V_4
-      IL_0094:  ldfld      int32 Match01/Test1/X14::item
+      IL_0094:  ldfld      int32 assembly/Test1/X14::item
       IL_0099:  ldloc.0
       IL_009a:  ldc.i4.6
       IL_009b:  shl
@@ -806,25 +806,25 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  call       class [runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 Match01/Test1::GetHashCode(class [runtime]System.Collections.IEqualityComparer)
+      IL_0006:  callvirt   instance int32 assembly/Test1::GetHashCode(class [runtime]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } 
 
-    .method public hidebysig instance bool Equals(class Match01/Test1 obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
+    .method public hidebysig instance bool Equals(class assembly/Test1 obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  4
       .locals init (int32 V_0,
                int32 V_1,
-               class Match01/Test1/X11 V_2,
-               class Match01/Test1/X11 V_3,
-               class Match01/Test1/X12 V_4,
-               class Match01/Test1/X12 V_5,
-               class Match01/Test1/X13 V_6,
-               class Match01/Test1/X13 V_7,
-               class Match01/Test1/X14 V_8,
-               class Match01/Test1/X14 V_9)
+               class assembly/Test1/X11 V_2,
+               class assembly/Test1/X11 V_3,
+               class assembly/Test1/X12 V_4,
+               class assembly/Test1/X12 V_5,
+               class assembly/Test1/X13 V_6,
+               class assembly/Test1/X13 V_7,
+               class assembly/Test1/X14 V_8,
+               class assembly/Test1/X14 V_9)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_00c0
 
@@ -832,71 +832,71 @@
       IL_0007:  brfalse    IL_00be
 
       IL_000c:  ldarg.0
-      IL_000d:  ldfld      int32 Match01/Test1::_tag
+      IL_000d:  ldfld      int32 assembly/Test1::_tag
       IL_0012:  stloc.0
       IL_0013:  ldarg.1
-      IL_0014:  ldfld      int32 Match01/Test1::_tag
+      IL_0014:  ldfld      int32 assembly/Test1::_tag
       IL_0019:  stloc.1
       IL_001a:  ldloc.0
       IL_001b:  ldloc.1
       IL_001c:  bne.un     IL_00bc
 
       IL_0021:  ldarg.0
-      IL_0022:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0022:  call       instance int32 assembly/Test1::get_Tag()
       IL_0027:  switch     ( 
                             IL_003c,
                             IL_0059,
                             IL_007a,
                             IL_009b)
       IL_003c:  ldarg.0
-      IL_003d:  castclass  Match01/Test1/X11
+      IL_003d:  castclass  assembly/Test1/X11
       IL_0042:  stloc.2
       IL_0043:  ldarg.1
-      IL_0044:  castclass  Match01/Test1/X11
+      IL_0044:  castclass  assembly/Test1/X11
       IL_0049:  stloc.3
       IL_004a:  ldloc.2
-      IL_004b:  ldfld      int32 Match01/Test1/X11::item
+      IL_004b:  ldfld      int32 assembly/Test1/X11::item
       IL_0050:  ldloc.3
-      IL_0051:  ldfld      int32 Match01/Test1/X11::item
+      IL_0051:  ldfld      int32 assembly/Test1/X11::item
       IL_0056:  ceq
       IL_0058:  ret
 
       IL_0059:  ldarg.0
-      IL_005a:  castclass  Match01/Test1/X12
+      IL_005a:  castclass  assembly/Test1/X12
       IL_005f:  stloc.s    V_4
       IL_0061:  ldarg.1
-      IL_0062:  castclass  Match01/Test1/X12
+      IL_0062:  castclass  assembly/Test1/X12
       IL_0067:  stloc.s    V_5
       IL_0069:  ldloc.s    V_4
-      IL_006b:  ldfld      int32 Match01/Test1/X12::item
+      IL_006b:  ldfld      int32 assembly/Test1/X12::item
       IL_0070:  ldloc.s    V_5
-      IL_0072:  ldfld      int32 Match01/Test1/X12::item
+      IL_0072:  ldfld      int32 assembly/Test1/X12::item
       IL_0077:  ceq
       IL_0079:  ret
 
       IL_007a:  ldarg.0
-      IL_007b:  castclass  Match01/Test1/X13
+      IL_007b:  castclass  assembly/Test1/X13
       IL_0080:  stloc.s    V_6
       IL_0082:  ldarg.1
-      IL_0083:  castclass  Match01/Test1/X13
+      IL_0083:  castclass  assembly/Test1/X13
       IL_0088:  stloc.s    V_7
       IL_008a:  ldloc.s    V_6
-      IL_008c:  ldfld      int32 Match01/Test1/X13::item
+      IL_008c:  ldfld      int32 assembly/Test1/X13::item
       IL_0091:  ldloc.s    V_7
-      IL_0093:  ldfld      int32 Match01/Test1/X13::item
+      IL_0093:  ldfld      int32 assembly/Test1/X13::item
       IL_0098:  ceq
       IL_009a:  ret
 
       IL_009b:  ldarg.0
-      IL_009c:  castclass  Match01/Test1/X14
+      IL_009c:  castclass  assembly/Test1/X14
       IL_00a1:  stloc.s    V_8
       IL_00a3:  ldarg.1
-      IL_00a4:  castclass  Match01/Test1/X14
+      IL_00a4:  castclass  assembly/Test1/X14
       IL_00a9:  stloc.s    V_9
       IL_00ab:  ldloc.s    V_8
-      IL_00ad:  ldfld      int32 Match01/Test1/X14::item
+      IL_00ad:  ldfld      int32 assembly/Test1/X14::item
       IL_00b2:  ldloc.s    V_9
-      IL_00b4:  ldfld      int32 Match01/Test1/X14::item
+      IL_00b4:  ldfld      int32 assembly/Test1/X14::item
       IL_00b9:  ceq
       IL_00bb:  ret
 
@@ -919,9 +919,9 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  5
-      .locals init (class Match01/Test1 V_0)
+      .locals init (class assembly/Test1 V_0)
       IL_0000:  ldarg.1
-      IL_0001:  isinst     Match01/Test1
+      IL_0001:  isinst     assembly/Test1
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
       IL_0008:  brfalse.s  IL_0013
@@ -929,7 +929,7 @@
       IL_000a:  ldarg.0
       IL_000b:  ldloc.0
       IL_000c:  ldarg.2
-      IL_000d:  callvirt   instance bool Match01/Test1::Equals(class Match01/Test1,
+      IL_000d:  callvirt   instance bool assembly/Test1::Equals(class assembly/Test1,
                                                                class [runtime]System.Collections.IEqualityComparer)
       IL_0012:  ret
 
@@ -937,21 +937,21 @@
       IL_0014:  ret
     } 
 
-    .method public hidebysig virtual final instance bool  Equals(class Match01/Test1 obj) cil managed
+    .method public hidebysig virtual final instance bool  Equals(class assembly/Test1 obj) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  4
       .locals init (int32 V_0,
                int32 V_1,
-               class Match01/Test1/X11 V_2,
-               class Match01/Test1/X11 V_3,
-               class Match01/Test1/X12 V_4,
-               class Match01/Test1/X12 V_5,
-               class Match01/Test1/X13 V_6,
-               class Match01/Test1/X13 V_7,
-               class Match01/Test1/X14 V_8,
-               class Match01/Test1/X14 V_9)
+               class assembly/Test1/X11 V_2,
+               class assembly/Test1/X11 V_3,
+               class assembly/Test1/X12 V_4,
+               class assembly/Test1/X12 V_5,
+               class assembly/Test1/X13 V_6,
+               class assembly/Test1/X13 V_7,
+               class assembly/Test1/X14 V_8,
+               class assembly/Test1/X14 V_9)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_00c0
 
@@ -959,71 +959,71 @@
       IL_0007:  brfalse    IL_00be
 
       IL_000c:  ldarg.0
-      IL_000d:  ldfld      int32 Match01/Test1::_tag
+      IL_000d:  ldfld      int32 assembly/Test1::_tag
       IL_0012:  stloc.0
       IL_0013:  ldarg.1
-      IL_0014:  ldfld      int32 Match01/Test1::_tag
+      IL_0014:  ldfld      int32 assembly/Test1::_tag
       IL_0019:  stloc.1
       IL_001a:  ldloc.0
       IL_001b:  ldloc.1
       IL_001c:  bne.un     IL_00bc
 
       IL_0021:  ldarg.0
-      IL_0022:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0022:  call       instance int32 assembly/Test1::get_Tag()
       IL_0027:  switch     ( 
                             IL_003c,
                             IL_0059,
                             IL_007a,
                             IL_009b)
       IL_003c:  ldarg.0
-      IL_003d:  castclass  Match01/Test1/X11
+      IL_003d:  castclass  assembly/Test1/X11
       IL_0042:  stloc.2
       IL_0043:  ldarg.1
-      IL_0044:  castclass  Match01/Test1/X11
+      IL_0044:  castclass  assembly/Test1/X11
       IL_0049:  stloc.3
       IL_004a:  ldloc.2
-      IL_004b:  ldfld      int32 Match01/Test1/X11::item
+      IL_004b:  ldfld      int32 assembly/Test1/X11::item
       IL_0050:  ldloc.3
-      IL_0051:  ldfld      int32 Match01/Test1/X11::item
+      IL_0051:  ldfld      int32 assembly/Test1/X11::item
       IL_0056:  ceq
       IL_0058:  ret
 
       IL_0059:  ldarg.0
-      IL_005a:  castclass  Match01/Test1/X12
+      IL_005a:  castclass  assembly/Test1/X12
       IL_005f:  stloc.s    V_4
       IL_0061:  ldarg.1
-      IL_0062:  castclass  Match01/Test1/X12
+      IL_0062:  castclass  assembly/Test1/X12
       IL_0067:  stloc.s    V_5
       IL_0069:  ldloc.s    V_4
-      IL_006b:  ldfld      int32 Match01/Test1/X12::item
+      IL_006b:  ldfld      int32 assembly/Test1/X12::item
       IL_0070:  ldloc.s    V_5
-      IL_0072:  ldfld      int32 Match01/Test1/X12::item
+      IL_0072:  ldfld      int32 assembly/Test1/X12::item
       IL_0077:  ceq
       IL_0079:  ret
 
       IL_007a:  ldarg.0
-      IL_007b:  castclass  Match01/Test1/X13
+      IL_007b:  castclass  assembly/Test1/X13
       IL_0080:  stloc.s    V_6
       IL_0082:  ldarg.1
-      IL_0083:  castclass  Match01/Test1/X13
+      IL_0083:  castclass  assembly/Test1/X13
       IL_0088:  stloc.s    V_7
       IL_008a:  ldloc.s    V_6
-      IL_008c:  ldfld      int32 Match01/Test1/X13::item
+      IL_008c:  ldfld      int32 assembly/Test1/X13::item
       IL_0091:  ldloc.s    V_7
-      IL_0093:  ldfld      int32 Match01/Test1/X13::item
+      IL_0093:  ldfld      int32 assembly/Test1/X13::item
       IL_0098:  ceq
       IL_009a:  ret
 
       IL_009b:  ldarg.0
-      IL_009c:  castclass  Match01/Test1/X14
+      IL_009c:  castclass  assembly/Test1/X14
       IL_00a1:  stloc.s    V_8
       IL_00a3:  ldarg.1
-      IL_00a4:  castclass  Match01/Test1/X14
+      IL_00a4:  castclass  assembly/Test1/X14
       IL_00a9:  stloc.s    V_9
       IL_00ab:  ldloc.s    V_8
-      IL_00ad:  ldfld      int32 Match01/Test1/X14::item
+      IL_00ad:  ldfld      int32 assembly/Test1/X14::item
       IL_00b2:  ldloc.s    V_9
-      IL_00b4:  ldfld      int32 Match01/Test1/X14::item
+      IL_00b4:  ldfld      int32 assembly/Test1/X14::item
       IL_00b9:  ceq
       IL_00bb:  ret
 
@@ -1046,16 +1046,16 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  4
-      .locals init (class Match01/Test1 V_0)
+      .locals init (class assembly/Test1 V_0)
       IL_0000:  ldarg.1
-      IL_0001:  isinst     Match01/Test1
+      IL_0001:  isinst     assembly/Test1
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
       IL_0008:  brfalse.s  IL_0012
 
       IL_000a:  ldarg.0
       IL_000b:  ldloc.0
-      IL_000c:  callvirt   instance bool Match01/Test1::Equals(class Match01/Test1)
+      IL_000c:  callvirt   instance bool assembly/Test1::Equals(class assembly/Test1)
       IL_0011:  ret
 
       IL_0012:  ldc.i4.0
@@ -1067,40 +1067,76 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance int32 Match01/Test1::get_Tag()
+      .get instance int32 assembly/Test1::get_Tag()
     } 
     .property instance bool IsX11()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX11()
+      .get instance bool assembly/Test1::get_IsX11()
     } 
     .property instance bool IsX12()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX12()
+      .get instance bool assembly/Test1::get_IsX12()
     } 
     .property instance bool IsX13()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX13()
+      .get instance bool assembly/Test1::get_IsX13()
     } 
     .property instance bool IsX14()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX14()
+      .get instance bool assembly/Test1::get_IsX14()
     } 
   } 
 
-  .method assembly static int32  CompareTo$cont@4(class Match01/Test1 this,
-                                                  class Match01/Test1 obj,
+  .method public static int32  select1(class assembly/Test1 x) cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  call       instance int32 assembly/Test1::get_Tag()
+    IL_0007:  switch     ( 
+                          IL_001c,
+                          IL_0028,
+                          IL_002a,
+                          IL_002c)
+    IL_001c:  ldarg.0
+    IL_001d:  castclass  assembly/Test1/X11
+    IL_0022:  ldfld      int32 assembly/Test1/X11::item
+    IL_0027:  ret
+
+    IL_0028:  ldc.i4.2
+    IL_0029:  ret
+
+    IL_002a:  ldc.i4.3
+    IL_002b:  ret
+
+    IL_002c:  ldc.i4.4
+    IL_002d:  ret
+  } 
+
+  .method public static int32  fm(class assembly/Test1 y) cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       int32 assembly::select1(class assembly/Test1)
+    IL_0006:  ret
+  } 
+
+  .method assembly static int32  CompareTo$cont@4(class assembly/Test1 this,
+                                                  class assembly/Test1 obj,
                                                   class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -1108,47 +1144,47 @@
     .maxstack  5
     .locals init (int32 V_0,
              int32 V_1,
-             class Match01/Test1/X11 V_2,
-             class Match01/Test1/X11 V_3,
+             class assembly/Test1/X11 V_2,
+             class assembly/Test1/X11 V_3,
              class [runtime]System.Collections.IComparer V_4,
              int32 V_5,
              int32 V_6,
-             class Match01/Test1/X12 V_7,
-             class Match01/Test1/X12 V_8,
-             class Match01/Test1/X13 V_9,
-             class Match01/Test1/X13 V_10,
-             class Match01/Test1/X14 V_11,
-             class Match01/Test1/X14 V_12)
+             class assembly/Test1/X12 V_7,
+             class assembly/Test1/X12 V_8,
+             class assembly/Test1/X13 V_9,
+             class assembly/Test1/X13 V_10,
+             class assembly/Test1/X14 V_11,
+             class assembly/Test1/X14 V_12)
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      int32 Match01/Test1::_tag
+    IL_0001:  ldfld      int32 assembly/Test1::_tag
     IL_0006:  stloc.0
     IL_0007:  ldarg.1
-    IL_0008:  ldfld      int32 Match01/Test1::_tag
+    IL_0008:  ldfld      int32 assembly/Test1::_tag
     IL_000d:  stloc.1
     IL_000e:  ldloc.0
     IL_000f:  ldloc.1
     IL_0010:  bne.un     IL_0108
 
     IL_0015:  ldarg.0
-    IL_0016:  call       instance int32 Match01/Test1::get_Tag()
+    IL_0016:  call       instance int32 assembly/Test1::get_Tag()
     IL_001b:  switch     ( 
                           IL_0030,
                           IL_0063,
                           IL_009a,
                           IL_00d1)
     IL_0030:  ldarg.0
-    IL_0031:  castclass  Match01/Test1/X11
+    IL_0031:  castclass  assembly/Test1/X11
     IL_0036:  stloc.2
     IL_0037:  ldarg.1
-    IL_0038:  castclass  Match01/Test1/X11
+    IL_0038:  castclass  assembly/Test1/X11
     IL_003d:  stloc.3
     IL_003e:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0043:  stloc.s    V_4
     IL_0045:  ldloc.2
-    IL_0046:  ldfld      int32 Match01/Test1/X11::item
+    IL_0046:  ldfld      int32 assembly/Test1/X11::item
     IL_004b:  stloc.s    V_5
     IL_004d:  ldloc.3
-    IL_004e:  ldfld      int32 Match01/Test1/X11::item
+    IL_004e:  ldfld      int32 assembly/Test1/X11::item
     IL_0053:  stloc.s    V_6
     IL_0055:  ldloc.s    V_5
     IL_0057:  ldloc.s    V_6
@@ -1160,18 +1196,18 @@
     IL_0062:  ret
 
     IL_0063:  ldarg.0
-    IL_0064:  castclass  Match01/Test1/X12
+    IL_0064:  castclass  assembly/Test1/X12
     IL_0069:  stloc.s    V_7
     IL_006b:  ldarg.1
-    IL_006c:  castclass  Match01/Test1/X12
+    IL_006c:  castclass  assembly/Test1/X12
     IL_0071:  stloc.s    V_8
     IL_0073:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0078:  stloc.s    V_4
     IL_007a:  ldloc.s    V_7
-    IL_007c:  ldfld      int32 Match01/Test1/X12::item
+    IL_007c:  ldfld      int32 assembly/Test1/X12::item
     IL_0081:  stloc.s    V_5
     IL_0083:  ldloc.s    V_8
-    IL_0085:  ldfld      int32 Match01/Test1/X12::item
+    IL_0085:  ldfld      int32 assembly/Test1/X12::item
     IL_008a:  stloc.s    V_6
     IL_008c:  ldloc.s    V_5
     IL_008e:  ldloc.s    V_6
@@ -1183,18 +1219,18 @@
     IL_0099:  ret
 
     IL_009a:  ldarg.0
-    IL_009b:  castclass  Match01/Test1/X13
+    IL_009b:  castclass  assembly/Test1/X13
     IL_00a0:  stloc.s    V_9
     IL_00a2:  ldarg.1
-    IL_00a3:  castclass  Match01/Test1/X13
+    IL_00a3:  castclass  assembly/Test1/X13
     IL_00a8:  stloc.s    V_10
     IL_00aa:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_00af:  stloc.s    V_4
     IL_00b1:  ldloc.s    V_9
-    IL_00b3:  ldfld      int32 Match01/Test1/X13::item
+    IL_00b3:  ldfld      int32 assembly/Test1/X13::item
     IL_00b8:  stloc.s    V_5
     IL_00ba:  ldloc.s    V_10
-    IL_00bc:  ldfld      int32 Match01/Test1/X13::item
+    IL_00bc:  ldfld      int32 assembly/Test1/X13::item
     IL_00c1:  stloc.s    V_6
     IL_00c3:  ldloc.s    V_5
     IL_00c5:  ldloc.s    V_6
@@ -1206,18 +1242,18 @@
     IL_00d0:  ret
 
     IL_00d1:  ldarg.0
-    IL_00d2:  castclass  Match01/Test1/X14
+    IL_00d2:  castclass  assembly/Test1/X14
     IL_00d7:  stloc.s    V_11
     IL_00d9:  ldarg.1
-    IL_00da:  castclass  Match01/Test1/X14
+    IL_00da:  castclass  assembly/Test1/X14
     IL_00df:  stloc.s    V_12
     IL_00e1:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_00e6:  stloc.s    V_4
     IL_00e8:  ldloc.s    V_11
-    IL_00ea:  ldfld      int32 Match01/Test1/X14::item
+    IL_00ea:  ldfld      int32 assembly/Test1/X14::item
     IL_00ef:  stloc.s    V_5
     IL_00f1:  ldloc.s    V_12
-    IL_00f3:  ldfld      int32 Match01/Test1/X14::item
+    IL_00f3:  ldfld      int32 assembly/Test1/X14::item
     IL_00f8:  stloc.s    V_6
     IL_00fa:  ldloc.s    V_5
     IL_00fc:  ldloc.s    V_6
@@ -1234,9 +1270,9 @@
     IL_010b:  ret
   } 
 
-  .method assembly static int32  'CompareTo$cont@4-1'(class Match01/Test1 this,
+  .method assembly static int32  'CompareTo$cont@4-1'(class assembly/Test1 this,
                                                       object obj,
-                                                      class Match01/Test1 objTemp,
+                                                      class assembly/Test1 objTemp,
                                                       class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -1244,48 +1280,48 @@
     .maxstack  5
     .locals init (int32 V_0,
              int32 V_1,
-             class Match01/Test1/X11 V_2,
-             class Match01/Test1/X11 V_3,
+             class assembly/Test1/X11 V_2,
+             class assembly/Test1/X11 V_3,
              int32 V_4,
              int32 V_5,
-             class Match01/Test1/X12 V_6,
-             class Match01/Test1/X12 V_7,
-             class Match01/Test1/X13 V_8,
-             class Match01/Test1/X13 V_9,
-             class Match01/Test1/X14 V_10,
-             class Match01/Test1/X14 V_11)
+             class assembly/Test1/X12 V_6,
+             class assembly/Test1/X12 V_7,
+             class assembly/Test1/X13 V_8,
+             class assembly/Test1/X13 V_9,
+             class assembly/Test1/X14 V_10,
+             class assembly/Test1/X14 V_11)
     IL_0000:  ldarg.1
-    IL_0001:  unbox.any  Match01/Test1
+    IL_0001:  unbox.any  assembly/Test1
     IL_0006:  brfalse    IL_00fb
 
     IL_000b:  ldarg.0
-    IL_000c:  ldfld      int32 Match01/Test1::_tag
+    IL_000c:  ldfld      int32 assembly/Test1::_tag
     IL_0011:  stloc.0
     IL_0012:  ldarg.2
-    IL_0013:  ldfld      int32 Match01/Test1::_tag
+    IL_0013:  ldfld      int32 assembly/Test1::_tag
     IL_0018:  stloc.1
     IL_0019:  ldloc.0
     IL_001a:  ldloc.1
     IL_001b:  bne.un     IL_00f7
 
     IL_0020:  ldarg.0
-    IL_0021:  call       instance int32 Match01/Test1::get_Tag()
+    IL_0021:  call       instance int32 assembly/Test1::get_Tag()
     IL_0026:  switch     ( 
                           IL_003b,
                           IL_0067,
                           IL_0097,
                           IL_00c7)
     IL_003b:  ldarg.0
-    IL_003c:  castclass  Match01/Test1/X11
+    IL_003c:  castclass  assembly/Test1/X11
     IL_0041:  stloc.2
     IL_0042:  ldarg.2
-    IL_0043:  castclass  Match01/Test1/X11
+    IL_0043:  castclass  assembly/Test1/X11
     IL_0048:  stloc.3
     IL_0049:  ldloc.2
-    IL_004a:  ldfld      int32 Match01/Test1/X11::item
+    IL_004a:  ldfld      int32 assembly/Test1/X11::item
     IL_004f:  stloc.s    V_4
     IL_0051:  ldloc.3
-    IL_0052:  ldfld      int32 Match01/Test1/X11::item
+    IL_0052:  ldfld      int32 assembly/Test1/X11::item
     IL_0057:  stloc.s    V_5
     IL_0059:  ldloc.s    V_4
     IL_005b:  ldloc.s    V_5
@@ -1297,16 +1333,16 @@
     IL_0066:  ret
 
     IL_0067:  ldarg.0
-    IL_0068:  castclass  Match01/Test1/X12
+    IL_0068:  castclass  assembly/Test1/X12
     IL_006d:  stloc.s    V_6
     IL_006f:  ldarg.2
-    IL_0070:  castclass  Match01/Test1/X12
+    IL_0070:  castclass  assembly/Test1/X12
     IL_0075:  stloc.s    V_7
     IL_0077:  ldloc.s    V_6
-    IL_0079:  ldfld      int32 Match01/Test1/X12::item
+    IL_0079:  ldfld      int32 assembly/Test1/X12::item
     IL_007e:  stloc.s    V_4
     IL_0080:  ldloc.s    V_7
-    IL_0082:  ldfld      int32 Match01/Test1/X12::item
+    IL_0082:  ldfld      int32 assembly/Test1/X12::item
     IL_0087:  stloc.s    V_5
     IL_0089:  ldloc.s    V_4
     IL_008b:  ldloc.s    V_5
@@ -1318,16 +1354,16 @@
     IL_0096:  ret
 
     IL_0097:  ldarg.0
-    IL_0098:  castclass  Match01/Test1/X13
+    IL_0098:  castclass  assembly/Test1/X13
     IL_009d:  stloc.s    V_8
     IL_009f:  ldarg.2
-    IL_00a0:  castclass  Match01/Test1/X13
+    IL_00a0:  castclass  assembly/Test1/X13
     IL_00a5:  stloc.s    V_9
     IL_00a7:  ldloc.s    V_8
-    IL_00a9:  ldfld      int32 Match01/Test1/X13::item
+    IL_00a9:  ldfld      int32 assembly/Test1/X13::item
     IL_00ae:  stloc.s    V_4
     IL_00b0:  ldloc.s    V_9
-    IL_00b2:  ldfld      int32 Match01/Test1/X13::item
+    IL_00b2:  ldfld      int32 assembly/Test1/X13::item
     IL_00b7:  stloc.s    V_5
     IL_00b9:  ldloc.s    V_4
     IL_00bb:  ldloc.s    V_5
@@ -1339,16 +1375,16 @@
     IL_00c6:  ret
 
     IL_00c7:  ldarg.0
-    IL_00c8:  castclass  Match01/Test1/X14
+    IL_00c8:  castclass  assembly/Test1/X14
     IL_00cd:  stloc.s    V_10
     IL_00cf:  ldarg.2
-    IL_00d0:  castclass  Match01/Test1/X14
+    IL_00d0:  castclass  assembly/Test1/X14
     IL_00d5:  stloc.s    V_11
     IL_00d7:  ldloc.s    V_10
-    IL_00d9:  ldfld      int32 Match01/Test1/X14::item
+    IL_00d9:  ldfld      int32 assembly/Test1/X14::item
     IL_00de:  stloc.s    V_4
     IL_00e0:  ldloc.s    V_11
-    IL_00e2:  ldfld      int32 Match01/Test1/X14::item
+    IL_00e2:  ldfld      int32 assembly/Test1/X14::item
     IL_00e7:  stloc.s    V_5
     IL_00e9:  ldloc.s    V_4
     IL_00eb:  ldloc.s    V_5
@@ -1368,45 +1404,9 @@
     IL_00fc:  ret
   } 
 
-  .method public static int32  select1(class Match01/Test1 x) cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  nop
-    IL_0001:  ldarg.0
-    IL_0002:  call       instance int32 Match01/Test1::get_Tag()
-    IL_0007:  switch     ( 
-                          IL_001c,
-                          IL_0028,
-                          IL_002a,
-                          IL_002c)
-    IL_001c:  ldarg.0
-    IL_001d:  castclass  Match01/Test1/X11
-    IL_0022:  ldfld      int32 Match01/Test1/X11::item
-    IL_0027:  ret
-
-    IL_0028:  ldc.i4.2
-    IL_0029:  ret
-
-    IL_002a:  ldc.i4.3
-    IL_002b:  ret
-
-    IL_002c:  ldc.i4.4
-    IL_002d:  ret
-  } 
-
-  .method public static int32  fm(class Match01/Test1 y) cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  call       int32 Match01::select1(class Match01/Test1)
-    IL_0006:  ret
-  } 
-
 } 
 
-.class private abstract auto ansi sealed '<StartupCode$assembly>'.$Match01
+.class private abstract auto ansi sealed '<StartupCode$assembly>'.$assembly
        extends [runtime]System.Object
 {
   .method public static void  main@() cil managed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.RealInternalSignatureOff.il.netcore.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/Match01.fs.RealInternalSignatureOff.il.netcore.release.bsl
@@ -29,15 +29,15 @@
 
 
 
-.class public abstract auto ansi sealed Match01
+.class public abstract auto ansi sealed assembly
        extends [runtime]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
   .class abstract auto autochar serializable nested public beforefieldinit Test1
          extends [runtime]System.Object
-         implements class [runtime]System.IEquatable`1<class Match01/Test1>,
+         implements class [runtime]System.IEquatable`1<class assembly/Test1>,
                     [runtime]System.Collections.IStructuralEquatable,
-                    class [runtime]System.IComparable`1<class Match01/Test1>,
+                    class [runtime]System.IComparable`1<class assembly/Test1>,
                     [runtime]System.IComparable,
                     [runtime]System.Collections.IStructuralComparable
   {
@@ -54,7 +54,7 @@
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X11
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                                         2B 58 31 31 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -76,10 +76,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.0
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X11::item
+        IL_0009:  stfld      int32 assembly/Test1/X11::item
         IL_000e:  ret
       } 
 
@@ -90,7 +90,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X11::item
+        IL_0001:  ldfld      int32 assembly/Test1/X11::item
         IL_0006:  ret
       } 
 
@@ -101,12 +101,12 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X11::get_Item()
+        .get instance int32 assembly/Test1/X11::get_Item()
       } 
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X12
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                                         2B 58 31 32 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -128,10 +128,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.1
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X12::item
+        IL_0009:  stfld      int32 assembly/Test1/X12::item
         IL_000e:  ret
       } 
 
@@ -142,7 +142,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X12::item
+        IL_0001:  ldfld      int32 assembly/Test1/X12::item
         IL_0006:  ret
       } 
 
@@ -153,12 +153,12 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X12::get_Item()
+        .get instance int32 assembly/Test1/X12::get_Item()
       } 
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X13
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                                         2B 58 31 33 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -180,10 +180,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.2
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X13::item
+        IL_0009:  stfld      int32 assembly/Test1/X13::item
         IL_000e:  ret
       } 
 
@@ -194,7 +194,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X13::item
+        IL_0001:  ldfld      int32 assembly/Test1/X13::item
         IL_0006:  ret
       } 
 
@@ -205,12 +205,12 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 02 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X13::get_Item()
+        .get instance int32 assembly/Test1/X13::get_Item()
       } 
     } 
 
     .class auto ansi serializable nested public beforefieldinit specialname X14
-           extends Match01/Test1
+           extends assembly/Test1
     {
       .custom instance void [runtime]System.Diagnostics.DebuggerTypeProxyAttribute::.ctor(class [runtime]System.Type) = ( 01 00 20 4D 61 74 63 68 30 31 2B 54 65 73 74 31   
                                                                                                                                         2B 58 31 34 40 44 65 62 75 67 54 79 70 65 50 72   
@@ -232,10 +232,10 @@
         .maxstack  8
         IL_0000:  ldarg.0
         IL_0001:  ldc.i4.3
-        IL_0002:  call       instance void Match01/Test1::.ctor(int32)
+        IL_0002:  call       instance void assembly/Test1::.ctor(int32)
         IL_0007:  ldarg.0
         IL_0008:  ldarg.1
-        IL_0009:  stfld      int32 Match01/Test1/X14::item
+        IL_0009:  stfld      int32 assembly/Test1/X14::item
         IL_000e:  ret
       } 
 
@@ -246,7 +246,7 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      int32 Match01/Test1/X14::item
+        IL_0001:  ldfld      int32 assembly/Test1/X14::item
         IL_0006:  ret
       } 
 
@@ -257,18 +257,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 03 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X14::get_Item()
+        .get instance int32 assembly/Test1/X14::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X11@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X11 _obj
+      .field assembly class assembly/Test1/X11 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X11 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X11 obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -281,7 +281,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X11 Match01/Test1/X11@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X11 assembly/Test1/X11@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -292,8 +292,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X11 Match01/Test1/X11@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X11::item
+        IL_0001:  ldfld      class assembly/Test1/X11 assembly/Test1/X11@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X11::item
         IL_000b:  ret
       } 
 
@@ -304,18 +304,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X11@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X11@DebugTypeProxy::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X12@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X12 _obj
+      .field assembly class assembly/Test1/X12 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X12 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X12 obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -328,7 +328,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X12 Match01/Test1/X12@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X12 assembly/Test1/X12@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -339,8 +339,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X12 Match01/Test1/X12@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X12::item
+        IL_0001:  ldfld      class assembly/Test1/X12 assembly/Test1/X12@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X12::item
         IL_000b:  ret
       } 
 
@@ -351,18 +351,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 01 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X12@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X12@DebugTypeProxy::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X13@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X13 _obj
+      .field assembly class assembly/Test1/X13 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X13 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X13 obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -375,7 +375,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X13 Match01/Test1/X13@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X13 assembly/Test1/X13@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -386,8 +386,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X13 Match01/Test1/X13@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X13::item
+        IL_0001:  ldfld      class assembly/Test1/X13 assembly/Test1/X13@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X13::item
         IL_000b:  ret
       } 
 
@@ -398,18 +398,18 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 02 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X13@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X13@DebugTypeProxy::get_Item()
       } 
     } 
 
     .class auto ansi nested assembly beforefieldinit specialname X14@DebugTypeProxy
            extends [runtime]System.Object
     {
-      .field assembly class Match01/Test1/X14 _obj
+      .field assembly class assembly/Test1/X14 _obj
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      .method public specialname rtspecialname instance void  .ctor(class Match01/Test1/X14 obj) cil managed
+      .method public specialname rtspecialname instance void  .ctor(class assembly/Test1/X14 obj) cil managed
       {
         .custom instance void [runtime]System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute::.ctor(valuetype [runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes,
                                                                                                                 class [runtime]System.Type) = ( 01 00 60 06 00 00 0D 4D 61 74 63 68 30 31 2B 54   
@@ -422,7 +422,7 @@
         IL_0001:  call       instance void [runtime]System.Object::.ctor()
         IL_0006:  ldarg.0
         IL_0007:  ldarg.1
-        IL_0008:  stfld      class Match01/Test1/X14 Match01/Test1/X14@DebugTypeProxy::_obj
+        IL_0008:  stfld      class assembly/Test1/X14 assembly/Test1/X14@DebugTypeProxy::_obj
         IL_000d:  ret
       } 
 
@@ -433,8 +433,8 @@
         
         .maxstack  8
         IL_0000:  ldarg.0
-        IL_0001:  ldfld      class Match01/Test1/X14 Match01/Test1/X14@DebugTypeProxy::_obj
-        IL_0006:  ldfld      int32 Match01/Test1/X14::item
+        IL_0001:  ldfld      class assembly/Test1/X14 assembly/Test1/X14@DebugTypeProxy::_obj
+        IL_0006:  ldfld      int32 assembly/Test1/X14::item
         IL_000b:  ret
       } 
 
@@ -445,7 +445,7 @@
                                                                                                     int32) = ( 01 00 04 00 00 00 03 00 00 00 00 00 00 00 00 00 ) 
         .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
         .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-        .get instance int32 Match01/Test1/X14@DebugTypeProxy::get_Item()
+        .get instance int32 assembly/Test1/X14@DebugTypeProxy::get_Item()
       } 
     } 
 
@@ -466,11 +466,11 @@
       IL_0001:  call       instance void [runtime]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
-      IL_0008:  stfld      int32 Match01/Test1::_tag
+      IL_0008:  stfld      int32 assembly/Test1::_tag
       IL_000d:  ret
     } 
 
-    .method public static class Match01/Test1 NewX11(int32 item) cil managed
+    .method public static class assembly/Test1 NewX11(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 00 00 00 00 00 00 ) 
@@ -479,7 +479,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X11::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X11::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -490,13 +490,13 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.0
       IL_0007:  ceq
       IL_0009:  ret
     } 
 
-    .method public static class Match01/Test1 NewX12(int32 item) cil managed
+    .method public static class assembly/Test1 NewX12(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 01 00 00 00 00 00 ) 
@@ -505,7 +505,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X12::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X12::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -516,13 +516,13 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.1
       IL_0007:  ceq
       IL_0009:  ret
     } 
 
-    .method public static class Match01/Test1 NewX13(int32 item) cil managed
+    .method public static class assembly/Test1 NewX13(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 02 00 00 00 00 00 ) 
@@ -531,7 +531,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X13::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X13::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -542,13 +542,13 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.2
       IL_0007:  ceq
       IL_0009:  ret
     } 
 
-    .method public static class Match01/Test1 NewX14(int32 item) cil managed
+    .method public static class assembly/Test1 NewX14(int32 item) cil managed
     {
       .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags,
                                                                                                   int32) = ( 01 00 08 00 00 00 03 00 00 00 00 00 ) 
@@ -557,7 +557,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  newobj     instance void Match01/Test1/X14::.ctor(int32)
+      IL_0001:  newobj     instance void assembly/Test1/X14::.ctor(int32)
       IL_0006:  ret
     } 
 
@@ -568,7 +568,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0001:  call       instance int32 assembly/Test1::get_Tag()
       IL_0006:  ldc.i4.3
       IL_0007:  ceq
       IL_0009:  ret
@@ -581,7 +581,7 @@
       
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  ldfld      int32 Match01/Test1::_tag
+      IL_0001:  ldfld      int32 assembly/Test1::_tag
       IL_0006:  ret
     } 
 
@@ -592,10 +592,10 @@
       
       .maxstack  8
       IL_0000:  ldstr      "%+0.8A"
-      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,string>::.ctor(string)
-      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,string>::.ctor(string)
+      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
       IL_000f:  ldarg.0
-      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>::Invoke(!0)
+      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>::Invoke(!0)
       IL_0015:  ret
     } 
 
@@ -605,14 +605,14 @@
       
       .maxstack  8
       IL_0000:  ldstr      "%+A"
-      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class Match01/Test1>::.ctor(string)
-      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
+      IL_0005:  newobj     instance void class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`5<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string,class assembly/Test1>::.ctor(string)
+      IL_000a:  call       !!0 [FSharp.Core]Microsoft.FSharp.Core.ExtraTopLevelOperators::PrintFormatToString<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>>(class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [FSharp.Core]Microsoft.FSharp.Core.Unit,string,string>)
       IL_000f:  ldarg.0
-      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class Match01/Test1,string>::Invoke(!0)
+      IL_0010:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class assembly/Test1,string>::Invoke(!0)
       IL_0015:  ret
     } 
 
-    .method public hidebysig virtual final instance int32  CompareTo(class Match01/Test1 obj) cil managed
+    .method public hidebysig virtual final instance int32  CompareTo(class assembly/Test1 obj) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
@@ -626,8 +626,8 @@
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
       IL_0008:  ldnull
-      IL_0009:  call       int32 Match01::CompareTo$cont@4(class Match01/Test1,
-                                                           class Match01/Test1,
+      IL_0009:  call       int32 assembly::CompareTo$cont@4(class assembly/Test1,
+                                                           class assembly/Test1,
                                                            class [FSharp.Core]Microsoft.FSharp.Core.Unit)
       IL_000e:  ret
 
@@ -651,8 +651,8 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldarg.1
-      IL_0002:  unbox.any  Match01/Test1
-      IL_0007:  callvirt   instance int32 Match01/Test1::CompareTo(class Match01/Test1)
+      IL_0002:  unbox.any  assembly/Test1
+      IL_0007:  callvirt   instance int32 assembly/Test1::CompareTo(class assembly/Test1)
       IL_000c:  ret
     } 
 
@@ -661,9 +661,9 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  6
-      .locals init (class Match01/Test1 V_0)
+      .locals init (class assembly/Test1 V_0)
       IL_0000:  ldarg.1
-      IL_0001:  unbox.any  Match01/Test1
+      IL_0001:  unbox.any  assembly/Test1
       IL_0006:  stloc.0
       IL_0007:  ldarg.0
       IL_0008:  brfalse.s  IL_0014
@@ -672,14 +672,14 @@
       IL_000b:  ldarg.1
       IL_000c:  ldloc.0
       IL_000d:  ldnull
-      IL_000e:  call       int32 Match01::'CompareTo$cont@4-1'(class Match01/Test1,
+      IL_000e:  call       int32 assembly::'CompareTo$cont@4-1'(class assembly/Test1,
                                                                object,
-                                                               class Match01/Test1,
+                                                               class assembly/Test1,
                                                                class [FSharp.Core]Microsoft.FSharp.Core.Unit)
       IL_0013:  ret
 
       IL_0014:  ldarg.1
-      IL_0015:  unbox.any  Match01/Test1
+      IL_0015:  unbox.any  assembly/Test1
       IL_001a:  brfalse.s  IL_001e
 
       IL_001c:  ldc.i4.m1
@@ -695,30 +695,30 @@
       
       .maxstack  7
       .locals init (int32 V_0,
-               class Match01/Test1/X11 V_1,
-               class Match01/Test1/X12 V_2,
-               class Match01/Test1/X13 V_3,
-               class Match01/Test1/X14 V_4)
+               class assembly/Test1/X11 V_1,
+               class assembly/Test1/X12 V_2,
+               class assembly/Test1/X13 V_3,
+               class assembly/Test1/X14 V_4)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_00a5
 
       IL_0006:  ldc.i4.0
       IL_0007:  stloc.0
       IL_0008:  ldarg.0
-      IL_0009:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0009:  call       instance int32 assembly/Test1::get_Tag()
       IL_000e:  switch     ( 
                             IL_0023,
                             IL_0043,
                             IL_0063,
                             IL_0083)
       IL_0023:  ldarg.0
-      IL_0024:  castclass  Match01/Test1/X11
+      IL_0024:  castclass  assembly/Test1/X11
       IL_0029:  stloc.1
       IL_002a:  ldc.i4.0
       IL_002b:  stloc.0
       IL_002c:  ldc.i4     0x9e3779b9
       IL_0031:  ldloc.1
-      IL_0032:  ldfld      int32 Match01/Test1/X11::item
+      IL_0032:  ldfld      int32 assembly/Test1/X11::item
       IL_0037:  ldloc.0
       IL_0038:  ldc.i4.6
       IL_0039:  shl
@@ -733,13 +733,13 @@
       IL_0042:  ret
 
       IL_0043:  ldarg.0
-      IL_0044:  castclass  Match01/Test1/X12
+      IL_0044:  castclass  assembly/Test1/X12
       IL_0049:  stloc.2
       IL_004a:  ldc.i4.1
       IL_004b:  stloc.0
       IL_004c:  ldc.i4     0x9e3779b9
       IL_0051:  ldloc.2
-      IL_0052:  ldfld      int32 Match01/Test1/X12::item
+      IL_0052:  ldfld      int32 assembly/Test1/X12::item
       IL_0057:  ldloc.0
       IL_0058:  ldc.i4.6
       IL_0059:  shl
@@ -754,13 +754,13 @@
       IL_0062:  ret
 
       IL_0063:  ldarg.0
-      IL_0064:  castclass  Match01/Test1/X13
+      IL_0064:  castclass  assembly/Test1/X13
       IL_0069:  stloc.3
       IL_006a:  ldc.i4.2
       IL_006b:  stloc.0
       IL_006c:  ldc.i4     0x9e3779b9
       IL_0071:  ldloc.3
-      IL_0072:  ldfld      int32 Match01/Test1/X13::item
+      IL_0072:  ldfld      int32 assembly/Test1/X13::item
       IL_0077:  ldloc.0
       IL_0078:  ldc.i4.6
       IL_0079:  shl
@@ -775,13 +775,13 @@
       IL_0082:  ret
 
       IL_0083:  ldarg.0
-      IL_0084:  castclass  Match01/Test1/X14
+      IL_0084:  castclass  assembly/Test1/X14
       IL_0089:  stloc.s    V_4
       IL_008b:  ldc.i4.3
       IL_008c:  stloc.0
       IL_008d:  ldc.i4     0x9e3779b9
       IL_0092:  ldloc.s    V_4
-      IL_0094:  ldfld      int32 Match01/Test1/X14::item
+      IL_0094:  ldfld      int32 assembly/Test1/X14::item
       IL_0099:  ldloc.0
       IL_009a:  ldc.i4.6
       IL_009b:  shl
@@ -806,25 +806,25 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  call       class [runtime]System.Collections.IEqualityComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericEqualityComparer()
-      IL_0006:  callvirt   instance int32 Match01/Test1::GetHashCode(class [runtime]System.Collections.IEqualityComparer)
+      IL_0006:  callvirt   instance int32 assembly/Test1::GetHashCode(class [runtime]System.Collections.IEqualityComparer)
       IL_000b:  ret
     } 
 
-    .method public hidebysig instance bool Equals(class Match01/Test1 obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
+    .method public hidebysig instance bool Equals(class assembly/Test1 obj, class [runtime]System.Collections.IEqualityComparer comp) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  4
       .locals init (int32 V_0,
                int32 V_1,
-               class Match01/Test1/X11 V_2,
-               class Match01/Test1/X11 V_3,
-               class Match01/Test1/X12 V_4,
-               class Match01/Test1/X12 V_5,
-               class Match01/Test1/X13 V_6,
-               class Match01/Test1/X13 V_7,
-               class Match01/Test1/X14 V_8,
-               class Match01/Test1/X14 V_9)
+               class assembly/Test1/X11 V_2,
+               class assembly/Test1/X11 V_3,
+               class assembly/Test1/X12 V_4,
+               class assembly/Test1/X12 V_5,
+               class assembly/Test1/X13 V_6,
+               class assembly/Test1/X13 V_7,
+               class assembly/Test1/X14 V_8,
+               class assembly/Test1/X14 V_9)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_00c0
 
@@ -832,71 +832,71 @@
       IL_0007:  brfalse    IL_00be
 
       IL_000c:  ldarg.0
-      IL_000d:  ldfld      int32 Match01/Test1::_tag
+      IL_000d:  ldfld      int32 assembly/Test1::_tag
       IL_0012:  stloc.0
       IL_0013:  ldarg.1
-      IL_0014:  ldfld      int32 Match01/Test1::_tag
+      IL_0014:  ldfld      int32 assembly/Test1::_tag
       IL_0019:  stloc.1
       IL_001a:  ldloc.0
       IL_001b:  ldloc.1
       IL_001c:  bne.un     IL_00bc
 
       IL_0021:  ldarg.0
-      IL_0022:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0022:  call       instance int32 assembly/Test1::get_Tag()
       IL_0027:  switch     ( 
                             IL_003c,
                             IL_0059,
                             IL_007a,
                             IL_009b)
       IL_003c:  ldarg.0
-      IL_003d:  castclass  Match01/Test1/X11
+      IL_003d:  castclass  assembly/Test1/X11
       IL_0042:  stloc.2
       IL_0043:  ldarg.1
-      IL_0044:  castclass  Match01/Test1/X11
+      IL_0044:  castclass  assembly/Test1/X11
       IL_0049:  stloc.3
       IL_004a:  ldloc.2
-      IL_004b:  ldfld      int32 Match01/Test1/X11::item
+      IL_004b:  ldfld      int32 assembly/Test1/X11::item
       IL_0050:  ldloc.3
-      IL_0051:  ldfld      int32 Match01/Test1/X11::item
+      IL_0051:  ldfld      int32 assembly/Test1/X11::item
       IL_0056:  ceq
       IL_0058:  ret
 
       IL_0059:  ldarg.0
-      IL_005a:  castclass  Match01/Test1/X12
+      IL_005a:  castclass  assembly/Test1/X12
       IL_005f:  stloc.s    V_4
       IL_0061:  ldarg.1
-      IL_0062:  castclass  Match01/Test1/X12
+      IL_0062:  castclass  assembly/Test1/X12
       IL_0067:  stloc.s    V_5
       IL_0069:  ldloc.s    V_4
-      IL_006b:  ldfld      int32 Match01/Test1/X12::item
+      IL_006b:  ldfld      int32 assembly/Test1/X12::item
       IL_0070:  ldloc.s    V_5
-      IL_0072:  ldfld      int32 Match01/Test1/X12::item
+      IL_0072:  ldfld      int32 assembly/Test1/X12::item
       IL_0077:  ceq
       IL_0079:  ret
 
       IL_007a:  ldarg.0
-      IL_007b:  castclass  Match01/Test1/X13
+      IL_007b:  castclass  assembly/Test1/X13
       IL_0080:  stloc.s    V_6
       IL_0082:  ldarg.1
-      IL_0083:  castclass  Match01/Test1/X13
+      IL_0083:  castclass  assembly/Test1/X13
       IL_0088:  stloc.s    V_7
       IL_008a:  ldloc.s    V_6
-      IL_008c:  ldfld      int32 Match01/Test1/X13::item
+      IL_008c:  ldfld      int32 assembly/Test1/X13::item
       IL_0091:  ldloc.s    V_7
-      IL_0093:  ldfld      int32 Match01/Test1/X13::item
+      IL_0093:  ldfld      int32 assembly/Test1/X13::item
       IL_0098:  ceq
       IL_009a:  ret
 
       IL_009b:  ldarg.0
-      IL_009c:  castclass  Match01/Test1/X14
+      IL_009c:  castclass  assembly/Test1/X14
       IL_00a1:  stloc.s    V_8
       IL_00a3:  ldarg.1
-      IL_00a4:  castclass  Match01/Test1/X14
+      IL_00a4:  castclass  assembly/Test1/X14
       IL_00a9:  stloc.s    V_9
       IL_00ab:  ldloc.s    V_8
-      IL_00ad:  ldfld      int32 Match01/Test1/X14::item
+      IL_00ad:  ldfld      int32 assembly/Test1/X14::item
       IL_00b2:  ldloc.s    V_9
-      IL_00b4:  ldfld      int32 Match01/Test1/X14::item
+      IL_00b4:  ldfld      int32 assembly/Test1/X14::item
       IL_00b9:  ceq
       IL_00bb:  ret
 
@@ -919,9 +919,9 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  5
-      .locals init (class Match01/Test1 V_0)
+      .locals init (class assembly/Test1 V_0)
       IL_0000:  ldarg.1
-      IL_0001:  isinst     Match01/Test1
+      IL_0001:  isinst     assembly/Test1
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
       IL_0008:  brfalse.s  IL_0013
@@ -929,7 +929,7 @@
       IL_000a:  ldarg.0
       IL_000b:  ldloc.0
       IL_000c:  ldarg.2
-      IL_000d:  callvirt   instance bool Match01/Test1::Equals(class Match01/Test1,
+      IL_000d:  callvirt   instance bool assembly/Test1::Equals(class assembly/Test1,
                                                                class [runtime]System.Collections.IEqualityComparer)
       IL_0012:  ret
 
@@ -937,21 +937,21 @@
       IL_0014:  ret
     } 
 
-    .method public hidebysig virtual final instance bool  Equals(class Match01/Test1 obj) cil managed
+    .method public hidebysig virtual final instance bool  Equals(class assembly/Test1 obj) cil managed
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  4
       .locals init (int32 V_0,
                int32 V_1,
-               class Match01/Test1/X11 V_2,
-               class Match01/Test1/X11 V_3,
-               class Match01/Test1/X12 V_4,
-               class Match01/Test1/X12 V_5,
-               class Match01/Test1/X13 V_6,
-               class Match01/Test1/X13 V_7,
-               class Match01/Test1/X14 V_8,
-               class Match01/Test1/X14 V_9)
+               class assembly/Test1/X11 V_2,
+               class assembly/Test1/X11 V_3,
+               class assembly/Test1/X12 V_4,
+               class assembly/Test1/X12 V_5,
+               class assembly/Test1/X13 V_6,
+               class assembly/Test1/X13 V_7,
+               class assembly/Test1/X14 V_8,
+               class assembly/Test1/X14 V_9)
       IL_0000:  ldarg.0
       IL_0001:  brfalse    IL_00c0
 
@@ -959,71 +959,71 @@
       IL_0007:  brfalse    IL_00be
 
       IL_000c:  ldarg.0
-      IL_000d:  ldfld      int32 Match01/Test1::_tag
+      IL_000d:  ldfld      int32 assembly/Test1::_tag
       IL_0012:  stloc.0
       IL_0013:  ldarg.1
-      IL_0014:  ldfld      int32 Match01/Test1::_tag
+      IL_0014:  ldfld      int32 assembly/Test1::_tag
       IL_0019:  stloc.1
       IL_001a:  ldloc.0
       IL_001b:  ldloc.1
       IL_001c:  bne.un     IL_00bc
 
       IL_0021:  ldarg.0
-      IL_0022:  call       instance int32 Match01/Test1::get_Tag()
+      IL_0022:  call       instance int32 assembly/Test1::get_Tag()
       IL_0027:  switch     ( 
                             IL_003c,
                             IL_0059,
                             IL_007a,
                             IL_009b)
       IL_003c:  ldarg.0
-      IL_003d:  castclass  Match01/Test1/X11
+      IL_003d:  castclass  assembly/Test1/X11
       IL_0042:  stloc.2
       IL_0043:  ldarg.1
-      IL_0044:  castclass  Match01/Test1/X11
+      IL_0044:  castclass  assembly/Test1/X11
       IL_0049:  stloc.3
       IL_004a:  ldloc.2
-      IL_004b:  ldfld      int32 Match01/Test1/X11::item
+      IL_004b:  ldfld      int32 assembly/Test1/X11::item
       IL_0050:  ldloc.3
-      IL_0051:  ldfld      int32 Match01/Test1/X11::item
+      IL_0051:  ldfld      int32 assembly/Test1/X11::item
       IL_0056:  ceq
       IL_0058:  ret
 
       IL_0059:  ldarg.0
-      IL_005a:  castclass  Match01/Test1/X12
+      IL_005a:  castclass  assembly/Test1/X12
       IL_005f:  stloc.s    V_4
       IL_0061:  ldarg.1
-      IL_0062:  castclass  Match01/Test1/X12
+      IL_0062:  castclass  assembly/Test1/X12
       IL_0067:  stloc.s    V_5
       IL_0069:  ldloc.s    V_4
-      IL_006b:  ldfld      int32 Match01/Test1/X12::item
+      IL_006b:  ldfld      int32 assembly/Test1/X12::item
       IL_0070:  ldloc.s    V_5
-      IL_0072:  ldfld      int32 Match01/Test1/X12::item
+      IL_0072:  ldfld      int32 assembly/Test1/X12::item
       IL_0077:  ceq
       IL_0079:  ret
 
       IL_007a:  ldarg.0
-      IL_007b:  castclass  Match01/Test1/X13
+      IL_007b:  castclass  assembly/Test1/X13
       IL_0080:  stloc.s    V_6
       IL_0082:  ldarg.1
-      IL_0083:  castclass  Match01/Test1/X13
+      IL_0083:  castclass  assembly/Test1/X13
       IL_0088:  stloc.s    V_7
       IL_008a:  ldloc.s    V_6
-      IL_008c:  ldfld      int32 Match01/Test1/X13::item
+      IL_008c:  ldfld      int32 assembly/Test1/X13::item
       IL_0091:  ldloc.s    V_7
-      IL_0093:  ldfld      int32 Match01/Test1/X13::item
+      IL_0093:  ldfld      int32 assembly/Test1/X13::item
       IL_0098:  ceq
       IL_009a:  ret
 
       IL_009b:  ldarg.0
-      IL_009c:  castclass  Match01/Test1/X14
+      IL_009c:  castclass  assembly/Test1/X14
       IL_00a1:  stloc.s    V_8
       IL_00a3:  ldarg.1
-      IL_00a4:  castclass  Match01/Test1/X14
+      IL_00a4:  castclass  assembly/Test1/X14
       IL_00a9:  stloc.s    V_9
       IL_00ab:  ldloc.s    V_8
-      IL_00ad:  ldfld      int32 Match01/Test1/X14::item
+      IL_00ad:  ldfld      int32 assembly/Test1/X14::item
       IL_00b2:  ldloc.s    V_9
-      IL_00b4:  ldfld      int32 Match01/Test1/X14::item
+      IL_00b4:  ldfld      int32 assembly/Test1/X14::item
       IL_00b9:  ceq
       IL_00bb:  ret
 
@@ -1046,16 +1046,16 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       
       .maxstack  4
-      .locals init (class Match01/Test1 V_0)
+      .locals init (class assembly/Test1 V_0)
       IL_0000:  ldarg.1
-      IL_0001:  isinst     Match01/Test1
+      IL_0001:  isinst     assembly/Test1
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
       IL_0008:  brfalse.s  IL_0012
 
       IL_000a:  ldarg.0
       IL_000b:  ldloc.0
-      IL_000c:  callvirt   instance bool Match01/Test1::Equals(class Match01/Test1)
+      IL_000c:  callvirt   instance bool assembly/Test1::Equals(class assembly/Test1)
       IL_0011:  ret
 
       IL_0012:  ldc.i4.0
@@ -1067,40 +1067,76 @@
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance int32 Match01/Test1::get_Tag()
+      .get instance int32 assembly/Test1::get_Tag()
     } 
     .property instance bool IsX11()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX11()
+      .get instance bool assembly/Test1::get_IsX11()
     } 
     .property instance bool IsX12()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX12()
+      .get instance bool assembly/Test1::get_IsX12()
     } 
     .property instance bool IsX13()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX13()
+      .get instance bool assembly/Test1::get_IsX13()
     } 
     .property instance bool IsX14()
     {
       .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [runtime]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [runtime]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
-      .get instance bool Match01/Test1::get_IsX14()
+      .get instance bool assembly/Test1::get_IsX14()
     } 
   } 
 
-  .method assembly static int32  CompareTo$cont@4(class Match01/Test1 this,
-                                                  class Match01/Test1 obj,
+  .method public static int32  select1(class assembly/Test1 x) cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  call       instance int32 assembly/Test1::get_Tag()
+    IL_0007:  switch     ( 
+                          IL_001c,
+                          IL_0028,
+                          IL_002a,
+                          IL_002c)
+    IL_001c:  ldarg.0
+    IL_001d:  castclass  assembly/Test1/X11
+    IL_0022:  ldfld      int32 assembly/Test1/X11::item
+    IL_0027:  ret
+
+    IL_0028:  ldc.i4.2
+    IL_0029:  ret
+
+    IL_002a:  ldc.i4.3
+    IL_002b:  ret
+
+    IL_002c:  ldc.i4.4
+    IL_002d:  ret
+  } 
+
+  .method public static int32  fm(class assembly/Test1 y) cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       int32 assembly::select1(class assembly/Test1)
+    IL_0006:  ret
+  } 
+
+  .method assembly static int32  CompareTo$cont@4(class assembly/Test1 this,
+                                                  class assembly/Test1 obj,
                                                   class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -1108,47 +1144,47 @@
     .maxstack  5
     .locals init (int32 V_0,
              int32 V_1,
-             class Match01/Test1/X11 V_2,
-             class Match01/Test1/X11 V_3,
+             class assembly/Test1/X11 V_2,
+             class assembly/Test1/X11 V_3,
              class [runtime]System.Collections.IComparer V_4,
              int32 V_5,
              int32 V_6,
-             class Match01/Test1/X12 V_7,
-             class Match01/Test1/X12 V_8,
-             class Match01/Test1/X13 V_9,
-             class Match01/Test1/X13 V_10,
-             class Match01/Test1/X14 V_11,
-             class Match01/Test1/X14 V_12)
+             class assembly/Test1/X12 V_7,
+             class assembly/Test1/X12 V_8,
+             class assembly/Test1/X13 V_9,
+             class assembly/Test1/X13 V_10,
+             class assembly/Test1/X14 V_11,
+             class assembly/Test1/X14 V_12)
     IL_0000:  ldarg.0
-    IL_0001:  ldfld      int32 Match01/Test1::_tag
+    IL_0001:  ldfld      int32 assembly/Test1::_tag
     IL_0006:  stloc.0
     IL_0007:  ldarg.1
-    IL_0008:  ldfld      int32 Match01/Test1::_tag
+    IL_0008:  ldfld      int32 assembly/Test1::_tag
     IL_000d:  stloc.1
     IL_000e:  ldloc.0
     IL_000f:  ldloc.1
     IL_0010:  bne.un     IL_0108
 
     IL_0015:  ldarg.0
-    IL_0016:  call       instance int32 Match01/Test1::get_Tag()
+    IL_0016:  call       instance int32 assembly/Test1::get_Tag()
     IL_001b:  switch     ( 
                           IL_0030,
                           IL_0063,
                           IL_009a,
                           IL_00d1)
     IL_0030:  ldarg.0
-    IL_0031:  castclass  Match01/Test1/X11
+    IL_0031:  castclass  assembly/Test1/X11
     IL_0036:  stloc.2
     IL_0037:  ldarg.1
-    IL_0038:  castclass  Match01/Test1/X11
+    IL_0038:  castclass  assembly/Test1/X11
     IL_003d:  stloc.3
     IL_003e:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0043:  stloc.s    V_4
     IL_0045:  ldloc.2
-    IL_0046:  ldfld      int32 Match01/Test1/X11::item
+    IL_0046:  ldfld      int32 assembly/Test1/X11::item
     IL_004b:  stloc.s    V_5
     IL_004d:  ldloc.3
-    IL_004e:  ldfld      int32 Match01/Test1/X11::item
+    IL_004e:  ldfld      int32 assembly/Test1/X11::item
     IL_0053:  stloc.s    V_6
     IL_0055:  ldloc.s    V_5
     IL_0057:  ldloc.s    V_6
@@ -1160,18 +1196,18 @@
     IL_0062:  ret
 
     IL_0063:  ldarg.0
-    IL_0064:  castclass  Match01/Test1/X12
+    IL_0064:  castclass  assembly/Test1/X12
     IL_0069:  stloc.s    V_7
     IL_006b:  ldarg.1
-    IL_006c:  castclass  Match01/Test1/X12
+    IL_006c:  castclass  assembly/Test1/X12
     IL_0071:  stloc.s    V_8
     IL_0073:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_0078:  stloc.s    V_4
     IL_007a:  ldloc.s    V_7
-    IL_007c:  ldfld      int32 Match01/Test1/X12::item
+    IL_007c:  ldfld      int32 assembly/Test1/X12::item
     IL_0081:  stloc.s    V_5
     IL_0083:  ldloc.s    V_8
-    IL_0085:  ldfld      int32 Match01/Test1/X12::item
+    IL_0085:  ldfld      int32 assembly/Test1/X12::item
     IL_008a:  stloc.s    V_6
     IL_008c:  ldloc.s    V_5
     IL_008e:  ldloc.s    V_6
@@ -1183,18 +1219,18 @@
     IL_0099:  ret
 
     IL_009a:  ldarg.0
-    IL_009b:  castclass  Match01/Test1/X13
+    IL_009b:  castclass  assembly/Test1/X13
     IL_00a0:  stloc.s    V_9
     IL_00a2:  ldarg.1
-    IL_00a3:  castclass  Match01/Test1/X13
+    IL_00a3:  castclass  assembly/Test1/X13
     IL_00a8:  stloc.s    V_10
     IL_00aa:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_00af:  stloc.s    V_4
     IL_00b1:  ldloc.s    V_9
-    IL_00b3:  ldfld      int32 Match01/Test1/X13::item
+    IL_00b3:  ldfld      int32 assembly/Test1/X13::item
     IL_00b8:  stloc.s    V_5
     IL_00ba:  ldloc.s    V_10
-    IL_00bc:  ldfld      int32 Match01/Test1/X13::item
+    IL_00bc:  ldfld      int32 assembly/Test1/X13::item
     IL_00c1:  stloc.s    V_6
     IL_00c3:  ldloc.s    V_5
     IL_00c5:  ldloc.s    V_6
@@ -1206,18 +1242,18 @@
     IL_00d0:  ret
 
     IL_00d1:  ldarg.0
-    IL_00d2:  castclass  Match01/Test1/X14
+    IL_00d2:  castclass  assembly/Test1/X14
     IL_00d7:  stloc.s    V_11
     IL_00d9:  ldarg.1
-    IL_00da:  castclass  Match01/Test1/X14
+    IL_00da:  castclass  assembly/Test1/X14
     IL_00df:  stloc.s    V_12
     IL_00e1:  call       class [runtime]System.Collections.IComparer [FSharp.Core]Microsoft.FSharp.Core.LanguagePrimitives::get_GenericComparer()
     IL_00e6:  stloc.s    V_4
     IL_00e8:  ldloc.s    V_11
-    IL_00ea:  ldfld      int32 Match01/Test1/X14::item
+    IL_00ea:  ldfld      int32 assembly/Test1/X14::item
     IL_00ef:  stloc.s    V_5
     IL_00f1:  ldloc.s    V_12
-    IL_00f3:  ldfld      int32 Match01/Test1/X14::item
+    IL_00f3:  ldfld      int32 assembly/Test1/X14::item
     IL_00f8:  stloc.s    V_6
     IL_00fa:  ldloc.s    V_5
     IL_00fc:  ldloc.s    V_6
@@ -1234,9 +1270,9 @@
     IL_010b:  ret
   } 
 
-  .method assembly static int32  'CompareTo$cont@4-1'(class Match01/Test1 this,
+  .method assembly static int32  'CompareTo$cont@4-1'(class assembly/Test1 this,
                                                       object obj,
-                                                      class Match01/Test1 objTemp,
+                                                      class assembly/Test1 objTemp,
                                                       class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar) cil managed
   {
     .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
@@ -1244,48 +1280,48 @@
     .maxstack  5
     .locals init (int32 V_0,
              int32 V_1,
-             class Match01/Test1/X11 V_2,
-             class Match01/Test1/X11 V_3,
+             class assembly/Test1/X11 V_2,
+             class assembly/Test1/X11 V_3,
              int32 V_4,
              int32 V_5,
-             class Match01/Test1/X12 V_6,
-             class Match01/Test1/X12 V_7,
-             class Match01/Test1/X13 V_8,
-             class Match01/Test1/X13 V_9,
-             class Match01/Test1/X14 V_10,
-             class Match01/Test1/X14 V_11)
+             class assembly/Test1/X12 V_6,
+             class assembly/Test1/X12 V_7,
+             class assembly/Test1/X13 V_8,
+             class assembly/Test1/X13 V_9,
+             class assembly/Test1/X14 V_10,
+             class assembly/Test1/X14 V_11)
     IL_0000:  ldarg.1
-    IL_0001:  unbox.any  Match01/Test1
+    IL_0001:  unbox.any  assembly/Test1
     IL_0006:  brfalse    IL_00fb
 
     IL_000b:  ldarg.0
-    IL_000c:  ldfld      int32 Match01/Test1::_tag
+    IL_000c:  ldfld      int32 assembly/Test1::_tag
     IL_0011:  stloc.0
     IL_0012:  ldarg.2
-    IL_0013:  ldfld      int32 Match01/Test1::_tag
+    IL_0013:  ldfld      int32 assembly/Test1::_tag
     IL_0018:  stloc.1
     IL_0019:  ldloc.0
     IL_001a:  ldloc.1
     IL_001b:  bne.un     IL_00f7
 
     IL_0020:  ldarg.0
-    IL_0021:  call       instance int32 Match01/Test1::get_Tag()
+    IL_0021:  call       instance int32 assembly/Test1::get_Tag()
     IL_0026:  switch     ( 
                           IL_003b,
                           IL_0067,
                           IL_0097,
                           IL_00c7)
     IL_003b:  ldarg.0
-    IL_003c:  castclass  Match01/Test1/X11
+    IL_003c:  castclass  assembly/Test1/X11
     IL_0041:  stloc.2
     IL_0042:  ldarg.2
-    IL_0043:  castclass  Match01/Test1/X11
+    IL_0043:  castclass  assembly/Test1/X11
     IL_0048:  stloc.3
     IL_0049:  ldloc.2
-    IL_004a:  ldfld      int32 Match01/Test1/X11::item
+    IL_004a:  ldfld      int32 assembly/Test1/X11::item
     IL_004f:  stloc.s    V_4
     IL_0051:  ldloc.3
-    IL_0052:  ldfld      int32 Match01/Test1/X11::item
+    IL_0052:  ldfld      int32 assembly/Test1/X11::item
     IL_0057:  stloc.s    V_5
     IL_0059:  ldloc.s    V_4
     IL_005b:  ldloc.s    V_5
@@ -1297,16 +1333,16 @@
     IL_0066:  ret
 
     IL_0067:  ldarg.0
-    IL_0068:  castclass  Match01/Test1/X12
+    IL_0068:  castclass  assembly/Test1/X12
     IL_006d:  stloc.s    V_6
     IL_006f:  ldarg.2
-    IL_0070:  castclass  Match01/Test1/X12
+    IL_0070:  castclass  assembly/Test1/X12
     IL_0075:  stloc.s    V_7
     IL_0077:  ldloc.s    V_6
-    IL_0079:  ldfld      int32 Match01/Test1/X12::item
+    IL_0079:  ldfld      int32 assembly/Test1/X12::item
     IL_007e:  stloc.s    V_4
     IL_0080:  ldloc.s    V_7
-    IL_0082:  ldfld      int32 Match01/Test1/X12::item
+    IL_0082:  ldfld      int32 assembly/Test1/X12::item
     IL_0087:  stloc.s    V_5
     IL_0089:  ldloc.s    V_4
     IL_008b:  ldloc.s    V_5
@@ -1318,16 +1354,16 @@
     IL_0096:  ret
 
     IL_0097:  ldarg.0
-    IL_0098:  castclass  Match01/Test1/X13
+    IL_0098:  castclass  assembly/Test1/X13
     IL_009d:  stloc.s    V_8
     IL_009f:  ldarg.2
-    IL_00a0:  castclass  Match01/Test1/X13
+    IL_00a0:  castclass  assembly/Test1/X13
     IL_00a5:  stloc.s    V_9
     IL_00a7:  ldloc.s    V_8
-    IL_00a9:  ldfld      int32 Match01/Test1/X13::item
+    IL_00a9:  ldfld      int32 assembly/Test1/X13::item
     IL_00ae:  stloc.s    V_4
     IL_00b0:  ldloc.s    V_9
-    IL_00b2:  ldfld      int32 Match01/Test1/X13::item
+    IL_00b2:  ldfld      int32 assembly/Test1/X13::item
     IL_00b7:  stloc.s    V_5
     IL_00b9:  ldloc.s    V_4
     IL_00bb:  ldloc.s    V_5
@@ -1339,16 +1375,16 @@
     IL_00c6:  ret
 
     IL_00c7:  ldarg.0
-    IL_00c8:  castclass  Match01/Test1/X14
+    IL_00c8:  castclass  assembly/Test1/X14
     IL_00cd:  stloc.s    V_10
     IL_00cf:  ldarg.2
-    IL_00d0:  castclass  Match01/Test1/X14
+    IL_00d0:  castclass  assembly/Test1/X14
     IL_00d5:  stloc.s    V_11
     IL_00d7:  ldloc.s    V_10
-    IL_00d9:  ldfld      int32 Match01/Test1/X14::item
+    IL_00d9:  ldfld      int32 assembly/Test1/X14::item
     IL_00de:  stloc.s    V_4
     IL_00e0:  ldloc.s    V_11
-    IL_00e2:  ldfld      int32 Match01/Test1/X14::item
+    IL_00e2:  ldfld      int32 assembly/Test1/X14::item
     IL_00e7:  stloc.s    V_5
     IL_00e9:  ldloc.s    V_4
     IL_00eb:  ldloc.s    V_5
@@ -1368,45 +1404,9 @@
     IL_00fc:  ret
   } 
 
-  .method public static int32  select1(class Match01/Test1 x) cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  nop
-    IL_0001:  ldarg.0
-    IL_0002:  call       instance int32 Match01/Test1::get_Tag()
-    IL_0007:  switch     ( 
-                          IL_001c,
-                          IL_0028,
-                          IL_002a,
-                          IL_002c)
-    IL_001c:  ldarg.0
-    IL_001d:  castclass  Match01/Test1/X11
-    IL_0022:  ldfld      int32 Match01/Test1/X11::item
-    IL_0027:  ret
-
-    IL_0028:  ldc.i4.2
-    IL_0029:  ret
-
-    IL_002a:  ldc.i4.3
-    IL_002b:  ret
-
-    IL_002c:  ldc.i4.4
-    IL_002d:  ret
-  } 
-
-  .method public static int32  fm(class Match01/Test1 y) cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  call       int32 Match01::select1(class Match01/Test1)
-    IL_0006:  ret
-  } 
-
 } 
 
-.class private abstract auto ansi sealed '<StartupCode$assembly>'.$Match01
+.class private abstract auto ansi sealed '<StartupCode$assembly>'.$assembly
        extends [runtime]System.Object
 {
   .method public static void  main@() cil managed

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction06.fs.RealInternalSignatureOff.OptimizeOn.il.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction06.fs.RealInternalSignatureOff.OptimizeOn.il.release.bsl
@@ -63,6 +63,18 @@
     IL_002f:  ret
   } 
 
+  .method public static int32  TestFunction6() cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldnull
+    IL_0001:  call       int32 assembly::f@10(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+    IL_0006:  ldnull
+    IL_0007:  call       int32 assembly::f@10(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+    IL_000c:  add
+    IL_000d:  ret
+  } 
+
   .method assembly static int32  f@10(class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar0) cil managed
   {
     
@@ -83,18 +95,6 @@
     IL_001e:  ldloc.0
     IL_001f:  add
     IL_0020:  ret
-  } 
-
-  .method public static int32  TestFunction6() cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldnull
-    IL_0001:  call       int32 assembly::f@10(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
-    IL_0006:  ldnull
-    IL_0007:  call       int32 assembly::f@10(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
-    IL_000c:  add
-    IL_000d:  ret
   } 
 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction23.fs.RealInternalSignatureOff.OptimizeOn.il.net472.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction23.fs.RealInternalSignatureOff.OptimizeOn.il.net472.release.bsl
@@ -86,6 +86,23 @@
 
   } 
 
+  .method public static class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> f<a>(!!a x) cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldnull
+    IL_0001:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+    IL_0006:  nop
+    IL_0007:  ldnull
+    IL_0008:  ldnull
+    IL_0009:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+    IL_000e:  nop
+    IL_000f:  ldnull
+    IL_0010:  newobj     instance void class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(!0,
+                                                                                                                                                                          !1)
+    IL_0015:  ret
+  } 
+
   .method assembly static void  g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar0) cil managed
   {
     
@@ -108,23 +125,6 @@
                                                                                                                                                          class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_002d:  pop
     IL_002e:  ret
-  } 
-
-  .method public static class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> f<a>(!!a x) cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldnull
-    IL_0001:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
-    IL_0006:  nop
-    IL_0007:  ldnull
-    IL_0008:  ldnull
-    IL_0009:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
-    IL_000e:  nop
-    IL_000f:  ldnull
-    IL_0010:  newobj     instance void class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(!0,
-                                                                                                                                                                          !1)
-    IL_0015:  ret
   } 
 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction23.fs.RealInternalSignatureOff.OptimizeOn.il.netcore.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction23.fs.RealInternalSignatureOff.OptimizeOn.il.netcore.release.bsl
@@ -87,6 +87,23 @@
 
   } 
 
+  .method public static class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> f<a>(!!a x) cil managed
+  {
+    
+    .maxstack  8
+    IL_0000:  ldnull
+    IL_0001:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+    IL_0006:  nop
+    IL_0007:  ldnull
+    IL_0008:  ldnull
+    IL_0009:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
+    IL_000e:  nop
+    IL_000f:  ldnull
+    IL_0010:  newobj     instance void class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(!0,
+                                                                                                                                                                                !1)
+    IL_0015:  ret
+  } 
+
   .method assembly static void  g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit unitVar0) cil managed
   {
     
@@ -109,23 +126,6 @@
                                                                                                                                                          class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<!!0,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>)
     IL_002d:  pop
     IL_002e:  ret
-  } 
-
-  .method public static class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> f<a>(!!a x) cil managed
-  {
-    
-    .maxstack  8
-    IL_0000:  ldnull
-    IL_0001:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
-    IL_0006:  nop
-    IL_0007:  ldnull
-    IL_0008:  ldnull
-    IL_0009:  call       void assembly::g@12(class [FSharp.Core]Microsoft.FSharp.Core.Unit)
-    IL_000e:  nop
-    IL_000f:  ldnull
-    IL_0010:  newobj     instance void class [runtime]System.Tuple`2<class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit>::.ctor(!0,
-                                                                                                                                                                                !1)
-    IL_0015:  ret
   } 
 
 } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOff.OptimizeOff.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOff.OptimizeOff.il.bsl
@@ -33,6 +33,76 @@
        extends [runtime]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class auto ansi serializable sealed nested assembly beforefieldinit matchResult@38
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class assembly/matchResult@38 @_instance
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
+    {
+      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } 
+
+    .method public strict virtual instance bool Invoke(int32 n) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool assembly::condition(int32)
+      IL_0006:  ret
+    } 
+
+    .method private specialname rtspecialname static void  .cctor() cil managed
+    {
+      
+      .maxstack  10
+      IL_0000:  newobj     instance void assembly/matchResult@38::.ctor()
+      IL_0005:  stsfld     class assembly/matchResult@38 assembly/matchResult@38::@_instance
+      IL_000a:  ret
+    } 
+
+  } 
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit functionResult@43
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class assembly/functionResult@43 @_instance
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
+    {
+      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } 
+
+    .method public strict virtual instance bool Invoke(int32 n) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool assembly::condition(int32)
+      IL_0006:  ret
+    } 
+
+    .method private specialname rtspecialname static void  .cctor() cil managed
+    {
+      
+      .maxstack  10
+      IL_0000:  newobj     instance void assembly/functionResult@43::.ctor()
+      IL_0005:  stsfld     class assembly/functionResult@43 assembly/functionResult@43::@_instance
+      IL_000a:  ret
+    } 
+
+  } 
+
   .class auto ansi serializable sealed nested assembly beforefieldinit f@8
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>
   {
@@ -159,76 +229,6 @@
       IL_0038:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
       IL_003d:  ret
-    } 
-
-  } 
-
-  .class auto ansi serializable sealed nested assembly beforefieldinit matchResult@38
-         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
-  {
-    .field static assembly initonly class assembly/matchResult@38 @_instance
-    .method assembly specialname rtspecialname instance void  .ctor() cil managed
-    {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
-      IL_0006:  ret
-    } 
-
-    .method public strict virtual instance bool Invoke(int32 n) cil managed
-    {
-      
-      .maxstack  8
-      IL_0000:  ldarg.1
-      IL_0001:  call       bool assembly::condition(int32)
-      IL_0006:  ret
-    } 
-
-    .method private specialname rtspecialname static void  .cctor() cil managed
-    {
-      
-      .maxstack  10
-      IL_0000:  newobj     instance void assembly/matchResult@38::.ctor()
-      IL_0005:  stsfld     class assembly/matchResult@38 assembly/matchResult@38::@_instance
-      IL_000a:  ret
-    } 
-
-  } 
-
-  .class auto ansi serializable sealed nested assembly beforefieldinit functionResult@43
-         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
-  {
-    .field static assembly initonly class assembly/functionResult@43 @_instance
-    .method assembly specialname rtspecialname instance void  .ctor() cil managed
-    {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
-      IL_0006:  ret
-    } 
-
-    .method public strict virtual instance bool Invoke(int32 n) cil managed
-    {
-      
-      .maxstack  8
-      IL_0000:  ldarg.1
-      IL_0001:  call       bool assembly::condition(int32)
-      IL_0006:  ret
-    } 
-
-    .method private specialname rtspecialname static void  .cctor() cil managed
-    {
-      
-      .maxstack  10
-      IL_0000:  newobj     instance void assembly/functionResult@43::.ctor()
-      IL_0005:  stsfld     class assembly/functionResult@43 assembly/functionResult@43::@_instance
-      IL_000a:  ret
     } 
 
   } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOff.OptimizeOn.il.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOff.OptimizeOn.il.release.bsl
@@ -128,50 +128,6 @@
     IL_0004:  ret
   } 
 
-  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> f@7(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> l) cil managed
-  {
-    
-    .maxstack  4
-    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
-             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
-             int32 V_2)
-    IL_0000:  nop
-    IL_0001:  ldarg.1
-    IL_0002:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0007:  brfalse.s  IL_000b
-
-    IL_0009:  br.s       IL_0011
-
-    IL_000b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
-    IL_0010:  ret
-
-    IL_0011:  ldarg.1
-    IL_0012:  stloc.0
-    IL_0013:  ldloc.0
-    IL_0014:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0019:  stloc.1
-    IL_001a:  ldloc.0
-    IL_001b:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
-    IL_0020:  stloc.2
-    IL_0021:  nop
-    IL_0022:  ldarg.0
-    IL_0023:  ldloc.2
-    IL_0024:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
-    IL_0029:  brfalse.s  IL_0033
-
-    IL_002b:  ldarg.0
-    IL_002c:  ldloc.1
-    IL_002d:  starg.s    l
-    IL_002f:  starg.s    condition
-    IL_0031:  br.s       IL_0000
-
-    IL_0033:  ldloc.2
-    IL_0034:  ldloc.1
-    IL_0035:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_003a:  ret
-  } 
-
   .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> dropWhileWithMatch(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
@@ -185,49 +141,6 @@
     IL_0004:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> assembly::f@7(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>,
                                                                                                               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>)
     IL_0009:  ret
-  } 
-
-  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'f@26-1'(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> _arg1) cil managed
-  {
-    
-    .maxstack  4
-    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
-             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
-             int32 V_2)
-    IL_0000:  ldarg.1
-    IL_0001:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0006:  brfalse.s  IL_000a
-
-    IL_0008:  br.s       IL_0010
-
-    IL_000a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
-    IL_000f:  ret
-
-    IL_0010:  ldarg.1
-    IL_0011:  stloc.0
-    IL_0012:  ldloc.0
-    IL_0013:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0018:  stloc.1
-    IL_0019:  ldloc.0
-    IL_001a:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
-    IL_001f:  stloc.2
-    IL_0020:  nop
-    IL_0021:  ldarg.0
-    IL_0022:  ldloc.2
-    IL_0023:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
-    IL_0028:  brfalse.s  IL_0032
-
-    IL_002a:  ldarg.0
-    IL_002b:  ldloc.1
-    IL_002c:  starg.s    _arg1
-    IL_002e:  starg.s    condition
-    IL_0030:  br.s       IL_0000
-
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.1
-    IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0039:  ret
   } 
 
   .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> dropWhileWithFunction(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
@@ -275,6 +188,93 @@
     .maxstack  8
     IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> '<StartupCode$assembly>'.$assembly::'format@1-1'
     IL_0005:  ret
+  } 
+
+  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> f@7(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> l) cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+             int32 V_2)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0007:  brfalse.s  IL_000b
+
+    IL_0009:  br.s       IL_0011
+
+    IL_000b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_0010:  ret
+
+    IL_0011:  ldarg.1
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0019:  stloc.1
+    IL_001a:  ldloc.0
+    IL_001b:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+    IL_0020:  stloc.2
+    IL_0021:  nop
+    IL_0022:  ldarg.0
+    IL_0023:  ldloc.2
+    IL_0024:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+    IL_0029:  brfalse.s  IL_0033
+
+    IL_002b:  ldarg.0
+    IL_002c:  ldloc.1
+    IL_002d:  starg.s    l
+    IL_002f:  starg.s    condition
+    IL_0031:  br.s       IL_0000
+
+    IL_0033:  ldloc.2
+    IL_0034:  ldloc.1
+    IL_0035:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_003a:  ret
+  } 
+
+  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'f@26-1'(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> _arg1) cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+             int32 V_2)
+    IL_0000:  ldarg.1
+    IL_0001:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0006:  brfalse.s  IL_000a
+
+    IL_0008:  br.s       IL_0010
+
+    IL_000a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_000f:  ret
+
+    IL_0010:  ldarg.1
+    IL_0011:  stloc.0
+    IL_0012:  ldloc.0
+    IL_0013:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0018:  stloc.1
+    IL_0019:  ldloc.0
+    IL_001a:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+    IL_001f:  stloc.2
+    IL_0020:  nop
+    IL_0021:  ldarg.0
+    IL_0022:  ldloc.2
+    IL_0023:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+    IL_0028:  brfalse.s  IL_0032
+
+    IL_002a:  ldarg.0
+    IL_002b:  ldloc.1
+    IL_002c:  starg.s    _arg1
+    IL_002e:  starg.s    condition
+    IL_0030:  br.s       IL_0000
+
+    IL_0032:  ldloc.2
+    IL_0033:  ldloc.1
+    IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_0039:  ret
   } 
 
   .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOn.OptimizeOff.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOn.OptimizeOff.il.bsl
@@ -33,6 +33,76 @@
        extends [runtime]System.Object
 {
   .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 07 00 00 00 00 00 ) 
+  .class auto ansi serializable sealed nested assembly beforefieldinit matchResult@38
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class assembly/matchResult@38 @_instance
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
+    {
+      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } 
+
+    .method public strict virtual instance bool Invoke(int32 n) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool assembly::condition(int32)
+      IL_0006:  ret
+    } 
+
+    .method private specialname rtspecialname static void  .cctor() cil managed
+    {
+      
+      .maxstack  10
+      IL_0000:  newobj     instance void assembly/matchResult@38::.ctor()
+      IL_0005:  stsfld     class assembly/matchResult@38 assembly/matchResult@38::@_instance
+      IL_000a:  ret
+    } 
+
+  } 
+
+  .class auto ansi serializable sealed nested assembly beforefieldinit functionResult@43
+         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
+  {
+    .field static assembly initonly class assembly/functionResult@43 @_instance
+    .method assembly specialname rtspecialname instance void  .ctor() cil managed
+    {
+      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+      
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
+      IL_0006:  ret
+    } 
+
+    .method public strict virtual instance bool Invoke(int32 n) cil managed
+    {
+      
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  call       bool assembly::condition(int32)
+      IL_0006:  ret
+    } 
+
+    .method private specialname rtspecialname static void  .cctor() cil managed
+    {
+      
+      .maxstack  10
+      IL_0000:  newobj     instance void assembly/functionResult@43::.ctor()
+      IL_0005:  stsfld     class assembly/functionResult@43 assembly/functionResult@43::@_instance
+      IL_000a:  ret
+    } 
+
+  } 
+
   .class auto ansi serializable sealed nested assembly beforefieldinit f@8
          extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>>
   {
@@ -159,76 +229,6 @@
       IL_0038:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
                                                                                                                                                                       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
       IL_003d:  ret
-    } 
-
-  } 
-
-  .class auto ansi serializable sealed nested assembly beforefieldinit matchResult@38
-         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
-  {
-    .field static assembly initonly class assembly/matchResult@38 @_instance
-    .method assembly specialname rtspecialname instance void  .ctor() cil managed
-    {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
-      IL_0006:  ret
-    } 
-
-    .method public strict virtual instance bool Invoke(int32 n) cil managed
-    {
-      
-      .maxstack  8
-      IL_0000:  ldarg.1
-      IL_0001:  call       bool assembly::condition(int32)
-      IL_0006:  ret
-    } 
-
-    .method private specialname rtspecialname static void  .cctor() cil managed
-    {
-      
-      .maxstack  10
-      IL_0000:  newobj     instance void assembly/matchResult@38::.ctor()
-      IL_0005:  stsfld     class assembly/matchResult@38 assembly/matchResult@38::@_instance
-      IL_000a:  ret
-    } 
-
-  } 
-
-  .class auto ansi serializable sealed nested assembly beforefieldinit functionResult@43
-         extends class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>
-  {
-    .field static assembly initonly class assembly/functionResult@43 @_instance
-    .method assembly specialname rtspecialname instance void  .ctor() cil managed
-    {
-      .custom instance void [runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-      .custom instance void [runtime]System.Diagnostics.DebuggerNonUserCodeAttribute::.ctor() = ( 01 00 00 00 ) 
-      
-      .maxstack  8
-      IL_0000:  ldarg.0
-      IL_0001:  call       instance void class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::.ctor()
-      IL_0006:  ret
-    } 
-
-    .method public strict virtual instance bool Invoke(int32 n) cil managed
-    {
-      
-      .maxstack  8
-      IL_0000:  ldarg.1
-      IL_0001:  call       bool assembly::condition(int32)
-      IL_0006:  ret
-    } 
-
-    .method private specialname rtspecialname static void  .cctor() cil managed
-    {
-      
-      .maxstack  10
-      IL_0000:  newobj     instance void assembly/functionResult@43::.ctor()
-      IL_0005:  stsfld     class assembly/functionResult@43 assembly/functionResult@43::@_instance
-      IL_000a:  ret
     } 
 
   } 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOn.OptimizeOn.il.release.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/Verify13043.fs.RealInternalSignatureOn.OptimizeOn.il.release.bsl
@@ -128,50 +128,6 @@
     IL_0004:  ret
   } 
 
-  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> f@7(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> l) cil managed
-  {
-    
-    .maxstack  4
-    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
-             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
-             int32 V_2)
-    IL_0000:  nop
-    IL_0001:  ldarg.1
-    IL_0002:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0007:  brfalse.s  IL_000b
-
-    IL_0009:  br.s       IL_0011
-
-    IL_000b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
-    IL_0010:  ret
-
-    IL_0011:  ldarg.1
-    IL_0012:  stloc.0
-    IL_0013:  ldloc.0
-    IL_0014:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0019:  stloc.1
-    IL_001a:  ldloc.0
-    IL_001b:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
-    IL_0020:  stloc.2
-    IL_0021:  nop
-    IL_0022:  ldarg.0
-    IL_0023:  ldloc.2
-    IL_0024:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
-    IL_0029:  brfalse.s  IL_0033
-
-    IL_002b:  ldarg.0
-    IL_002c:  ldloc.1
-    IL_002d:  starg.s    l
-    IL_002f:  starg.s    condition
-    IL_0031:  br.s       IL_0000
-
-    IL_0033:  ldloc.2
-    IL_0034:  ldloc.1
-    IL_0035:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_003a:  ret
-  } 
-
   .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> dropWhileWithMatch(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationArgumentCountsAttribute::.ctor(int32[]) = ( 01 00 02 00 00 00 01 00 00 00 01 00 00 00 00 00 ) 
@@ -185,49 +141,6 @@
     IL_0004:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> assembly::f@7(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>,
                                                                                                               class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>)
     IL_0009:  ret
-  } 
-
-  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'f@26-1'(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> _arg1) cil managed
-  {
-    
-    .maxstack  4
-    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
-             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
-             int32 V_2)
-    IL_0000:  ldarg.1
-    IL_0001:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0006:  brfalse.s  IL_000a
-
-    IL_0008:  br.s       IL_0010
-
-    IL_000a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
-    IL_000f:  ret
-
-    IL_0010:  ldarg.1
-    IL_0011:  stloc.0
-    IL_0012:  ldloc.0
-    IL_0013:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
-    IL_0018:  stloc.1
-    IL_0019:  ldloc.0
-    IL_001a:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
-    IL_001f:  stloc.2
-    IL_0020:  nop
-    IL_0021:  ldarg.0
-    IL_0022:  ldloc.2
-    IL_0023:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
-    IL_0028:  brfalse.s  IL_0032
-
-    IL_002a:  ldarg.0
-    IL_002b:  ldloc.1
-    IL_002c:  starg.s    _arg1
-    IL_002e:  starg.s    condition
-    IL_0030:  br.s       IL_0000
-
-    IL_0032:  ldloc.2
-    IL_0033:  ldloc.1
-    IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
-                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
-    IL_0039:  ret
   } 
 
   .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> dropWhileWithFunction(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> list) cil managed
@@ -275,6 +188,93 @@
     .maxstack  8
     IL_0000:  ldsfld     class [FSharp.Core]Microsoft.FSharp.Core.PrintfFormat`4<class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>,class [FSharp.Core]Microsoft.FSharp.Core.Unit>,class [runtime]System.IO.TextWriter,class [FSharp.Core]Microsoft.FSharp.Core.Unit,class [FSharp.Core]Microsoft.FSharp.Core.Unit> '<StartupCode$assembly>'.$assembly::'format@1-1'
     IL_0005:  ret
+  } 
+
+  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> f@7(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> l) cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+             int32 V_2)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0007:  brfalse.s  IL_000b
+
+    IL_0009:  br.s       IL_0011
+
+    IL_000b:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_0010:  ret
+
+    IL_0011:  ldarg.1
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0019:  stloc.1
+    IL_001a:  ldloc.0
+    IL_001b:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+    IL_0020:  stloc.2
+    IL_0021:  nop
+    IL_0022:  ldarg.0
+    IL_0023:  ldloc.2
+    IL_0024:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+    IL_0029:  brfalse.s  IL_0033
+
+    IL_002b:  ldarg.0
+    IL_002c:  ldloc.1
+    IL_002d:  starg.s    l
+    IL_002f:  starg.s    condition
+    IL_0031:  br.s       IL_0000
+
+    IL_0033:  ldloc.2
+    IL_0034:  ldloc.1
+    IL_0035:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_003a:  ret
+  } 
+
+  .method assembly static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> 'f@26-1'(class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool> condition, class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> _arg1) cil managed
+  {
+    
+    .maxstack  4
+    .locals init (class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_0,
+             class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32> V_1,
+             int32 V_2)
+    IL_0000:  ldarg.1
+    IL_0001:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0006:  brfalse.s  IL_000a
+
+    IL_0008:  br.s       IL_0010
+
+    IL_000a:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_Empty()
+    IL_000f:  ret
+
+    IL_0010:  ldarg.1
+    IL_0011:  stloc.0
+    IL_0012:  ldloc.0
+    IL_0013:  call       instance class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_TailOrNull()
+    IL_0018:  stloc.1
+    IL_0019:  ldloc.0
+    IL_001a:  call       instance !0 class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::get_HeadOrDefault()
+    IL_001f:  stloc.2
+    IL_0020:  nop
+    IL_0021:  ldarg.0
+    IL_0022:  ldloc.2
+    IL_0023:  callvirt   instance !1 class [FSharp.Core]Microsoft.FSharp.Core.FSharpFunc`2<int32,bool>::Invoke(!0)
+    IL_0028:  brfalse.s  IL_0032
+
+    IL_002a:  ldarg.0
+    IL_002b:  ldloc.1
+    IL_002c:  starg.s    _arg1
+    IL_002e:  starg.s    condition
+    IL_0030:  br.s       IL_0000
+
+    IL_0032:  ldloc.2
+    IL_0033:  ldloc.1
+    IL_0034:  call       class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0> class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>::Cons(!0,
+                                                                                                                                                                    class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!0>)
+    IL_0039:  ret
   } 
 
   .property class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<int32>

--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedTypeCheckTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedTypeCheckTests.fs
@@ -191,7 +191,7 @@ let ``type check neg55`` () = singleNegTest ( "typecheck/sigs") "neg55"
 [<FactForDESKTOP>]
 let ``type check neg56`` () = singleNegTest ( "typecheck/sigs") "neg56"
 
-[<FactForDESKTOP(Skip = "Failing in new test framework")>]
+[<Fact>]
 let ``type check neg56_a`` () = singleNegTest ( "typecheck/sigs") "neg56_a"
 
 [<FactForDESKTOP>]

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -2283,9 +2283,6 @@ module TypecheckTests =
     let ``type check neg49`` () = singleNegTest (testConfig "typecheck/sigs") "neg49"
 
     [<Fact>]
-    let ``type check neg56_a`` () = singleNegTest (testConfig "typecheck/sigs") "neg56_a"   
-
-    [<Fact>]
     let ``type check neg94`` () = singleNegTest (testConfig "typecheck/sigs") "neg94" 
 
     [<Fact>]

--- a/tests/fsharp/typecheck/sigs/neg14.bsl
+++ b/tests/fsharp/typecheck/sigs/neg14.bsl
@@ -1,4 +1,12 @@
 
 neg14a.fs(9,6,9,33): typecheck error FS0343: The type 'missingInterfaceInSignature' implements 'System.IComparable' explicitly but provides no corresponding override for 'Object.Equals'. An implementation of 'Object.Equals' has been automatically provided, implemented via 'System.IComparable'. Consider implementing the override 'Object.Equals' explicitly
 
+neg14a.fs(2,8,2,11): typecheck error FS0193: Module 'Lib' requires a type 'z'
+
+neg14a.fs(2,8,2,11): typecheck error FS0193: Module 'Lib' requires a type 'missingTypeVariableInSignature'
+
+neg14a.fs(2,8,2,11): typecheck error FS0193: Module 'Lib' requires a type 'missingTypeInImplementation'
+
+neg14a.fs(2,8,2,11): typecheck error FS0193: Module 'Lib' requires a type 'fieldsInWrongOrder'
+
 neg14b.fs(2,13,2,14): typecheck error FS0039: The value, constructor, namespace or type 'X' is not defined.

--- a/tests/fsharp/typecheck/sigs/neg56_a.bsl
+++ b/tests/fsharp/typecheck/sigs/neg56_a.bsl
@@ -1,2 +1,4 @@
 
 neg56_a.fs(11,35,11,47): typecheck error FS1125: The instantiation of the generic type 'list1' is missing and can't be inferred from the arguments or return type of this member. Consider providing a type instantiation when accessing this type, e.g. 'list1<_>'.
+
+neg56_a.fs(15,18,15,33): typecheck error FS3068: The function or member 'toList' is used in a way that requires further type annotations at its definition to ensure consistency of inferred types. The inferred signature is 'static member private list1.toList: ('a list1 -> 'a list)'.


### PR DESCRIPTION
This fixes remaining CI failures and enables by default `--parallelcompilation`. This includes:

- Parallel reference resolution
- Parallel optimizations #14390
- Parallel ILxGen #14372
- Graph based type checking #14494

**NOTE: For deterministic builds only parallel reference resolution will be enabled.**

`--parallelcompilation-` switch can be used to revert all of the above to previous behavior.

See tracking issue #18989

TODO:

- [x] restore switches
- [x] double check that with everything off things still work

Some il baselines changed because of reordered methods.

_This work was encouraged and kindly sponsored by [Amplifying F#](https://amplifyingfsharp.io/) initiative 🚀_