### PR TITLE
Revert "Bump xcopy-msbuild in global.json"

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,7 +16,7 @@
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "18.1.0"
+    "xcopy-msbuild": "17.14.16"
   },
   "native-tools": {
     "perl": "5.38.2.2"


### PR DESCRIPTION
Reverts dotnet/fsharp#19078

Apparently this is an invalid version (atm); also this change might not be needed after all