### PR TITLE
Add CCR-OptOut review instruction

### DIFF
--- a/.github/instructions/CcrOptout.instructions.md
+++ b/.github/instructions/CcrOptout.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+If the pull request you are reviewing has the label `CCR-OptOut`, stop any review, do not post any comment, immediately finish and ignore all other instructions for reviewing.


### PR DESCRIPTION
Adds a Copilot code review instruction that skips reviewing PRs labeled `CCR-OptOut`.

The instruction file uses `excludeAgent: cloud-agent` so it only applies to Copilot code review, not the coding agent.