### PR TITLE
Fix syntax highlighting for optional parameters (?ident) in member declarations

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.300.md
@@ -31,6 +31,7 @@
 * Fix nativeptr in interfaces leads to TypeLoadException. (Issue [#14508](https://github.com/dotnet/fsharp/issues/14508), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix box instruction for literal upcasts. (Issue [#18319](https://github.com/dotnet/fsharp/issues/18319), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix Decimal Literal causes InvalidProgramException in Debug builds. (Issue [#18956](https://github.com/dotnet/fsharp/issues/18956), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
+* Fixed incorrect syntax highlighting of optional parameters (`?ident`) in member declarations, where tokens were incorrectly classified as `Namespace` by `GetPartialLongNameExAux`. ([PR #XXXXX](https://github.com/dotnet/fsharp/pull/19640))
 
 ### Added
 * FSharpType: add ImportILType ([PR #19300](https://github.com/dotnet/fsharp/pull/19300))

--- a/docs/release-notes/.FSharp.Compiler.Service/10.0.300.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/10.0.300.md
@@ -31,7 +31,6 @@
 * Fix nativeptr in interfaces leads to TypeLoadException. (Issue [#14508](https://github.com/dotnet/fsharp/issues/14508), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix box instruction for literal upcasts. (Issue [#18319](https://github.com/dotnet/fsharp/issues/18319), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
 * Fix Decimal Literal causes InvalidProgramException in Debug builds. (Issue [#18956](https://github.com/dotnet/fsharp/issues/18956), [PR #19338](https://github.com/dotnet/fsharp/pull/19338))
-* Fixed incorrect syntax highlighting of optional parameters (`?ident`) in member declarations, where tokens were incorrectly classified as `Namespace` by `GetPartialLongNameExAux`. ([PR #XXXXX](https://github.com/dotnet/fsharp/pull/19640))
 
 ### Added
 * FSharpType: add ImportILType ([PR #19300](https://github.com/dotnet/fsharp/pull/19300))

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -35,7 +35,6 @@
 * Fix signature generation: `private` keyword placement for prefix-style type abbreviations. ([Issue #15560](https://github.com/dotnet/fsharp/issues/15560), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 * Fix signature generation: missing `[<Class>]` attribute for types without visible constructors. ([Issue #16531](https://github.com/dotnet/fsharp/issues/16531), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 * Fix methods being tagged as `Member` instead of `Method` in tooltips. ([Issue #10540](https://github.com/dotnet/fsharp/issues/10540), [PR #19507](https://github.com/dotnet/fsharp/pull/19507))
-* Fixed incorrect syntax highlighting of optional parameters (`?ident`) in member declarations, where tokens were incorrectly classified as `Namespace` by `GetPartialLongNameExAux`. ([PR #XXXXX](https://github.com/dotnet/fsharp/pull/19640))
 
 ### Added
 

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -35,6 +35,7 @@
 * Fix signature generation: `private` keyword placement for prefix-style type abbreviations. ([Issue #15560](https://github.com/dotnet/fsharp/issues/15560), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 * Fix signature generation: missing `[<Class>]` attribute for types without visible constructors. ([Issue #16531](https://github.com/dotnet/fsharp/issues/16531), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 * Fix methods being tagged as `Member` instead of `Method` in tooltips. ([Issue #10540](https://github.com/dotnet/fsharp/issues/10540), [PR #19507](https://github.com/dotnet/fsharp/pull/19507))
+* Fixed incorrect syntax highlighting of optional parameters (`?ident`) in member declarations, where tokens were incorrectly classified as `Namespace` by `GetPartialLongNameExAux`. ([PR #XXXXX](https://github.com/dotnet/fsharp/pull/19640))
 
 ### Added
 

--- a/src/Compiler/Service/QuickParse.fs
+++ b/src/Compiler/Service/QuickParse.fs
@@ -394,7 +394,7 @@ module QuickParse =
                     AtStartOfIdentifier(pos + 1, current, throwAwayNext, lastDotPos)
                 else
                     let remainingLength = lineStr.Length - pos
-                
+
                     if IsTick pos && remainingLength > 1 && IsTick(pos + 1) then
                         InQuotedIdentifier(pos + 2, pos + 2, current, throwAwayNext, lastDotPos)
                     elif IsStartOfComment pos then

--- a/src/Compiler/Service/QuickParse.fs
+++ b/src/Compiler/Service/QuickParse.fs
@@ -401,11 +401,11 @@ module QuickParse =
                             EatComment(1, pos + 1, EatCommentCallContext.StartIdentifier(current, throwAwayNext), lastDotPos)
                         elif IsIdentifierStartCharacter pos then
                             InUnquotedIdentifier(pos, pos + 1, current, throwAwayNext, lastDotPos)
-                        elif
+                        elif // handles optional parameters
                             lineStr[pos] = '?'
                             && (pos + 1 < lineStr.Length)
                             && IsIdentifierPartCharacter(pos + 1)
-                        ->
+                        then
                             InUnquotedIdentifier(pos + 1, pos + 2, current, throwAwayNext, lastDotPos)
                     elif IsDot pos then
                         if pos = 0 then

--- a/src/Compiler/Service/QuickParse.fs
+++ b/src/Compiler/Service/QuickParse.fs
@@ -407,24 +407,24 @@ module QuickParse =
                             && IsIdentifierPartCharacter(pos + 1)
                         then
                             InUnquotedIdentifier(pos + 1, pos + 2, current, throwAwayNext, lastDotPos)
-                    elif IsDot pos then
-                        if pos = 0 then
-                            // dot on first char of line, currently treat it like empty identifier to the left
-                            AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
-                        elif not (pos > 0 && (IsIdentifierPartCharacter(pos - 1) || IsWhitespace(pos - 1))) then
-                            // it's not dots as part.of.a.long.ident, it's e.g. the range operator (..), or some other multi-char operator ending in dot
-                            if lineStr[pos - 1] = ')' then
-                                // one very problematic case is someCall(args).Name
-                                // without special logic, we will decide that ). is an operator and parse Name as the plid
-                                // but in fact this is an expression tail, and we don't want a plid, rather we need to use expression typings at that location
-                                // so be sure not to treat the name here as a plid
-                                AtStartOfIdentifier(pos + 1, [], true, None) // Throw away what we have, and the next apparent plid, and start over.
+                        elif IsDot pos then
+                            if pos = 0 then
+                                // dot on first char of line, currently treat it like empty identifier to the left
+                                AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
+                            elif not (pos > 0 && (IsIdentifierPartCharacter(pos - 1) || IsWhitespace(pos - 1))) then
+                                // it's not dots as part.of.a.long.ident, it's e.g. the range operator (..), or some other multi-char operator ending in dot
+                                if lineStr[pos - 1] = ')' then
+                                    // one very problematic case is someCall(args).Name
+                                    // without special logic, we will decide that ). is an operator and parse Name as the plid
+                                    // but in fact this is an expression tail, and we don't want a plid, rather we need to use expression typings at that location
+                                    // so be sure not to treat the name here as a plid
+                                    AtStartOfIdentifier(pos + 1, [], true, None) // Throw away what we have, and the next apparent plid, and start over.
+                                else
+                                    AtStartOfIdentifier(pos + 1, [], false, None) // Throw away what we have and start over.
                             else
-                                AtStartOfIdentifier(pos + 1, [], false, None) // Throw away what we have and start over.
+                                AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
                         else
-                            AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
-                    else
-                        AtStartOfIdentifier(pos + 1, [], throwAwayNext, None)
+                            AtStartOfIdentifier(pos + 1, [], throwAwayNext, None)
 
             let partialLongName = AtStartOfIdentifier(0, [], false, None)
 

--- a/src/Compiler/Service/QuickParse.fs
+++ b/src/Compiler/Service/QuickParse.fs
@@ -390,41 +390,41 @@ module QuickParse =
                             EndColumn = index
                             LastDotPos = lastDotPos
                         }
-                    else if IsWhitespace pos then
-                        AtStartOfIdentifier(pos + 1, current, throwAwayNext, lastDotPos)
-                    else
-                        let remainingLength = lineStr.Length - pos
+                elif IsWhitespace pos then
+                    AtStartOfIdentifier(pos + 1, current, throwAwayNext, lastDotPos)
+                else
+                    let remainingLength = lineStr.Length - pos
                 
-                        if IsTick pos && remainingLength > 1 && IsTick(pos + 1) then
-                            InQuotedIdentifier(pos + 2, pos + 2, current, throwAwayNext, lastDotPos)
-                        elif IsStartOfComment pos then
-                            EatComment(1, pos + 1, EatCommentCallContext.StartIdentifier(current, throwAwayNext), lastDotPos)
-                        elif IsIdentifierStartCharacter pos then
-                            InUnquotedIdentifier(pos, pos + 1, current, throwAwayNext, lastDotPos)
-                        elif // handles optional parameters
-                            lineStr[pos] = '?'
-                            && (pos + 1 < lineStr.Length)
-                            && IsIdentifierPartCharacter(pos + 1)
-                        then
-                            InUnquotedIdentifier(pos + 1, pos + 2, current, throwAwayNext, lastDotPos)
-                        elif IsDot pos then
-                            if pos = 0 then
-                                // dot on first char of line, currently treat it like empty identifier to the left
-                                AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
-                            elif not (pos > 0 && (IsIdentifierPartCharacter(pos - 1) || IsWhitespace(pos - 1))) then
-                                // it's not dots as part.of.a.long.ident, it's e.g. the range operator (..), or some other multi-char operator ending in dot
-                                if lineStr[pos - 1] = ')' then
-                                    // one very problematic case is someCall(args).Name
-                                    // without special logic, we will decide that ). is an operator and parse Name as the plid
-                                    // but in fact this is an expression tail, and we don't want a plid, rather we need to use expression typings at that location
-                                    // so be sure not to treat the name here as a plid
-                                    AtStartOfIdentifier(pos + 1, [], true, None) // Throw away what we have, and the next apparent plid, and start over.
-                                else
-                                    AtStartOfIdentifier(pos + 1, [], false, None) // Throw away what we have and start over.
+                    if IsTick pos && remainingLength > 1 && IsTick(pos + 1) then
+                        InQuotedIdentifier(pos + 2, pos + 2, current, throwAwayNext, lastDotPos)
+                    elif IsStartOfComment pos then
+                        EatComment(1, pos + 1, EatCommentCallContext.StartIdentifier(current, throwAwayNext), lastDotPos)
+                    elif IsIdentifierStartCharacter pos then
+                        InUnquotedIdentifier(pos, pos + 1, current, throwAwayNext, lastDotPos)
+                    elif // handles optional parameters
+                        lineStr[pos] = '?'
+                        && (pos + 1 < lineStr.Length)
+                        && IsIdentifierPartCharacter(pos + 1)
+                    then
+                        InUnquotedIdentifier(pos + 1, pos + 2, current, throwAwayNext, lastDotPos)
+                    elif IsDot pos then
+                        if pos = 0 then
+                            // dot on first char of line, currently treat it like empty identifier to the left
+                            AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
+                        elif not (pos > 0 && (IsIdentifierPartCharacter(pos - 1) || IsWhitespace(pos - 1))) then
+                            // it's not dots as part.of.a.long.ident, it's e.g. the range operator (..), or some other multi-char operator ending in dot
+                            if lineStr[pos - 1] = ')' then
+                                // one very problematic case is someCall(args).Name
+                                // without special logic, we will decide that ). is an operator and parse Name as the plid
+                                // but in fact this is an expression tail, and we don't want a plid, rather we need to use expression typings at that location
+                                // so be sure not to treat the name here as a plid
+                                AtStartOfIdentifier(pos + 1, [], true, None) // Throw away what we have, and the next apparent plid, and start over.
                             else
-                                AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
+                                AtStartOfIdentifier(pos + 1, [], false, None) // Throw away what we have and start over.
                         else
-                            AtStartOfIdentifier(pos + 1, [], throwAwayNext, None)
+                            AtStartOfIdentifier(pos + 1, "" :: current, throwAwayNext, Some pos)
+                    else
+                        AtStartOfIdentifier(pos + 1, [], throwAwayNext, None)
 
             let partialLongName = AtStartOfIdentifier(0, [], false, None)
 

--- a/src/Compiler/Service/QuickParse.fs
+++ b/src/Compiler/Service/QuickParse.fs
@@ -390,17 +390,23 @@ module QuickParse =
                             EndColumn = index
                             LastDotPos = lastDotPos
                         }
-                else if IsWhitespace pos then
-                    AtStartOfIdentifier(pos + 1, current, throwAwayNext, lastDotPos)
-                else
-                    let remainingLength = lineStr.Length - pos
-
-                    if IsTick pos && remainingLength > 1 && IsTick(pos + 1) then
-                        InQuotedIdentifier(pos + 2, pos + 2, current, throwAwayNext, lastDotPos)
-                    elif IsStartOfComment pos then
-                        EatComment(1, pos + 1, EatCommentCallContext.StartIdentifier(current, throwAwayNext), lastDotPos)
-                    elif IsIdentifierStartCharacter pos then
-                        InUnquotedIdentifier(pos, pos + 1, current, throwAwayNext, lastDotPos)
+                    else if IsWhitespace pos then
+                        AtStartOfIdentifier(pos + 1, current, throwAwayNext, lastDotPos)
+                    else
+                        let remainingLength = lineStr.Length - pos
+                
+                        if IsTick pos && remainingLength > 1 && IsTick(pos + 1) then
+                            InQuotedIdentifier(pos + 2, pos + 2, current, throwAwayNext, lastDotPos)
+                        elif IsStartOfComment pos then
+                            EatComment(1, pos + 1, EatCommentCallContext.StartIdentifier(current, throwAwayNext), lastDotPos)
+                        elif IsIdentifierStartCharacter pos then
+                            InUnquotedIdentifier(pos, pos + 1, current, throwAwayNext, lastDotPos)
+                        elif
+                            lineStr[pos] = '?'
+                            && (pos + 1 < lineStr.Length)
+                            && IsIdentifierPartCharacter(pos + 1)
+                        ->
+                            InUnquotedIdentifier(pos + 1, pos + 2, current, throwAwayNext, lastDotPos)
                     elif IsDot pos then
                         if pos = 0 then
                             // dot on first char of line, currently treat it like empty identifier to the left

--- a/tests/FSharp.Compiler.Service.Tests/QuickParseTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/QuickParseTests.fs
@@ -71,3 +71,29 @@ let ``QuickParse does not treat question mark as identifier in other contexts``(
     | None ->
         // Or we might get None, which is also acceptable
         ()
+
+[<Fact>]
+let ``GetPartialLongNameEx correctly parses optional parameter in member declaration``() =
+    let lineStr = "member x.TestMethod(?optionalParam) = optionalParam"
+    
+    // Cursor positioned at end of "optionalParam"
+    let pos = 33
+    Assert.Equal('m', lineStr[pos])
+    
+    let result = QuickParse.GetPartialLongNameEx(lineStr, pos)
+    
+    Assert.Equal("optionalParam", result.PartialIdent)
+    Assert.Equal<string list>([], result.QualifyingIdents)
+
+[<Fact>]
+let ``GetPartialLongNameEx handles optional parameter with type annotation``() =
+    let lineStr = "member x.TestMethod(?optionalParam:string) = optionalParam"
+    
+    // Cursor at end of "optionalParam" before the colon
+    let pos = 33
+    Assert.Equal('m', lineStr[pos])
+    
+    let result = QuickParse.GetPartialLongNameEx(lineStr, pos)
+    
+    Assert.Equal("optionalParam", result.PartialIdent)
+    Assert.Equal<string list>([], result.QualifyingIdents)


### PR DESCRIPTION
## Fixed
Fixes #19591.

## Summary

Fixes incorrect syntax highlighting of optional parameters (`?ident`) in member declarations. Previously, tokens following an optional parameter prefix were incorrectly classified as namespaces/types, causing the entire line to be highlighted as such.

## Problem

`GetPartialLongNameExAux` performs a left-to-right scan of the line using a state machine. When it encountered a `?` character at the start of an identifier position, `AtStartOfIdentifier` had no case for it — so it fell through to the final `else` branch, which discards all accumulated state (`current`, `lastDotPos`) and restarts the parse. This caused the qualifier context (e.g. `TestType.x`) to be lost, leaving the subsequent identifier without a proper classification.

`GetCompleteIdentifierIslandImplAux` already handled `?` correctly by skipping to `index + 1`, but `GetPartialLongNameExAux` lacked the equivalent treatment.

## Fix

Added an `elif` branch in `AtStartOfIdentifier` that recognises the optional parameter prefix — when the current character is `?` and the next character is a valid identifier character, the parser skips the `?` and enters `InUnquotedIdentifier` from the following position, preserving the accumulated qualifier context.

```fsharp
elif
    lineStr[pos] = '?'
    && (pos + 1 < lineStr.Length)
    && IsIdentifierPartCharacter(pos + 1)
then
    InUnquotedIdentifier(pos + 1, pos + 2, current, throwAwayNext, lastDotPos)
```

## Impact

No behavioural changes outside of optional parameter syntax. The fix is localised to `QuickParse.fs` and does not touch any public API.