### PR TITLE
Update xcopy-msbuild to 18.0.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,7 +16,7 @@
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.13.0"
+    "xcopy-msbuild": "18.0.0"
   },
   "native-tools": {
     "perl": "5.38.2.2"


### PR DESCRIPTION
Release/dev18.0 insertion pipeline has been failing for a while with error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found. This will fix it hopefully