### PR TITLE
Activity: pass default version values to the source constructors

### DIFF
--- a/src/Compiler/Utilities/Activity.fs
+++ b/src/Compiler/Utilities/Activity.fs
@@ -135,7 +135,7 @@ module internal Activity =
 
             depth this 0
 
-    let private activitySource = new ActivitySource(ActivityNames.FscSourceName)
+    let private activitySource = new ActivitySource(ActivityNames.FscSourceName, "")
 
     let start (name: string) (tags: (string * string) seq) : System.IDisposable | null =
         let activity = activitySource.CreateActivity(name, ActivityKind.Internal)
@@ -173,7 +173,8 @@ module internal Activity =
 
             let profilingTags = [| workingSetMB; gc0; gc1; gc2; handles; threads |]
 
-        let private profiledSource = new ActivitySource(ActivityNames.ProfiledSourceName)
+        let private profiledSource =
+            new ActivitySource(ActivityNames.ProfiledSourceName, "")
 
         let startAndMeasureEnvironmentStats (name: string) : System.IDisposable | null = profiledSource.StartActivity(name)
 


### PR DESCRIPTION
With a newer SDK a new `ActivitySource` constructor overload is now available, which leads to an exception on an older runtime used in Rider. This change passes the default value explicitly, so the previous overload is used.