### PR TITLE
Bump xcopy-msbuild in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,7 +16,7 @@
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.14.16"
+    "xcopy-msbuild": "18.1.0"
   },
   "native-tools": {
     "perl": "5.38.2.2"


### PR DESCRIPTION
Bumps version of xcopy-msbuild in global.json to 18.1

Insertion pipelines are failing because of this https://github.com/dotnet/msbuild/issues/12669 but we should be on msbuild 18.1 already, so this version of xcopy-msbuild might be to blame