### PR TITLE
Add regression test: #14057, Renaming operator with dot only renames right of dot

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/PrettyNaming.fs
+++ b/tests/FSharp.Compiler.Service.Tests/PrettyNaming.fs
@@ -70,3 +70,19 @@ let ``IsLogicalTernaryOperator`` (logicalName: string, result: bool) =
 let ``IsLogicalInfixOpName`` (logicalName: string, result: bool) =
     IsLogicalInfixOpName logicalName
     |> Assert.shouldBe result
+
+// https://github.com/dotnet/fsharp/issues/14057
+// Operators containing '.' must be recognized as operators so that
+// Tokenizer.fixupSpan does not split them at the dot.
+[<Theory>]
+[<InlineData("-.-", true)>]
+[<InlineData(".+.", true)>]
+[<InlineData("...", true)>]
+[<InlineData("+", true)>]
+[<InlineData("-", true)>]
+[<InlineData("*", true)>]
+[<InlineData(".", true)>]
+[<InlineData("foo", false)>]
+[<InlineData("Foo.Bar", false)>]
+let ``IsOperatorDisplayName - operators with dots`` (displayName: string, result: bool) =
+    IsOperatorDisplayName displayName |> Assert.shouldBe result

--- a/tests/FSharp.Compiler.Service.Tests/Symbols.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Symbols.fs
@@ -1357,3 +1357,51 @@ let test = System.DateTimeKind.Utc
             | None ->
                 failwith "Expected metadata text, got None"
         | _ -> failwith "Expected FSharpEntity symbol"
+
+module OperatorsWithDots =
+    // https://github.com/dotnet/fsharp/issues/14057
+    [<Fact>]
+    let ``Operator containing dot is resolved as single symbol`` () =
+        let _, checkResults =
+            getParseAndCheckResults
+                """
+let ( -.- ) x y = x - y
+let result = 1 -.- 2
+"""
+
+        let symbolUse = findSymbolUseByName "op_MinusDotMinus" checkResults
+
+        match symbolUse.Symbol with
+        | :? FSharpMemberOrFunctionOrValue as mfv ->
+            Assert.Equal("(-.-)", mfv.DisplayName)
+
+            // Verify the operator is found at definition and usage sites
+            let allUses = checkResults.GetUsesOfSymbolInFile(symbolUse.Symbol)
+            Assert.True(allUses.Length >= 2, $"Expected at least 2 uses (def + use), got %d{allUses.Length}")
+        | symbol -> failwith $"Expected FSharpMemberOrFunctionOrValue but got %A{symbol}"
+
+    [<Fact>]
+    let ``Operator with dot has correct symbol range at usage site`` () =
+        let _, checkResults =
+            getParseAndCheckResults
+                """
+let ( -.- ) x y = x - y
+let result = 1 -.- 2
+"""
+
+        let usageSymbols =
+            checkResults.GetAllUsesOfAllSymbolsInFile()
+            |> Seq.filter (fun su ->
+                match su.Symbol with
+                | :? FSharpMemberOrFunctionOrValue as mfv ->
+                    mfv.LogicalName = "op_MinusDotMinus" && su.Range.StartLine = 3
+                | _ -> false)
+            |> Seq.toArray
+
+        Assert.True(usageSymbols.Length >= 1, $"Expected usage of -.- on line 3, got %d{usageSymbols.Length}")
+
+        // Verify the range spans the full operator (3 chars: -.-), not just part after '.'
+        let range = usageSymbols.[0].Range
+        let rangeLength = range.EndColumn - range.StartColumn
+
+        Assert.Equal(3, rangeLength)


### PR DESCRIPTION
Fixes #14057

Adds regression tests verifying that operators containing `.` (like `-.-`) are handled correctly:

1. **`IsOperatorDisplayName` tests** (PrettyNaming.fs): Verifies that `-.-`, `.+.`, `...` and other operators with dots are correctly identified as operator display names. This function is used by `Tokenizer.fixupSpan` to prevent splitting operators at dots.

2. **Symbol resolution tests** (Symbols.fs):
   - Verifies `-.-` operator is resolved as a single symbol with display name `(-.-)`
   - Verifies `GetUsesOfSymbolInFile` finds both definition and usage
   - Verifies the symbol range at usage site spans all 3 characters (`-.-`), not just the part after the dot

All tests pass on current main, confirming the fix in `Tokenizer.fixupSpan` works correctly.