### PR TITLE
Parser: fix unexpected diagnostics in debug builds, improve error messages

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -49,6 +49,7 @@
 * Fix signature generation: type params with special characters missing backtick escaping. ([Issue #19595](https://github.com/dotnet/fsharp/issues/19595), [PR #19609](https://github.com/dotnet/fsharp/pull/19609))
 * Fix internal error when using custom attribute with `[<Optional>]` value type parameter and no `[<DefaultParameterValue>]`. ([Issue #8353](https://github.com/dotnet/fsharp/issues/8353), [PR #19484](https://github.com/dotnet/fsharp/pull/19484))
 * Fix parallel compilation of scripts ([PR #19649](https://github.com/dotnet/fsharp/pull/19649))
+* Parser: fix unexpected diagnostics in debug builds, improve error messages ([PR #19730](https://github.com/dotnet/fsharp/pull/19730))
 
 ### Added
 

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -497,6 +497,8 @@ module OldStyleMessages =
     let NONTERM_classDefnMemberE () = Message("NONTERM.classDefnMember", "")
     let NONTERM_defnBindingsE () = Message("NONTERM.defnBindings", "")
     let NONTERM_classMemberSpfnE () = Message("NONTERM.classMemberSpfn", "")
+    let NONTERM_classMemberSpfnGetSetElementsE () = Message("NONTERM.classMemberSpfnGetSetElements", "")
+    let NONTERM_autoPropsDefnDeclE () = Message("NONTERM.autoPropsDefnDecl", "")
     let NONTERM_valSpfnE () = Message("NONTERM.valSpfn", "")
     let NONTERM_tyconSpfnE () = Message("NONTERM.tyconSpfn", "")
     let NONTERM_anonLambdaExprE () = Message("NONTERM.anonLambdaExpr", "")
@@ -1469,6 +1471,12 @@ type Exception with
                             true
                         | [ Parser.NONTERM_classMemberSpfn ] ->
                             os.AppendString(NONTERM_classMemberSpfnE().Format)
+                            true
+                        | [ Parser.NONTERM_classMemberSpfnGetSetElements ] ->
+                            os.AppendString(NONTERM_classMemberSpfnGetSetElementsE().Format)
+                            true
+                        | [ Parser.NONTERM_autoPropsDefnDecl ] ->
+                            os.AppendString(NONTERM_autoPropsDefnDeclE().Format)
                             true
                         | [ Parser.NONTERM_valSpfn ] ->
                             os.AppendString(NONTERM_valSpfnE().Format)

--- a/src/Compiler/FSStrings.resx
+++ b/src/Compiler/FSStrings.resx
@@ -789,6 +789,12 @@
   <data name="NONTERM.classMemberSpfn" xml:space="preserve">
     <value> in member signature</value>
   </data>
+    <data name="NONTERM.classMemberSpfnGetSetElements" xml:space="preserve">
+    <value> in property definition</value>
+  </data>
+  <data name="NONTERM.autoPropsDefnDecl" xml:space="preserve">
+    <value> in auto property definition</value>
+  </data>
   <data name="NONTERM.valSpfn" xml:space="preserve">
     <value> in value signature</value>
   </data>

--- a/src/Compiler/xlf/FSStrings.cs.xlf
+++ b/src/Compiler/xlf/FSStrings.cs.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.de.xlf
+++ b/src/Compiler/xlf/FSStrings.de.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.es.xlf
+++ b/src/Compiler/xlf/FSStrings.es.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.fr.xlf
+++ b/src/Compiler/xlf/FSStrings.fr.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.it.xlf
+++ b/src/Compiler/xlf/FSStrings.it.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.ja.xlf
+++ b/src/Compiler/xlf/FSStrings.ja.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.ko.xlf
+++ b/src/Compiler/xlf/FSStrings.ko.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.pl.xlf
+++ b/src/Compiler/xlf/FSStrings.pl.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.pt-BR.xlf
+++ b/src/Compiler/xlf/FSStrings.pt-BR.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.ru.xlf
+++ b/src/Compiler/xlf/FSStrings.ru.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.tr.xlf
+++ b/src/Compiler/xlf/FSStrings.tr.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSStrings.zh-Hans.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/src/Compiler/xlf/FSStrings.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSStrings.zh-Hant.xlf
@@ -67,6 +67,16 @@
         <target state="new">This attribute is not valid for use on this language element</target>
         <note />
       </trans-unit>
+      <trans-unit id="NONTERM.autoPropsDefnDecl">
+        <source> in auto property definition</source>
+        <target state="new"> in auto property definition</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NONTERM.classMemberSpfnGetSetElements">
+        <source> in property definition</source>
+        <target state="new"> in property definition</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoConstructorsAvailableForType">
         <source>No constructors are available for the type '{0}'</source>
         <target state="new">No constructors are available for the type '{0}'</target>

--- a/tests/service/data/SyntaxTree/Member/Abstract - Property 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Abstract - Property 03.fs.bsl
@@ -45,4 +45,4 @@ ImplFile
 
 (6,0)-(6,1) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:5). Try indenting this further.
 To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
-(6,0)-(6,1) parse error Incomplete structured construct at or before this point in member definition. Expected identifier, '(', '(*)' or other token.
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in property definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 05.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 05.fs.bsl
@@ -66,4 +66,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(4,15)-(5,4) parse error Incomplete structured construct at or before this point in member definition. Expected identifier or other token.
+(4,15)-(5,4) parse error Incomplete structured construct at or before this point in auto property definition. Expected identifier or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 06.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 06.fs.bsl
@@ -43,4 +43,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(4,18)-(4,19) parse error Unexpected symbol '=' in member definition
+(4,18)-(4,19) parse error Unexpected symbol '=' in auto property definition

--- a/tests/service/data/SyntaxTree/Member/Auto property 08.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 08.fs.bsl
@@ -46,4 +46,4 @@ ImplFile
 
 (6,0)-(6,1) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:22). Try indenting this further.
 To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
-(6,0)-(6,1) parse error Incomplete structured construct at or before this point. Expected identifier, '(', '(*)' or other token.
+(6,0)-(6,1) parse error Incomplete structured construct at or before this point in property definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 09.fs.bsl
@@ -69,4 +69,4 @@ ImplFile
 
 (5,4)-(5,10) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:23). Try indenting this further.
 To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
-(5,4)-(5,10) parse error Incomplete structured construct at or before this point. Expected identifier, '(', '(*)' or other token.
+(5,4)-(5,10) parse error Incomplete structured construct at or before this point in property definition. Expected identifier, '(', '(*)' or other token.

--- a/tests/service/data/SyntaxTree/Member/Auto property 10.fs.bsl
+++ b/tests/service/data/SyntaxTree/Member/Auto property 10.fs.bsl
@@ -45,4 +45,4 @@ ImplFile
 
 (5,0)-(5,0) parse error Unexpected syntax or possible incorrect indentation: this token is offside of context started at position (4:22). Try indenting this further.
 To continue using non-conforming indentation, pass the '--strict-indentation-' flag to the compiler, or set the language version to F# 7.
-(5,0)-(5,0) parse error Incomplete structured construct at or before this point. Expected identifier, '(', '(*)' or other token.
+(5,0)-(5,0) parse error Incomplete structured construct at or before this point in property definition. Expected identifier, '(', '(*)' or other token.


### PR DESCRIPTION
Fixes parser diagnostics in property tests in debug builds. It also improves the error messages.

The diagnostics were added in syntax tree tests for properties, making it more difficult to work on the parser:
```
(6,0)-(6,1) parse error Incomplete structured construct at or before this point. (no 'in' context found: [[NONTERM_classMemberSpfnGetSetElements];
 [NONTERM_classMemberSpfnGetSetElements; NONTERM_classMemberSpfnGetSetElements];
 [NONTERM_classMemberSpfnGetSetElements; NONTERM_classMemberSpfnGetSetElements;
  NONTERM_classMemberSpfnGetSetElements];
 [NONTERM_classMemberSpfnGetSetElements; NONTERM_classMemberSpfnGetSetElements;
  NONTERM_classMemberSpfnGetSetElements];
 [NONTERM_classMemberSpfnGetSet; NONTERM_classMemberSpfnGetSet];
 [NONTERM_autoPropsDefnDecl]; [NONTERM_autoPropsDefnDecl];
 [NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl;
  NONTERM_autoPropsDefnDecl];
 [NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl;
  NONTERM_autoPropsDefnDecl];
 [NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl;
  NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl];
 [NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl;
  NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl];
 [NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl;
  NONTERM_autoPropsDefnDecl; NONTERM_autoPropsDefnDecl]]). Expected identifier, '(', '(*)' or other token.
```