### PR TITLE
IlxGen: fix missing CompilationMapping attribute for generic values

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -35,6 +35,7 @@
 * Fix signature generation: `private` keyword placement for prefix-style type abbreviations. ([Issue #15560](https://github.com/dotnet/fsharp/issues/15560), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 * Fix signature generation: missing `[<Class>]` attribute for types without visible constructors. ([Issue #16531](https://github.com/dotnet/fsharp/issues/16531), [PR #19586](https://github.com/dotnet/fsharp/pull/19586))
 * Fix methods being tagged as `Member` instead of `Method` in tooltips. ([Issue #10540](https://github.com/dotnet/fsharp/issues/10540), [PR #19507](https://github.com/dotnet/fsharp/pull/19507))
+* IlxGen: fix missing CompilationMapping attribute for generic values ([PR #19643](https://github.com/dotnet/fsharp/pull/19643))
 
 ### Added
 

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -9863,8 +9863,14 @@ and GenMethodForBinding
                         | _ -> ilAttrsThatGoOnPrimaryItem
                     | _ -> ilAttrsThatGoOnPrimaryItem
 
+                let compilationMappingAttrs =
+                    [
+                        if v.MemberInfo.IsNone && curriedArgInfos.IsEmpty then
+                            mkCompilationMappingAttr g (int SourceConstructFlags.Value)
+                    ]
+
                 let ilCustomAttrs =
-                    mkILCustomAttrs (ilAttrs @ sourceNameAttribs @ ilAttrsCompilerGenerated)
+                    mkILCustomAttrs (ilAttrs @ compilationMappingAttrs @ sourceNameAttribs @ ilAttrsCompilerGenerated)
 
                 let mdef = mdef.With(customAttrs = ilCustomAttrs)
                 mdef

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/CodeGenRegressions/CodeGenRegressions_Observations.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/CodeGenRegressions/CodeGenRegressions_Observations.fs
@@ -193,3 +193,28 @@ type MyClass() =
         |> shouldSucceed
         |> verifyAssemblyReference "System.Xml"
         |> ignore
+
+
+    // https://github.com/dotnet/fsharp/issues/19428
+    [<Fact>]
+    let ``Issue_19428_CompilationMappingOnGenericValue`` () =
+        FSharp """
+module GenericValueTest
+
+let l = []
+let empty<'T> = Seq.empty<'T>
+"""
+        |> compile
+        |> shouldSucceed
+        |> verifyIL [
+            """
+  .method public static class [FSharp.Core]Microsoft.FSharp.Collections.FSharpList`1<!!a> l<a>() cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 )
+"""
+            """
+  .method public static class [runtime]System.Collections.Generic.IEnumerable`1<!!T> empty<T>() cil managed
+  {
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 )
+"""
+        ]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOff.OptimizeOff.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOff.OptimizeOff.il.bsl
@@ -36,6 +36,7 @@
   .method public static !!a  Null<class a>() cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.LiteralAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
     
     .maxstack  3
     .locals init (!!a V_0)
@@ -94,7 +95,6 @@
   } 
 
 } 
-
 
 
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOff.OptimizeOn.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOff.OptimizeOn.il.bsl
@@ -41,6 +41,7 @@
   .method public static !!a  Null<class a>() cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.LiteralAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
     
     .maxstack  3
     .locals init (!!a V_0)
@@ -102,7 +103,6 @@
   } 
 
 } 
-
 
 
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOn.OptimizeOff.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOn.OptimizeOff.il.bsl
@@ -36,6 +36,7 @@
   .method public static !!a  Null<class a>() cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.LiteralAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
     
     .maxstack  3
     .locals init (!!a V_0)
@@ -111,7 +112,6 @@
   } 
 
 } 
-
 
 
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOn.OptimizeOn.il.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TestFunctions/TestFunction09b4.fs.RealInternalSignatureOn.OptimizeOn.il.bsl
@@ -41,6 +41,7 @@
   .method public static !!a  Null<class a>() cil managed
   {
     .custom instance void [FSharp.Core]Microsoft.FSharp.Core.LiteralAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.CompilationMappingAttribute::.ctor(valuetype [FSharp.Core]Microsoft.FSharp.Core.SourceConstructFlags) = ( 01 00 09 00 00 00 00 00 ) 
     
     .maxstack  3
     .locals init (!!a V_0)
@@ -121,7 +122,6 @@
   } 
 
 } 
-
 
 
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/fsharp/issues/19428.