### PR TITLE
Replace PAT with WIF service connection for VS insertion (v2)

### DIFF
--- a/eng/release/insert-into-vs.yml
+++ b/eng/release/insert-into-vs.yml
@@ -17,9 +17,6 @@ stages:
       name: NetCore1ESPool-Svc-Internal
       image: windows.vs2026preview.scout.amd64
     variables:
-    - group: DotNet-VSTS-Infra-Access
-    - name: InsertAccessToken
-      value: $(dn-bot-devdiv-build-rw-code-rw-release-rw)
     - name: InsertBuildPolicy
       value: ${{ parameters.insertBuildPolicy }}
     - name: InsertTargetBranch
@@ -70,6 +67,19 @@ stages:
           $autoCompleteStr = if ($autoComplete) { 'true' } else { 'false' }
           Write-Host "Setting InsertAutoComplete to '$autoCompleteStr'"
           Write-Host "##vso[task.setvariable variable=InsertAutoComplete]$autoCompleteStr"
+    - task: AzureCLI@2
+      displayName: 'Get DevDiv Access Token (WIF)'
+      inputs:
+        azureSubscription: 'dnceng-fsharp-vs-insertion-wif'
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          $token = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
+          Write-Host "##vso[task.setvariable variable=InsertAccessToken;issecret=true]$token"
+      condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'), eq(variables['Build.SourceBranch'], 'refs/heads/${{ parameters.componentBranchName }}')))
+    - script: git config --global credential.helper ""
+      displayName: 'Disable GCM (Entra token too large for credential store)'
+      condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], '${{ parameters.componentBranchName }}'), eq(variables['Build.SourceBranch'], 'refs/heads/${{ parameters.componentBranchName }}')))
     - task: ms-vseng.MicroBuildShipTasks.55100717-a81d-45ea-a363-b8fe3ec375ad.MicroBuildInsertVsPayload@5
       displayName: 'Insert VS Payload'
       inputs:


### PR DESCRIPTION
## Summary

Re-apply the VS insertion pipeline migration from the `dn-bot-devdiv-build-rw-code-rw-release-rw` PAT to the `dnceng-fsharp-vs-insertion-wif` Entra Workload Identity Federation (WIF) service connection.

This is a v2 of #19683, which was reverted. This version adds a GCM credential-store fix.

## Changes

- Remove `DotNet-VSTS-Infra-Access` variable group reference (no longer needed)
- Remove `InsertAccessToken` variable that pulled from the PAT secret
- Add `AzureCLI@2` step that authenticates via the WIF service connection and acquires a bearer token for Azure DevOps
- Set `InsertAccessToken` as a secret pipeline variable from the WIF-acquired token
- **NEW:** Disable Git Credential Manager before `MicroBuildInsertVsPayload@5` to prevent `0x6f7` errors caused by Entra JWT tokens exceeding the Windows Credential Store size limit

## Context

This is part of the dnceng PAT-to-Entra migration ([WI 10091](https://dev.azure.com/dnceng/internal/_workitems/edit/10091)). The 1ES PAT disable policy requires all non-packaging PATs to be migrated to Entra-based credentials.

The replacement service connection `dnceng-fsharp-vs-insertion-wif` uses:
- App Registration: `dnceng-fsharp-vs-insertion-wif` (appId: `bf297404-7399-4e71-ac5f-f9be7bca6904`)
- WIF Service Connection in dnceng/internal (id: `84a9d9d1-ab12-4359-a544-0ac10c2934fd`)
- DevDiv enrollment: SP enrolled with Contribute, Contribute to PRs, Create tag, Manage notes, Read on the VS repo

## What changed since v1 (#19683)

1. **DevDiv repo permissions fixed** — the VSEng team confirmed permissions were set but they weren't actually applied; this has been corrected
2. **GCM credential store fix** — added `git config --global credential.helper ""` step before the insertion task to prevent the `fatal: Failed to write item to store. [0x6f7]` error and ~8-minute clone delay caused by GCM trying to cache the oversized Entra JWT
3. **Update build information permission** — granted to the SP at project level in dnceng/internal (bit 64, Build security namespace)

## Validation

Post-merge: monitor the first insertion build to confirm `AzureCLI@2` authenticates successfully, git operations complete without GCM delays, and `MicroBuildInsertVsPayload@5` creates the VS insertion PR.