### PR TITLE
Tests: Add collection equality assert with better message

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -3789,8 +3789,7 @@ let ``Test Project25 symbol uses of type-provided members`` () =
         |> Array.ofSeq
         |> Array.map (fun s -> (s.Symbol.FullName, Project25.cleanFileName s.FileName, tups s.Range, attribsOfSymbol s.Symbol))
 
-    allUses |> shouldEqual
-
+    let expected =
          [|("FSharp", "file1", ((3, 5), (3, 11)), ["namespace"]);
            ("FSharp.Data", "file1", ((3, 12), (3, 16)), ["namespace"]);
            ("Microsoft.FSharp", "file1", ((3, 5), (3, 11)), ["namespace"]);
@@ -3820,6 +3819,12 @@ let ``Test Project25 symbol uses of type-provided members`` () =
             ["class"; "provided"; "staticinst"; "erased"]);
            ("FSharp.Data.XmlProvider<...>.GetSample", "file1", ((10, 8), (10, 78)),
             ["member"]); ("TypeProviderTests", "file1", ((2, 7), (2, 24)), ["module"])|]
+
+    printfn "actual =\n%A" allUses
+    printfn "expected =\n%A" expected
+
+    allUses |> shouldBeEqualCollections expected
+
     let getSampleSymbolUseOpt =
         backgroundTypedParse1.GetSymbolUseAtLocation(5,25,"",["GetSample"])
 

--- a/tests/FSharp.Test.Utilities/Assert.fs
+++ b/tests/FSharp.Test.Utilities/Assert.fs
@@ -78,3 +78,39 @@ module Assert =
                 sb.ToString ()
 
             Some msg
+
+    let shouldBeEqualCollections (expected: seq<'T>) (actual: seq<'T>) =
+        let expectedList = Seq.toList expected
+        let actualList = Seq.toList actual
+        if expectedList = actualList then
+            ()
+        else
+            let unexpectedlyMissing = List.except actualList expectedList
+            let unexpectedlyPresent = List.except expectedList actualList
+            let inline newLine (sb: System.Text.StringBuilder) = sb.AppendLine() |> ignore
+            let sb = System.Text.StringBuilder()
+            if not unexpectedlyMissing.IsEmpty then
+                sb.Append "Unexpectedly missing (expected, not actual):" |> ignore
+                for item in unexpectedlyMissing do
+                    newLine sb
+                    sb.Append "    " |> ignore
+                    sb.Append(sprintf "%A" item) |> ignore
+                newLine sb
+                newLine sb
+            if not unexpectedlyPresent.IsEmpty then
+                sb.Append "Unexpectedly present (actual, not expected):" |> ignore
+                for item in unexpectedlyPresent do
+                    newLine sb
+                    sb.Append "    " |> ignore
+                    sb.Append(sprintf "%A" item) |> ignore
+                newLine sb
+                newLine sb
+            if unexpectedlyMissing.IsEmpty && unexpectedlyPresent.IsEmpty then
+                sb.Append "Same elements but in different order. Positional differences:" |> ignore
+                for i in 0 .. expectedList.Length - 1 do
+                    if expectedList[i] <> actualList[i] then
+                        newLine sb
+                        sb.Append(sprintf "    [%d] expected %A but was %A" i expectedList[i] actualList[i]) |> ignore
+                newLine sb
+            Assert.True(false, sb.ToString())
+


### PR DESCRIPTION
Should allow to see what's failing in flaky `Test Project25 symbol uses of type-provided members`  #19364

Added shouldBeEqualCollections to Assert.fs for detailed collection comparison, including reporting missing/unexpected items and positional differences. Updated Project25 symbol uses test to use this helper and print actual/expected values for easier debugging.


