### PR TITLE
Add regression test: #3660, array of functions invocation correctness

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CodeGenRegressions/CodeGenRegressions_Closures.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CodeGenRegressions/CodeGenRegressions_Closures.fs
@@ -376,7 +376,7 @@ let runAll (fArr: (int -> int) array) x =
     let mutable n = 0
 
     for i = 0 to fArr.Length - 1 do
-        n <- n + fArr.[i] x
+        n <- n + fArr[i] x
 
     n
 
@@ -409,7 +409,7 @@ let runAll (fArr: (int -> int) array) x =
     let mutable n = 0
 
     for i = 0 to fArr.Length - 1 do
-        n <- n + fArr.[i] x
+        n <- n + fArr[i] x
 
     n
 """


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/3660

Adds a regression test verifying that invoking functions from an array works correctly at runtime. Tests the `for i = 0 to fArr.Length - 1 do n <- n + fArr.[i] x` pattern that previously caused needless closure allocations.