### PR TITLE
Remove workaround in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,5 +31,5 @@
         "FSHARPCORE_USE_PACKAGE": "false",
         "PATH": "${localWorkspaceFolder}/.dotnet:${containerEnv:PATH}"
     },
-    "postCreateCommand": [ "bash", "-c", "eng/common/dotnet.sh && cp -r .dotnet/sdk/* /usr/share/dotnet/sdk && cp -r .dotnet/shared/Microsoft.NETCore.App/* /usr/share/dotnet/shared/Microsoft.NETCore.App" ]
+    "postCreateCommand": [ "bash", "-c", "eng/common/dotnet.sh", "build", "FSharp.Compiler.Service.sln" ]
 }


### PR DESCRIPTION
## Description

In #18847, a workaround was introduced that dealt with two problems
1. The use of new (non-public) dotnet versions in the repo
2. The difference in dotnet installations provided by the container image and expected by the sdk / ionide.

The second part is no longer necessary, therefore the ugly copy operations should be removed.

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes should not be necessary
