### PR TITLE
Scoped #nowarn / #warnon

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/WarnScopeTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/WarnScopeTests.fs
@@ -94,6 +94,19 @@ module N.M
 ()
 """; errors = Map["9.0", [Err(3350, 6); Warn(20, 3)]; "10.0", [Warn(20, 3); Warn(20, 7)]]}
 
+let private warn42ScopedTest = {source = """
+module N.M
+
+type T =
+    | A : int -> T
+#nowarn "42"
+type U =
+    | B : int -> U
+#warnon "42"
+type V =
+    | C : int -> V
+"""; errors = Map["10.0", [Warn(42, 5); Warn(42, 11)]]}
+
 let mkProjectOptionsAndChecker langVersion =
     let options = createProjectOptions [onOffTest.source] [$"--langversion:{langVersion}"]
     let checker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=CompilerAssertHelpers.UseTransparentCompiler)
@@ -122,6 +135,13 @@ let ParseAndCheckProjectTest langVersion =
     let options, checker = mkProjectOptionsAndChecker langVersion
     let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunImmediate
     checkDiagnostics onOffTest.errors[langVersion] (Array.toList wholeProjectResults.Diagnostics)
+
+[<Fact>]
+let ``Warn42 directives are scoped in language version 10`` () =
+    let options = createProjectOptions [warn42ScopedTest.source] ["--langversion:10.0"]
+    let checker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=CompilerAssertHelpers.UseTransparentCompiler)
+    let wholeProjectResults = checker.ParseAndCheckProject(options) |> Async.RunImmediate
+    checkDiagnostics warn42ScopedTest.errors["10.0"] (Array.toList wholeProjectResults.Diagnostics)
     
 [<InlineData("9.0")>]
 [<InlineData("10.0")>]


### PR DESCRIPTION
Support `#nowarn "42"` and `#warnon "42"` directives that scope to a region of the file (not just file-global). Track the active warning mask through the AST.

### What changed
- Added a regression in `WarnScopeTests` for language version `10.0` using FS0042-producing syntax.
- Verifies `#nowarn "42"` suppresses warnings only within the scoped region and `#warnon "42"` re-enables warning emission afterward.

### Validation
- `./eng/common/dotnet.sh test --project tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj -- --filter-class "*WarnScopeTests*"`

Closes #29
