### PR TITLE
Add regression test: #13194, Completion/tooltip with quote in member name

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CompletionTests.fs
@@ -728,3 +728,17 @@ match A 1 with
 type T() =
     override {caret}
 """
+
+// https://github.com/dotnet/fsharp/issues/13194
+[<Fact>]
+let ``Completion works for member whose name contains a single quote`` () =
+    let info =
+        Checker.getCompletionInfo
+            """
+/// Doc for normalize prime
+let normalize' x = x + 1
+
+normaliz{caret}
+"""
+
+    assertHasItemWithNames [ "normalize'" ] info

--- a/tests/FSharp.Compiler.Service.Tests/TooltipTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/TooltipTests.fs
@@ -568,3 +568,37 @@ let f (x{caret}: #seq<int list>) = ()
 """
     |> assertAndGetSingleToolTipText
     |> Assert.shouldBeEquivalentTo "val x: #seq<int list>"
+
+// https://github.com/dotnet/fsharp/issues/13194
+[<Fact>]
+let ``Tooltip works for member whose name contains a single quote`` () =
+    Checker.getTooltip """
+module Foo
+
+/// This is a doc for normalize prime
+let normalize' x = x + 1
+
+let y = normaliz{caret}e' 5
+"""
+    |> assertAndGetSingleToolTipText
+    |> Assert.shouldBeEquivalentTo "val normalize': x: int -> int"
+
+// https://github.com/dotnet/fsharp/issues/13194
+[<Fact>]
+let ``Sig file XML doc fallback works for member whose name contains a single quote`` () =
+    let sigSource =
+        """
+module Foo
+
+/// Normalize with a prime
+val normalize': int -> int
+"""
+
+    let implSource =
+        """
+module Foo
+
+let normaliz{caret}e' x = x + 1
+"""
+
+    testXmlDocFallbackToSigFileWhileInImplFile sigSource implSource "Normalize with a prime"


### PR DESCRIPTION
Fixes #13194

Adds regression tests verifying that tooltip and completion work correctly for F# members whose names contain a single quote (`'`):

1. **Tooltip test**: Verifies `GetToolTip` returns correct text for `normalize'` usage
2. **Sig file fallback test**: Verifies XML doc from `.fsi` is shown for `normalize'` in `.fs`
3. **Completion test**: Verifies `normalize'` appears in completion list

All tests pass on current main, confirming the fix in `tryGetSummaryNode` (XPath quote handling) works.