### PR TITLE
Fix flaky test: cancellationpropagatestotask

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -255,10 +255,13 @@ type AsyncType() =
 
     [<Fact>]
     member _.CancellationPropagatesToTask () =
+        let ewh = new ManualResetEvent(false)
         let a = async {
+                ewh.Set() |> Assert.True
                 while true do ()
             }
         let t = Async.StartAsTask a
+        ewh.WaitOne() |> Assert.True
         Async.CancelDefaultToken ()
         let mutable exceptionThrown = false
         try


### PR DESCRIPTION
Automated fix for flaky test.

Test: FSharp.Core.UnitTests.Control.AsyncType.CancellationPropagatesToTask