### PR TITLE
Fix null check bug in FSI settings initialization

### DIFF
--- a/src/fsi/console.fs
+++ b/src/fsi/console.fs
@@ -629,7 +629,7 @@ type internal ReadLineConsole() =
                     deleteWordLeadingToCursor ()
                     change ()
                 | _ ->
-                    // Note: If KeyChar=0, the not a proper char, e.g. it could be part of a multi key-press character,
+                    // Note: If KeyChar=0, it's not a proper char, e.g. it could be part of a multi key-press character,
                     //       e.g. e-acute is ' and e with the French (Belgium) IME and US Intl KB.
                     // Here: skip KeyChar=0 (except for F6 which maps to 0x1A (ctrl-Z?)).
                     if key.KeyChar <> '\000' || key.Key = ConsoleKey.F6 then

--- a/src/fsi/fsimain.fs
+++ b/src/fsi/fsimain.fs
@@ -224,7 +224,7 @@ let evaluateSession (argv: string[]) =
             else
                 let fsiTy = fsiAssembly.GetType("FSharp.Compiler.Interactive.Settings")
 
-                if isNull fsiAssembly then
+                if isNull fsiTy then
                     failwith "failed to find type FSharp.Compiler.Interactive.Settings in FSharp.Compiler.Interactive.Settings.dll"
 
                 Some(callStaticMethod fsiTy "get_fsi" [])


### PR DESCRIPTION
- Fix a copy-paste bug in `fsimain.fs` where the second null check tested `fsiAssembly` instead of `fsiTy`, making it dead code (the first branch already handles `fsiAssembly` being null) and silently passing null to `callStaticMethod` when the `Settings` type isn't found
- Fix a small comment typo in `console.fs` ("the not" → "it's not")