### PR TITLE
Add regression test: #11331, accessibility error for internal type in public constructor sig

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Signatures/Signatures.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Signatures/Signatures.fs
@@ -140,3 +140,29 @@ module SignatureConformance =
         |> withDiagnosticMessageMatches "GetEnumerator"
         |> withDiagnosticMessageDoesntMatch "The compiled names differ"
         |> ignore
+
+    // https://github.com/dotnet/fsharp/issues/11331
+    [<Fact>]
+    let ``Issue 11331 - Public constructor taking internal type should report FS0410 in signature`` () =
+        Fsi
+            """
+module WrongAccessibility.Library
+
+type internal A = class end
+
+type B =
+    new: a: A -> B
+            """
+        |> withAdditionalSourceFile (
+            FsSource
+                """
+module WrongAccessibility.Library
+
+type internal A = class end
+
+type B(a: A) = class end
+            """
+        )
+        |> compile
+        |> shouldFail
+        |> withErrorCode 0410


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/11331

Adds a regression test verifying that a public constructor taking an internal type in a .fsi signature file correctly reports FS0410 (less accessible type used in public declaration).