### PR TITLE
Make state-machine workflow repo-rules path configurable via env var

### DIFF
--- a/.github/workflows/agentic-state-machine.lock.yml
+++ b/.github/workflows/agentic-state-machine.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"21c77c4aa434153a69f6f746dbea5f9abe823e1252873fcfb7bb4506c8812cc7","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"71400152c6c11fb2714da42e8ebb1eb04814247589a0e62b7465e408a5c14c8a","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -25,6 +25,9 @@
 # Reads all agentic workflow .md files in this repo, extracts the
 # state machine they define, renders Mermaid diagrams + tables in
 # .github/docs/state-machine.md. Weekly. Opens PR if changed.
+#
+# Frontmatter env variables:
+#   - REPO_RULES_PATH: (main workflow)
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -67,6 +70,9 @@ concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
 run-name: "Agentic State Machine — Diagram Generator"
+
+env:
+  REPO_RULES_PATH: .github/tooling-check-repo-rules.md
 
 jobs:
   activation:
@@ -155,6 +161,7 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
+          GH_AW_ENV_REPO_RULES_PATH: ${{ env.REPO_RULES_PATH }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -167,19 +174,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_96518c4ea1ca6788_EOF'
+          cat << 'GH_AW_PROMPT_e07a3fc958bc8e06_EOF'
           <system>
-          GH_AW_PROMPT_96518c4ea1ca6788_EOF
+          GH_AW_PROMPT_e07a3fc958bc8e06_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_96518c4ea1ca6788_EOF'
+          cat << 'GH_AW_PROMPT_e07a3fc958bc8e06_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_96518c4ea1ca6788_EOF
+          GH_AW_PROMPT_e07a3fc958bc8e06_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_96518c4ea1ca6788_EOF'
+          cat << 'GH_AW_PROMPT_e07a3fc958bc8e06_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -209,17 +216,18 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_96518c4ea1ca6788_EOF
+          GH_AW_PROMPT_e07a3fc958bc8e06_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_96518c4ea1ca6788_EOF'
+          cat << 'GH_AW_PROMPT_e07a3fc958bc8e06_EOF'
           </system>
           {{#runtime-import .github/workflows/agentic-state-machine.md}}
-          GH_AW_PROMPT_96518c4ea1ca6788_EOF
+          GH_AW_PROMPT_e07a3fc958bc8e06_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_ENV_REPO_RULES_PATH: ${{ env.REPO_RULES_PATH }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -230,6 +238,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_ENV_REPO_RULES_PATH: ${{ env.REPO_RULES_PATH }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -249,6 +258,7 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
+                GH_AW_ENV_REPO_RULES_PATH: process.env.GH_AW_ENV_REPO_RULES_PATH,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -379,9 +389,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f63147129cd97ff0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b6af6404580da34f_EOF'
           {"create_pull_request":{"allowed_files":[".github/docs/**"],"draft":false,"labels":["automation","NO_RELEASE_NOTES"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Agentic State Machine] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f63147129cd97ff0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b6af6404580da34f_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -577,7 +587,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_903e0d922f6fd3f9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_5e35f616fd809094_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -621,7 +631,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_903e0d922f6fd3f9_EOF
+          GH_AW_MCP_CONFIG_5e35f616fd809094_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/agentic-state-machine.md
+++ b/.github/workflows/agentic-state-machine.md
@@ -29,6 +29,9 @@ safe-outputs:
     draft: false
     max: 1
     allowed-files: [".github/docs/**"]
+
+env:
+  REPO_RULES_PATH: ".github/tooling-check-repo-rules.md"
 ---
 
 # Agentic State Machine — Diagram Generator
@@ -38,8 +41,8 @@ You read all agentic workflow `.md` files in `.github/workflows/`, extract what 
 </role>
 
 <rules>
-1. Read ALL `.md` files in `.github/workflows/` except `docs/` and `agentic-state-machine.md` (this file).
-2. Also read `.github/tooling-check-repo-rules.md` if it exists.
+1. Read ALL `.md` files in `.github/workflows/` except `docs/`, `shared/`, and `agentic-state-machine.md` (this file).
+2. Read `${{ env.REPO_RULES_PATH }}` from this repo's **default branch** via `get_file_contents` for repo-specific context, workflow descriptions, and diagram hints. If the file does not exist, proceed without it.
 3. If `.github/docs/state-machine.md` exists, read it. Compare source hashes in the `<!-- sources: ... -->` footer against current files (use `sha256sum`). If unchanged → `noop`. If changed → update incrementally, minimal diff.
 4. Every transition edge must label its actor: 👤 human, 🤖 agent-name, ⚙️ CI, ⏰ scheduler.
 5. Do not hardcode sections for "issues" or "PRs". Discover what lifecycle groups exist from the workflows themselves. A workflow that maintains files/branches is its own group.


### PR DESCRIPTION
Makes the agentic-state-machine workflow reusable across repos via `gh aw add`.

**Changes:**
- Add `env.REPO_RULES_PATH` (defaults to `.github/tooling-check-repo-rules.md` for this repo)
- Body references `${{ env.REPO_RULES_PATH }}` instead of a hardcoded path
- Exclude `shared/` from workflow discovery (for repos that use shared imports)
- Rules file is now optional — workflow proceeds without it if not found

**Cross-repo adoption pattern:**
```sh
# In another repo:
gh aw add dotnet/fsharp/agentic-state-machine
# Override the env var in local frontmatter:
# env:
#   REPO_RULES_PATH: ".github/my-repo-rules.md"
gh aw compile
```

Future updates via `gh aw update` will 3-way merge, preserving local overrides.