### PR TITLE
Fix AttributeUsage.AllowMultiple not inherited for C#-defined attributes

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -25,6 +25,7 @@
 * Fix nativeptr in interfaces leads to TypeLoadException. (Issue [#14508](https://github.com/dotnet/fsharp/issues/14508), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix box instruction for literal upcasts. (Issue [#18319](https://github.com/dotnet/fsharp/issues/18319), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix Decimal Literal causes InvalidProgramException in Debug builds. (Issue [#18956](https://github.com/dotnet/fsharp/issues/18956), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
+* Fix `AttributeUsage.AllowMultiple` not being inherited for attributes subclassed in C#. ([Issue #17107](https://github.com/dotnet/fsharp/issues/17107), [PR #19315](https://github.com/dotnet/fsharp/pull/19315))
 
 ### Added
 

--- a/src/Compiler/Checking/PostInferenceChecks.fs
+++ b/src/Compiler/Checking/PostInferenceChecks.fs
@@ -2036,8 +2036,19 @@ and CheckAttribs cenv env (attribs: Attribs) =
         |> Seq.filter (fun (_, count) -> count > 1)
         |> Seq.map fst
         |> Seq.toList
-        // Filter for allowMultiple = false
-        |> List.filter (fun (tcref, _, m) -> TryFindAttributeUsageAttribute cenv.g m tcref <> Some true)
+        // Filter for allowMultiple = false, walking the inheritance chain to find AttributeUsage
+        |> List.filter (fun (tcref, _, m) ->
+            let rec allowsMultiple (tcref: TyconRef) =
+                match TryFindAttributeUsageAttribute cenv.g m tcref with
+                | Some res -> res
+                | None ->
+                    generalizedTyconRef cenv.g tcref
+                    |> GetSuperTypeOfType cenv.g cenv.amap m
+                    |> Option.bind (tryTcrefOfAppTy cenv.g >> ValueOption.toOption)
+                    |> Option.map allowsMultiple
+                    |> Option.defaultValue false
+
+            not (allowsMultiple tcref))
 
     if cenv.reportErrors then
        for tcref, _, m in duplicates do

--- a/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
@@ -814,9 +814,10 @@ module internal AttributeHelpers =
 
     /// Try to find the AllowMultiple value of the AttributeUsage attribute on a type definition.
     let TryFindAttributeUsageAttribute g m tcref =
-        TryBindTyconRefAttribute
+        tryBindTyconRefAttributeCore
             g
             m
+            (ValueSome WellKnownILAttributes.AttributeUsageAttribute)
             g.attrib_AttributeUsageAttribute
             tcref
             (fun (_, named) ->

--- a/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
@@ -812,30 +812,28 @@ module internal AttributeHelpers =
              | [ Some(:? bool as v: obj) ], _ -> Some v
              | _ -> None)
 
-    /// Try to find the resolved attributeusage for an type by walking its inheritance tree and picking the correct attribute usage value
+    /// Try to find the AllowMultiple value of the AttributeUsage attribute on a type definition.
     let TryFindAttributeUsageAttribute g m tcref =
-        [| yield tcref; yield! supersOfTyconRef tcref |]
-        |> Array.tryPick (fun tcref ->
-            TryBindTyconRefAttribute
-                g
-                m
-                g.attrib_AttributeUsageAttribute
-                tcref
-                (fun (_, named) ->
-                    named
-                    |> List.tryPick (function
-                        | "AllowMultiple", _, _, ILAttribElem.Bool res -> Some res
-                        | _ -> None))
-                (fun (Attrib(_, _, _, named, _, _, _)) ->
-                    named
-                    |> List.tryPick (function
-                        | AttribNamedArg("AllowMultiple", _, _, AttribBoolArg res) -> Some res
-                        | _ -> None))
-                (fun (_, named) ->
-                    named
-                    |> List.tryPick (function
-                        | "AllowMultiple", Some(:? bool as res: obj) -> Some res
-                        | _ -> None)))
+        TryBindTyconRefAttribute
+            g
+            m
+            g.attrib_AttributeUsageAttribute
+            tcref
+            (fun (_, named) ->
+                named
+                |> List.tryPick (function
+                    | "AllowMultiple", _, _, ILAttribElem.Bool res -> Some res
+                    | _ -> None))
+            (fun (Attrib(_, _, _, named, _, _, _)) ->
+                named
+                |> List.tryPick (function
+                    | AttribNamedArg("AllowMultiple", _, _, AttribBoolArg res) -> Some res
+                    | _ -> None))
+            (fun (_, named) ->
+                named
+                |> List.tryPick (function
+                    | "AllowMultiple", Some(:? bool as res: obj) -> Some res
+                    | _ -> None))
 
     /// Try to find a specific attribute on a type definition, where the attribute accepts a string argument.
     ///

--- a/src/Compiler/TypedTree/TypedTreeOps.Attributes.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.Attributes.fsi
@@ -194,7 +194,7 @@ module internal AttributeHelpers =
     /// Check if a TyconRef has AllowNullLiteralAttribute, returning Some true/Some false/None.
     val TyconRefAllowsNull: g: TcGlobals -> tcref: TyconRef -> bool option
 
-    /// Try to find the AttributeUsage attribute, looking for the value of the AllowMultiple named parameter
+    /// Try to find the AllowMultiple value of the AttributeUsage attribute on a type definition.
     val TryFindAttributeUsageAttribute: TcGlobals -> range -> TyconRef -> bool option
 
     val (|AttribBitwiseOrExpr|_|): TcGlobals -> Expr -> (Expr * Expr) voption

--- a/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fs
@@ -1542,11 +1542,3 @@ module internal MemberRepresentation =
         match tycon.TypeContents.tcaug_super with
         | None -> g.obj_ty_noNulls
         | Some ty -> ty
-
-    /// walk a TyconRef's inheritance tree, yielding any parent types as an array
-    let supersOfTyconRef (tcref: TyconRef) =
-        tcref
-        |> Array.unfold (fun tcref ->
-            match tcref.TypeContents.tcaug_super with
-            | Some(TType_app(sup, _, _)) -> Some(sup, sup)
-            | _ -> None)

--- a/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fsi
+++ b/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fsi
@@ -357,9 +357,6 @@ module internal MemberRepresentation =
 
     val superOfTycon: TcGlobals -> Tycon -> TType
 
-    /// walk a TyconRef's inheritance tree, yielding any parent types as an array
-    val supersOfTyconRef: TyconRef -> TyconRef array
-
     val GetTraitConstraintInfosOfTypars: TcGlobals -> Typars -> TraitConstraintInfo list
 
     val GetTraitWitnessInfosOfTypars: TcGlobals -> numParentTypars: int -> typars: Typars -> TraitWitnessInfos

--- a/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/AttributeCheckingTests.fs
@@ -77,3 +77,114 @@ type C() =
         |> withReferences [csharpBaseClass]
         |> compile
         |> shouldSucceed
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``C# attribute subclass inherits AllowMultiple true from base`` () =
+        let csharpLib =
+            CSharp """
+            using System;
+
+            [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+            public class BaseAttribute : Attribute { }
+            public class ChildAttribute : BaseAttribute { }
+            """ |> withName "csAttrLib"
+
+        FSharp """
+module Test
+
+[<Child; Child>]
+type C() = class end
+        """
+        |> withReferences [csharpLib]
+        |> compile
+        |> shouldSucceed
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``C# attribute subclass inherits AllowMultiple false from base`` () =
+        let csharpLib =
+            CSharp """
+            using System;
+
+            [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+            public class BaseAttribute : Attribute { }
+            public class ChildAttribute : BaseAttribute { }
+            """ |> withName "csAttrLib"
+
+        FSharp """
+module Test
+
+[<Child; Child>]
+type C() = class end
+        """
+        |> withReferences [csharpLib]
+        |> compile
+        |> shouldFail
+        |> withSingleDiagnostic (Error 429, Line 4, Col 10, Line 4, Col 15, "The attribute type 'ChildAttribute' has 'AllowMultiple=false'. Multiple instances of this attribute cannot be attached to a single language element.")
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``C# attribute multi-level inheritance inherits AllowMultiple true`` () =
+        let csharpLib =
+            CSharp """
+            using System;
+
+            [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+            public class BaseAttribute : Attribute { }
+            public class MiddleAttribute : BaseAttribute { }
+            public class LeafAttribute : MiddleAttribute { }
+            """ |> withName "csAttrLib"
+
+        FSharp """
+module Test
+
+[<Leaf; Leaf>]
+type C() = class end
+        """
+        |> withReferences [csharpLib]
+        |> compile
+        |> shouldSucceed
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``C# attribute subclass with own AttributeUsage overrides base AllowMultiple`` () =
+        let csharpLib =
+            CSharp """
+            using System;
+
+            [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+            public class BaseAttribute : Attribute { }
+
+            [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+            public class ChildAttribute : BaseAttribute { }
+            """ |> withName "csAttrLib"
+
+        FSharp """
+module Test
+
+[<Child; Child>]
+type C() = class end
+        """
+        |> withReferences [csharpLib]
+        |> compile
+        |> shouldFail
+        |> withSingleDiagnostic (Error 429, Line 4, Col 10, Line 4, Col 15, "The attribute type 'ChildAttribute' has 'AllowMultiple=false'. Multiple instances of this attribute cannot be attached to a single language element.")
+
+    [<FSharp.Test.FactForNETCOREAPP>]
+    let ``F# attribute subclass of C# base inherits AllowMultiple true`` () =
+        let csharpLib =
+            CSharp """
+            using System;
+
+            [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+            public class BaseAttribute : Attribute { }
+            """ |> withName "csAttrLib"
+
+        FSharp """
+module Test
+
+type ChildAttribute() = inherit BaseAttribute()
+
+[<Child; Child>]
+type C() = class end
+        """
+        |> withReferences [csharpLib]
+        |> compile
+        |> shouldSucceed


### PR DESCRIPTION
## Description

The F# compiler was not walking the inheritance chain for IL-imported (C#) attribute types when checking AllowMultiple. The `supersOfTyconRef` function only used `tcaug_super`, which is not populated for IL types.

This fix parameterizes `TryFindAttributeUsageAttribute` with a getSuper resolver function. The caller in PostInferenceChecks now passes a resolver using GetSuperTypeOfType, which correctly handles both F# and IL-imported types via ILTypeDef.Extends.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #17107

## Checklist

- [x] Test cases added
- [x] Release notes entry updated