### PR TITLE
Migrate dn-bot-devdiv-drop-rw-code-rw PAT to WIF service connection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,16 +189,25 @@ extends:
                 targetPath: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
                 artifactName: 'NativeSymbols'
               condition: succeeded()
+            - task: AzureCLI@2
+              displayName: Get DevDiv Drop Access Token
+              inputs:
+                azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+                scriptType: pscore
+                scriptLocation: inlineScript
+                inlineScript: |
+                  $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+                  Write-Host "##vso[task.setvariable variable=DevDivDropAccessToken;issecret=true]$token"
+              condition: succeeded()
             - task: 1ES.MicroBuildVstsDrop@1
               displayName: Upload VSTS Drop
               inputs:
                 dropName: $(VisualStudioDropName)
                 dropFolder: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(_BuildConfig)\Insertion'
                 dropRetentionDays: 90
-                accessToken: $(dn-bot-devdiv-drop-rw-code-rw)
+                accessToken: $(DevDivDropAccessToken)
                 dropServiceUri: 'https://devdiv.artifacts.visualstudio.com'
                 vsDropServiceUri: 'https://vsdrop.corp.microsoft.com/file/v1'
-
               condition: succeeded()
 
     #---------------------------------------------------------------------------------------------------------------------#
@@ -239,3 +248,4 @@ extends:
         insertTeamEmail: fsharpteam@microsoft.com
         insertTeamName: 'F#'
         completeInsertion: 'auto'
+


### PR DESCRIPTION
## Summary

Migrate the `dn-bot-devdiv-drop-rw-code-rw` PAT to Workload Identity Federation (WIF) for VSTS drop uploads.

## Changes

- Add `AzureCLI@2` step before `1ES.MicroBuildVstsDrop@1` to obtain a DevDiv-scoped access token via the `dnceng-devdiv-drop-rw-code-rw-wif` service connection
- Replace `accessToken: $(dn-bot-devdiv-drop-rw-code-rw)` with the WIF-obtained `$(DevDivDropAccessToken)` variable

## Validation

- **Test build [2952255](https://dev.azure.com/dnceng/internal/_build/results?buildId=2952255)** — queued from `dev/mjanecke/wif-drop-token` branch on the AzDO mirror
  - ✅ `Get DevDiv Drop Access Token` (AzureCLI@2) — succeeded
  - ✅ `Upload VSTS Drop` (1ES.MicroBuildVstsDrop@1) — succeeded

## Context

Part of PAT-to-Entra migration tracked by [AB#10146](https://dev.azure.com/dnceng/internal/_workitems/edit/10146).
