### PR TITLE
Fix quoting in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" --restore --build $@
+"$scriptroot/eng/build.sh" --restore --build "$@"


### PR DESCRIPTION


## Description

This allows it to accept arguments that contain spaces, such as propreties like "/p:OfficialBuilder=Foo Bar".

Fixes the regression introduced in https://github.com/dotnet/fsharp/pull/19211

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**

I can't add labels :laughing: 