### PR TITLE
Add Redist and Tasks.Extensions dlls to swix

### DIFF
--- a/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
+++ b/setup/Swix/Microsoft.FSharp.Compiler.MSBuild/Microsoft.FSharp.Compiler.MSBuild.csproj
@@ -105,9 +105,11 @@ folder "InstallDir:Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\System.Resources.Extensions.dll"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\System.Runtime.CompilerServices.Unsafe.dll"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\System.Threading.Tasks.Dataflow.dll"
+  file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\System.Threading.Tasks.Extensions.dll"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\Microsoft.Build.Framework.dll"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\Microsoft.Build.Tasks.Core.dll"
   file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\Microsoft.Build.Utilities.Core.dll"
+  file source="$(BinariesFolder)fsc\$(Configuration)\$(TargetFramework)\Microsoft.IO.Redist.dll"
   file source="$(BinariesFolder)FSharp.Core\$(Configuration)\netstandard2.0\FSharp.Core.dll" vs.file.ngen=yes vs.file.ngenArchitecture=All vs.file.ngenPriority=2
   file source="$(BinariesFolder)FSharp.Core\$(Configuration)\netstandard2.0\FSharp.Core.xml"
   file source="$(BinariesFolder)FSharp.Build\$(Configuration)\netstandard2.0\FSharp.Build.dll" vs.file.ngen=no vs.file.ngenArchitecture=All vs.file.ngenPriority=2


### PR DESCRIPTION
Apparently some change to MSBuild made it so these dlls are dropped, we need to make sure we copy them to VS install dir.

As a follow up we should investigate if this file needs to be manually maintained like this and why we specify this allow-list instead of copying everything or having an exclusion list or auto generating this list somehow.