### PR TITLE
chore: update actions/github-script from v6 to v7

### DIFF
--- a/.github/workflows/repository_lockdown_check.yml
+++ b/.github/workflows/repository_lockdown_check.yml
@@ -35,7 +35,7 @@ jobs:
     # If not, create a new comment
     - name: Create comment
       if: steps.fc.outputs.comment-id == '' && failure()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ github.token }}
         script: |
@@ -50,7 +50,7 @@ jobs:
     # If yes, update the comment
     - name: Update comment
       if: steps.fc.outputs.comment-id != '' && failure()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ github.token }}
         script: |
@@ -65,7 +65,7 @@ jobs:
     # If comment exists, but we are no longer in maintenance mode, delete the comment.
     - name: Delete comment
       if: steps.fc.outputs.comment-id != '' && success()
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ github.token }}
         script: |


### PR DESCRIPTION
The `repository_lockdown` CI job was failing because `actions/github-script@v6` resolved to a SHA (`d7906e4ad0b1822421a7e6a35d5ca353c962f410`) that is no longer available on GitHub's CDN, returning 404 when the runner tried to download the action archive.

Bumps the three usages in `.github/workflows/repository_lockdown_check.yml` to `actions/github-script@v7`, which is currently available and keeps the same script API.

Split out of #19812.
