### PR TITLE
CE builder method resolution

### DIFF
--- a/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckComputationExpressions.fs
@@ -47,6 +47,7 @@ type ComputationExpressionContext<'a> =
         cenv: TcFileState
         env: TcEnv
         tpenv: UnscopedTyparEnv
+        tryFindBuilderMethod: string -> MethInfo list
         customOperationMethodsIndexedByKeyword:
             IDictionary<string, list<string * bool * bool * bool * bool * bool * bool * option<string> * MethInfo>>
         customOperationMethodsIndexedByMethodName:
@@ -177,11 +178,6 @@ let transferVarSpaceReferences (expr: Expr) =
         if anyReferenced then
             for v in vals do
                 v.SetHasBeenReferenced()
-
-let hasMethInfo nm cenv env mBuilderVal ad builderTy =
-    match TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad nm builderTy with
-    | [] -> false
-    | _ -> true
 
 let getCustomOperationMethods (cenv: TcFileState) (env: TcEnv) ad mBuilderVal builderTy =
     let allMethInfos =
@@ -999,7 +995,8 @@ let inline addVarsToVarSpace (varSpace: LazyWithContext<Val list * TcEnv, range>
     )
 
 let tryFindBuilderMethod (ceenv: ComputationExpressionContext<_>) (m: range) (methodName: string) =
-    TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult ceenv.cenv ceenv.env m ceenv.ad methodName ceenv.builderTy
+    let _ = m
+    ceenv.tryFindBuilderMethod methodName
 
 let hasBuilderMethod ceenv m methodName =
     tryFindBuilderMethod ceenv m methodName |> isNil |> not
@@ -2958,6 +2955,26 @@ let TcComputationExpression (cenv: TcFileState) env (overallTy: OverallTy) tpenv
 
     let builderValName = CompilerGeneratedName "builder"
     let mBuilderVal = interpExpr.Range
+    let builderMethodCache = Dictionary<string, MethInfo list>()
+
+    let tryFindBuilderMethodByName methodName =
+        match builderMethodCache.TryGetValue(methodName) with
+        | true, methInfos -> methInfos
+        | false, _ ->
+            let methInfos =
+                TryFindIntrinsicOrExtensionMethInfo
+                    ResultCollectionSettings.AllResults
+                    cenv
+                    env
+                    mBuilderVal
+                    ad
+                    methodName
+                    builderTy
+
+            builderMethodCache[methodName] <- methInfos
+            methInfos
+
+    let hasBuilderMethodByName methodName = tryFindBuilderMethodByName methodName |> isNil |> not
 
     // Give bespoke error messages for the FSharp.Core "query" builder
     let isQuery =
@@ -2971,11 +2988,10 @@ let TcComputationExpression (cenv: TcFileState) env (overallTy: OverallTy) tpenv
             valRefEq cenv.g vref cenv.g.query_value_vref
         | _ -> false
 
-    let sourceMethInfo =
-        TryFindIntrinsicOrExtensionMethInfo ResultCollectionSettings.AtMostOneResult cenv env mBuilderVal ad "Source" builderTy
+    let sourceMethInfo = tryFindBuilderMethodByName "Source"
 
     /// Decide if the builder is an auto-quote builder
-    let isAutoQuote = hasMethInfo "Quote" cenv env mBuilderVal ad builderTy
+    let isAutoQuote = hasBuilderMethodByName "Quote"
 
     let customOperationMethods =
         getCustomOperationMethods cenv env ad mBuilderVal builderTy
@@ -3014,9 +3030,9 @@ let TcComputationExpression (cenv: TcFileState) env (overallTy: OverallTy) tpenv
     // positions as 'yield'.  'yield!' may be present in the computation expression.
     let enableImplicitYield =
         cenv.g.langVersion.SupportsFeature LanguageFeature.ImplicitYield
-        && (hasMethInfo "Yield" cenv env mBuilderVal ad builderTy
-            && hasMethInfo "Combine" cenv env mBuilderVal ad builderTy
-            && hasMethInfo "Delay" cenv env mBuilderVal ad builderTy
+        && (hasBuilderMethodByName "Yield"
+            && hasBuilderMethodByName "Combine"
+            && hasBuilderMethodByName "Delay"
             && YieldFree cenv comp)
 
     let origComp = comp
@@ -3026,6 +3042,7 @@ let TcComputationExpression (cenv: TcFileState) env (overallTy: OverallTy) tpenv
             cenv = cenv
             env = env
             tpenv = tpenv
+            tryFindBuilderMethod = tryFindBuilderMethodByName
             customOperationMethodsIndexedByKeyword = customOperationMethodsIndexedByKeyword
             customOperationMethodsIndexedByMethodName = customOperationMethodsIndexedByMethodName
             sourceMethInfo = sourceMethInfo

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/ComputationExpressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Expressions/ComputationExpressions/ComputationExpressions.fs
@@ -322,6 +322,48 @@ module LetUseBangTests =
                 "This construct may only be used within computation expressions. To return a value from an ordinary function simply write the expression without 'return'.")
         ]
 
+[<Fact>]
+let ``Computation expression method lookup uses builder members, not top-level values`` () =
+    FSharp """
+    let Return x = x
+
+    type Builder() =
+        member _.Bind(x, f) = f x
+
+    let builder = Builder()
+
+    let _ =
+        builder {
+            return 1
+        }
+    """
+    |> asExe
+    |> compile
+    |> shouldFail
+    |> withErrorCode 708
+    |> withDiagnosticMessageMatches "'Return' method"
+
+[<Fact>]
+let ``Missing Delay on builder gives FS0708`` () =
+    FSharp """
+    type Builder() =
+        member _.While(guard, body) = ()
+        member _.Zero() = ()
+
+    let builder = Builder()
+
+    let _ =
+        builder {
+            while false do
+                ()
+        }
+    """
+    |> asExe
+    |> compile
+    |> shouldFail
+    |> withErrorCode 708
+    |> withDiagnosticMessageMatches "'Delay' method"
+
 // https://github.com/dotnet/fsharp/issues/3783
 [<Fact>]
 let ``Issue 3783 - Mutually recursive computation expression should not raise NullReferenceException`` () =


### PR DESCRIPTION
Per the F# spec, look up `Bind`, `Return`, `Combine`, `Delay`, `Zero`, `Run`, etc. on the builder type. Handle missing methods with a clear diagnostic.

## What changed
- Centralized CE builder method lookup into a single cached lookup keyed by method name and bound to the builder type.
- Routed CE method presence checks through that lookup.
- Added regression tests for:
  - method lookup using builder members (not top-level values);
  - missing `Delay` producing FS0708.

## Validation
- /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp//FSharp.slnx:
publish
  Determining projects to restore...
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.Core/FSharp.Core.fsproj (in 135 ms).
  1 of 2 projects are up-to-date for restore.
  Determining projects to restore...
  All projects are up-to-date for restore.
  Determining projects to restore...
  All projects are up-to-date for restore.
  Determining projects to restore...
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/Compiler/FSharp.Compiler.Service.fsproj (in 21 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj (in 21 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.Build/FSharp.Build.fsproj (in 20 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/fsc/fscProject/fsc.fsproj (in 23 ms).
  1 of 5 projects are up-to-date for restore.
  Determining projects to restore...
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj (in 81 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/fsi/fsiProject/fsi.fsproj (in 81 ms).
  3 of 5 projects are up-to-date for restore.
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Proto/netstandard2.0/FSharp.Core.dll
  fslex -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fslex/Proto/net10.0/osx-arm64/fslex.dll
  fslex -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/Bootstrap/fslex/
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Proto/netstandard2.0/FSharp.Core.dll
  fsyacc -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsyacc/Proto/net10.0/osx-arm64/fsyacc.dll
  fsyacc -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/Bootstrap/fsyacc/
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Proto/netstandard2.0/FSharp.Core.dll
  AssemblyCheck -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/AssemblyCheck/Proto/net10.0/osx-arm64/AssemblyCheck.dll
  AssemblyCheck -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/Bootstrap/AssemblyCheck/
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Proto/netstandard2.0/FSharp.Core.dll
  FSharp.DependencyManager.Nuget -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.DependencyManager.Nuget/Proto/netstandard2.0/FSharp.DependencyManager.Nuget.dll
  FSharp.Compiler.Service -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Service/Proto/netstandard2.0/FSharp.Compiler.Service.dll
  FSharp.Build -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Build/Proto/netstandard2.0/FSharp.Build.dll
  fsc -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsc/Proto/net10.0/osx-arm64/fsc.dll
  fsc -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/Bootstrap/fsc/
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Proto/netstandard2.0/FSharp.Core.dll
  FSharp.DependencyManager.Nuget -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.DependencyManager.Nuget/Proto/netstandard2.0/FSharp.DependencyManager.Nuget.dll
  FSharp.Compiler.Service -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Service/Proto/netstandard2.0/FSharp.Compiler.Service.dll
  FSharp.Compiler.Interactive.Settings -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Interactive.Settings/Proto/netstandard2.0/FSharp.Compiler.Interactive.Settings.dll
  fsi -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsi/Proto/net10.0/osx-arm64/fsi.dll
  fsi -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/Bootstrap/fsi/
  Determining projects to restore...
  Tool 'dotnet-counters' (version '8.0.547301') was restored. Available commands: dotnet-counters
  Tool 'dotnet-dump' (version '8.0.547301') was restored. Available commands: dotnet-dump
  Tool 'dotnet-gcdump' (version '8.0.547301') was restored. Available commands: dotnet-gcdump
  Tool 'dotnet-sos' (version '8.0.547301') was restored. Available commands: dotnet-sos
  Tool 'dotnet-symbol' (version '8.0.547301') was restored. Available commands: dotnet-symbol
  Tool 'dotnet-trace' (version '8.0.547301') was restored. Available commands: dotnet-trace
  Tool 'fantomas' (version '7.0.1') was restored. Available commands: fantomas
  Tool 'dotnet-ilverify' (version '9.0.0') was restored. Available commands: ilverify
  
  Restore was successful.
  All projects are up-to-date for restore.
  Determining projects to restore...
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.Core/FSharp.Core.fsproj (in 142 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj (in 142 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/fsi/fsiProject/fsi.fsproj (in 141 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.Build/FSharp.Build.fsproj (in 147 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/Compiler/FSharp.Compiler.Service.fsproj (in 144 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj (in 145 ms).
  Restored /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/src/fsc/fscProject/fsc.fsproj (in 143 ms).
  14 of 21 projects are up-to-date for restore.
  Misc -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/Misc/Release/netstandard2.0/Misc.dll
  CSharp_Analysis -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/CSharp_Analysis/Release/netstandard2.0/CSharp_Analysis.dll
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Release/netstandard2.0/FSharp.Core.dll
  FSharp.Compiler.Interactive.Settings -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Interactive.Settings/Release/netstandard2.0/FSharp.Compiler.Interactive.Settings.dll
  FSharp.DependencyManager.Nuget -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.DependencyManager.Nuget/Release/netstandard2.0/FSharp.DependencyManager.Nuget.dll
  FSharp.Build -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Build/Release/netstandard2.0/FSharp.Build.dll
  FSharp.Core -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core/Release/netstandard2.1/FSharp.Core.dll
  TestTP -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/TestTP/Release/netstandard2.0/TestTP.dll
  FSharp.Compiler.Service -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Service/Release/netstandard2.0/FSharp.Compiler.Service.dll
  fscAnyCpu -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fscAnyCpu/Release/net472/fscAnyCpu.exe
  fscArm64 -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fscArm64/Release/net472/fscArm64.exe
  fsiAnyCpu -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsiAnyCpu/Release/net472/fsiAnyCpu.exe
  fsiArm64 -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsiArm64/Release/net472/fsiArm64.exe
  FSharp.Compiler.Service -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Service/Release/net10.0/FSharp.Compiler.Service.dll
  fsc -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsc/Release/net10.0/fsc.dll
  fsi -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/fsi/Release/net10.0/fsi.dll
  FSharp.Test.Utilities -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Test.Utilities/Release/net10.0/FSharp.Test.Utilities.dll
  FSharp.Build.UnitTests -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Build.UnitTests/Release/net10.0/FSharp.Build.UnitTests.dll
  FSharpSuite.Tests -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharpSuite.Tests/Release/net10.0/FSharpSuite.Tests.dll
  FSharp.Compiler.Private.Scripting.UnitTests -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Private.Scripting.UnitTests/Release/net10.0/FSharp.Compiler.Private.Scripting.UnitTests.dll
  FSharp.Compiler.Service.Tests -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.Service.Tests/Release/net10.0/FSharp.Compiler.Service.Tests.dll
  FSharp.Compiler.ComponentTests -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.ComponentTests/Release/net10.0/FSharp.Compiler.ComponentTests.dll
  FSharp.Core.UnitTests -> /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Core.UnitTests/Release/net10.0/FSharp.Core.UnitTests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:01:36.84
- Running tests from /Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.ComponentTests/Release/net10.0/FSharp.Compiler.ComponentTests.dll (net10.0|arm64)
/Users/rodrigovidalaraujo/multica_workspaces/d0baa83f-ce7f-4419-8e5b-b72fac8c083a/c3accc25/workdir/fsharp/artifacts/bin/FSharp.Compiler.ComponentTests/Release/net10.0/FSharp.Compiler.ComponentTests.dll (net10.0|arm64) passed (3s 695ms)

Test run summary: Passed!
  total: 2
  failed: 0
  succeeded: 2
  skipped: 0
  duration: 3s 979ms

Closes #36