### PR TITLE
Remove unused variable group DotNet-Symbol-Server-Pats

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,7 +124,6 @@ extends:
                   zipSources: false
 
             variables:
-            - group: DotNet-Symbol-Server-Pats
             - group: DotNet-DevDiv-Insertion-Workflow-Variables
             - name: _SignType
               value: Real


### PR DESCRIPTION
It seems like this was unused already and recently also deprecated