### PR TITLE
Use union merge strategy for release notes to avoid conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,10 @@
 *.fsproj text merge=union
 *.dbproj text merge=union
 
+# Release notes are append-only unordered lists; union merge avoids conflicts
+# when multiple PRs each add an entry under the same heading.
+docs/release-notes/**/*.md text merge=union
+
 # Standard to msysgit
 *.doc	 diff=astextplain
 *.DOC	 diff=astextplain


### PR DESCRIPTION
Release notes files are append-only unordered lists where each PR adds one entry. With the default merge strategy, concurrent PRs that both append under the same heading (e.g. `### Fixed`) produce merge conflicts even though order doesn't matter.

The `union` merge driver keeps both sides, eliminating these spurious conflicts. This is consistent with the existing use of `merge=union` for `.sln` and project files in this repo.