### PR TITLE
Update output path for NoneSubstituteTextFiles target to include subdirectory

### DIFF
--- a/FSharpBuild.Directory.Build.targets
+++ b/FSharpBuild.Directory.Build.targets
@@ -26,9 +26,9 @@
     </NoneSubstituteText>
   </ItemDefinitionGroup>
 
-  <Target Name="NoneSubstituteTextFiles"
-          Inputs="@(NoneSubstituteText)"
-          Outputs="@(NoneSubstituteText->'$(IntermediateOutputPath)%(Filename)%(Extension)')"
+    <Target Name="NoneSubstituteTextFiles"
+      Inputs="@(NoneSubstituteText)"
+          Outputs="@(NoneSubstituteText->'$(IntermediateOutputPath)%(SubDir)%(Filename)%(Extension)')"
           BeforeTargets="AssignTargetPaths;BeforeBuild;GenerateFSharpTextResources">
 
     <ItemGroup>


### PR DESCRIPTION
## Description

This fix is only to be able to build on Mac OS X. Intention is to see if the build scripts are green in Ubuntu and Windows.

NO_RELEASE_NOTES