### PR TITLE
Remove dead BUILDING_WITH_LKG define

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,7 +59,6 @@
          since it's a non-arcade and non-sourcebuild scenario -->
     <FsLexPath>$(ArtifactsDir)/bin/fslex/$(Configuration)/$(FSharpNetCoreProductDefaultTargetFramework)/$(RuntimeIdentifier)/fslex.dll</FsLexPath>
     <FsYaccPath>$(ArtifactsDir)/bin/fsyacc/$(Configuration)/$(FSharpNetCoreProductDefaultTargetFramework)/$(RuntimeIdentifier)/fsyacc.dll</FsYaccPath>
-    <DefineConstants>BUILDING_WITH_LKG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)/eng/Versions.props" Condition="'$(DISABLE_ARCADE)' == 'true'" />

--- a/FSharp.Profiles.props
+++ b/FSharp.Profiles.props
@@ -2,10 +2,6 @@
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <Project>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Proto'">
-    <DefineConstants>BUILDING_WITH_LKG;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.fsproj' and $(TolerateUnusedBindings) != 'true'">
     <WarningsAsErrors>1182;$(WarningsAsErrors)</WarningsAsErrors>
     <WarnOn>1182;3879;$(WarnOn)</WarnOn>


### PR DESCRIPTION
PR #19235 removed all the `#if BUILDING_WITH_LKG` conditionals from source code, but left the constant itself defined in `Directory.Build.props` and `FSharp.Profiles.props`. It's dead code now — no `#if` directive references it. This removes both definitions.

Fixes #18061