### PR TITLE
Parser: recover on unfinished if and binary expressions

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -57,6 +57,8 @@
 * Fix parser recovery, name resolution, and code completion for unfinished enum patterns ([PR #19708](https://github.com/dotnet/fsharp/pull/19708))
 * Parser: fix unexpected diagnostics in debug builds, improve error messages ([PR #19730](https://github.com/dotnet/fsharp/pull/19730))
 * Fix signature conformance: overloaded member with unit parameter `M(())` now matches sig `member M: unit -> unit`. ([Issue #19596](https://github.com/dotnet/fsharp/issues/19596), [PR #19615](https://github.com/dotnet/fsharp/pull/19615))
+* Parser: recover on unfinished if and binary expressions
+([PR #19724](https://github.com/dotnet/fsharp/pull/19724))
 
 ### Added
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -241,7 +241,7 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 
 /* start with lowest */
 
-%nonassoc prec_atompat_pathop_error
+%nonassoc prec_recover               /* the lowest precedence to use as the last chance recovery */
 %nonassoc prec_args_error            /* less than RPAREN */
 %nonassoc prec_atomexpr_lparen_error /* less than RPAREN */
 
@@ -4335,6 +4335,16 @@ declExpr:
         let trivia = { IfKeyword = mIf; IsElif = false; ThenKeyword = mThen; ElseKeyword = None; IfToThenRange = m }
         SynExpr.IfThenElse($2, arbExpr ("if1", mThen), None, spIfToThen, true, m, trivia) }
 
+  | IF declExpr %prec prec_recover
+      { let mIf = rhs parseState 1
+        errorR (Error(FSComp.SR.parsIncompleteIf (), mIf))
+        let ifExpr = $2
+        let mThen = ifExpr.Range.EndRange
+        let m = unionRanges mIf mThen
+        let spIfToThen = DebugPointAtBinding.Yes m
+        let trivia = { IfKeyword = mIf; IsElif = false; ThenKeyword = mThen; ElseKeyword = None; IfToThenRange = m }
+        SynExpr.IfThenElse($2, arbExpr ("if4", mThen), None, spIfToThen, true, m, trivia) }
+
   | IF recover %prec expr_if
       { errorR (Error(FSComp.SR.parsIncompleteIf (), rhs parseState 1))
         let m = rhs parseState 1
@@ -4698,6 +4708,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "&&")
        mkSynInfix mOp $1 "&&" (arbExpr ("declExprInfixAmpAmp", mOp.EndRange)) }
 
+  | declExpr AMP_AMP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "&&")
+       mkSynInfix mOp $1 "&&" (arbExpr ("declExprInfixAmpAmp2", mOp.EndRange)) }
+
   | declExpr INFIX_AMP_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
 
@@ -4713,6 +4728,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "=")
        mkSynInfix mOp $1 "=" (arbExpr ("declExprInfixEquals", mOp.EndRange)) }
+
+  | declExpr EQUALS %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "=")
+       mkSynInfix mOp $1 "=" (arbExpr ("declExprInfixEquals2", mOp.EndRange)) }
 
   | declExpr INFIX_COMPARE_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -6935,7 +6955,7 @@ pathOp:
      { let ident, trivia = $1
        SynLongIdent([ident], [], [Some trivia]) }
 
-  | ident DOT %prec prec_atompat_pathop_error
+  | ident DOT %prec prec_recover
      { let mDot = rhs parseState 2
        reportParseErrorAt mDot.EndRange (FSComp.SR.parsIdentifierExpected())
        SynLongIdent([$1], [mDot], [None]) }

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -4684,6 +4684,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "in")
        mkSynInfix mOp $1 "@in" (arbExpr ("declExprInfixJoinIn", mOp.EndRange)) }
 
+  | declExpr JOIN_IN %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "in")
+       mkSynInfix mOp $1 "@in" (arbExpr ("declExprInfixJoinIn2", mOp.EndRange)) }
+
   | declExpr BAR_BAR declExpr
      { mkSynInfix (rhs parseState 2) $1 "||" $3 }
 
@@ -4692,6 +4697,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "||")
        mkSynInfix mOp $1 "||" (arbExpr ("declExprInfixBarBar", mOp.EndRange)) }
 
+  | declExpr BAR_BAR %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "||")
+       mkSynInfix mOp $1 "||" (arbExpr ("declExprInfixBarBar2", mOp.EndRange)) }
+
   | declExpr INFIX_BAR_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
 
@@ -4699,6 +4709,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixBarOp", mOp.EndRange)) }
+
+  | declExpr INFIX_BAR_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixBarOp2", mOp.EndRange)) }
 
   | declExpr AMP_AMP declExpr
      { mkSynInfix (rhs parseState 2) $1 "&&" $3 }
@@ -4721,6 +4736,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixAmpOp", (rhs parseState 3).StartRange)) }
 
+  | declExpr INFIX_AMP_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixAmpOp2", (rhs parseState 3).StartRange)) }
+
   | declExpr EQUALS declExpr
      { mkSynInfix (rhs parseState 2) $1 "=" $3 }
 
@@ -4742,6 +4762,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix", mOp.EndRange)) }
 
+  | declExpr INFIX_COMPARE_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfix2", mOp.EndRange)) }
+
   | declExpr DOLLAR declExpr
      { mkSynInfix (rhs parseState 2) $1 "$" $3 }
 
@@ -4749,6 +4774,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "$")
        mkSynInfix mOp $1 "$" (arbExpr ("declExprInfixDollar", mOp.EndRange)) }
+
+  | declExpr DOLLAR %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "$")
+       mkSynInfix mOp $1 "$" (arbExpr ("declExprInfixDollar2", mOp.EndRange)) }
 
   | declExpr LESS declExpr
      { mkSynInfix (rhs parseState 2) $1 "<" $3 }
@@ -4758,6 +4788,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "<")
        mkSynInfix mOp $1 "<" (arbExpr ("declExprInfixLess", mOp.EndRange)) }
 
+  | declExpr LESS %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "<")
+       mkSynInfix mOp $1 "<" (arbExpr ("declExprInfixLess2", mOp.EndRange)) }
+
   | declExpr GREATER declExpr
      { mkSynInfix (rhs parseState 2) $1 ">" $3 }
 
@@ -4765,6 +4800,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression ">")
        mkSynInfix mOp $1 ">" (arbExpr ("declExprInfixGreater", mOp.EndRange)) }
+
+  | declExpr GREATER %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression ">")
+       mkSynInfix mOp $1 ">" (arbExpr ("declExprInfixGreater2", mOp.EndRange)) }
 
   | declExpr INFIX_AT_HAT_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4782,6 +4822,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPercent", mOp.EndRange)) }
 
+  | declExpr PERCENT_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPercent2", mOp.EndRange)) }
+
   | declExpr COLON_COLON declExpr
      { let mOp = rhs parseState 2
        let m = unionRanges $1.Range $3.Range
@@ -4797,6 +4842,14 @@ declExpr:
        let tupExpr = SynExpr.Tuple(false, [$1; (arbExpr ("declExprInfixColonColon", mOp.EndRange))], [mOp], m)
        SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, m) }
 
+  | declExpr COLON_COLON %prec prec_recover
+     { let mOp = rhs parseState 2
+       let m = unionRanges $1.Range mOp
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "::")
+       let identExpr = mkSynOperator mOp "::"
+       let tupExpr = SynExpr.Tuple(false, [$1; (arbExpr ("declExprInfixColonColon2", mOp.EndRange))], [mOp], m)
+       SynExpr.App(ExprAtomicFlag.NonAtomic, true, identExpr, tupExpr, m) }
+
   | declExpr PLUS_MINUS_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
 
@@ -4804,6 +4857,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPlusMinus", mOp.EndRange)) }
+
+  | declExpr PLUS_MINUS_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixPlusMinus2", mOp.EndRange)) }
 
   | declExpr MINUS declExpr
      { mkSynInfix (rhs parseState 2) $1 "-" $3 }
@@ -4813,6 +4871,11 @@ declExpr:
         reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "-")
         mkSynInfix mOp $1 "-" (arbExpr ("declExprInfixMinus", mOp.EndRange)) }
 
+  | declExpr MINUS %prec prec_recover
+      { let mOp = rhs parseState 2
+        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "-")
+        mkSynInfix mOp $1 "-" (arbExpr ("declExprInfixMinus2", mOp.EndRange)) }
+
   | declExpr STAR declExpr
      { mkSynInfix (rhs parseState 2) $1 "*" $3 }
 
@@ -4820,6 +4883,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "*")
        mkSynInfix mOp $1 "*" (arbExpr ("declExprInfixStar", mOp.EndRange)) }
+
+  | declExpr STAR %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression "*")
+       mkSynInfix mOp $1 "*" (arbExpr ("declExprInfixStar2", mOp.EndRange)) }
 
   | declExpr INFIX_STAR_DIV_MOD_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
@@ -4829,6 +4897,11 @@ declExpr:
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarDivMod", mOp.EndRange)) }
 
+  | declExpr INFIX_STAR_DIV_MOD_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarDivMod2", mOp.EndRange)) }
+
   | declExpr INFIX_STAR_STAR_OP declExpr
      { mkSynInfix (rhs parseState 2) $1 $2 $3 }
 
@@ -4836,6 +4909,11 @@ declExpr:
      { let mOp = rhs parseState 2
        reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
        mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarStar", mOp.EndRange)) }
+
+  | declExpr INFIX_STAR_STAR_OP %prec prec_recover
+     { let mOp = rhs parseState 2
+       reportParseErrorAt mOp (FSComp.SR.parsUnfinishedExpression $2)
+       mkSynInfix mOp $1 $2 (arbExpr ("declExprInfixStarStar2", mOp.EndRange)) }
 
   | declExpr DOT_DOT declExpr
       { let wholem = rhs2 parseState 1 3

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/OffsideExceptions/OffsideExceptions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/LexicalFiltering/OffsideExceptions/OffsideExceptions.fs
@@ -242,27 +242,9 @@ module A
         """
         |> typecheck
         |> shouldFail
-        |> withResults [
-             { Error = Error 10
-               Range = { StartLine = 5
-                         StartColumn = 1
-                         EndLine = 5
-                         EndColumn = 3 }
-               Message =
-                "Incomplete structured construct at or before this point in expression" };
-             { Error = Error 589
-               Range = { StartLine = 3
-                         StartColumn = 13
-                         EndLine = 3
-                         EndColumn = 15 }
-               Message =
-                "Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'." };
-             { Error = Error 10
-               Range = { StartLine = 5
-                         StartColumn = 31
-                         EndLine = 5
-                         EndColumn = 33 }
-               Message = "Unexpected infix operator in implementation file" }
+        |> withDiagnostics [
+             Error 589, Line 3, Col 13, Line 3, Col 15, "Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'."
+             Error 10, Line 5, Col 31, Line 5, Col 33, "Unexpected infix operator in implementation file"
         ] |> ignore
 
 

--- a/tests/fsharp/typecheck/sigs/neg29.bsl
+++ b/tests/fsharp/typecheck/sigs/neg29.bsl
@@ -1,8 +1,8 @@
 
 neg29.fs(5,19,6,16): parse error FS0010: Incomplete structured construct at or before this point in type name. Expected '>' or other token.
 
-neg29.fs(6,19,6,20): parse error FS0010: Unexpected symbol '(' in expression
-
 neg29.fs(6,18,6,19): parse error FS3156: Unexpected token '>' or incomplete expression
+
+neg29.fs(6,19,6,20): parse error FS0010: Unexpected symbol '(' in definition. Expected incomplete structured construct at or before this point or other token.
 
 neg29.fs(9,1,9,1): parse error FS0010: Incomplete structured construct at or before this point in implementation file

--- a/tests/service/data/SyntaxTree/Expression/Binary - Eq 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Eq 05.fs.bsl
@@ -21,7 +21,7 @@ ImplFile
                                     [Some (OriginalNotation "=")]), None,
                                  (3,4--3,5)), Ident a, (3,2--3,5)),
                            ArbitraryAfterError
-                             ("declExprInfixEquals", (3,5--3,5)), (3,2--3,5));
+                             ("declExprInfixEquals2", (3,5--3,5)), (3,2--3,5));
                         App
                           (NonAtomic, false,
                            App
@@ -41,5 +41,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(3,5)-(3,6) parse error Unexpected symbol ',' in expression
 (3,4)-(3,5) parse error Unexpected token '=' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/Binary - Eq 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Eq 06.fs.bsl
@@ -32,7 +32,7 @@ ImplFile
                                     [Some (OriginalNotation "=")]), None,
                                  (3,11--3,12)), Ident b, (3,9--3,12)),
                            ArbitraryAfterError
-                             ("declExprInfixEquals", (3,12--3,12)), (3,9--3,12));
+                             ("declExprInfixEquals2", (3,12--3,12)), (3,9--3,12));
                         App
                           (NonAtomic, false,
                            App
@@ -52,5 +52,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(3,12)-(3,13) parse error Unexpected symbol ',' in expression
 (3,11)-(3,12) parse error Unexpected token '=' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/Binary - Plus 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Binary - Plus 04.fs.bsl
@@ -24,7 +24,7 @@ ImplFile
                                ([op_Addition], [], [Some (OriginalNotation "+")]),
                              None, (3,2--3,3)), Ident a, (3,0--3,3)),
                        ArbitraryAfterError
-                         ("declExprInfixPlusMinus", (3,3--3,3)), (3,0--3,3)),
+                         ("declExprInfixPlusMinus2", (3,3--3,3)), (3,0--3,3)),
                     (3,0--4,2)), Const (Unit, (4,3--4,5)), (3,0--4,5)),
               (3,0--4,5))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
@@ -33,5 +33,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(4,0)-(4,2) parse error Unexpected infix operator in expression
 (3,2)-(3,3) parse error Unexpected token '+' or incomplete expression

--- a/tests/service/data/SyntaxTree/Expression/If 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 03.fs.bsl
@@ -6,7 +6,7 @@ ImplFile
           [Expr
              (IfThenElse
                 (Const (Bool true, (3,3--3,7)),
-                 ArbitraryAfterError ("if1", (3,7--3,7)), None, Yes (3,0--3,7),
+                 ArbitraryAfterError ("if4", (3,7--3,7)), None, Yes (3,0--3,7),
                  true, (3,0--3,7), { IfKeyword = (3,0--3,2)
                                      IsElif = false
                                      ThenKeyword = (3,7--3,7)
@@ -19,5 +19,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(3,8)-(5,0) parse error Incomplete structured construct at or before this point in expression
 (3,0)-(3,2) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.

--- a/tests/service/data/SyntaxTree/Expression/If 11.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 11.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if true &&
+
+    ()

--- a/tests/service/data/SyntaxTree/Expression/If 11.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 11.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 11.fs", false, QualifiedNameOfFile Module, [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (Sequential
+                   (SuppressNeither, true,
+                    IfThenElse
+                      (App
+                         (NonAtomic, false,
+                          App
+                            (NonAtomic, true,
+                             LongIdent
+                               (false,
+                                SynLongIdent
+                                  ([op_BooleanAnd], [],
+                                   [Some (OriginalNotation "&&")]), None,
+                                (4,12--4,14)), Const (Bool true, (4,7--4,11)),
+                             (4,7--4,14)),
+                          ArbitraryAfterError
+                            ("declExprInfixAmpAmp2", (4,14--4,14)), (4,7--4,14)),
+                       ArbitraryAfterError ("if4", (4,14--4,14)), None,
+                       Yes (4,4--4,14), true, (4,4--4,14),
+                       { IfKeyword = (4,4--4,6)
+                         IsElif = false
+                         ThenKeyword = (4,14--4,14)
+                         ElseKeyword = None
+                         IfToThenRange = (4,4--4,14) }),
+                    Const (Unit, (6,4--6,6)), (4,4--6,6),
+                    { SeparatorRange = None }), (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
+To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
+(4,12)-(4,14) parse error Unexpected token '&&' or incomplete expression
+(4,4)-(4,6) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.

--- a/tests/service/data/SyntaxTree/Expression/If 12.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 12.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if true &&
+
+()

--- a/tests/service/data/SyntaxTree/Expression/If 12.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 12.fs.bsl
@@ -1,0 +1,38 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 12.fs", false, QualifiedNameOfFile Module, [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (IfThenElse
+                   (App
+                      (NonAtomic, false,
+                       App
+                         (NonAtomic, true,
+                          LongIdent
+                            (false,
+                             SynLongIdent
+                               ([op_BooleanAnd], [],
+                                [Some (OriginalNotation "&&")]), None,
+                             (4,12--4,14)), Const (Bool true, (4,7--4,11)),
+                          (4,7--4,14)),
+                       ArbitraryAfterError ("declExprInfixAmpAmp", (4,14--4,14)),
+                       (4,7--4,14)), ArbitraryAfterError ("if4", (4,14--4,14)),
+                    None, Yes (4,4--4,14), true, (4,4--4,14),
+                    { IfKeyword = (4,4--4,6)
+                      IsElif = false
+                      ThenKeyword = (4,14--4,14)
+                      ElseKeyword = None
+                      IfToThenRange = (4,4--4,14) }), (3,0--4,14)), (3,0--4,14));
+           Expr (Const (Unit, (6,0--6,2)), (6,0--6,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(6,0)-(6,1) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
+To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
+(4,12)-(4,14) parse error Unexpected token '&&' or incomplete expression
+(4,4)-(4,6) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.

--- a/tests/service/data/SyntaxTree/Expression/If 13.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 13.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if true =
+
+    ()

--- a/tests/service/data/SyntaxTree/Expression/If 13.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 13.fs.bsl
@@ -1,0 +1,40 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 13.fs", false, QualifiedNameOfFile Module, [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (Sequential
+                   (SuppressNeither, true,
+                    IfThenElse
+                      (App
+                         (NonAtomic, false,
+                          App
+                            (NonAtomic, true,
+                             LongIdent
+                               (false,
+                                SynLongIdent
+                                  ([op_Equality], [],
+                                   [Some (OriginalNotation "=")]), None,
+                                (4,12--4,13)), Const (Bool true, (4,7--4,11)),
+                             (4,7--4,13)),
+                          ArbitraryAfterError
+                            ("declExprInfixEquals2", (4,13--4,13)), (4,7--4,13)),
+                       ArbitraryAfterError ("if4", (4,13--4,13)), None,
+                       Yes (4,4--4,13), true, (4,4--4,13),
+                       { IfKeyword = (4,4--4,6)
+                         IsElif = false
+                         ThenKeyword = (4,13--4,13)
+                         ElseKeyword = None
+                         IfToThenRange = (4,4--4,13) }),
+                    Const (Unit, (6,4--6,6)), (4,4--6,6),
+                    { SeparatorRange = None }), (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(4,12)-(4,13) parse error Unexpected token '=' or incomplete expression
+(4,4)-(4,6) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.

--- a/tests/service/data/SyntaxTree/Expression/If 14.fs
+++ b/tests/service/data/SyntaxTree/Expression/If 14.fs
@@ -1,0 +1,6 @@
+module Module
+
+do
+    if true ==
+
+    ()

--- a/tests/service/data/SyntaxTree/Expression/If 14.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/If 14.fs.bsl
@@ -1,0 +1,42 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/If 14.fs", false, QualifiedNameOfFile Module, [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Do
+                (Sequential
+                   (SuppressNeither, true,
+                    IfThenElse
+                      (App
+                         (NonAtomic, false,
+                          App
+                            (NonAtomic, true,
+                             LongIdent
+                               (false,
+                                SynLongIdent
+                                  ([op_EqualsEquals], [],
+                                   [Some (OriginalNotation "==")]), None,
+                                (4,12--4,14)), Const (Bool true, (4,7--4,11)),
+                             (4,7--4,14)),
+                          ArbitraryAfterError ("declExprInfix2", (4,14--4,14)),
+                          (4,7--4,14)),
+                       ArbitraryAfterError ("if4", (4,14--4,14)), None,
+                       Yes (4,4--4,14), true, (4,4--4,14),
+                       { IfKeyword = (4,4--4,6)
+                         IsElif = false
+                         ThenKeyword = (4,14--4,14)
+                         ElseKeyword = None
+                         IfToThenRange = (4,4--4,14) }),
+                    Const (Unit, (6,4--6,6)), (4,4--6,6),
+                    { SeparatorRange = None }), (3,0--6,6)), (3,0--6,6))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--6,6), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(6,4)-(6,5) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
+To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
+(4,12)-(4,14) parse error Unexpected token '==' or incomplete expression
+(4,4)-(4,6) parse error Incomplete conditional. Expected 'if <expr> then <expr>' or 'if <expr> then <expr> else <expr>'.


### PR DESCRIPTION
An alternative take on #17257.

This PR continues the approach from #19708 and applies it to additional rules. Unlike that PR, the new precedence used in a rule that has much more productions, which sometimes is a bit riskier, but, together with the lowest precedence possible, it gives good recovery in cases that previously didn't work and hopefully won't interfere with other rules.