### PR TITLE
Add regression test for #3841: Hash directive indentation in nested module

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Language/CompilerDirectiveTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/CompilerDirectiveTests.fs
@@ -24,6 +24,28 @@ module ``Test Compiler Directives`` =
             |> shouldFail
             |> withSingleDiagnostic (Warning 213, Line 2, Col 1, Line 2, Col 10, "'' is not a valid assembly name")
 
+    // https://github.com/dotnet/fsharp/issues/3841
+    [<Fact>]
+    let ``Hash directive inside nested module produces indentation error`` () =
+        Fsx
+            """
+let x = 42
+
+module Nested =
+    let foo = 123
+
+#r "SomeAssembly"
+
+    let bar = 1
+
+let y = x
+            """
+        |> withLangVersion80
+        |> compile
+        |> shouldFail
+        |> withSingleDiagnostic
+            (Error 58, Line 11, Col 1, Line 11, Col 4, "Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (9:5). Try indenting this further.\nTo continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.")
+
 module ``Test compiler directives in FSI`` =
     [<Fact>]
     let ``r# "" is invalid`` () =


### PR DESCRIPTION
Fixes #3841

Adds a regression test verifying that a hash directive (`#r`) at column 0 inside a nested module produces FS0058 indentation error with F# 8 strict indentation rules.

Previously, no indentation warning was given when a hash directive broke the indentation context of a nested module, causing subsequent declarations to silently end up in the wrong scope.