### PR TITLE
Add regression test: #12023, FSI can load System.Drawing.Common via nuget

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Scripting/Interactive.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Scripting/Interactive.fs
@@ -93,6 +93,17 @@ module ``External FSI tests`` =
         |> runFsi
         |> shouldFail
 
+    // https://github.com/dotnet/fsharp/issues/12023
+    [<FSharp.Test.FactSkipOnSignedBuild>]
+    let ``Issue 12023 - FSI can load System.Drawing.Common via nuget reference``() =
+        Fsx """
+#r "nuget: System.Drawing.Common"
+open System.Drawing
+printfn "Assembly loaded: %s" (typeof<Color>.Assembly.GetName().Name)
+        """
+        |> runFsi
+        |> shouldSucceed
+
 
     [<Fact>]
     let ``Internals visible over a large number of submissions``() =


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/12023

Verifies that FSI can load System.Drawing.Common via `#r "nuget:"` without FS0193 assembly loading errors.