### PR TITLE
Add InlineIfLambda to Array.init

### DIFF
--- a/docs/release-notes/.FSharp.Core/11.0.100.md
+++ b/docs/release-notes/.FSharp.Core/11.0.100.md
@@ -2,3 +2,4 @@
 
 * Fix `Array.exists2` documentation examples to use equal-length arrays; the previous examples would throw `ArgumentException` at runtime instead of returning the documented `false`/`true` values. ([PR #19672](https://github.com/dotnet/fsharp/pull/19672))
 * Move `Async.StartChild` to the "Starting Async Computations" docs category alongside `Async.StartChildAsTask`. ([Issue #19667](https://github.com/dotnet/fsharp/issues/19667))
+* Add InlineIfLambda to Array.init ([PR #19672](https://github.com/dotnet/fsharp/pull/19869))

--- a/docs/release-notes/.FSharp.Core/11.0.100.md
+++ b/docs/release-notes/.FSharp.Core/11.0.100.md
@@ -2,4 +2,4 @@
 
 * Fix `Array.exists2` documentation examples to use equal-length arrays; the previous examples would throw `ArgumentException` at runtime instead of returning the documented `false`/`true` values. ([PR #19672](https://github.com/dotnet/fsharp/pull/19672))
 * Move `Async.StartChild` to the "Starting Async Computations" docs category alongside `Async.StartChildAsTask`. ([Issue #19667](https://github.com/dotnet/fsharp/issues/19667))
-* Add InlineIfLambda to Array.init ([PR #19672](https://github.com/dotnet/fsharp/pull/19869))
+* Add `InlineIfLambda` to `Array.init` ([PR #19869](https://github.com/dotnet/fsharp/pull/19869))

--- a/src/FSharp.Core/array.fs
+++ b/src/FSharp.Core/array.fs
@@ -47,7 +47,7 @@ module Array =
             Some array.[array.Length - 1]
 
     [<CompiledName("Initialize")>]
-    let inline init count initializer =
+    let inline init count ([<InlineIfLambda>] initializer) =
         Microsoft.FSharp.Primitives.Basics.Array.init count initializer
 
     [<CompiledName("ZeroCreate")>]


### PR DESCRIPTION
## Description

`InlineIfLambda` is present on `Primitives.Basics.Array.init` but missing on `Array.init`, which means [a closure is created if necessary](https://sharplab.io/#v2:DYLgZgzgPsCmAuACAlgO2G2iAeiAUA2gDwCS6mJYAMgIYC2ARgCY0B8AuomAJSIC8XfLwDUiAIwBYAFDS4SNBlRZsuPHgBUxMotiVajFh3W8e/HF2myEiAF6IA5v2mIXiObbsCAygE8I8WDoAOgARGgCAFWQ6WCCAOQB7AHdQmh9nVxV8MABXVCFEAFpWRF9/QNTI6NjElLCfRFFHURsbbiA).

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [ ] Release notes entry updated:
    > Please make sure to add an entry with short succinct description of the change as well as link to this pull request to the respective release notes file, if applicable.
    >
    > Release notes files:
    > - If anything under `src/Compiler` has been changed, please make sure to make an entry in `docs/release-notes/.FSharp.Compiler.Service/<version>.md`, where `<version>` is usually "highest" one, e.g. `42.8.200`
    > - If language feature was added (i.e. `LanguageFeatures.fsi` was changed), please add it to `docs/release-notes/.Language/preview.md`
    > - If a change to `FSharp.Core` was made, please make sure to edit `docs/release-notes/.FSharp.Core/<version>.md` where version is "highest" one, e.g. `8.0.200`.

    > Information about the release notes entries format can be found in the [documentation](https://fsharp.github.io/fsharp-compiler-docs/release-notes/About.html).
    > Example:
    > * More inlines for Result module. ([PR #16106](https://github.com/dotnet/fsharp/pull/16106))
    > * Correctly handle assembly imports with public key token of 0 length. ([Issue #16359](https://github.com/dotnet/fsharp/issues/16359), [PR #16363](https://github.com/dotnet/fsharp/pull/16363))
    > *`while!` ([Language suggestion #1038](https://github.com/fsharp/fslang-suggestions/issues/1038), [PR #14238](https://github.com/dotnet/fsharp/pull/14238))

    > **If you believe that release notes are not necessary for this PR, please add `NO_RELEASE_NOTES` label to the pull request.**