### PR TITLE
Fix AddOpen suggesting wrong namespace for generic types

### DIFF
--- a/vsintegration/src/FSharp.Editor/CodeFixes/AddOpenCodeFixProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeFixes/AddOpenCodeFixProvider.fs
@@ -10,6 +10,7 @@ open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.CodeFixes
 
 open FSharp.Compiler.EditorServices
+open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 
@@ -159,8 +160,26 @@ type internal AddOpenCodeFixProvider [<ImportingConstructor>] (assemblyContentPr
                         let isAttribute =
                             ParsedInput.GetEntityKind(unresolvedIdentRange.Start, parseResults.ParseTree) = Some EntityKind.Attribute
 
-                        let entities =
+                        let hasTypeArgs =
+                            let endPos = context.Span.End
+                            let remainingText = sourceText.ToString(TextSpan(endPos, min 1 (sourceText.Length - endPos)))
+                            remainingText.StartsWith "<"
+
+                        let allSymbols =
                             assemblyContentProvider.GetAllEntitiesInProjectAndReferencedAssemblies checkResults
+
+                        let filteredSymbols =
+                            if hasTypeArgs then
+                                allSymbols
+                                |> Array.filter (fun s ->
+                                    match s.Symbol with
+                                    | :? FSharpEntity as e -> e.GenericParameters.Count > 0
+                                    | _ -> true)
+                            else
+                                allSymbols
+
+                        let entities =
+                            filteredSymbols
                             |> Array.collect (fun s ->
                                 [|
                                     yield s.TopRequireQualifiedAccessParent, s.AutoOpenParent, s.Namespace, s.CleanedIdents

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddOpenOnTopOnTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeFixes/AddOpenOnTopOnTests.fs
@@ -465,3 +465,26 @@ module FlatList =
     let actual = codeFix |> tryFix code Auto
 
     Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Fixes FS0039 for missing opens - generic type suggests correct namespace`` () =
+    let code =
+        """
+let x (enumerator: IEnumerator<int>) = ()
+"""
+
+    let expected =
+        Some
+            {
+                Message = "open System.Collections.Generic"
+                FixedCode =
+                    """
+open System.Collections.Generic
+
+let x (enumerator: IEnumerator<int>) = ()
+"""
+            }
+
+    let actual = codeFix |> tryFix code Auto
+
+    Assert.Equal(expected, actual)


### PR DESCRIPTION
## Description

When using a generic type like `IEnumerator<'t>`, the AddOpen code fix was suggesting `open System.Collections` instead of the correct `open System.Collections.Generic`.

This happened because both `System.Collections.IEnumerator` (non-generic) and `System.Collections.Generic.IEnumerator<'T>` (generic) matched by name, and whichever came first in the entity list was picked via `Seq.tryHead`.

## Changes

In `AddOpenCodeFixProvider.fs`:
- Check if the source text has type arguments (`<`) immediately after the unresolved identifier
- When type arguments are present, filter out non-generic entities so only the matching generic version is suggested

In `AddOpenOnTopOnTests.fs`:
- Added a test case for `IEnumerator<int>` verifying it suggests `open System.Collections.Generic`

## Testing

Added a new test case that reproduces the exact scenario from the issue.

Fixes #16155