### PR TITLE
Fix flaky async/task tests under CI load

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -49,9 +49,10 @@ type AsyncType() =
     [<VolatileField>]
     let mutable spinloop = true
         
-    let waitASec (t:Task) =
-        let result = t.Wait(TimeSpan(hours=0,minutes=0,seconds=1))
-        Assert.True(result, "Task did not finish after waiting for a second.")
+    // Use a generous timeout to avoid flaky failures on loaded CI machines where the thread pool may be saturated.
+    let waitForCompletion (t: Task) =
+        let result = t.Wait(TimeSpan.FromSeconds(30.0))
+        Assert.True(result, "Task did not finish after waiting for 30 seconds.")
 
     [<Fact>]
     member _.AsyncRunSynchronouslyReusesThreadPoolThread() =
@@ -154,7 +155,7 @@ type AsyncType() =
         let s = "Hello tasks!"
         let a = async { return s }
         let t : Task<string> = Async.StartAsTask a
-        waitASec t
+        waitForCompletion t
         Assert.True (t.IsCompleted)
         Assert.AreEqual(s, t.Result)
 
@@ -212,7 +213,7 @@ type AsyncType() =
         innerTcs.SetResult ()
 
         try
-            waitASec tcs.Task
+            waitForCompletion tcs.Task
         with :? AggregateException as a ->
             match a.InnerException with
             | :? TaskCanceledException -> ()
@@ -246,7 +247,7 @@ type AsyncType() =
         let t = Async.StartAsTask a
         let mutable exceptionThrown = false
         try
-            // waitASec t
+            // waitForCompletion t
             t.Wait()
         with
             e -> exceptionThrown <- true
@@ -265,7 +266,7 @@ type AsyncType() =
         Async.CancelDefaultToken ()
         let mutable exceptionThrown = false
         try
-            waitASec t
+            waitForCompletion t
         with e -> exceptionThrown <- true
         Assert.True (exceptionThrown)
         Assert.True(t.IsCanceled)
@@ -299,7 +300,7 @@ type AsyncType() =
         let s = "Hello tasks!"
         let a = async { return s }
         let t : Task<string> = Async.StartImmediateAsTask a
-        waitASec t
+        waitForCompletion t
         Assert.True (t.IsCompleted)
         Assert.AreEqual(s, t.Result)
 
@@ -308,7 +309,7 @@ type AsyncType() =
         let s = "Hello tasks!"
         let a = async { return s }
         let t = Async.StartImmediateAsTask a
-        waitASec t
+        waitForCompletion t
         Assert.True (t.IsCompleted)
         Assert.AreEqual(s, t.Result)
 

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/Tasks.fs
@@ -411,15 +411,17 @@ type Basics() =
     member _.testNonBlocking() =
         printfn "Running testNonBlocking..."
         let allowContinue = new SemaphoreSlim(0)
+        let continueToFinish = new ManualResetEventSlim(false)
         let finished = new ManualResetEventSlim()
         let t =
             task {
                 do! allowContinue.WaitAsync()
-                Thread.Sleep(100)
+                continueToFinish.Wait()
                 finished.Set()
             }
         allowContinue.Release() |> ignore
         require (not finished.IsSet) "sleep blocked caller"
+        continueToFinish.Set()
         t.Wait()
 
     [<Fact>]
@@ -1120,7 +1122,7 @@ type Basics() =
                     try
                         ranInitial.Set()
                         do! Task.Yield()
-                        Thread.Sleep(100) // shouldn't be blocking so we should get through to requires before this finishes
+                        do! stepOutside.WaitAsync()
                         ranNext.Set()
                     finally
                         ranFinally <- ranFinally + 1
@@ -1128,6 +1130,7 @@ type Basics() =
                 }
             require ranInitial.IsSet "didn't run initial"
             require (not ranNext.IsSet) "ran next too early"
+            stepOutside.Release() |> ignore
             try
                 t.Wait()
                 require false "shouldn't get here"

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/TasksDynamic.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/TasksDynamic.fs
@@ -362,15 +362,17 @@ type Basics() =
     member _.testNonBlocking() =
         printfn "Running testNonBlocking..."
         let allowContinue = new SemaphoreSlim(0)
+        let continueToFinish = new ManualResetEventSlim(false)
         let finished = new ManualResetEventSlim()
         let t =
             taskDynamic {
                 do! allowContinue.WaitAsync()
-                Thread.Sleep(100)
+                continueToFinish.Wait()
                 finished.Set()
             }
         allowContinue.Release() |> ignore
         require (not finished.IsSet) "sleep blocked caller"
+        continueToFinish.Set()
         t.Wait()
 
     [<Fact>]
@@ -997,7 +999,7 @@ type Basics() =
                     try
                         ranInitial.Set()
                         do! Task.Yield()
-                        Thread.Sleep(100) // shouldn't be blocking so we should get through to requires before this finishes
+                        do! stepOutside.WaitAsync()
                         ranNext.Set()
                     finally
                         ranFinally <- ranFinally + 1
@@ -1005,6 +1007,7 @@ type Basics() =
                 }
             require ranInitial.IsSet "didn't run initial"
             require (not ranNext.IsSet) "ran next too early"
+            stepOutside.Release() |> ignore
             try
                 t.Wait()
                 require false "shouldn't get here"


### PR DESCRIPTION
## Summary

Fixes flaky test failures observed in internal CI pipelines (Run 20260420.7, Run 20260421.2) caused by timing-sensitive synchronization in async/task tests.

### Root causes

**1. Too-short "must complete" timeout (AsyncType.fs)**
- `waitASec` used a 1-second `Task.Wait` timeout. Under CI thread-pool saturation, `Async.StartAsTask` can't schedule even trivial computations within 1 second.
- Fix: Increased to 30 seconds (matching the pattern already used by `StartAsTaskCancellation` in the same file).

**2. Race on `Thread.Sleep(100)` as synchronization (Tasks.fs, TasksDynamic.fs)**
- `testNonBlocking` and `testExceptionThrownInFinally` used `Thread.Sleep(100)` in task bodies, then asserted a condition "before the sleep finishes". Under CI load, the calling thread can be preempted >100ms, causing the sleep to complete before the assertion runs.
- Fix: Replaced with event-based synchronization (ManualResetEventSlim gate / SemaphoreSlim). Note: `testExceptionThrownInFinally` already had an unused `stepOutside` SemaphoreSlim declared for this purpose — now wired up, matching the pattern in the adjacent `test2ndExceptionThrownInFinally`.

### Files changed
- `AsyncType.fs` — `waitASec` → `waitForCompletion` (1s → 30s timeout)
- `Tasks.fs` — `testNonBlocking`, `testExceptionThrownInFinally`
- `TasksDynamic.fs` — `testNonBlocking`, `testExceptionThrownInFinally`