### PR TITLE
Reduce Repo Assist schedule from hourly to 4x daily

### DIFF
--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -35,7 +35,7 @@
 #
 # Source: githubnext/agentics/workflows/repo-assist.md@9135cdfde26838a01779aa966628308404ec1f02
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4e6092f0d8670f2f559de36f3886738595b336c4ed991a881f1ccf78144384f5","compiler_version":"v0.62.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"d75bcc7a75f547113f447da58a55e31496f5d71e97c382008b2356d2a3893cc0","compiler_version":"v0.62.0","strict":true}
 
 name: "Repo Assist"
 "on":
@@ -66,7 +66,7 @@ name: "Repo Assist"
     - created
     - edited
   schedule:
-  - cron: "25 */1 * * *"
+  - cron: "25 */6 * * *"
   workflow_dispatch: null
 
 permissions: {}

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -14,7 +14,7 @@ description: |
   Always polite, constructive, and mindful of the project's goals.
 
 on:
-  schedule: every 1h
+  schedule: every 6h
   workflow_dispatch:
   slash_command:
     name: repo-assist


### PR DESCRIPTION
Change the Repo Assist agentic workflow schedule from `every 1h` to `every 6h` (4 runs per day instead of 24).

Recompiled via `gh aw compile` — cron updated from `25 */1 * * *` to `25 */6 * * *`.