### PR TITLE
Fix internal error FS0073 w/nested inline SRTP and multiple overloads

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix internal error FS0073 "Undefined or unsolved type variable" in IlxGen when nested inline SRTP functions with multiple overloads leave unsolved typars in the non-witness codegen path. ([Issue #19709](https://github.com/dotnet/fsharp/issues/19709), [PR #19710](https://github.com/dotnet/fsharp/pull/19710))
 * Fix NRE when calling virtual Object methods on value types through inline SRTP functions. ([Issue #8098](https://github.com/dotnet/fsharp/issues/8098), [PR #19511](https://github.com/dotnet/fsharp/pull/19511))
 * Fix DU case names matching IWSAM member names no longer cause duplicate property entries. (Issue [#14321](https://github.com/dotnet/fsharp/issues/14321), [PR #19341](https://github.com/dotnet/fsharp/pull/19341))
 * Fix DefaultAugmentation(false) duplicate entry in method table. (Issue [#16565](https://github.com/dotnet/fsharp/issues/16565), [PR #19341](https://github.com/dotnet/fsharp/pull/19341))

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -529,6 +529,9 @@ type TypeReprEnv
             // Random value for post-hoc diagnostic analysis on generated tree *
             uint16 666
 
+    /// Check if a type parameter is in the environment
+    member _.ContainsKey(tp: Typar) = reprs.ContainsKey(tp.Stamp)
+
     /// Add an additional type parameter to the environment. If the parameter is a units-of-measure parameter
     /// then it is ignored, since it doesn't correspond to a .NET type parameter.
     member tyenv.AddOne(tp: Typar) =
@@ -708,7 +711,15 @@ and GenTypeAux cenv m (tyenv: TypeReprEnv) voidOK ptrsOK ty =
         else
             EraseClosures.mkILTyFuncTy cenv.ilxPubCloEnv
 
-    | TType_var(tp, _) -> mkILTyvarTy tyenv[tp, m]
+    | TType_var(tp, _) ->
+        if tyenv.ContainsKey tp then
+            mkILTyvarTy tyenv[tp, m]
+        else
+            // Unsolved type variable not in the TypeReprEnv — can arise in fsi for inline SRTP
+            // functions where constraint resolution leaves phantom typars unsolved.
+            // Default the typar and generate the type for the default to avoid an ICE.
+            let defaultTy = TypeRelations.ChooseTyparSolution g cenv.amap tp
+            GenTypeAux cenv m tyenv voidOK ptrsOK defaultTy
 
     | TType_measure _ -> g.ilg.typ_Int32
 

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -715,7 +715,7 @@ and GenTypeAux cenv m (tyenv: TypeReprEnv) voidOK ptrsOK ty =
         if tyenv.ContainsKey tp then
             mkILTyvarTy tyenv[tp, m]
         else
-            // Unsolved type variable not in the TypeReprEnv — can arise in fsi for inline SRTP
+            // Unsolved type variable not in the TypeReprEnv — can arise for inline SRTP
             // functions where constraint resolution leaves phantom typars unsolved.
             // Default the typar and generate the type for the default to avoid an ICE.
             let defaultTy = TypeRelations.ChooseTyparSolution g cenv.amap tp

--- a/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ConstraintSolver/MemberConstraints.fs
@@ -239,3 +239,60 @@ let inline inverse m =
             """
         |> typecheck
         |> shouldSucceed
+
+    [<Fact>]
+    let ``Nested inline SRTP with multiple overloads should not cause internal error`` () =
+        // Regression test: unsolved type variables in trait constraint solutions during codegen
+        // caused FS0073 "internal error: Undefined or unsolved type variable" when an inline
+        // SRTP function was wrapped in another SRTP dispatch layer with multiple overloads.
+        FSharp
+            """
+type App<'F, 'a> = | App of 'F * 'a
+
+type LA = LA
+type LB = LB
+
+type D =
+    static member inline Pur(_witness: App<LA, _>, x: 'a) : App<LA, 'a> = App(LA, x)
+    static member inline Pur(_witness: App<LB, _>, x: 'a) : App<LB, list<'a>> = App(LB, [x])
+
+let inline pur_impl (_mthd: ^M, output: ^F, x: 'a) : ^F
+    when (^M or ^F) : (static member Pur : ^F * 'a -> ^F) =
+    ((^M or ^F) : (static member Pur : ^F * 'a -> ^F) (output, x))
+
+let inline pur (x: 'a) : ^F =
+    pur_impl (Unchecked.defaultof<D>, Unchecked.defaultof< ^F>, x)
+
+type D with
+    static member inline Invoke(_witness: App<LA, _>, f: App<LA, 'a -> 'b>, x: App<LA, 'a>) : App<LA, 'b> =
+        let (App(_, fv)) = f
+        let (App(_, xv)) = x
+        App(LA, fv xv)
+    static member inline Invoke(_witness: App<LB, _>, f: App<LB, list<'a -> 'b>>, x: App<LB, list<'a>>) : App<LB, list<'b>> =
+        let (App(_, fv)) = f
+        let (App(_, xv)) = x
+        App(LB, List.map2 (fun f x -> f x) fv xv)
+
+let inline invoke_impl (_mthd: ^M, output: ^R, f: ^FF, x: ^FX) : ^R
+    when (^M or ^R) : (static member Invoke : ^R * ^FF * ^FX -> ^R) =
+    ((^M or ^R) : (static member Invoke : ^R * ^FF * ^FX -> ^R) (output, f, x))
+
+let inline invoke (f: ^FF) (x: ^FX) : ^R =
+    invoke_impl (Unchecked.defaultof<D>, Unchecked.defaultof< ^R>, f, x)
+
+[<EntryPoint>]
+let main _ =
+    // Test pur with two overloads (Pur has wildcard _ in App<LA, _>)
+    let (App(LA, v)) : App<LA, int> = pur 1
+    if v <> 1 then failwith "pur failed"
+
+    // Test invoke with two overloads (Invoke has wildcard _ in App<LA, _>)
+    let f : App<LA, int -> int> = pur (fun x -> x + 1)
+    let x : App<LA, int> = pur 2
+    let (App(LA, r)) : App<LA, int> = invoke f x
+    if r <> 3 then failwith "invoke failed"
+    0
+            """
+        |> asExe
+        |> compileExeAndRun
+        |> shouldSucceed


### PR DESCRIPTION

**Root cause:** In `CodegenWitnessExprForTraitConstraint`, when `SolveMemberConstraint` resolves a trait call, `FreshenMethInfo` creates fresh type parameters for the method. During overload resolution, the fresh typar for a wildcard `_` position gets unified with the trait call's anonymous typar, but neither gets solved to a concrete type. The solution's `minst` then carries these unsolved typars through `GenWitnessExpr` → `BuildFSharpMethodCall` → IlxGen, where they crash because the typar isn't in the `TypeReprEnv`.

**Fix:** After `SolveMemberConstraint` succeeds, identify any unsolved typars in the solution's `minst` that were **freshly introduced** during resolution (not present in the original trait constraint's types) and default them using `ChooseTyparSolution`. This ensures all type arguments in the generated expression are concrete before they reach IL codegen, without affecting typars from the calling context.

Fixes #19709

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated
