### PR TITLE
CE tail-call final methods

### DIFF
--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -4513,7 +4513,14 @@ and GenApp (cenv: cenv) cgbuf eenv (f, fty, tyargs, curriedArgs, m) sequel =
                 if isNil laterArgs && not isSelfInit then
                     let isDllImport = IsValRefIsDllImport g vref
                     let hasByrefArg = mspec.FormalArgTypes |> List.exists IsILTypeByref
-                    let makesNoCriticalTailcalls = vref.MakesNoCriticalTailcalls
+                    // CE final method calls (Delay/Quote/Run) are intentionally in tail position and
+                    // should remain eligible for tailcall emission even if the callee is otherwise
+                    // marked as not making critical tailcalls.
+                    let makesNoCriticalTailcalls =
+                        if m.NotedSourceConstruct = NotedSourceConstruct.DelayOrQuoteOrRun then
+                            false
+                        else
+                            vref.MakesNoCriticalTailcalls
                     let hasStructObjArg = (boxity = AsValue) && takesInstanceArg
 
                     CanTailcall(
@@ -5592,7 +5599,13 @@ and GenILCall
 
     let boxity = (if valu then AsValue else AsObject)
     let mustGenerateUnitAfterCall = isNil returnTys
-    let makesNoCriticalTailcalls = (newobj || not virt) // Don't tailcall for 'newobj', or 'call' to IL code
+    // Keep the default conservative behavior for IL 'call', except for CE-final calls
+    // (Delay/Quote/Run), where not tailcalling can lead to stack growth in recursive CEs.
+    let makesNoCriticalTailcalls =
+        if m.NotedSourceConstruct = NotedSourceConstruct.DelayOrQuoteOrRun then
+            false
+        else
+            (newobj || not virt) // Don't tailcall for 'newobj', or 'call' to IL code
     let hasStructObjArg = valu && ilMethRef.CallingConv.IsInstance
 
     let tail =

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/TailCalls.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/TailCalls.fs
@@ -12,6 +12,36 @@ module ``Tail Calls`` =
         opts |> ignoreWarnings |> withOptions ["-g"; "--optimize-"; "--tailcalls+"] |> compile
 
     [<Fact>]
+    let ``Computation expression final Run is tailcalled`` () =
+        FSharp
+            """
+module TailCallCE
+
+type B() =
+    member _.Delay(f: unit -> int) = f()
+    member _.Run(x: int) = x
+    member _.Return(x: int) = x
+    member _.ReturnFrom(x: int) = x
+
+let b = B()
+
+let rec loop n =
+    b {
+        if n = 0 then
+            return 0
+        else
+            return! loop (n - 1)
+    }
+            """
+        |> compileWithTailCalls
+        |> shouldSucceed
+        |> verifyILContains [
+            "IL_0014:  tail."
+            "callvirt   instance int32 TailCallCE/B::Run(int32)"
+        ]
+        |> shouldSucceed
+
+    [<Fact>]
     let ``TailCall 01``() =
         FSharp """
 module TailCall01
@@ -306,4 +336,3 @@ let main _ =
         |> run
         |> shouldSucceed
         |> verifyOutput "value = 42\n"
-


### PR DESCRIPTION
Emit the final method call of a CE (typically `Run`) as a `tail.call` so async/task computations don't blow the stack.

Closes #40