### PR TITLE
Add regression test: #16410, no spurious FS3570 with KeyValue active pattern

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/DiagnosticRegressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/DiagnosticRegressionTests.fs
@@ -1,0 +1,27 @@
+module ErrorMessages.DiagnosticRegressionTests
+
+open Xunit
+open FSharp.Test.Compiler
+
+// https://github.com/dotnet/fsharp/issues/16410
+[<Fact>]
+let ``Issue 16410 - no spurious FS3570 warning with KeyValue active pattern`` () =
+    FSharp
+        """
+open System.Collections.Generic
+
+module Map =
+    let update empty k f m =
+        match Map.tryFind k m with
+        | Some v -> Map.add k (f v) m
+        | None -> Map.add k (f empty) m
+
+let invert (dict: IDictionary<'k,#seq<'k>>): Map<'k,Set<'k>> =
+    (Map.empty, dict)
+    ||> Seq.fold (fun res (KeyValue (k, ks)) ->
+            (res, ks)
+            ||> Seq.fold (fun res vk -> res |> Map.update Set.empty vk _.Add(k))
+        )
+        """
+    |> typecheck
+    |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -300,6 +300,7 @@
     <Compile Include="ErrorMessages\MissingElseBranch.fs" />
     <Compile Include="ErrorMessages\MissingExpressionTests.fs" />
     <Compile Include="ErrorMessages\ModuleTests.fs" />
+    <Compile Include="ErrorMessages\DiagnosticRegressionTests.fs" />
     <Compile Include="ErrorMessages\NameResolutionTests.fs" />
     <Compile Include="ErrorMessages\SuggestionsTests.fs" />
     <Compile Include="ErrorMessages\TypeMismatchTests.fs" />


### PR DESCRIPTION
Adds a regression test for https://github.com/dotnet/fsharp/issues/16410

Verifies that using the `KeyValue` active pattern with underscore member access (`_.Add(k)`) does not produce a spurious FS3570 warning about ambiguous `_`.

Fixes #16410