### PR TITLE
Symbols: add ObsoleteDiagnosticInfo

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -61,6 +61,7 @@
 ### Added
 
 * Added warning FS3884 when a function or delegate value is used as an interpolated string argument. ([PR #19289](https://github.com/dotnet/fsharp/pull/19289))
+* Symbols: add ObsoleteDiagnosticInfo ([PR #19359](https://github.com/dotnet/fsharp/pull/19359))
 * Add `#version;;` directive to F# Interactive to display version and environment information. ([Issue #13307](https://github.com/dotnet/fsharp/issues/13307), [PR #19332](https://github.com/dotnet/fsharp/pull/19332))
 
 ### Changed

--- a/src/Compiler/Checking/AttributeChecking.fs
+++ b/src/Compiler/Checking/AttributeChecking.fs
@@ -6,11 +6,11 @@ module internal FSharp.Compiler.AttributeChecking
 
 open System
 open System.Collections.Generic
+open FSharp.Compiler.Text.Range
 open Internal.Utilities.Library
 open FSharp.Compiler.AbstractIL.IL 
 open FSharp.Compiler 
 open FSharp.Compiler.DiagnosticsLogger
-open FSharp.Compiler.Features
 open FSharp.Compiler.Import
 open FSharp.Compiler.Infos
 open FSharp.Compiler.TcGlobals
@@ -255,25 +255,31 @@ let rec MethInfoHasWellKnownAttribute g (m: range) (ilFlag: WellKnownILAttribute
 let MethInfoHasWellKnownAttributeSpec (g: TcGlobals) (m: range) (spec: WellKnownMethAttribute) (minfo: MethInfo) =
     MethInfoHasWellKnownAttribute g m spec.ILFlag spec.ValFlag spec.AttribInfo minfo
 
-let private CheckCompilerFeatureRequiredAttribute cattrs msg m =
-    // In some cases C# will generate both ObsoleteAttribute and CompilerFeatureRequiredAttribute.
-    // Specifically, when default constructor is generated for class with any required members in them.
-    // ObsoleteAttribute should be ignored if CompilerFeatureRequiredAttribute is present, and its name is "RequiredMembers".
+let private reportObsoleteDiagnostic m diagnostic =
+    match diagnostic with
+    | Some(ObsoleteDiagnosticInfo(isError, id, msg, urlFormat)) ->
+        let obsoleteDiagnostic = ObsoleteDiagnostic(isError, id, msg, urlFormat, m)
+        if isError then
+            ErrorD(obsoleteDiagnostic)
+        else
+            WarnD(obsoleteDiagnostic)
+
+    | _ -> CompleteD
+
+let private HasCompilerFeatureRequiredAttribute (cattrs: ILAttributes) =
     match cattrs with
-    | ILAttribDecoded WellKnownILAttributes.CompilerFeatureRequiredAttribute ([ILAttribElem.String (Some featureName) ], _) when featureName = "RequiredMembers" ->
-        CompleteD
-    | _ ->
-        ErrorD (ObsoleteDiagnostic(true, None, msg, None, m))
-        
+    | ILAttribDecoded WellKnownILAttributes.CompilerFeatureRequiredAttribute ([ ILAttribElem.String(Some featureName) ], _) -> featureName = "RequiredMembers"
+    | _ -> false
+
 let private extractILAttribValueFrom name namedArgs   =
     match namedArgs with 
     | ExtractILAttributeNamedArg name (AttribElemStringArg v) -> Some v 
     | _ -> None
 
-let private extractILAttributeInfo namedArgs =
+let private extractILObsoleteAttributeInfo namedArgs =
     let diagnosticId = extractILAttribValueFrom "DiagnosticId" namedArgs
     let urlFormat = extractILAttribValueFrom "UrlFormat" namedArgs
-    (diagnosticId, urlFormat)
+    diagnosticId, urlFormat
 
 let private CheckILExperimentalAttributes cattrs m =
     match cattrs with
@@ -296,47 +302,39 @@ let private CheckILExperimentalAttributes cattrs m =
     // Empty constructor or only UrlFormat property are not allowed.
     | _ -> CompleteD
 
-let private CheckILObsoleteAttributes (g: TcGlobals) isByrefLikeTyconRef cattrs m =
+let TryGetILObsoleteInfo (g: TcGlobals) isByrefLikeTyconRef cattrs : ObsoleteDiagnosticInfo option =
     if isByrefLikeTyconRef then
+        None
+    else
+        match TryDecodeILAttribute g.attrib_SystemObsolete.TypeRef cattrs with
+        | Some([ attribElement ], namedArgs) ->
+            let diagnosticId, urlFormat = extractILObsoleteAttributeInfo namedArgs
+            let msg =
+                match attribElement with
+                | ILAttribElem.String(Some msg) -> Some msg
+                | ILAttribElem.String None
+                | _ -> None
+
+            Some(ObsoleteDiagnosticInfo(false, diagnosticId, msg, urlFormat))
+
+        | Some([ILAttribElem.String msg; ILAttribElem.Bool isError ], namedArgs) ->
+            let diagnosticId, urlFormat = extractILObsoleteAttributeInfo namedArgs
+            Some(ObsoleteDiagnosticInfo(isError, diagnosticId, msg, urlFormat))
+
+        | Some(_, namedArgs) ->
+            let diagnosticId, urlFormat = extractILObsoleteAttributeInfo namedArgs
+            Some(ObsoleteDiagnosticInfo(false, diagnosticId, None, urlFormat))
+
+        | None -> None
+
+let private CheckILObsoleteAttributes (g: TcGlobals) isByrefLikeTyconRef cattrs m =
+    // In some cases C# will generate both ObsoleteAttribute and CompilerFeatureRequiredAttribute.
+    // Specifically, when default constructor is generated for class with any required members in them.
+    // ObsoleteAttribute should be ignored if CompilerFeatureRequiredAttribute is present, and its name is "RequiredMembers".
+    if isByrefLikeTyconRef || HasCompilerFeatureRequiredAttribute cattrs then
         CompleteD
     else
-        match cattrs with
-        // [Obsolete]
-        // [Obsolete("Message")]
-        // [Obsolete("Message", true)]
-        // [Obsolete("Message", DiagnosticId = "DiagnosticId")]
-        // [Obsolete("Message", DiagnosticId = "DiagnosticId", UrlFormat = "UrlFormat")]
-        // [Obsolete(DiagnosticId = "DiagnosticId")]
-        // [Obsolete(DiagnosticId = "DiagnosticId", UrlFormat = "UrlFormat")]
-        // [Obsolete("Message", true, DiagnosticId = "DiagnosticId")]
-        // [Obsolete("Message", true, DiagnosticId = "DiagnosticId", UrlFormat = "UrlFormat")]
-        // Constructors deciding on IsError and Message properties.
-        | ILAttribDecoded WellKnownILAttributes.ObsoleteAttribute decoded ->
-            match decoded with
-            | ([ attribElement ], namedArgs) ->
-                let diagnosticId, urlFormat = extractILAttributeInfo namedArgs
-                let msg = 
-                    match attribElement with 
-                    | ILAttribElem.String (Some msg) -> Some msg
-                    | ILAttribElem.String None
-                    | _ -> None
-
-                WarnD (ObsoleteDiagnostic(false, diagnosticId, msg, urlFormat, m))
-            | ([ILAttribElem.String msg; ILAttribElem.Bool isError ], namedArgs) ->
-                let diagnosticId, urlFormat = extractILAttributeInfo namedArgs
-                if isError then
-                    if g.langVersion.SupportsFeature(LanguageFeature.RequiredPropertiesSupport) then
-                        CheckCompilerFeatureRequiredAttribute cattrs msg m
-                    else
-                        ErrorD (ObsoleteDiagnostic(true, diagnosticId, msg, urlFormat, m))
-                else
-                    WarnD (ObsoleteDiagnostic(false, diagnosticId, msg, urlFormat, m))
-            // Only DiagnosticId, UrlFormat
-            | (_, namedArgs) ->
-                let diagnosticId, urlFormat = extractILAttributeInfo namedArgs
-                WarnD(ObsoleteDiagnostic(false, diagnosticId, None, urlFormat, m))
-        // No arguments
-        | _ -> CompleteD
+        TryGetILObsoleteInfo g isByrefLikeTyconRef cattrs |> reportObsoleteDiagnostic m
 
 /// Check IL attributes for Experimental, warnings as data
 let private CheckILAttributes (g: TcGlobals) isByrefLikeTyconRef cattrs m =
@@ -354,23 +352,39 @@ let private extractObsoleteAttributeInfo namedArgs =
     let urlFormat = extractILAttribValueFrom "UrlFormat" namedArgs
     (diagnosticId, urlFormat)
 
+let TryGetFSharpObsoleteInfo g attribs : ObsoleteDiagnosticInfo option =
+    // [<Obsolete>]
+    // [<Obsolete("Message")>]
+    // [<Obsolete("Message", true)>]
+    // [<Obsolete("Message", DiagnosticId = "DiagnosticId")>]
+    // [<Obsolete("Message", DiagnosticId = "DiagnosticId", UrlFormat = "UrlFormat")>]
+    // [<Obsolete(DiagnosticId = "DiagnosticId")>]
+    // [<Obsolete(DiagnosticId = "DiagnosticId", UrlFormat = "UrlFormat")>]
+    // [<Obsolete("Message", true, DiagnosticId = "DiagnosticId")>]
+    // [<Obsolete("Message", true, DiagnosticId = "DiagnosticId", UrlFormat = "UrlFormat")>]
+    // Constructors deciding on IsError and Message properties.
+    match TryFindFSharpAttribute g g.attrib_SystemObsolete attribs with
+    | Some(Attrib(unnamedArgs = [ AttribStringArg s ]; propVal = namedArgs)) ->
+        let diagnosticId, urlFormat = extractObsoleteAttributeInfo namedArgs
+        Some(ObsoleteDiagnosticInfo(false, diagnosticId, Some s, urlFormat))
+
+    | Some(Attrib(unnamedArgs = [ AttribStringArg s; AttribBoolArg(isError) ]; propVal = namedArgs)) -> 
+        let diagnosticId, urlFormat = extractObsoleteAttributeInfo namedArgs
+        Some(ObsoleteDiagnosticInfo(isError, diagnosticId, Some s, urlFormat))
+
+    // Only DiagnosticId, UrlFormat
+    | Some(Attrib(propVal = namedArgs)) ->
+        let diagnosticId, urlFormat = extractObsoleteAttributeInfo namedArgs
+        Some(ObsoleteDiagnosticInfo(false, diagnosticId, None, urlFormat))
+
+    | None -> None
+
 let private CheckObsoleteAttributes g attribs m =
     trackErrors {
-        match attribs with
-        | EntityAttrib g WellKnownEntityAttributes.ObsoleteAttribute (Attrib(unnamedArgs= [ AttribStringArg s ]; propVal= namedArgs)) ->
-            let diagnosticId, urlFormat = extractObsoleteAttributeInfo namedArgs
-            do! WarnD(ObsoleteDiagnostic(false, diagnosticId, Some s, urlFormat, m))
-        | EntityAttrib g WellKnownEntityAttributes.ObsoleteAttribute (Attrib(unnamedArgs= [ AttribStringArg s; AttribBoolArg(isError) ]; propVal= namedArgs)) -> 
-            let diagnosticId, urlFormat = extractObsoleteAttributeInfo namedArgs
-            if isError then
-                do! ErrorD (ObsoleteDiagnostic(true, diagnosticId, Some s, urlFormat, m))
-            else
-                do! WarnD (ObsoleteDiagnostic(false, diagnosticId, Some s, urlFormat, m))
-        // Only DiagnosticId, UrlFormat
-        | EntityAttrib g WellKnownEntityAttributes.ObsoleteAttribute (Attrib(propVal= namedArgs)) ->
-            let diagnosticId, urlFormat = extractObsoleteAttributeInfo namedArgs
-            do! WarnD(ObsoleteDiagnostic(false, diagnosticId, None, urlFormat, m))
-        | _ ->  ()
+        match TryGetFSharpObsoleteInfo g attribs with
+        | Some _ as diag ->
+            do! reportObsoleteDiagnostic m diag
+        | _ -> ()
     }
     
 let private CheckCompilerMessageAttribute g attribs m =
@@ -431,22 +445,23 @@ let CheckFSharpAttributes (g:TcGlobals) attribs m =
         }
 
 #if !NO_TYPEPROVIDERS
-/// Check a list of provided attributes for 'ObsoleteAttribute', returning errors and warnings as data
-let private CheckProvidedAttributes (g: TcGlobals) m (provAttribs: Tainted<IProvidedCustomAttributeProvider>)  = 
+let TryGetProvidedObsoleteInfo (g: TcGlobals) m (provAttribs: Tainted<IProvidedCustomAttributeProvider>) : ObsoleteDiagnosticInfo option =
     let (AttribInfo(tref, _)) = g.attrib_SystemObsolete
-    match provAttribs.PUntaint((fun a -> a.GetAttributeConstructorArgs(provAttribs.TypeProvider.PUntaintNoFailure(id), tref.FullName)), m) with
-    | Some ([ Some (:? string as msg) ], _) -> WarnD(ObsoleteDiagnostic(false, None, Some msg, None, m))
-    | Some ([ Some (:? string as msg); Some (:?bool as isError) ], _) ->
-        if isError then 
-            ErrorD (ObsoleteDiagnostic(true, None, Some msg, None, m))
-        else 
-            WarnD (ObsoleteDiagnostic(false, None, Some msg, None, m))
-    | Some ([ None ], _) -> 
-        WarnD(ObsoleteDiagnostic(false, None, None, None, m))
-    | Some _ -> 
-        WarnD(ObsoleteDiagnostic(false, None, None, None, m))
-    | None -> 
-        CompleteD
+    match provAttribs.PUntaint(_.GetAttributeConstructorArgs(provAttribs.TypeProvider.PUntaintNoFailure(id), tref.FullName), m) with
+    | Some([ Some (:? string as msg) ], _) ->
+        Some(ObsoleteDiagnosticInfo(false, None, Some msg, None))
+
+    | Some([ Some (:? string as msg); Some (:? bool as isError) ], _) ->
+        Some(ObsoleteDiagnosticInfo(isError, None, Some msg, None))
+
+    | Some _ ->
+        Some(ObsoleteDiagnosticInfo(false, None, None, None))
+
+    | _ -> None
+
+/// Check a list of provided attributes for 'ObsoleteAttribute', returning errors and warnings as data
+let private CheckProvidedAttributes (g: TcGlobals) m (provAttribs: Tainted<IProvidedCustomAttributeProvider>) =
+    TryGetProvidedObsoleteInfo g m provAttribs |> reportObsoleteDiagnostic m
 #endif
 
 /// Indicate if IL attributes contain 'ObsoleteAttribute'. Used to suppress the item in intellisense.
@@ -507,12 +522,21 @@ let CheckPropInfoAttributes pinfo m =
 #if !NO_TYPEPROVIDERS
     | ProvidedProp (amap, pi, m) ->  
         CheckProvidedAttributes amap.g m (pi.PApply((fun st -> (st :> IProvidedCustomAttributeProvider)), m))
-         
 #endif
 
+let TryGetPropObsoleteInfo pinfo =
+    match pinfo with
+    | ILProp(ILPropInfo(_, pdef)) -> TryGetILObsoleteInfo pinfo.TcGlobals false pdef.CustomAttrs
+    | FSProp(g, _, Some vref, _) 
+    | FSProp(g, _, _, Some vref) -> TryGetFSharpObsoleteInfo g vref.Attribs
+    | FSProp _ -> failwith "CheckPropInfoAttributes: unreachable"
+#if !NO_TYPEPROVIDERS
+    | ProvidedProp (amap, pi, m) ->
+        TryGetProvidedObsoleteInfo amap.g m (pi.PApply((fun st -> (st :> IProvidedCustomAttributeProvider)), m)) 
+#endif
       
 /// Check the attributes associated with a IL field, returning warnings and errors as data.
-let CheckILFieldAttributes g (finfo:ILFieldInfo) m = 
+let CheckILFieldAttributes g (finfo: ILFieldInfo) m = 
     match finfo with 
     | ILFieldInfo(_, pd) -> 
         CheckILAttributes g false pd.CustomAttrs m |> CommitOperationResult
@@ -521,15 +545,34 @@ let CheckILFieldAttributes g (finfo:ILFieldInfo) m =
         CheckProvidedAttributes amap.g m (fi.PApply((fun st -> (st :> IProvidedCustomAttributeProvider)), m)) |> CommitOperationResult
 #endif
 
+let TryGetILFieldObsoleteInfo g (finfo : ILFieldInfo) =
+    match finfo with 
+    | ILFieldInfo(_, pd) -> TryGetILObsoleteInfo g false pd.CustomAttrs
+#if !NO_TYPEPROVIDERS
+    | ProvidedField (amap, fi, m) -> 
+        TryGetProvidedObsoleteInfo amap.g m (fi.PApply((fun st -> (st :> IProvidedCustomAttributeProvider)), m))
+#endif
+
 /// Check the attributes on an entity, returning errors and warnings as data.
 let CheckEntityAttributes g (tcref: TyconRef) m =    
-    if tcref.IsILTycon then 
+    if tcref.IsILTycon then
         CheckILAttributes g (isByrefLikeTyconRef g m tcref) tcref.ILTyconRawMetadata.CustomAttrs m
-    else 
+    else
         CheckFSharpAttributes g tcref.Attribs m
-        
+
+let TryGetEntityObsoleteInfo g (tcref: TyconRef) =
+    if tcref.IsILTycon then
+        TryGetILObsoleteInfo g (isByrefLikeTyconRef g range0 tcref) tcref.ILTyconRawMetadata.CustomAttrs
+    else
+        TryGetFSharpObsoleteInfo g tcref.Attribs
+    
 let CheckILEventAttributes g (tcref: TyconRef) cattrs m  =    
     CheckILAttributes g (isByrefLikeTyconRef g m tcref) cattrs m
+
+let TryGetEventObsoleteInfo (einfo: EventInfo) =
+    match einfo with
+    | ILEvent(ILEventInfo(_, ilEventDef)) -> TryGetILObsoleteInfo einfo.TcGlobals false ilEventDef.CustomAttrs 
+    | _ -> None
 
 let CheckUnitOfMeasureAttributes g (measure: Measure) = 
     let checkAttribs tm m =
@@ -579,6 +622,16 @@ let CheckMethInfoAttributes g m tyargsOpt (minfo: MethInfo) =
         | Some res -> do! res
         | None -> () // no attribute = no errors 
 }
+
+let TryGetMethodObsoleteInfo minfo =
+    BindMethInfoAttributes range0 minfo
+        (TryGetILObsoleteInfo minfo.TcGlobals false)
+        (TryGetFSharpObsoleteInfo minfo.TcGlobals)
+#if !NO_TYPEPROVIDERS
+        (TryGetProvidedObsoleteInfo minfo.TcGlobals range0)
+#else
+        (fun _provAttribs -> None)
+#endif 
 
 /// Indicate if a method has 'Obsolete', 'CompilerMessageAttribute' or 'TypeProviderEditorHideMethodsAttribute'. 
 /// Used to suppress the item in intellisense.

--- a/src/Compiler/Checking/AttributeChecking.fsi
+++ b/src/Compiler/Checking/AttributeChecking.fsi
@@ -55,6 +55,8 @@ val TryBindMethInfoAttribute:
         'a option
 #endif
 
+val TryGetMethodObsoleteInfo: minfo: MethInfo -> ObsoleteDiagnosticInfo option
+
 val TryFindMethInfoStringAttribute:
     g: TcGlobals -> m: range -> attribSpec: BuiltinAttribInfo -> minfo: MethInfo -> string option
 
@@ -86,13 +88,19 @@ val CheckILAttributesForUnseenStored: g: TcGlobals -> cattrsStored: ILAttributes
 
 val CheckFSharpAttributesForHidden: g: TcGlobals -> attribs: Attrib list -> bool
 
-val CheckFSharpAttributesForObsolete: g: TcGlobals -> attribs: Attrib list -> bool
+val TryGetFSharpObsoleteInfo: g: TcGlobals -> attribs: Attrib list -> ObsoleteDiagnosticInfo option
+
+val CheckFSharpAttributesForObsolete: g: TcGlobals -> attribs: Attribs -> bool
 
 val CheckFSharpAttributesForUnseen: g: TcGlobals -> attribs: Attrib list -> allowObsolete: bool -> bool
 
 val CheckPropInfoAttributes: pinfo: PropInfo -> m: range -> OperationResult<unit>
 
+val TryGetPropObsoleteInfo: pinfo: PropInfo -> ObsoleteDiagnosticInfo option
+
 val CheckILFieldAttributes: g: TcGlobals -> finfo: ILFieldInfo -> m: range -> unit
+
+val TryGetILFieldObsoleteInfo: g: TcGlobals -> finfo: ILFieldInfo -> ObsoleteDiagnosticInfo option
 
 val CheckMethInfoAttributes:
     g: TcGlobals -> m: range -> tyargsOpt: 'a option -> minfo: MethInfo -> OperationResult<unit>
@@ -106,6 +114,8 @@ val ILFieldInfoIsUnseen: finfo: ILFieldInfo -> bool
 val EventInfoIsUnseen: allowObsolete: bool -> einfo: EventInfo -> bool
 
 val CheckEntityAttributes: g: TcGlobals -> tcref: TyconRef -> m: range -> OperationResult<unit>
+
+val TryGetEntityObsoleteInfo: g: TcGlobals -> tcref: TyconRef -> ObsoleteDiagnosticInfo option
 
 val CheckUnionCaseAttributes: g: TcGlobals -> x: UnionCaseRef -> m: range -> OperationResult<unit>
 
@@ -125,3 +135,5 @@ val IsSecurityCriticalAttribute: g: TcGlobals -> Attrib -> bool
 val IsAssemblyVersionAttribute: g: TcGlobals -> Attrib -> bool
 
 val CheckILEventAttributes: g: TcGlobals -> tcref: TyconRef -> cattrs: ILAttributes -> m: range -> OperationResult<unit>
+
+val TryGetEventObsoleteInfo: einfo: EventInfo -> ObsoleteDiagnosticInfo option

--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -132,7 +132,9 @@ exception DiagnosticWithSuggestions of number: int * message: string * range: ra
 /// A diagnostic that is raised when enabled manually, or by default with a language feature
 exception DiagnosticEnabledWithLanguageFeature of number: int * message: string * range: range * enabledByLangFeature: bool
 
-/// A diagnostic that is raised when a diagnostic is obsolete
+type ObsoleteDiagnosticInfo =
+    | ObsoleteDiagnosticInfo of isError: bool * diagnosticId: string option * message: string option * urlFormat: string option
+
 exception ObsoleteDiagnostic of
     isError: bool *
     diagnosticId: string option *

--- a/src/Compiler/Facilities/DiagnosticsLogger.fsi
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fsi
@@ -87,6 +87,13 @@ exception DiagnosticWithSuggestions of
     identifier: string *
     suggestions: Suggestions
 
+type ObsoleteDiagnosticInfo =
+    | ObsoleteDiagnosticInfo of
+        isError: bool *
+        diagnosticId: string option *
+        message: string option *
+        urlFormat: string option
+
 exception ObsoleteDiagnostic of
     isError: bool *
     diagnosticId: string option *

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -4,6 +4,7 @@ namespace rec FSharp.Compiler.Symbols
 
 open System
 open System.Collections.Generic
+open FSharp.Compiler.DiagnosticsLogger
 open Internal.Utilities.Collections
 open Internal.Utilities.Library
 open FSharp.Compiler
@@ -219,6 +220,19 @@ type FSharpDisplayContext(denv: TcGlobals -> DisplayEnv) =
     member x.WithTopLevelPrefixGenericParameters () =
         FSharpDisplayContext(fun g -> (denv g).UseTopLevelPrefixGenericParameterStyle())
 
+
+[<Struct>]
+type ObsoleteDiagnosticInfo =
+    { IsError: bool
+      DiagnosticId: string option
+      Message: string option
+      UrlFormat: string option }
+
+    static member FromDiagnosticInfo(info) =
+        let (ObsoleteDiagnosticInfo(isError, id, msg, urlFormat)) = info
+        { IsError = isError; DiagnosticId = id; Message = msg; UrlFormat = urlFormat }
+
+
 // delay the realization of 'item' in case it is unresolved
 type FSharpSymbol(cenv: SymbolEnv, item: unit -> Item, access: FSharpSymbol -> CcuThunk -> AccessorDomain -> bool) =
 
@@ -358,6 +372,9 @@ type FSharpSymbol(cenv: SymbolEnv, item: unit -> Item, access: FSharpSymbol -> C
 
     member sym.TryGetAttribute<'T>() =
         sym.Attributes |> Seq.tryFind (fun attr -> attr.IsAttribute<'T>())
+
+    abstract ObsoleteDiagnosticInfo: ObsoleteDiagnosticInfo option
+    default _.ObsoleteDiagnosticInfo = None
 
 type FSharpEntity(cenv: SymbolEnv, entity: EntityRef, tyargs: TType list) = 
     inherit FSharpSymbol(cenv, 
@@ -854,6 +871,9 @@ type FSharpEntity(cenv: SymbolEnv, entity: EntityRef, tyargs: TType list) =
     member x.TryGetMembersFunctionsAndValues() = 
         try x.MembersFunctionsAndValues with _ -> [||] :> _
 
+    override this.ObsoleteDiagnosticInfo =
+        TryGetEntityObsoleteInfo cenv.g entity |> Option.map ObsoleteDiagnosticInfo.FromDiagnosticInfo
+
     member this.TryGetMetadataText() =
         match entity.TryDeref with
         | ValueSome _ ->
@@ -1288,7 +1308,16 @@ type FSharpField(cenv: SymbolEnv, d: FSharpFieldData)  =
             | Choice1Of3 r -> r.Accessibility
             | Choice2Of3 _ -> taccessPublic
             | Choice3Of3 _ -> taccessPublic
-        FSharpAccessibility access 
+        FSharpAccessibility access
+
+    override this.ObsoleteDiagnosticInfo =
+        let infoOption =
+            match d.TryRecdField with
+            | Choice1Of3 recdField -> TryGetFSharpObsoleteInfo cenv.g recdField.FieldAttribs
+            | Choice2Of3 ilFieldInfo -> TryGetILFieldObsoleteInfo cenv.g ilFieldInfo
+            | Choice3Of3 _ -> None
+
+        infoOption |> Option.map ObsoleteDiagnosticInfo.FromDiagnosticInfo
 
     member private x.V = d
 
@@ -2531,6 +2560,17 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
             |> Option.map (fun enclosingEntityFullName -> 
                     Array.append (enclosingEntityFullName.Split '.') [| x.CompiledName |])
         else None
+
+    override this.ObsoleteDiagnosticInfo =
+        let infoOption =
+            match d with
+            | E einfo -> TryGetEventObsoleteInfo einfo
+            | P pinfo -> TryGetPropObsoleteInfo pinfo
+            | M minfo
+            | C minfo -> TryGetMethodObsoleteInfo minfo
+            | V vref -> TryGetFSharpObsoleteInfo cenv.g vref.Attribs
+        
+        infoOption |> Option.map ObsoleteDiagnosticInfo.FromDiagnosticInfo
 
 type FSharpType(cenv, ty:TType) =
 

--- a/src/Compiler/Symbols/Symbols.fs
+++ b/src/Compiler/Symbols/Symbols.fs
@@ -222,7 +222,7 @@ type FSharpDisplayContext(denv: TcGlobals -> DisplayEnv) =
 
 
 [<Struct>]
-type ObsoleteDiagnosticInfo =
+type FSharpObsoleteDiagnosticInfo =
     { IsError: bool
       DiagnosticId: string option
       Message: string option
@@ -373,7 +373,7 @@ type FSharpSymbol(cenv: SymbolEnv, item: unit -> Item, access: FSharpSymbol -> C
     member sym.TryGetAttribute<'T>() =
         sym.Attributes |> Seq.tryFind (fun attr -> attr.IsAttribute<'T>())
 
-    abstract ObsoleteDiagnosticInfo: ObsoleteDiagnosticInfo option
+    abstract ObsoleteDiagnosticInfo: FSharpObsoleteDiagnosticInfo option
     default _.ObsoleteDiagnosticInfo = None
 
 type FSharpEntity(cenv: SymbolEnv, entity: EntityRef, tyargs: TType list) = 
@@ -872,7 +872,7 @@ type FSharpEntity(cenv: SymbolEnv, entity: EntityRef, tyargs: TType list) =
         try x.MembersFunctionsAndValues with _ -> [||] :> _
 
     override this.ObsoleteDiagnosticInfo =
-        TryGetEntityObsoleteInfo cenv.g entity |> Option.map ObsoleteDiagnosticInfo.FromDiagnosticInfo
+        TryGetEntityObsoleteInfo cenv.g entity |> Option.map FSharpObsoleteDiagnosticInfo.FromDiagnosticInfo
 
     member this.TryGetMetadataText() =
         match entity.TryDeref with
@@ -1317,7 +1317,7 @@ type FSharpField(cenv: SymbolEnv, d: FSharpFieldData)  =
             | Choice2Of3 ilFieldInfo -> TryGetILFieldObsoleteInfo cenv.g ilFieldInfo
             | Choice3Of3 _ -> None
 
-        infoOption |> Option.map ObsoleteDiagnosticInfo.FromDiagnosticInfo
+        infoOption |> Option.map FSharpObsoleteDiagnosticInfo.FromDiagnosticInfo
 
     member private x.V = d
 
@@ -2570,7 +2570,7 @@ type FSharpMemberOrFunctionOrValue(cenv, d:FSharpMemberOrValData, item) =
             | C minfo -> TryGetMethodObsoleteInfo minfo
             | V vref -> TryGetFSharpObsoleteInfo cenv.g vref.Attribs
         
-        infoOption |> Option.map ObsoleteDiagnosticInfo.FromDiagnosticInfo
+        infoOption |> Option.map FSharpObsoleteDiagnosticInfo.FromDiagnosticInfo
 
 type FSharpType(cenv, ty:TType) =
 

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -79,6 +79,13 @@ type FSharpDisplayContext =
     /// for example, `int list seq` becomes `seq<int list>`
     member WithTopLevelPrefixGenericParameters: unit -> FSharpDisplayContext
 
+[<Struct>]
+type ObsoleteDiagnosticInfo =
+    { IsError: bool
+      DiagnosticId: string option
+      Message: string option
+      UrlFormat: string option }
+
 /// Represents a symbol in checked F# source code or a compiled .NET component.
 ///
 /// The subtype of the symbol may reveal further information and can be one of FSharpEntity, FSharpUnionCase
@@ -147,6 +154,8 @@ type FSharpSymbol =
 
     /// Indicates if this symbol has an attribute matching the full name of the given type parameter
     member HasAttribute<'T> : unit -> bool
+
+    abstract ObsoleteDiagnosticInfo: ObsoleteDiagnosticInfo option
 
 /// Represents an assembly as seen by the F# language
 type FSharpAssembly =

--- a/src/Compiler/Symbols/Symbols.fsi
+++ b/src/Compiler/Symbols/Symbols.fsi
@@ -80,7 +80,7 @@ type FSharpDisplayContext =
     member WithTopLevelPrefixGenericParameters: unit -> FSharpDisplayContext
 
 [<Struct>]
-type ObsoleteDiagnosticInfo =
+type FSharpObsoleteDiagnosticInfo =
     { IsError: bool
       DiagnosticId: string option
       Message: string option
@@ -155,7 +155,7 @@ type FSharpSymbol =
     /// Indicates if this symbol has an attribute matching the full name of the given type parameter
     member HasAttribute<'T> : unit -> bool
 
-    abstract ObsoleteDiagnosticInfo: ObsoleteDiagnosticInfo option
+    abstract ObsoleteDiagnosticInfo: FSharpObsoleteDiagnosticInfo option
 
 /// Represents an assembly as seen by the F# language
 type FSharpAssembly =

--- a/tests/FSharp.Compiler.Service.Tests/Checker.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Checker.fs
@@ -128,6 +128,9 @@ module CheckResultsExtensions =
         member this.GetCodeCompletionSuggestions(context: CodeCompletionContext, parseResults: FSharpParseFileResults, options: FSharpCodeCompletionOptions) =
             this.GetDeclarationListInfo(Some parseResults, context.Pos.Line, context.LineText, context.PartialIdentifier, options = options)
 
+        member this.GetMethodOverloads(context: ResolveContext, names: string list) =
+            this.GetMethodsAsSymbols(context.Pos.Line, context.Pos.Column, context.LineText, names)
+
 [<RequireQualifiedAccess>]
 module Checker =
     let getResolveContext (markedSource: string) =
@@ -185,3 +188,7 @@ module Checker =
 
     let getTooltip (markedSource: string) =
         getTooltipWithOptions [||] markedSource
+
+    let getMethodOverloads names (markedSource: string) =
+        let context, checkResults = getCheckedResolveContext markedSource
+        checkResults.GetMethodOverloads(context, names)

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
@@ -5299,6 +5299,8 @@ FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FShar
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] get_DeclaringEntity()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] BaseType
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] get_BaseType()
+FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.ISourceText] TryGetMetadataText()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[System.String] BasicQualifiedName
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[System.String] Namespace
@@ -5435,6 +5437,8 @@ FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] get_DeclaringEntity()
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpUnionCase] DeclaringUnionCase
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpUnionCase] get_DeclaringUnionCase()
+FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[System.Object] LiteralValue
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[System.Object] get_LiteralValue()
 FSharp.Compiler.Symbols.FSharpField: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpAttribute] FieldAttributes
@@ -5716,6 +5720,8 @@ FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSh
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue] get_EventForFSharpProperty()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] FullTypeSafe
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] get_FullTypeSafe()
+FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.TaggedText[]] GetReturnTypeLayout(FSharp.Compiler.Symbols.FSharpDisplayContext)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue]] GetOverloads(Boolean)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Object] LiteralValue
@@ -5812,6 +5818,8 @@ FSharp.Compiler.Symbols.FSharpSymbol: FSharp.Compiler.Symbols.FSharpAssembly get
 FSharp.Compiler.Symbols.FSharpSymbol: Int32 GetEffectivelySameAsHash()
 FSharp.Compiler.Symbols.FSharpSymbol: Int32 GetHashCode()
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpAttribute] TryGetAttribute[T]()
+FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] DeclarationLocation
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] ImplementationLocation
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] SignatureLocation
@@ -5997,6 +6005,25 @@ FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 GetHashCode(System.Collections.IEqua
 FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 Tag
 FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 get_Tag()
 FSharp.Compiler.Symbols.FSharpXmlDoc: System.String ToString()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo, System.Collections.IEqualityComparer)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(System.Object)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean IsError
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean get_IsError()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 CompareTo(FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 CompareTo(System.Object)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 CompareTo(System.Object, System.Collections.IComparer)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 GetHashCode()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] DiagnosticId
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] Message
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] UrlFormat
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_DiagnosticId()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_Message()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_UrlFormat()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: System.String ToString()
+FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Void .ctor(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtDo
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtInvisible
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtLet

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
@@ -5297,10 +5297,10 @@ FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Collections.FSharpList`1[
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Collections.FSharpList`1[System.String] get_AllCompilationPaths()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] DeclaringEntity
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] get_DeclaringEntity()
+FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] BaseType
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] get_BaseType()
-FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
-FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.ISourceText] TryGetMetadataText()
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[System.String] BasicQualifiedName
 FSharp.Compiler.Symbols.FSharpEntity: Microsoft.FSharp.Core.FSharpOption`1[System.String] Namespace
@@ -5435,10 +5435,10 @@ FSharp.Compiler.Symbols.FSharpField: FSharp.Compiler.Text.Range get_DeclarationL
 FSharp.Compiler.Symbols.FSharpField: Int32 GetHashCode()
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] DeclaringEntity
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] get_DeclaringEntity()
+FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpUnionCase] DeclaringUnionCase
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpUnionCase] get_DeclaringUnionCase()
-FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
-FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[System.Object] LiteralValue
 FSharp.Compiler.Symbols.FSharpField: Microsoft.FSharp.Core.FSharpOption`1[System.Object] get_LiteralValue()
 FSharp.Compiler.Symbols.FSharpField: System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpAttribute] FieldAttributes
@@ -5718,10 +5718,10 @@ FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSh
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpEntity] get_DeclaringEntity()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue] EventForFSharpProperty
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue] get_EventForFSharpProperty()
+FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] FullTypeSafe
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpType] get_FullTypeSafe()
-FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
-FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.TaggedText[]] GetReturnTypeLayout(FSharp.Compiler.Symbols.FSharpDisplayContext)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Collections.Generic.IList`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue]] GetOverloads(Boolean)
 FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue: Microsoft.FSharp.Core.FSharpOption`1[System.Object] LiteralValue
@@ -5755,6 +5755,25 @@ FSharp.Compiler.Symbols.FSharpObjectExprOverride: Microsoft.FSharp.Collections.F
 FSharp.Compiler.Symbols.FSharpObjectExprOverride: Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Symbols.FSharpGenericParameter] get_GenericParameters()
 FSharp.Compiler.Symbols.FSharpObjectExprOverride: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue]] CurriedParameterGroups
 FSharp.Compiler.Symbols.FSharpObjectExprOverride: Microsoft.FSharp.Collections.FSharpList`1[Microsoft.FSharp.Collections.FSharpList`1[FSharp.Compiler.Symbols.FSharpMemberOrFunctionOrValue]] get_CurriedParameterGroups()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Boolean Equals(FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Boolean Equals(FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo, System.Collections.IEqualityComparer)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Boolean Equals(System.Object)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Boolean IsError
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Boolean get_IsError()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Int32 CompareTo(FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Int32 CompareTo(System.Object)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Int32 CompareTo(System.Object, System.Collections.IComparer)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Int32 GetHashCode()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] DiagnosticId
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] Message
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] UrlFormat
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_DiagnosticId()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_Message()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_UrlFormat()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: System.String ToString()
+FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo: Void .ctor(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Boolean IsOwnNamespace
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: Boolean get_IsOwnNamespace()
 FSharp.Compiler.Symbols.FSharpOpenDeclaration: FSharp.Compiler.Syntax.SynOpenDeclTarget Target
@@ -5818,8 +5837,8 @@ FSharp.Compiler.Symbols.FSharpSymbol: FSharp.Compiler.Symbols.FSharpAssembly get
 FSharp.Compiler.Symbols.FSharpSymbol: Int32 GetEffectivelySameAsHash()
 FSharp.Compiler.Symbols.FSharpSymbol: Int32 GetHashCode()
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpAttribute] TryGetAttribute[T]()
-FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
-FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
+FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] ObsoleteDiagnosticInfo
+FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Symbols.FSharpObsoleteDiagnosticInfo] get_ObsoleteDiagnosticInfo()
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] DeclarationLocation
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] ImplementationLocation
 FSharp.Compiler.Symbols.FSharpSymbol: Microsoft.FSharp.Core.FSharpOption`1[FSharp.Compiler.Text.Range] SignatureLocation
@@ -6005,25 +6024,6 @@ FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 GetHashCode(System.Collections.IEqua
 FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 Tag
 FSharp.Compiler.Symbols.FSharpXmlDoc: Int32 get_Tag()
 FSharp.Compiler.Symbols.FSharpXmlDoc: System.String ToString()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo, System.Collections.IEqualityComparer)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(System.Object)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean IsError
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Boolean get_IsError()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 CompareTo(FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 CompareTo(System.Object)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 CompareTo(System.Object, System.Collections.IComparer)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 GetHashCode()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Int32 GetHashCode(System.Collections.IEqualityComparer)
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] DiagnosticId
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] Message
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] UrlFormat
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_DiagnosticId()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_Message()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Microsoft.FSharp.Core.FSharpOption`1[System.String] get_UrlFormat()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: System.String ToString()
-FSharp.Compiler.Symbols.ObsoleteDiagnosticInfo: Void .ctor(Boolean, Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String], Microsoft.FSharp.Core.FSharpOption`1[System.String])
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtDo
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtInvisible
 FSharp.Compiler.Syntax.DebugPointAtBinding+Tags: Int32 NoneAtLet

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Common.fs" />
     <Compile Include="Checker.fs" />
     <Compile Include="TypeChecker\TypeCheckerRecoveryTests.fs" />
+    <Compile Include="TypeChecker\Obsolete.fs" />
     <Compile Include="GeneratedCodeSymbolsTests.fs" />
     <Compile Include="BreakpointLocationTests.fs" />
     <Compile Include="AssemblyReaderShim.fs" />

--- a/tests/FSharp.Compiler.Service.Tests/TypeChecker/Obsolete.fs
+++ b/tests/FSharp.Compiler.Service.Tests/TypeChecker/Obsolete.fs
@@ -1,0 +1,95 @@
+﻿module FSharp.Compiler.Service.Tests.TypeChecker.Obsolete
+
+open FSharp.Compiler.Service.Tests
+open FSharp.Compiler.Symbols
+open FSharp.Test.Assert
+open Xunit
+
+let checkObsoleteMessages message source =
+    let symbolUse = Checker.getSymbolUse source
+    symbolUse.Symbol.ObsoleteDiagnosticInfo.Value.Message.Value |> shouldEqual message
+
+let checkNotObsolete source =
+    let symbolUse = Checker.getSymbolUse source
+    symbolUse.Symbol.ObsoleteDiagnosticInfo |> shouldEqual None
+
+[<Fact>]
+let ``Method 01`` () =
+    checkObsoleteMessages "Message" """
+type Class() =
+    [<System.Obsolete "Message">]
+    static member Method{caret}() = ()
+"""
+
+[<Fact>]
+let ``Method 02`` () =
+    checkObsoleteMessages "Message" """
+type Class() =
+    [<System.Obsolete "Message">]
+    static member Method() = ()
+
+Class.Method{caret}()
+"""
+
+[<Fact>]
+let ``Method 03`` () =
+    checkObsoleteMessages "Message" """
+type Class() =
+    static member Method(i: int) = ()
+
+    [<System.Obsolete "Message">]
+    static member Method(s: string) = ()
+
+Class.Method{caret}("")
+"""
+
+[<Fact>]
+let ``Method 04`` () =
+    checkNotObsolete """
+type Class() =
+    static member Method(i: int) = ()
+
+    [<System.Obsolete "Message">]
+    static member Method(s: string) = ()
+
+Class.Method{caret}(1)
+"""
+
+[<Fact>]
+let ``Method 05`` () =
+    let methodOverloads =
+        Checker.getMethodOverloads ["Class"; "Method"] """
+type Class() =
+    static member Method(i: int) = ()
+
+    [<System.Obsolete "Message">]
+    static member Method(s: string) = ()
+
+Class.Method({caret}1)
+"""
+    methodOverloads.Value
+    |> List.sortBy _.Symbol.DeclarationLocation.Value.StartLine
+    |> List.map (_.Symbol.ObsoleteDiagnosticInfo >> (Option.bind _.Message))
+    |> shouldEqual [ None; Some "Message"]
+
+[<Fact>]
+let ``Type 01 - Union`` () =
+    checkObsoleteMessages "Message" """
+[<System.Obsolete "Message">]
+type U{caret} = | A
+"""
+
+[<Fact>]
+let ``Value 01`` () =
+    checkObsoleteMessages "Message" """
+[<System.Obsolete "Message">]
+let s{caret} = ""
+"""
+
+[<Fact>]
+let ``Value 02`` () =
+    checkObsoleteMessages "Message" """
+[<System.Obsolete "Message">]
+let s = ""
+let s1 = s{caret}
+"""

--- a/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/CodeFixHelpers.fs
@@ -73,7 +73,7 @@ module internal CodeFixHelpers =
 
         TelemetryReporter.ReportSingleEvent(TelemetryEvents.CodefixActivated, props)
 
-    let createTextChangeCodeFix (codeFix, context: CodeFixContext) =
+    let createTextChangeCodeFix (codeFix: FSharpCodeFix, context: CodeFixContext) =
         CodeAction.Create(
             codeFix.Message,
             (fun cancellationToken ->


### PR DESCRIPTION
* Extracts fast checks for `Obsolete` attribute to get this info via FCS Symbols API
* Fixes `CompilerFeatureRequired`/`RequiredMembers` was not checked if there was no `Obsolete` attribute
* Adds `Checker.getMethodOverloads` test helper for resolve context-aware FCS tests
