### PR TITLE
Address signature generation bugs

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -27,6 +27,12 @@
 * Fix box instruction for literal upcasts. (Issue [#18319](https://github.com/dotnet/fsharp/issues/18319), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix Decimal Literal causes InvalidProgramException in Debug builds. (Issue [#18956](https://github.com/dotnet/fsharp/issues/18956), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix `AttributeUsage.AllowMultiple` not being inherited for attributes subclassed in C#. ([Issue #17107](https://github.com/dotnet/fsharp/issues/17107), [PR #19315](https://github.com/dotnet/fsharp/pull/19315))
+* Fix signature generation: recursive module `do` binding leaking compiler-generated val. ([Issue #13832](https://github.com/dotnet/fsharp/issues/13832), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
+* Fix signature generation: literal values in attribute arguments now preserve literal identifier name. ([Issue #13810](https://github.com/dotnet/fsharp/issues/13810), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
+* Fix signature generation: struct types with non-comparable/non-equatable fields now include `[<NoComparison>]`/`[<NoEquality>]`. ([Issue #15339](https://github.com/dotnet/fsharp/issues/15339), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
+* Fix signature generation: backtick escaping for identifiers containing backticks. ([Issue #15389](https://github.com/dotnet/fsharp/issues/15389), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
+* Fix signature generation: `private` keyword placement for prefix-style type abbreviations. ([Issue #15560](https://github.com/dotnet/fsharp/issues/15560), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
+* Fix signature generation: missing `[<Class>]` attribute for types without visible constructors. ([Issue #16531](https://github.com/dotnet/fsharp/issues/16531), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 
 ### Added
 

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -5900,7 +5900,7 @@ let CheckOneImplFile
 
         // Warn on version attributes.
         topAttrs.assemblyAttrs |> List.iter (function
-           | Attrib(tref, _, [ AttribExpr(Expr.Const (Const.String version, range, _), _) ], _, _, _, _) ->
+           | Attrib(tref, _, [ AttribExpr(_, Expr.Const (Const.String version, range, _)) ], _, _, _, _) ->
                 let attrName = tref.CompiledRepresentationForNamedType.FullName
                 let isValid() =
                     try parseILVersion version |> ignore; true

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -11650,8 +11650,11 @@ and TcAttributeEx canFail (cenv: cenv) (env: TcEnv) attrTgt attrEx (synAttr: Syn
                         match e with
                         | Expr.Const(_, m, _) ->
                             match literalIdents |> List.tryFind (fun (r, _) -> Range.equals r m) with
-                            | Some(_, vref) -> Expr.Val(vref, NormalValUse, m)
-                            | None -> e
+                            // Only use Expr.Val for local refs to avoid creating transitive assembly
+                            // dependencies in pickled metadata (VRefNonLocal would require the
+                            // external assembly to be available when importing this DLL).
+                            | Some(_, vref) when vref.IsLocalRef -> Expr.Val(vref, NormalValUse, m)
+                            | _ -> e
                         | _ -> e
 
                     AttribExpr(sourceExpr, EvalLiteralExprOrAttribArg g e)

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -11641,6 +11641,7 @@ and TcAttributeEx canFail (cenv: cenv) (env: TcEnv) attrTgt attrEx (synAttr: Syn
                             | _ -> acc
                         | SynExpr.Paren(expr = inner) -> collect inner acc
                         | SynExpr.Tuple(exprs = exprs) -> List.fold (fun a e -> collect e a) acc exprs
+                        | SynExpr.App(_, _, funcExpr, argExpr, _) -> collect funcExpr (collect argExpr acc)
                         | _ -> acc
 
                     collect arg []

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -11628,8 +11628,33 @@ and TcAttributeEx canFail (cenv: cenv) (env: TcEnv) attrTgt attrEx (synAttr: Syn
 
                 UnifyTypes cenv env mAttr ty (tyOfExpr g expr)
 
+                // Collect literal val references from the syntax expression to recover original names.
+                // TcVal inlines literal vals to Expr.Const, losing the original val reference.
+                // We recover it here by matching ranges from the syntax tree against the checked expression.
+                let literalIdents =
+                    let rec collect (synExpr: SynExpr) acc =
+                        match synExpr with
+                        | SynExpr.Ident ident ->
+                            match env.NameEnv.eUnqualifiedItems |> Map.tryFind ident.idText with
+                            | Some(Item.Value vref) when vref.LiteralValue.IsSome ->
+                                (ident.idRange, vref) :: acc
+                            | _ -> acc
+                        | SynExpr.Paren(expr = inner) -> collect inner acc
+                        | SynExpr.Tuple(exprs = exprs) -> List.fold (fun a e -> collect e a) acc exprs
+                        | _ -> acc
+
+                    collect arg []
+
                 let mkAttribExpr e =
-                    AttribExpr(e, EvalLiteralExprOrAttribArg g e)
+                    let sourceExpr =
+                        match e with
+                        | Expr.Const(_, m, _) ->
+                            match literalIdents |> List.tryFind (fun (r, _) -> Range.equals r m) with
+                            | Some(_, vref) -> Expr.Val(vref, NormalValUse, m)
+                            | None -> e
+                        | _ -> e
+
+                    AttribExpr(sourceExpr, EvalLiteralExprOrAttribArg g e)
                     
                 let checkPropSetterAttribAccess m (pinfo: PropInfo) =
                     let setterMeth = pinfo.SetterMethod

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -561,8 +561,10 @@ module PrintTypes =
     /// Layout a single attribute arg, following the cases of 'gen_attr_arg' in ilxgen.fs
     /// This is the subset of expressions we display in the NicePrint pretty printer 
     /// See also dataExprL - there is overlap between these that should be removed 
-    let rec layoutAttribArg denv arg = 
-        match arg with 
+    let rec layoutAttribArg denv arg =
+        match arg with
+        | Expr.Val (vref, _, _) when vref.LiteralValue.IsSome -> wordL (tagLocal vref.DisplayName)
+
         | Expr.Const (c, _, ty) -> 
             if isEnumTy denv.g ty then 
                 WordL.keywordEnum ^^ angleL (layoutType denv ty) ^^ bracketL (layoutConst denv.g ty c)
@@ -2551,7 +2553,7 @@ module InferredSigPrinting =
         let rec imdefsL denv x = aboveListL (x |> List.map (imdefL denv))
 
         and imdefL denv x = 
-            let filterVal (v: Val) = not v.IsCompilerGenerated && Option.isNone v.MemberInfo && not (v.LogicalName.Contains("@"))
+            let filterVal (v: Val) = not v.IsCompilerGenerated && Option.isNone v.MemberInfo && not (IsCompilerGeneratedName v.LogicalName)
             let filterExtMem (v: Val) = v.IsExtensionMember
 
             match x with 

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2551,7 +2551,7 @@ module InferredSigPrinting =
         let rec imdefsL denv x = aboveListL (x |> List.map (imdefL denv))
 
         and imdefL denv x = 
-            let filterVal (v: Val) = not v.IsCompilerGenerated && Option.isNone v.MemberInfo
+            let filterVal (v: Val) = not v.IsCompilerGenerated && Option.isNone v.MemberInfo && not (v.LogicalName.Contains("@"))
             let filterExtMem (v: Val) = v.IsExtensionMember
 
             match x with 

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2056,13 +2056,13 @@ module TastDefinitionPrinting =
 
         let nameL = ConvertLogicalNameToDisplayLayout (tagger >> mkNav tycon.DefinitionRange >> wordL) tycon.DisplayNameCore
 
-        let nameL = layoutAccessibility denv tycon.Accessibility nameL
-        let denv = denv.AddAccessibility tycon.Accessibility 
-
         let lhsL =
             let tps = tycon.TyparsNoRange
             let tpsL = layoutTyparDecls denv nameL tycon.IsPrefixDisplay tps
+            let tpsL = layoutAccessibility denv tycon.Accessibility tpsL
             typewordL ^^ tpsL
+
+        let denv = denv.AddAccessibility tycon.Accessibility
 
 
         let sortKey (minfo: MethInfo) = 

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2591,7 +2591,7 @@ module InferredSigPrinting =
         let rec imdefsL denv x = aboveListL (x |> List.map (imdefL denv))
 
         and imdefL denv x = 
-            let filterVal (v: Val) = not v.IsCompilerGenerated && Option.isNone v.MemberInfo && not (IsCompilerGeneratedName v.LogicalName)
+            let filterVal (v: Val) = not v.IsCompilerGenerated && Option.isNone v.MemberInfo && not (v.LogicalName.StartsWithOrdinal("doval@"))
             let filterExtMem (v: Val) = v.IsExtensionMember
 
             match x with 

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2041,10 +2041,7 @@ module TastDefinitionPrinting =
             elif isMeasure then
                 None, tagClass
             elif isClassTy g ty then
-                if denv.printVerboseSignatures then
-                    (if simplified then None else Some "class"), tagClass
-                else
-                    None, tagClass
+                (if simplified then None else Some "class"), tagClass
             else
                 None, tagUnknownType
 
@@ -2240,15 +2237,15 @@ module TastDefinitionPrinting =
         let needsStartEnd =
             match start with 
             | Some "class" ->
+                // When allDecls is empty, the repr layout produces 'class end' which is sufficient
+                not (isNil allDecls) &&
                 // 'inherits' is not enough for F# type kind inference to infer a class
                 // inherits.IsEmpty &&
                 ilFields.IsEmpty &&
                 // 'abstract' is not enough for F# type kind inference to infer a class by default in signatures
                 // 'static member' is surprisingly not enough for F# type kind inference to infer a class by default in signatures
                 // 'overrides' is surprisingly not enough for F# type kind inference to infer a class by default in signatures
-                //(meths |> List.forall (fun m -> m.IsAbstract || m.IsDefiniteFSharpOverride || not m.IsInstance)) &&
-                //(props |> List.forall (fun m -> (not m.HasGetter || m.GetterMethod.IsAbstract))) &&
-                //(props |> List.forall (fun m -> (not m.HasSetter || m.SetterMethod.IsAbstract))) &&
+                // Concrete instance methods and properties are also not enough (Error 938)
                 ctors.IsEmpty &&
                 instanceVals.IsEmpty &&
                 staticVals.IsEmpty

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -1988,6 +1988,47 @@ module TastDefinitionPrinting =
         let isMeasure = (tycon.TypeOrMeasureKind = TyparKind.Measure)
         let ty = generalizedTyconRef g tcref 
 
+        // Augment tycon.Attribs with synthetic [<NoComparison>] / [<NoEquality>] when the type
+        // is a candidate for comparison/equality augmentation but augmentation was not generated
+        // (e.g. struct with non-comparable fields). This ensures generated signatures compile. (#15339)
+        let augmentedAttribs =
+            let isTrueFSharpStruct =
+                tycon.IsFSharpStructOrEnumTycon && not tycon.IsFSharpEnumTycon
+
+            // Only structs need synthetic NoComparison/NoEquality in signatures.
+            // Reference types (records, unions) compile fine without them.
+            let canBeAugmentedWithCompare = isTrueFSharpStruct
+            let canBeAugmentedWithEquals = isTrueFSharpStruct
+
+            let mkSyntheticCoreAttrib (attrName: string) =
+                let fsharpCorePath = [| "Microsoft"; "FSharp"; "Core" |]
+                let attrTcref = mkNonLocalTyconRef (mkNonLocalEntityRef g.fslibCcu fsharpCorePath) attrName
+
+                let ilTypeRef =
+                    ILTypeRef.Create(g.ilg.fsharpCoreAssemblyScopeRef, [], "Microsoft.FSharp.Core." + attrName)
+
+                let ilMethodRef =
+                    ILMethodRef.Create(ilTypeRef, ILCallingConv.Instance, ".ctor", 0, [], ILType.Void)
+
+                Attrib(attrTcref, ILAttrib ilMethodRef, [], [], false, None, Range.range0)
+
+            let mutable attribs = tycon.Attribs
+
+            if canBeAugmentedWithCompare
+               && not (EntityHasWellKnownAttribute g WellKnownEntityAttributes.NoComparisonAttribute tycon)
+               && not (EntityHasWellKnownAttribute g WellKnownEntityAttributes.CustomComparisonAttribute tycon)
+               && tycon.GeneratedCompareToValues.IsNone then
+                attribs <- mkSyntheticCoreAttrib "NoComparisonAttribute" :: attribs
+
+            if canBeAugmentedWithEquals
+               && not (EntityHasWellKnownAttribute g WellKnownEntityAttributes.NoEqualityAttribute tycon)
+               && not (EntityHasWellKnownAttribute g WellKnownEntityAttributes.CustomEqualityAttribute tycon)
+               && not (EntityHasWellKnownAttribute g WellKnownEntityAttributes.ReferenceEqualityAttribute tycon)
+               && tycon.GeneratedHashAndEqualsValues.IsNone then
+                attribs <- mkSyntheticCoreAttrib "NoEqualityAttribute" :: attribs
+
+            attribs
+
         let start, tagger =
             if isStructTy g ty && not tycon.TypeAbbrev.IsSome then
                 // Always show [<Struct>] whether verbose or not
@@ -2011,7 +2052,7 @@ module TastDefinitionPrinting =
             if isFirstType then
                 WordL.keywordType
             else
-                wordL (tagKeyword "and") ^^ layoutAttribs denv start false tycon.TypeOrMeasureKind tycon.Attribs emptyL
+                wordL (tagKeyword "and") ^^ layoutAttribs denv start false tycon.TypeOrMeasureKind augmentedAttribs emptyL
 
         let nameL = ConvertLogicalNameToDisplayLayout (tagger >> mkNav tycon.DefinitionRange >> wordL) tycon.DisplayNameCore
 
@@ -2386,7 +2427,7 @@ module TastDefinitionPrinting =
                 |> addLhs
 
         typeDeclL 
-        |> fun tdl -> if isFirstType then layoutAttribs denv start false tycon.TypeOrMeasureKind tycon.Attribs tdl else tdl
+        |> fun tdl -> if isFirstType then layoutAttribs denv start false tycon.TypeOrMeasureKind augmentedAttribs tdl else tdl
         |> layoutXmlDocOfEntity denv infoReader tcref 
 
     // Layout: exception definition

--- a/src/Compiler/Checking/NicePrint.fs
+++ b/src/Compiler/Checking/NicePrint.fs
@@ -2041,7 +2041,10 @@ module TastDefinitionPrinting =
             elif isMeasure then
                 None, tagClass
             elif isClassTy g ty then
-                (if simplified then None else Some "class"), tagClass
+                if denv.showAttributes then
+                    (if simplified then None else Some "class"), tagClass
+                else
+                    None, tagClass
             else
                 None, tagUnknownType
 

--- a/src/Compiler/SyntaxTree/PrettyNaming.fs
+++ b/src/Compiler/SyntaxTree/PrettyNaming.fs
@@ -515,8 +515,8 @@ let DoesIdentifierNeedBackticks (name: string) : bool =
 let AddBackticksToIdentifierIfNeeded (name: string) : string =
     if
         DoesIdentifierNeedBackticks name
-        && not (name.StartsWithOrdinal("`"))
-        && not (name.EndsWithOrdinal("`"))
+        && not (name.StartsWithOrdinal("``"))
+        && not (name.EndsWithOrdinal("``"))
     then
         "``" + name + "``"
     else

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -2875,7 +2875,18 @@ and p_attribkind x st =
 and p_attrib (Attrib(a, b, c, d, e, _targets, f)) st = // AttributeTargets are not preserved
     p_tup6 (p_tcref "attrib") p_attribkind (p_list p_attrib_expr) (p_list p_attrib_arg) p_bool p_dummy_range (a, b, c, d, e, f) st
 
-and p_attrib_expr (AttribExpr(e1, e2)) st = p_tup2 p_expr p_expr (e1, e2) st
+and p_attrib_expr (AttribExpr(e1, e2)) st =
+    // Normalize Expr.Val back to Expr.Const before pickling.
+    // The literal name recovery (Expr.Val in source field) is an in-memory optimization
+    // for signature generation display. We must not change the pickle format, because
+    // old compilers reading Expr.Val in this position would show degraded attribute display.
+    let e1 =
+        match e1 with
+        | Expr.Val(vref, _, m) when vref.LiteralValue.IsSome ->
+            Expr.Const(vref.LiteralValue.Value, m, vref.Type)
+        | _ -> e1
+
+    p_tup2 p_expr p_expr (e1, e2) st
 
 and p_attrib_arg (AttribNamedArg(a, b, c, d)) st =
     p_tup4 p_string p_ty p_bool p_attrib_expr (a, b, c, d) st

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/misc/misc.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsc/misc/misc.fs
@@ -11,12 +11,14 @@ open System.IO
 module help_options =
 
     // ReqENU	SOURCE=dummy.fsx COMPILE_ONLY=1  PRECMD="\$FSC_PIPE >help40.txt -?     2>&1" POSTCMD="\$FSI_PIPE --nologo --quiet --exec ..\\..\\..\\comparer.fsx help40.txt help40.437.1033.bsl"	# -?
+    // Reset enableConsoleColoring before help tests to avoid global mutable state
+    // pollution from concurrent tests (e.g., ``fsc --consolecolors switch``).
     [<Fact>]
     let ``Help - variant 1``() =
         FSharp ""
         |> asExe
         |> withBufferWidth 120
-        |> withOptions ["-?"]
+        |> withOptions ["--consolecolors+"; "-?"]
         |> compile
         |> verifyOutputWithBaseline (Path.Combine(__SOURCE_DIRECTORY__, "compiler_help_output.bsl"))
         |> shouldSucceed
@@ -27,7 +29,7 @@ module help_options =
         FSharp ""
         |> asExe
         |> withBufferWidth 120
-        |> withOptions ["/?"]
+        |> withOptions ["--consolecolors+"; "/?"]
         |> compile
         |> verifyOutputWithBaseline (Path.Combine(__SOURCE_DIRECTORY__, "compiler_help_output.bsl"))
         |> shouldSucceed
@@ -38,7 +40,7 @@ module help_options =
         FSharp ""
         |> asExe
         |> withBufferWidth 120
-        |> withOptions ["--help"]
+        |> withOptions ["--consolecolors+"; "--help"]
         |> compile
         |> verifyOutputWithBaseline (Path.Combine(__SOURCE_DIRECTORY__, "compiler_help_output.bsl"))
         |> shouldSucceed

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -183,6 +183,18 @@ do ()
 namespace Foo
 namespace Bar"""
 
+// https://github.com/dotnet/fsharp/issues/13832
+[<Fact>]
+let ``Recursive module with do binding`` () =
+    FSharp
+        """
+module rec Foobar
+
+do ()
+"""
+    |> printSignatures
+    |> assertEqualIgnoreLineEnding "\nmodule Foobar"
+
 [<Fact>]
 let ``Empty namespace module`` () =
     FSharp

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -298,3 +298,21 @@ module SubModule =
 
     [<System.ComponentModel.Category (A)>]
     member Meh: unit -> unit"""
+
+// https://github.com/dotnet/fsharp/issues/15389
+[<Fact>]
+let ``Backtick in identifier is properly escaped in signature`` () =
+    FSharp
+        """
+module Foo
+
+let ```a` b`` (a:int) (b:int) = ()
+"""
+    |> printSignatures
+    |> prependNewline
+    |> assertEqualIgnoreLineEnding
+        """
+
+module Foo
+
+val ```a` b`` : a: int -> b: int -> unit"""

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -26,6 +26,7 @@ namespace Foo.Types
   type Area = | Area of string * int
 namespace Foo.Other
 
+  [<Class>]
   type Map<'t,'v> =
 
     member Calculate: Foo.Types.Area"""
@@ -45,6 +46,7 @@ type Foo =
         """
 namespace Hey.There
 
+  [<Class>]
   type Foo =
 
     static member Zero: Foo"""

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -262,3 +262,39 @@ namespace FSharp.MyStuff
   module Library =
 
     val batch: s: FSharp.Control.AsyncSeq<'t> -> FSharp.Control.AsyncSeq<'t>"""
+
+// https://github.com/dotnet/fsharp/issues/13810
+[<Fact>]
+let ``Literal value in attribute uses literal name`` () =
+    FSharp
+        """
+module Maybe
+
+open System.ComponentModel
+
+[<Literal>]
+let A = "A"
+
+module SubModule =
+    type Foo() =
+        [<Category(A)>]
+        member this.Meh () = ()
+"""
+    |> printSignatures
+    |> prependNewline
+    |> assertEqualIgnoreLineEnding
+        """
+
+module Maybe
+
+[<Literal>]
+val A: string = "A"
+
+module SubModule =
+
+  type Foo =
+
+    new: unit -> Foo
+
+    [<System.ComponentModel.Category (A)>]
+    member Meh: unit -> unit"""

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/ModuleOrNamespaceTests.fs
@@ -301,6 +301,64 @@ module SubModule =
     [<System.ComponentModel.Category (A)>]
     member Meh: unit -> unit"""
 
+// https://github.com/dotnet/fsharp/issues/13810
+[<Fact>]
+let ``Multiple literal values in attribute tuple args use literal names`` () =
+    let actual =
+        FSharp
+            """
+module TestMod
+
+open System
+
+[<AttributeUsage(AttributeTargets.All)>]
+type TwoArgAttribute(a: string, b: string) =
+    inherit Attribute()
+
+[<Literal>]
+let First = "first"
+
+[<Literal>]
+let Second = "second"
+
+type Foo() =
+    [<TwoArg(First, Second)>]
+    member _.Bar() = ()
+"""
+        |> printSignatures
+
+    // The attribute argument line should show literal names, not constant values
+    let attrLine = actual.Split('\n') |> Array.find (fun l -> l.Contains("TwoArg") && l.Contains("[<"))
+    Assert.Contains("First", attrLine)
+    Assert.Contains("Second", attrLine)
+    Assert.DoesNotContain("\"first\"", attrLine)
+    Assert.DoesNotContain("\"second\"", attrLine)
+
+// https://github.com/dotnet/fsharp/issues/13810 — known limitation:
+// Qualified literal references (e.g. Module.Literal) are not recovered;
+// the constant value is shown instead.
+[<Fact>]
+let ``Qualified literal in attribute shows constant value`` () =
+    FSharp
+        """
+module TestMod
+
+open System.ComponentModel
+
+module Constants =
+    [<Literal>]
+    let A = "QualifiedValue"
+
+type Foo() =
+    [<Category(Constants.A)>]
+    member this.Meh () = ()
+"""
+    |> printSignatures
+    |> prependNewline
+    |> fun actual ->
+        // Qualified literal refs are not recovered — constant value is shown
+        Assert.Contains("QualifiedValue", actual)
+
 // https://github.com/dotnet/fsharp/issues/15389
 [<Fact>]
 let ``Backtick in identifier is properly escaped in signature`` () =

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -496,3 +496,23 @@ type StructWithFunc =
     |> compile
     |> shouldSucceed
     |> ignore
+
+// https://github.com/dotnet/fsharp/issues/15560
+[<Fact>]
+let ``Private type abbreviation with prefix type parameter`` () =
+    let signatures =
+        FSharp
+            """
+module Foo
+
+type P<'a> = class end
+
+[<RequireQualifiedAccess>]
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module R =     
+    type private 'a P = unit -> 'a
+"""
+        |> printSignatures
+
+    Assert.Contains("type private 'a P", signatures)
+    Assert.DoesNotContain("type 'a private P", signatures)

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -441,3 +441,58 @@ type ExplicitClass =
     |> compile
     |> shouldSucceed
     |> ignore
+
+// https://github.com/dotnet/fsharp/issues/15339
+[<Fact>]
+let ``Struct with non-comparable field includes NoComparison in signature`` () =
+    let implSource =
+        """
+namespace FSInteractive
+
+open System
+
+[<Struct>]
+type LocalReadWriteLockCookie(locker: obj) =
+    interface IDisposable with
+        member _.Dispose () = ()
+"""
+
+    let generatedSignature =
+        FSharp implSource |> printSignatures
+
+    Assert.Contains("NoComparison", generatedSignature)
+
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
+    |> withOptions [ "--warnaserror:64" ]
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore
+
+// https://github.com/dotnet/fsharp/issues/15339
+[<Fact>]
+let ``Struct with non-equatable field includes NoEquality in signature`` () =
+    let implSource =
+        """
+namespace TestNs
+
+[<Struct>]
+type StructWithFunc =
+    val Fn: int -> int
+    new(f) = { Fn = f }
+"""
+
+    let generatedSignature =
+        FSharp implSource |> printSignatures
+
+    Assert.Contains("NoComparison", generatedSignature)
+    Assert.Contains("NoEquality", generatedSignature)
+
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
+    |> withOptions [ "--warnaserror:64" ]
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -240,6 +240,7 @@ type Foo =
         """
 module Lib
 
+[<Class>]
 type Foo =
 
   member Bar: int with get, set"""
@@ -257,6 +258,7 @@ type Foo =
         """
 module Lib
 
+[<Class>]
 type Foo =
 
   member Bar: a: int -> int with get
@@ -516,3 +518,80 @@ module R =
 
     Assert.Contains("type private 'a P", signatures)
     Assert.DoesNotContain("type 'a private P", signatures)
+
+// https://github.com/dotnet/fsharp/issues/16531
+[<Fact>]
+let ``Private constructor class with static members gets Class attribute in signature`` () =
+    let implSource =
+        """
+module Telplin
+
+type A private () = 
+    static member Foo () = ()
+"""
+
+    let generatedSignature =
+        FSharp implSource
+        |> printSignatures
+
+    // Static members alone are not enough for the compiler to infer class
+    Assert.Contains("Class", generatedSignature)
+
+    // Roundtrip: the generated signature must compile with the implementation
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
+    |> withOptions [ "--warnaserror:64" ]
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore
+
+// https://github.com/dotnet/fsharp/issues/16531
+[<Fact>]
+let ``Private constructor class with instance members gets Class attribute in signature`` () =
+    let implSource =
+        """
+module Telplin
+
+type A private () = 
+    member a.Foo () = ()
+"""
+
+    let generatedSignature =
+        FSharp implSource
+        |> printSignatures
+
+    // Private ctor is not visible in signature, so [<Class>] is needed
+    Assert.Contains("Class", generatedSignature)
+
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
+    |> withOptions [ "--warnaserror:64" ]
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore
+
+// https://github.com/dotnet/fsharp/issues/16531
+[<Fact>]
+let ``Public constructor class does not need Class attribute in signature`` () =
+    let implSource =
+        """
+module Telplin
+
+type B() = 
+    member b.Bar () = ()
+"""
+
+    let generatedSignature =
+        FSharp implSource
+        |> printSignatures
+
+    // Public constructor is visible, so [<Class>] should not be needed
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
+    |> withOptions [ "--warnaserror:64" ]
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore

--- a/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Signatures/TypeTests.fs
@@ -474,6 +474,46 @@ type LocalReadWriteLockCookie(locker: obj) =
 
 // https://github.com/dotnet/fsharp/issues/15339
 [<Fact>]
+let ``Struct with explicit NoComparison does not get duplicate attribute`` () =
+    let generatedSignature =
+        FSharp
+            """
+namespace TestNs
+
+[<Struct; NoComparison>]
+type AlreadyMarked =
+    val X: obj
+    new(x) = { X = x }
+"""
+        |> printSignatures
+
+    // Should NOT duplicate [<NoComparison>] — the explicit one is sufficient
+    let count = System.Text.RegularExpressions.Regex.Matches(generatedSignature, "NoComparison").Count
+    Assert.Equal(1, count)
+
+// https://github.com/dotnet/fsharp/issues/15339
+[<Fact>]
+let ``Struct with CustomComparison does not get NoComparison`` () =
+    let generatedSignature =
+        FSharp
+            """
+namespace TestNs
+
+open System
+
+[<Struct; CustomComparison; NoEquality>]
+type WithCustomCompare =
+    val X: obj
+    new(x) = { X = x }
+    interface IComparable with
+        member _.CompareTo(_) = 0
+"""
+        |> printSignatures
+
+    Assert.DoesNotContain("NoComparison", generatedSignature)
+
+// https://github.com/dotnet/fsharp/issues/15339
+[<Fact>]
 let ``Struct with non-equatable field includes NoEquality in signature`` () =
     let implSource =
         """
@@ -591,6 +631,54 @@ type B() =
     Fsi generatedSignature
     |> withAdditionalSourceFile (FsSource implSource)
     |> withOptions [ "--warnaserror:64" ]
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore
+
+// https://github.com/dotnet/fsharp/issues/16531
+[<Fact>]
+let ``Empty class with private constructor uses class end`` () =
+    let implSource =
+        """
+module Telplin
+
+type Empty private () = class end
+"""
+
+    let generatedSignature =
+        FSharp implSource
+        |> printSignatures
+
+    // Empty class should use 'class end' repr, not [<Class>] attribute
+    Assert.Contains("class end", generatedSignature)
+
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
+    |> ignoreWarnings
+    |> compile
+    |> shouldSucceed
+    |> ignore
+
+// https://github.com/dotnet/fsharp/issues/16531
+[<Fact>]
+let ``AbstractClass with private constructor roundtrips`` () =
+    let implSource =
+        """
+module Telplin
+
+[<AbstractClass>]
+type A private () =
+    abstract member M: unit -> unit
+"""
+
+    let generatedSignature =
+        FSharp implSource
+        |> printSignatures
+
+    // The generated signature should compile with the implementation
+    Fsi generatedSignature
+    |> withAdditionalSourceFile (FsSource implSource)
     |> ignoreWarnings
     |> compile
     |> shouldSucceed

--- a/tests/projects/CompilerCompat/CompilerCompatApp/Program.fs
+++ b/tests/projects/CompilerCompat/CompilerCompatApp/Program.fs
@@ -58,12 +58,18 @@ let main _argv =
             printfn "Literal: %d" CompilerCompatLib.Library.LiteralValue
             printfn "Reflected: %d" (CompilerCompatLib.Library.reflectedFunction 1)
 
-            if processed = "Processed: X=123, Y=test" then
-                printfn "SUCCESS: All compiler compatibility tests passed"
-                0
-            else
+            // Test literal attribute arg cross-compiler compatibility
+            let attrObj = CompilerCompatLib.Library.TypeWithLiteralAttrArg()
+            printfn "LiteralAttr: %s" (attrObj.GetValue())
+            if attrObj.GetValue() <> CompilerCompatLib.Library.LiteralAttrArg then
+                printfn "ERROR: Literal attr arg value mismatch"
+                1
+            elif processed <> "Processed: X=123, Y=test" then
                 printfn "ERROR: Processed result doesn't match expected"
                 1
+            else
+                printfn "SUCCESS: All compiler compatibility tests passed"
+                0
                 
     with ex ->
         printfn "ERROR: Exception occurred: %s" ex.Message

--- a/tests/projects/CompilerCompat/CompilerCompatLib/Library.fs
+++ b/tests/projects/CompilerCompat/CompilerCompatLib/Library.fs
@@ -40,3 +40,18 @@ module Library =
     /// Function with ReflectedDefinition
     [<ReflectedDefinition>]
     let reflectedFunction x = x + 1
+
+    /// Literal string used as an attribute argument.
+    /// Tests that Expr.Val in AttribExpr.source pickles/unpickles across compiler versions.
+    [<Literal>]
+    let LiteralAttrArg = "compat-test-value"
+
+    /// Custom attribute for cross-version literal attribute arg testing
+    type TestAttrAttribute(value: string) =
+        inherit System.Attribute()
+        member _.Value = value
+
+    /// Type decorated with an attribute whose argument is a literal val reference
+    [<TestAttr(LiteralAttrArg)>]
+    type TypeWithLiteralAttrArg() =
+        member _.GetValue() = LiteralAttrArg


### PR DESCRIPTION
## Summary

Fixes 6 signature generation bugs in `FSharpCheckFileResults.GenerateSignature`. All fixes ensure generated signatures roundtrip-compile with their implementations.

## Fixes

- Fixes #13832 — Recursive module `do` binding leaking compiler-generated val in signature
- Fixes #13810 — Literal values in attribute arguments reduced to constant values
- Fixes #15339 — Struct types missing `[<NoComparison>]`/`[<NoEquality>]` attributes
- Fixes #15389 — Backtick escaping incorrect for identifiers containing backticks
- Fixes #15560 — `private` keyword misplaced in prefix-style type abbreviation signatures
- Fixes #16531 — Missing `[<Class>]` attribute for types without visible constructors

## Design notes

**Literal attribute arg recovery**: `TcVal` inlines literal vals to `Expr.Const`, losing the original identifier. The fix recovers literal `ValRef` from the syntax tree via range matching and stores it as `Expr.Val` in `AttribExpr.source` for display. This is an **in-memory-only** optimization — `p_attrib_expr` normalizes back to `Expr.Const` before pickling, so the on-disk format is unchanged.

**Struct NoComparison/NoEquality**: When a struct type's fields prevent comparison/equality augmentation, synthetic attributes are injected in the display layer (NicePrint) only.

**[<Class>] emission**: The `printVerboseSignatures` gate was removed; class kind is now always tracked. The `needsStartEnd` heuristic determines whether `[<Class>]` or `class...end` is needed based on visible constructors, fields, and members.

## Binary compatibility

**Zero cross-version regression.** The pickle normalization in `p_attrib_expr` ensures that DLLs compiled with this change produce identical metadata to before. Old compilers reading new DLLs see `Expr.Const` in all positions — no behavioral change.