### PR TITLE
Work around for infinite restore in VS

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,10 @@
     <FsYaccPath>$(ArtifactsDir)/bin/fsyacc/$(Configuration)/$(FSharpNetCoreProductDefaultTargetFramework)/$(NETCoreSdkPortableRuntimeIdentifier)/fsyacc.dll</FsYaccPath>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(DesignTimeBuild)' == 'true'">
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="17.14.2120" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(UnitTestType)' == 'xunit'">
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVersion)" />


### PR DESCRIPTION
Proper fix would be on Arcade's side, but this is a temporary measure to make working with our sln less of a pain