### PR TITLE
Move Async.StartChild to "Starting Async Computations" docs category

### DIFF
--- a/docs/release-notes/.FSharp.Core/11.0.100.md
+++ b/docs/release-notes/.FSharp.Core/11.0.100.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 * Fix `Array.exists2` documentation examples to use equal-length arrays; the previous examples would throw `ArgumentException` at runtime instead of returning the documented `false`/`true` values. ([PR #19672](https://github.com/dotnet/fsharp/pull/19672))
+* Move `Async.StartChild` to the "Starting Async Computations" docs category alongside `Async.StartChildAsTask`. ([Issue #19667](https://github.com/dotnet/fsharp/issues/19667))

--- a/src/FSharp.Core/async.fsi
+++ b/src/FSharp.Core/async.fsi
@@ -355,7 +355,7 @@ namespace Microsoft.FSharp.Control
         ///
         /// <returns>A new computation that waits for the input computation to finish.</returns>
         ///
-        /// <category index="3">Cancellation and Exceptions</category>
+        /// <category index="0">Starting Async Computations</category>
         ///
         /// <example id="start-child-1">
         /// <code lang="fsharp">


### PR DESCRIPTION
## Description

In the rendered FSharp.Core Async docs, `StartChild` was grouped under "Cancellation and Exceptions" while its sibling `StartChildAsTask` sits under "Starting Async Computations". `StartChild` is really a mainstream way to kick off concurrent work, so it belongs next to `StartChildAsTask`. Just an XML doc category tweak — no code or behavior impact.

Fixes #19667

## Checklist

- [x] Release notes entry updated