### PR TITLE
Change Seq.empty to use Enumerable.Empty

### DIFF
--- a/docs/release-notes/.FSharp.Core/10.0.300.md
+++ b/docs/release-notes/.FSharp.Core/10.0.300.md
@@ -1,5 +1,7 @@
 ### Fixed
 
+* `Seq.empty` now uses `System.Linq.Enumerable.Empty<'T>()` instead of an internal DU, fixing serialization issues with JSON.NET, STJ, and ASP.NET ObjectResult. ([Issue #17864](https://github.com/dotnet/fsharp/issues/17864), [PR #19322](https://github.com/dotnet/fsharp/pull/19322))
+
 ### Added
 
 ### Changed

--- a/src/FSharp.Core/seq.fs
+++ b/src/FSharp.Core/seq.fs
@@ -608,7 +608,7 @@ module Seq =
         mkUnfoldSeq generator state
 
     [<CompiledName("Empty")>]
-    let empty<'T> = (EmptyEnumerable :> seq<'T>)
+    let empty<'T> = System.Linq.Enumerable.Empty<'T>()
 
     [<CompiledName("InitializeInfinite")>]
     let initInfinite initializer =

--- a/src/FSharp.Core/seqcore.fs
+++ b/src/FSharp.Core/seqcore.fs
@@ -62,16 +62,6 @@ module internal IEnumerator =
             
     let Empty<'T> () = (new EmptyEnumerator<'T>() :> IEnumerator<'T>)
 
-    [<NoEquality; NoComparison>]
-    type EmptyEnumerable<'T> =
-
-        | EmptyEnumerable
-
-        interface IEnumerable<'T> with
-            member _.GetEnumerator() = Empty<'T>()
-
-        interface IEnumerable with
-            member _.GetEnumerator() = (Empty<'T>() :> IEnumerator)
 
     type GeneratedEnumerable<'T, 'State>(openf: unit -> 'State, compute: 'State -> 'T option, closef: 'State -> unit) =
         let mutable started = false
@@ -313,17 +303,10 @@ module RuntimeHelpers =
                         let rec takeOuter() =
                             if outerEnum.MoveNext() then
                                 let ie = outerEnum.Current
-                                // Optimization to detect the statically-allocated empty IEnumerables
-                                match box ie with
-                                | :? EmptyEnumerable<'T> ->
-                                     // This one is empty, just skip, don't call GetEnumerator, try again
-                                     takeOuter()
-                                | _ ->
-                                     // OK, this one may not be empty.
-                                     // Don't forget to dispose of the enumerator for the inner list now we're done with it
-                                     currInnerEnum.Dispose()
-                                     currInnerEnum <- ie.GetEnumerator()
-                                     takeInner ()
+                                // Don't forget to dispose of the enumerator for the inner list now we're done with it
+                                currInnerEnum.Dispose()
+                                currInnerEnum <- ie.GetEnumerator()
+                                takeInner ()
                             else
                                 // We're done
                                 x.Finish()

--- a/src/FSharp.Core/seqcore.fsi
+++ b/src/FSharp.Core/seqcore.fsi
@@ -24,12 +24,6 @@ module internal IEnumerator =
 
     val Empty: unit -> IEnumerator<'T>
 
-    [<NoEqualityAttribute; NoComparisonAttribute>]
-    type EmptyEnumerable<'T> =
-        | EmptyEnumerable
-
-        interface IEnumerable
-        interface IEnumerable<'T>
 
     [<SealedAttribute>]
     type Singleton<'T> =

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Collections/SeqModule2.fs
@@ -2067,3 +2067,15 @@ type SeqModule2() =
         Assert.AreEqual([0; 0], Seq.insertManyAt 0 [0; 0] [] |> Seq.toList)
         CheckThrowsArgumentException (fun () -> Seq.insertManyAt -1 [0; 0] [1] |> Seq.toList |> ignore)
         CheckThrowsArgumentException (fun () -> Seq.insertManyAt 2 [0; 0] [1] |> Seq.toList |> ignore)
+
+    [<Fact>]
+    member _.EmptySerializesAsEmptyArray() =
+        let json = System.Text.Json.JsonSerializer.Serialize(Seq.empty<int>)
+        Assert.AreEqual("[]", json)
+
+    [<Fact>]
+    member _.EmptyFormatsCorrectly() =
+        // Seq.empty uses Enumerable.Empty which returns a cached empty array,
+        // so %A formats it with array notation
+        let formatted = sprintf "%A" Seq.empty<int>
+        Assert.AreEqual("[||]", formatted)


### PR DESCRIPTION
## Description

`Seq.empty` was implemented as a single-case DU (`EmptyEnumerable`) that carries a `[CompilationMapping(SourceConstructFlags.SumType)]` attribute. When serializers (JSON.NET, STJ, ASP.NET ObjectResult) inspect the runtime type via reflection, they detect this attribute and treat it as an F# union rather than a plain enumerable, causing `Seq.empty` to serialize as `"EmptyEnumerable"` instead of `[]` or throw `NotSupportedException`.

Replacing the implementation with `System.Linq.Enumerable.Empty<'T>()` fixes this — the runtime type is now a standard .NET type that serializers handle correctly. The internal `EmptyEnumerable` DU and a related type-check optimization in `ConcatEnumerator` are no longer needed and have been removed.

I basically did what was suggested in the ticket, so I hope I got it right. It's fun to hunt for simple issue that I might be able to help with. 

Fixes #17864

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated