### PR TITLE
Tests: extract 'should update baselines' checks

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/SyntaxTreeTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/SyntaxTreeTests.fs
@@ -7,6 +7,7 @@ open FSharp.Compiler.Service.Tests.Common
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 open FSharp.Test
+open FSharp.Test.Compiler
 open Xunit
 
 let testCasesDir = __SOURCE_DIRECTORY__ ++ ".." ++ "service" ++ "data" ++ "SyntaxTree"
@@ -186,18 +187,14 @@ let ParseFile fileName =
         else
             "No baseline was found"
 
-    let equals = expected = actual
-    let testUpdateBSLEnv = System.Environment.GetEnvironmentVariable("TEST_UPDATE_BSL")
-
-    let shouldUpdateBaseline =
-        (not (isNull testUpdateBSLEnv) && testUpdateBSLEnv.Trim() = "1" && not equals)
-
-    if shouldUpdateBaseline then
-        File.WriteAllText(bslPath, actual)
-    elif not equals then
-        File.WriteAllText(actualPath, actual)
-    else
+    if expected = actual then
         File.Delete(actualPath)
+    else
+        if shouldUpdateBaselines then
+            File.Delete(actualPath)
+            File.WriteAllText(bslPath, actual)
+        else
+            File.WriteAllText(actualPath, actual)
 
     Assert.Equal(expected, actual)
 

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -5,9 +5,7 @@ namespace FSharp.Test
 open FSharp.Compiler.Interactive.Shell
 open FSharp.Compiler.IO
 open FSharp.Compiler.Diagnostics
-open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
-open FSharp.Test.Assert
 open FSharp.Test.Utilities
 open FSharp.Test.ScriptHelpers
 open Microsoft.CodeAnalysis
@@ -27,9 +25,10 @@ open TestFramework
 
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
-open FSharp.Compiler.CodeAnalysis
 
 module rec Compiler =
+    let shouldUpdateBaselines =
+        Environment.GetEnvironmentVariable("TEST_UPDATE_BSL") <> null
 
     [<AutoOpen>]
     type SourceUtilities () =
@@ -1230,10 +1229,8 @@ Expected:
 {expected}
 Actual:
 {actual}"""
-    let updateBaseline () =
-        snd (Int32.TryParse(Environment.GetEnvironmentVariable("TEST_UPDATE_BSL"))) <> 0
     let updateBaseLineIfEnvironmentSaysSo baseline =
-        if updateBaseline () then
+        if shouldUpdateBaselines then
             if FileSystem.FileExistsShim baseline.FilePath then
                 FileSystem.CopyShim(baseline.FilePath, baseline.BslSource, true)
 
@@ -2020,7 +2017,7 @@ Actual:
                 match Assert.shouldBeSameMultilineStringSets expectedContent actualErrors with
                 | None -> ()
                 | Some diff ->
-                    if Environment.GetEnvironmentVariable("TEST_UPDATE_BSL") <> null then
+                    if shouldUpdateBaselines then
                         File.WriteAllText(path, actualErrors)
 
                     printfn $"{Path.GetFullPath path} \n {diff}"

--- a/tests/FSharp.Test.Utilities/SurfaceArea.fs
+++ b/tests/FSharp.Test.Utilities/SurfaceArea.fs
@@ -4,8 +4,9 @@ module FSharp.Test.SurfaceArea
     open System
     open System.IO
     open System.Reflection
-    open System.Text.RegularExpressions 
-        
+    open FSharp.Test.Compiler
+    open System.Text.RegularExpressions
+
     // Gets string form of public surface area for the currently-loaded assembly
     let private getSurfaceAreaForAssembly (assembly: Assembly) =
 
@@ -66,8 +67,10 @@ module FSharp.Test.SurfaceArea
             File.Delete(outFilePath)
 
         | Some diff ->
-            match Environment.GetEnvironmentVariable("TEST_UPDATE_BSL") with
-            | null ->
+            if shouldUpdateBaselines then
+                File.Delete(outFilePath)
+                File.WriteAllText(baselinePath, actual)
+            else
                 File.WriteAllText(outFilePath, actual)
 
                 let msg = $"""Assembly: %A{asm}
@@ -78,6 +81,3 @@ module FSharp.Test.SurfaceArea
                   {diff}"""
 
                 failwith msg
-            | _ ->
-                File.Delete(outFilePath)
-                File.WriteAllText(baselinePath, actual)


### PR DESCRIPTION
Unifies `TEST_UPDATE_BSL` checks, which makes it easier to enable it from code.

Syntax tree tests now remove actual syntax tree files when updating baselines. 