### PR TITLE
Add regression test: #6715, land is a valid identifier

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/DiagnosticRegressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/DiagnosticRegressionTests.fs
@@ -3,6 +3,23 @@ module ErrorMessages.DiagnosticRegressionTests
 open Xunit
 open FSharp.Test.Compiler
 
+// https://github.com/dotnet/fsharp/issues/6715
+[<Fact>]
+let ``Issue 6715 - land is a valid identifier after ML compat removal`` () =
+    FSharp
+        """
+let land = 3
+let lor = 4
+let lxor = 5
+let lsl = 6
+let lsr = 7
+let asr = 8
+let sum = land + lor + lxor + lsl + lsr + asr
+        """
+    |> asLibrary
+    |> typecheck
+    |> shouldSucceed
+
 // https://github.com/dotnet/fsharp/issues/15655
 [<Fact>]
 let ``Issue 15655 - error codes 999 and 3217 are distinct`` () =


### PR DESCRIPTION
Adds a regression test for https://github.com/dotnet/fsharp/issues/6715

Verifies that `land`, `lor`, `lxor`, `lsl`, `lsr`, and `asr` can be used as valid identifiers after the ML compatibility removal in PR #19143. Previously, `let land = 3` would produce the confusing FS0010 "Unexpected infix operator in binding" error.

Fixes #6715