### PR TITLE
Fix assorted typos in FSharp.Core comments and XML docs

### DIFF
--- a/src/FSharp.Core/math/z.fsi
+++ b/src/FSharp.Core/math/z.fsi
@@ -17,31 +17,31 @@ namespace Microsoft.FSharp.Core
 /// <category>Basic Types</category>
 type bigint = System.Numerics.BigInteger
 
-/// <summary>Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI' </summary>
+/// <summary>Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI' </summary>
 ///
 /// <category>Language Primitives</category>
 [<AutoOpen>]
 module NumericLiterals =
 
-    /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+    /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
     module NumericLiteralI =
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromZero: value: unit -> 'T
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromOne: value: unit -> 'T
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromInt32: value: int32 -> 'T
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromInt64: value: int64 -> 'T
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromString: text: string -> 'T
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromInt64Dynamic: value: int64 -> objnull
 
-        /// Provides a default implementations of F# numeric literal syntax  for literals of the form 'dddI'
+        /// Provides a default implementation of F# numeric literal syntax for literals of the form 'dddI'
         val FromStringDynamic: text: string -> objnull

--- a/src/FSharp.Core/prim-types.fs
+++ b/src/FSharp.Core/prim-types.fs
@@ -5995,8 +5995,8 @@ namespace Microsoft.FSharp.Core
                     }
 
                     let current () = 
-                        // according to IEnumerator<int>.Current documentation, the result of of Current
-                        // is undefined prior to the first call of MoveNext and post called to MoveNext
+                        // according to IEnumerator<int>.Current documentation, the result of Current
+                        // is undefined prior to the first call of MoveNext and post call to MoveNext
                         // that return false (see https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1.current?view=net-7.0)
                         // so we should be able to just return value here, and we could get rid of the 
                         // complete variable which would be faster
@@ -6053,8 +6053,8 @@ namespace Microsoft.FSharp.Core
                         let mutable value = n - GenericOne
 
                         let inline current () =
-                            // according to IEnumerator<int>.Current documentation, the result of of Current
-                            // is undefined prior to the first call of MoveNext and post called to MoveNext
+                            // according to IEnumerator<int>.Current documentation, the result of Current
+                            // is undefined prior to the first call of MoveNext and post call to MoveNext
                             // that return false (see https://learn.microsoft.com/dotnet/api/system.collections.generic.ienumerator-1.current?view=net-7.0)
                             // so we should be able to just return value here, which would be faster
                             let derefValue = value

--- a/src/FSharp.Core/tasks.fsi
+++ b/src/FSharp.Core/tasks.fsi
@@ -339,7 +339,7 @@ module MediumPriority =
     type TaskBuilder with
 
         /// <summary>
-        /// Implementation of the `and!` operation for a a task and a task-like value.
+        /// Implementation of the `and!` operation for a task and a task-like value.
         /// </summary>
         member inline MergeSources< ^TaskLike2, ^TResult1, ^TResult2, ^Awaiter2> :
             task1: Task< ^TResult1 > * task2: ^TaskLike2 -> Task<struct (^TResult1 * ^TResult2)>
@@ -379,7 +379,7 @@ module MediumPriority =
     type BackgroundTaskBuilder with
 
         /// <summary>
-        /// Implementation of the `and!` operation for a a task and a task-like value.
+        /// Implementation of the `and!` operation for a task and a task-like value.
         /// </summary>
         member inline MergeSources< ^TaskLike2, ^TResult1, ^TResult2, ^Awaiter2> :
             task1: Task< ^TResult1 > * task2: ^TaskLike2 -> Task<struct (^TResult1 * ^TResult2)>


### PR DESCRIPTION
A bunch of random typo fixes spotted while reading the code:

- Doubled word "a a task" in `tasks.fsi` XML docs
- Doubled word "of of Current" in `prim-types.fs` comments
- Grammar "post called to MoveNext" → "post call to MoveNext" in `prim-types.fs`
- Subject-verb "a default implementations" → "a default implementation" in `z.fsi` (9 instances)
- Stray double spaces in `z.fsi` XML docs