### PR TITLE
Fix semantic classification errors for generics, slices, CEs, and open type

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix semantic classification range overrun for generic method and constructor calls - the `<.>` type arguments (and on ctors the entire argument list) no longer pick up the surrounding `Method` / `DisposableType` color. ([Issue #19905 items 3, 4, 6](https://github.com/dotnet/fsharp/issues/19905))
 * Fix wide-range `Method` semantic classification covering the whole `delegate of . -> .` clause inside an F# delegate declaration. ([Issue #19905 item 1](https://github.com/dotnet/fsharp/issues/19905))
 * Tooltip "Full name" now shows demangled companion module names (e.g. `MyType.func` instead of `MyTypeModule.func`). ([Issue #17335](https://github.com/dotnet/fsharp/issues/17335), [PR #19867](https://github.com/dotnet/fsharp/pull/19867))
 * Fix internal error (FS0193) when calling an indexed property setter with a named argument that matches an indexer parameter. ([Issue #16034](https://github.com/dotnet/fsharp/issues/16034), [PR #19851](https://github.com/dotnet/fsharp/pull/19851))

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix computation-expression builder identifier being classified as a plain value (instead of `ComputationExpression`) when the CE is used inside a `[ for … do … ]` list / array comprehension. ([Issue #19905 item 2](https://github.com/dotnet/fsharp/issues/19905))
 * Fix semantic classification range overrun for generic method and constructor calls - the `<.>` type arguments (and on ctors the entire argument list) no longer pick up the surrounding `Method` / `DisposableType` color. ([Issue #19905 items 3, 4, 6](https://github.com/dotnet/fsharp/issues/19905))
 * Fix wide-range `Method` semantic classification covering the whole `delegate of . -> .` clause inside an F# delegate declaration. ([Issue #19905 item 1](https://github.com/dotnet/fsharp/issues/19905))
 * Tooltip "Full name" now shows demangled companion module names (e.g. `MyType.func` instead of `MyTypeModule.func`). ([Issue #17335](https://github.com/dotnet/fsharp/issues/17335), [PR #19867](https://github.com/dotnet/fsharp/pull/19867))

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix wide-range `Method` semantic classification covering the whole `delegate of . -> .` clause inside an F# delegate declaration. ([Issue #19905 item 1](https://github.com/dotnet/fsharp/issues/19905))
 * Tooltip "Full name" now shows demangled companion module names (e.g. `MyType.func` instead of `MyTypeModule.func`). ([Issue #17335](https://github.com/dotnet/fsharp/issues/17335), [PR #19867](https://github.com/dotnet/fsharp/pull/19867))
 * Fix internal error (FS0193) when calling an indexed property setter with a named argument that matches an indexer parameter. ([Issue #16034](https://github.com/dotnet/fsharp/issues/16034), [PR #19851](https://github.com/dotnet/fsharp/pull/19851))
 * Fix missing FS1182 ("unused binding") warning for unused `let` function bindings inside class types. ([Issue #13849](https://github.com/dotnet/fsharp/issues/13849), [PR #19805](https://github.com/dotnet/fsharp/pull/19805))

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix the closing `]` of an open-ended slice (`xs[0..]`) being colored as a method by the editor: the synthesized `GetSlice` / `SetSlice` member lookup now uses a synthetic identifier range so the classifier does not pick it up. ([Issue #19905 item 5](https://github.com/dotnet/fsharp/issues/19905))
 * Fix computation-expression builder identifier being classified as a plain value (instead of `ComputationExpression`) when the CE is used inside a `[ for … do … ]` list / array comprehension. ([Issue #19905 item 2](https://github.com/dotnet/fsharp/issues/19905))
 * Fix semantic classification range overrun for generic method and constructor calls - the `<.>` type arguments (and on ctors the entire argument list) no longer pick up the surrounding `Method` / `DisposableType` color. ([Issue #19905 items 3, 4, 6](https://github.com/dotnet/fsharp/issues/19905))
 * Fix wide-range `Method` semantic classification covering the whole `delegate of . -> .` clause inside an F# delegate declaration. ([Issue #19905 item 1](https://github.com/dotnet/fsharp/issues/19905))

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -6930,7 +6930,15 @@ and TcIndexingThen cenv env overallTy mWholeExpr mDot tpenv setInfo synLeftExprO
             match setInfo with
             // expr1.[expr2]
             | None  ->
-                [ DelayedDotLookup([ ident(nm, mWholeExpr)], mWholeExpr)
+                // For slice getters (isIndex=false: synthesized GetSlice call), syntheticize the
+                // synthesized identifier range so the resolver does not emit a Method classification
+                // covering the closing ']' of an open-ended slice (#19905 item 5). For the regular
+                // Item indexer (isIndex=true) keep the real range so symbol uses remain visible to
+                // IDE features.
+                let mIdent =
+                    if isIndex then mWholeExpr
+                    else mWholeExpr.MakeSynthetic()
+                [ DelayedDotLookup([ ident(nm, mIdent)], mIdent)
                   DelayedApp(ExprAtomicFlag.Atomic, true, synLeftExprOpt, MakeIndexParam None, mWholeExpr)
                   yield! delayed ]
 
@@ -6942,7 +6950,10 @@ and TcIndexingThen cenv env overallTy mWholeExpr mDot tpenv setInfo synLeftExprO
                       MakeDelayedSet(expr3, mWholeExpr)
                       yield! delayed ]
                 else
-                    [ DelayedDotLookup([ident("SetSlice", mOfLeftOfSet)], mOfLeftOfSet)
+                    // SetSlice synthesized identifier: syntheticize the range to suppress the
+                    // wide-range Method classification on the closing ']' (#19905 item 5).
+                    let mSyntheticSet = mOfLeftOfSet.MakeSynthetic()
+                    [ DelayedDotLookup([ident("SetSlice", mSyntheticSet)], mSyntheticSet)
                       DelayedApp(ExprAtomicFlag.Atomic, true, synLeftExprOpt, MakeIndexParam (Some expr3), mWholeExpr)
                       yield! delayed ]
 

--- a/src/Compiler/Checking/Expressions/CheckExpressions.fs
+++ b/src/Compiler/Checking/Expressions/CheckExpressions.fs
@@ -9217,7 +9217,7 @@ and TcMethodItemThen (cenv: cenv) overallTy env item methodName minfos tpenv mIt
         // FUTURE: can we do better than emptyTyparInst here, in order to display instantiations
         // of type variables in the quick info provided in the IDE? But note we haven't yet even checked if the
         // number of type arguments is correct...
-        CallNameResolutionSink cenv.tcSink (mExprAndTypeArgs, env.NameEnv, item, emptyTyparInst, ItemOccurrence.Use, env.eAccessRights)
+        CallNameResolutionSink cenv.tcSink (mItem, env.NameEnv, item, emptyTyparInst, ItemOccurrence.Use, env.eAccessRights)
 
         match otherDelayed with
         | DelayedApp(atomicFlag, _, _, arg, mExprAndArg) :: otherDelayed ->
@@ -9251,7 +9251,7 @@ and TcCtorItemThen (cenv: cenv) overallTy env item nm minfos tinstEnclosing tpen
     | DelayedTypeApp(tyargs, _mTypeArgs, mExprAndTypeArgs) :: DelayedApp(_, _, _, arg, mExprAndArg) :: otherDelayed ->
 
         let objTyAfterTyArgs, tpenv = TcNestedTypeApplication cenv NewTyparsOK CheckCxs ItemOccurrence.UseInType WarnOnIWSAM.Yes env tpenv mExprAndTypeArgs objTy tinstEnclosing tyargs
-        CallExprHasTypeSink cenv.tcSink (mExprAndArg, env.NameEnv, objTyAfterTyArgs, env.eAccessRights)
+        CallExprHasTypeSink cenv.tcSink (mItem, env.NameEnv, objTyAfterTyArgs, env.eAccessRights)
         let itemAfterTyArgs, minfosAfterTyArgs =
 #if !NO_TYPEPROVIDERS
             // If the type is provided and took static arguments then the constructor will have changed

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -228,7 +228,19 @@ module TcResolutionsExtensions =
                             elif vref.IsPropertyGetterMethod || vref.IsPropertySetterMethod then
                                 add m SemanticClassificationType.Property
                             elif vref.IsMember then
-                                add m SemanticClassificationType.Method
+                                // (#19905 item 1) Suppress wide-range Method classification produced by
+                                // the parser-synthesized SynValSig for an F# delegate's `Invoke` abstract
+                                // slot. Its idRange covers the whole `delegate of . -> .` clause, which
+                                // would otherwise paint keywords/punctuation as if they were a method call.
+                                let isSynthesizedDelegateInvoke =
+                                    let name = vref.LogicalName
+
+                                    (name = "Invoke" || name = "BeginInvoke" || name = "EndInvoke")
+                                    && vref.IsDispatchSlot
+                                    && vref.MemberApparentEntity.IsFSharpDelegateTycon
+
+                                if not isSynthesizedDelegateInvoke then
+                                    add m SemanticClassificationType.Method
                             elif IsOperatorDisplayName vref.DisplayName then
                                 add m SemanticClassificationType.Operator
                             else

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -206,6 +206,34 @@ module TcResolutionsExtensions =
 
                     let results = ImmutableArray.CreateBuilder()
 
+                    // (#19905 items 3 and 6) For Method/Property classifications, the CNR range may
+                    // span an entire dotted/generic prefix (e.g. `MyType.Method` or
+                    // `MailboxProcessor<int>.Start`). The wide range is needed for find-references and
+                    // goto-definition, but classification should color only the trailing identifier.
+                    // Narrow to the last `displayName.Length` characters of the range when the source
+                    // span is wider than the identifier and the range lies on a single line.
+                    let narrowMethodOrPropertyRange (displayName: string) (m: range) =
+                        if m.StartLine = m.EndLine
+                           && not (System.String.IsNullOrEmpty displayName)
+                           && displayName.Length > 0
+                           && m.EndColumn - m.StartColumn > displayName.Length
+                           && m.EndColumn >= displayName.Length then
+                            mkRange m.FileName (Position.mkPos m.EndLine (m.EndColumn - displayName.Length)) m.End
+                        else
+                            m
+
+                    // (#19905 item 4) For CtorGroup classifications on `new T<typeArgs>(...)`, the CNR
+                    // range covers the whole type-with-args. Narrow to the leading type-name portion so
+                    // DisposableType/ctor colors do not extend over the `<.>` type arguments.
+                    let narrowCtorRange (displayName: string) (m: range) =
+                        if m.StartLine = m.EndLine
+                           && not (System.String.IsNullOrEmpty displayName)
+                           && displayName.Length > 0
+                           && m.EndColumn - m.StartColumn > displayName.Length then
+                            mkRange m.FileName m.Start (Position.mkPos m.StartLine (m.StartColumn + displayName.Length))
+                        else
+                            m
+
                     let inline add m (typ: SemanticClassificationType) =
                         if duplicates.Add m then
                             results.Add(SemanticClassificationItem((m, typ)))
@@ -281,29 +309,30 @@ module TcResolutionsExtensions =
                             else
                                 add m SemanticClassificationType.RecordField
 
-                        | Item.Property(info = pinfo :: _), _, m ->
+                        | Item.Property(info = pinfo :: _) as item, _, m ->
                             if not pinfo.IsIndexer then
-                                add m SemanticClassificationType.Property
+                                add (narrowMethodOrPropertyRange item.DisplayNameCore m) SemanticClassificationType.Property
 
-                        | Item.CtorGroup(_, minfos), _, m ->
+                        | Item.CtorGroup(_, minfos) as item, _, m ->
+                            let mNarrow = narrowCtorRange item.DisplayNameCore m
                             match minfos with
-                            | [] -> add m SemanticClassificationType.ConstructorForReferenceType
+                            | [] -> add mNarrow SemanticClassificationType.ConstructorForReferenceType
                             | _ ->
                                 if
                                     minfos
                                     |> List.forall (fun minfo -> isDisposableTy g amap minfo.ApparentEnclosingType)
                                 then
-                                    add m SemanticClassificationType.DisposableType
+                                    add mNarrow SemanticClassificationType.DisposableType
                                 elif minfos |> List.forall (fun minfo -> isStructTy g minfo.ApparentEnclosingType) then
-                                    add m SemanticClassificationType.ConstructorForValueType
+                                    add mNarrow SemanticClassificationType.ConstructorForValueType
                                 else
-                                    add m SemanticClassificationType.ConstructorForReferenceType
+                                    add mNarrow SemanticClassificationType.ConstructorForReferenceType
 
                         | Item.DelegateCtor _, _, m -> add m SemanticClassificationType.ConstructorForReferenceType
 
-                        | Item.MethodGroup(_, minfos, _), _, m ->
+                        | Item.MethodGroup(_, minfos, _) as item, _, m ->
                             match minfos with
-                            | [] -> add m SemanticClassificationType.Method
+                            | [] -> add (narrowMethodOrPropertyRange item.DisplayNameCore m) SemanticClassificationType.Method
                             | _ ->
                                 let isSynthesizedDelegateMemberInDecl =
                                     minfos
@@ -314,15 +343,17 @@ module TcResolutionsExtensions =
                                         && minfo.ApparentEnclosingTyconRef.IsFSharpDelegateTycon
                                         && rangeContainsRange minfo.ApparentEnclosingTyconRef.Range m)
 
+                                let mNarrow = narrowMethodOrPropertyRange item.DisplayNameCore m
+
                                 if isSynthesizedDelegateMemberInDecl then
                                     ()
                                 elif
                                     minfos
                                     |> List.forall (fun minfo -> minfo.IsExtensionMember || minfo.IsCSharpStyleExtensionMember)
                                 then
-                                    add m SemanticClassificationType.ExtensionMethod
+                                    add mNarrow SemanticClassificationType.ExtensionMethod
                                 else
-                                    add m SemanticClassificationType.Method
+                                    add mNarrow SemanticClassificationType.Method
 
                         // Special case measures for struct types
                         | Item.Types(_, AppTy g (tyconRef, TType_measure _ :: _) :: _), LegitTypeOccurrence, m when

--- a/src/Compiler/Service/SemanticClassification.fs
+++ b/src/Compiler/Service/SemanticClassification.fs
@@ -180,18 +180,22 @@ module TcResolutionsExtensions =
 
                     // Custom builders like 'async { }' are both Item.Value and Item.CustomBuilder.
                     // We should prefer the latter, otherwise they would not get classified as CEs.
+                    // Inside list/array comprehensions the same range can host more than 2 CNRs; we
+                    // still want to keep the CustomBuilder ones if any are present.
                     let takeCustomBuilder (cnrs: CapturedNameResolution[]) =
                         assert (cnrs.Length > 0)
 
                         if cnrs.Length = 1 then
                             cnrs
-                        elif cnrs.Length = 2 then
-                            match cnrs[0].Item, cnrs[1].Item with
-                            | Item.Value _, Item.CustomBuilder _ -> [| cnrs[1] |]
-                            | Item.CustomBuilder _, Item.Value _ -> [| cnrs[0] |]
-                            | _ -> cnrs
                         else
-                            cnrs
+                            let customBuilders =
+                                cnrs
+                                |> Array.filter (fun cnr ->
+                                    match cnr.Item with
+                                    | Item.CustomBuilder _ -> true
+                                    | _ -> false)
+
+                            if customBuilders.Length > 0 then customBuilders else cnrs
 
                     let resolutions =
                         match range with

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
@@ -378,3 +378,97 @@ let mbx = new MailboxProcessor<int * int>(fun mbx -> async { return () })
             "Generic disposable constructor call should not produce a DisposableType span wider than the type name, but found: %A"
             (badWideDisposable |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
     )
+
+/// (#19905 item 2) A computation-expression builder identifier used inside a list comprehension
+/// must classify as ComputationExpression, not Value.
+[<Fact>]
+let ``CE builder name inside list comprehension is classified as ComputationExpression`` () =
+    let source = """
+type OptionalBuilder() =
+    member _.Zero() = None
+    member _.Bind(x, f) = Option.bind f x
+    member _.Return(x) = Some x
+    member _.ReturnFrom(x) = x
+
+let optional = OptionalBuilder()
+let myList = [1; 2; 3]
+let myNewList = [
+    for i in myList do
+        optional {
+            return! Some(i+1)
+        }
+]
+"""
+    let fileName, snapshot, checker = singleFileChecker source
+    let results = checker.ParseAndCheckFileInProject(fileName, snapshot) |> Async.RunSynchronously
+    let checkResults = getTypeCheckResult results
+    // Use a range-based call (mirrors what VS classification does); 'None' bypasses takeCustomBuilder.
+    let wholeFile = Range.mkRange fileName (Position.mkPos 1 0) (Position.mkPos 1000 0)
+    let classifications = checkResults.GetSemanticClassification(Some wholeFile, RelatedSymbolUseKind.All)
+
+    // The 'optional {' inside the comprehension is on line 12, starting at column 8 (8 spaces of indent).
+    let ceItemsOnLine12 =
+        classifications
+        |> Array.filter (fun c ->
+            c.Range.StartLine = 12
+            && c.Range.StartColumn = 8
+            && c.Type = SemanticClassificationType.ComputationExpression)
+
+    Assert.True(
+        ceItemsOnLine12.Length >= 1,
+        sprintf
+            "Expected ComputationExpression classification for 'optional' at line 12, col 8. Items on line 12: %A"
+            (classifications
+             |> Array.filter (fun i -> i.Range.StartLine = 12)
+             |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )
+
+    // And the same span must NOT also be classified as Value.
+    let valueItemsOnSameSpan =
+        classifications
+        |> Array.filter (fun c ->
+            c.Range.StartLine = 12
+            && c.Range.StartColumn = 8
+            && c.Range.EndColumn = 16
+            && c.Type = SemanticClassificationType.Value)
+
+    Assert.True(
+        valueItemsOnSameSpan.Length = 0,
+        sprintf
+            "Same span for 'optional' must not also be classified as Value, but found: %A"
+            (valueItemsOnSameSpan |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )
+
+/// (#19905 item 2 - guard) Top-level CE usage must keep classifying as ComputationExpression
+/// after the takeCustomBuilder generalization.
+[<Fact>]
+let ``CE builder name at top level still classifies as ComputationExpression`` () =
+    let source = """
+type OptionalBuilder() =
+    member _.Zero() = None
+    member _.Bind(x, f) = Option.bind f x
+    member _.Return(x) = Some x
+
+let optional = OptionalBuilder()
+let z = optional { return! Some 42 }
+"""
+    let fileName, snapshot, checker = singleFileChecker source
+    let results = checker.ParseAndCheckFileInProject(fileName, snapshot) |> Async.RunSynchronously
+    let checkResults = getTypeCheckResult results
+    let wholeFile = Range.mkRange fileName (Position.mkPos 1 0) (Position.mkPos 1000 0)
+    let classifications = checkResults.GetSemanticClassification(Some wholeFile, RelatedSymbolUseKind.All)
+
+    let ceItemsOnLine8 =
+        classifications
+        |> Array.filter (fun c ->
+            c.Range.StartLine = 8
+            && c.Type = SemanticClassificationType.ComputationExpression)
+
+    Assert.True(
+        ceItemsOnLine8.Length >= 1,
+        sprintf
+            "Expected ComputationExpression classification on line 8 for top-level CE usage. Items: %A"
+            (classifications
+             |> Array.filter (fun i -> i.Range.StartLine = 8)
+             |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
@@ -297,3 +297,84 @@ type SumDelegate = delegate of x: int * y: int -> int
             "Delegate declaration should not produce a wide Method classification, but found: %A"
             (badWideMethods |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
     )
+
+/// (#19905 item 3) For `MyType.Method<int>()`, the Method classification on the
+/// identifier must not extend past the identifier into the `<int>(` punctuation.
+[<Fact>]
+let ``Static generic method call should not extend Method range over type args`` () =
+    let source = """
+type MyType() =
+    static member Method<'a>() = Unchecked.defaultof<'a>
+
+let x = MyType.Method<int>()
+"""
+    let classifications = getClassifications source
+
+    // The method identifier on line 5 ("Method") spans columns 15..21 (6 chars).
+    // Before the fix, a single Method classification spanned the whole "Method<int>()"
+    // (~ columns 15..27, 12+ chars). Assert no Method classification on the call
+    // line has width > 8.
+    let badWideMethods =
+        classifications
+        |> Array.filter (fun c ->
+            c.Type = SemanticClassificationType.Method
+            && c.Range.StartLine = 5
+            && (c.Range.EndColumn - c.Range.StartColumn) > 8)
+
+    Assert.True(
+        badWideMethods.Length = 0,
+        sprintf
+            "Static generic method call should not produce a Method span wider than the identifier, but found: %A"
+            (badWideMethods |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )
+
+/// (#19905 item 6) Sibling of item 3: `MailboxProcessor<int>.Start(.)` - the
+/// method name should be a narrow Method classification, not a wide span.
+[<Fact>]
+let ``Generic type then static method call should not extend Method range over type args`` () =
+    let source = """
+let mbx = MailboxProcessor<int>.Start(fun mbx -> async { return () })
+"""
+    let classifications = getClassifications source
+
+    // "Start" on line 2 spans 5 chars. Before the fix, a wide Method classification
+    // covered "Start(fun mbx -> async { return () })".
+    let badWideMethods =
+        classifications
+        |> Array.filter (fun c ->
+            c.Type = SemanticClassificationType.Method
+            && c.Range.StartLine = 2
+            && (c.Range.EndColumn - c.Range.StartColumn) > 8)
+
+    Assert.True(
+        badWideMethods.Length = 0,
+        sprintf
+            "Generic-type static method call should not produce a Method span wider than the identifier, but found: %A"
+            (badWideMethods |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )
+
+/// (#19905 item 4) For `new MailboxProcessor<int * int>(...)`, the
+/// DisposableType classification must not extend over the constructor argument list.
+[<Fact>]
+let ``Generic disposable constructor call should not classify argument list as DisposableType`` () =
+    let source = """
+let mbx = new MailboxProcessor<int * int>(fun mbx -> async { return () })
+"""
+    let classifications = getClassifications source
+
+    // The type name "MailboxProcessor" spans 16 chars. Before the fix, a single
+    // DisposableType classification spanned everything from the type name through
+    // the entire argument list (~ 60+ chars).
+    let badWideDisposable =
+        classifications
+        |> Array.filter (fun c ->
+            c.Type = SemanticClassificationType.DisposableType
+            && c.Range.StartLine = 2
+            && (c.Range.EndColumn - c.Range.StartColumn) > 20)
+
+    Assert.True(
+        badWideDisposable.Length = 0,
+        sprintf
+            "Generic disposable constructor call should not produce a DisposableType span wider than the type name, but found: %A"
+            (badWideDisposable |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
@@ -271,3 +271,29 @@ type MyDelegate = delegate of int -> string
             && (let text = substringOfRange source c.Range
                 text = "BeginInvoke" || text = "EndInvoke"))
     Assert.Empty(asyncInvokeMethods)
+
+/// (#19905 item 1) The whole `delegate of . -> .` clause must not get a wide-range
+/// `Method` classification covering keywords/type punctuation.
+[<Fact>]
+let ``Delegate declaration body should not be classified as method`` () =
+    let source = """
+type SumDelegate = delegate of x: int * y: int -> int
+"""
+    let classifications = getClassifications source
+
+    // Any Method classification on line 2 must be no wider than a plausible identifier
+    // (e.g. "Invoke" = 6 columns). The wide range covering the delegate signature was
+    // ~36 columns wide. Use a generous threshold of 10 to remain robust to formatting tweaks.
+    let badWideMethods =
+        classifications
+        |> Array.filter (fun c ->
+            c.Type = SemanticClassificationType.Method
+            && c.Range.StartLine = 2
+            && (c.Range.EndColumn - c.Range.StartColumn) > 10)
+
+    Assert.True(
+        badWideMethods.Length = 0,
+        sprintf
+            "Delegate declaration should not produce a wide Method classification, but found: %A"
+            (badWideMethods |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/SemanticClassificationRegressions.fs
@@ -472,3 +472,59 @@ let z = optional { return! Some 42 }
              |> Array.filter (fun i -> i.Range.StartLine = 8)
              |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
     )
+
+/// (#19905 item 5) The synthesized GetSlice member on an open-ended slice must not
+/// produce a Method/Function classification that covers the closing ']'.
+[<Fact>]
+let ``Open-ended slice closing bracket is not classified as Method`` () =
+    let source = """
+let list = [1; 2; 3]
+let x    = list[0..]
+"""
+    let classifications = getClassifications source
+
+    // Line 3 contains "let x    = list[0..]".
+    let bracketCol = source.Replace("\r\n", "\n").Split('\n').[2].IndexOf(']')
+    Assert.True(bracketCol >= 0, "Test source must contain ']'")
+
+    let bad =
+        classifications
+        |> Array.filter (fun c ->
+            c.Type = SemanticClassificationType.Method
+            && c.Range.StartLine = 3
+            && c.Range.StartColumn <= bracketCol
+            && c.Range.EndColumn > bracketCol)
+
+    Assert.True(
+        bad.Length = 0,
+        sprintf
+            "Closing ']' of open-ended slice must not be inside a Method classification, but found: %A"
+            (bad |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )
+
+/// (#19905 item 5 - guard) Closed-bound slice should keep working.
+[<Fact>]
+let ``Closed-bound slice does not produce a wide Method classification`` () =
+    let source = """
+let list = [1; 2; 3]
+let y    = list[0..2]
+"""
+    let classifications = getClassifications source
+
+    let bracketCol = source.Replace("\r\n", "\n").Split('\n').[2].IndexOf(']')
+    Assert.True(bracketCol >= 0, "Test source must contain ']'")
+
+    let bad =
+        classifications
+        |> Array.filter (fun c ->
+            c.Type = SemanticClassificationType.Method
+            && c.Range.StartLine = 3
+            && c.Range.StartColumn <= bracketCol
+            && c.Range.EndColumn > bracketCol)
+
+    Assert.True(
+        bad.Length = 0,
+        sprintf
+            "Closing ']' of closed-bound slice must not be inside a Method classification, but found: %A"
+            (bad |> Array.map (fun i -> i.Range.StartColumn, i.Range.EndColumn, i.Type))
+    )

--- a/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ProjectAnalysisTests.fs
@@ -5676,6 +5676,49 @@ type UseTheThings(i:int) =
            (((37, 10), (37, 21)), "open type FSharpEnum2 // Unused, should appear.")]
     unusedOpensData |> shouldEqual expected
 
+/// (#19905 item 7) `open type X` where X is a class (not enum/module) with static
+/// members must be reported as USED when one of its static helpers is invoked.
+[<Fact>]
+let ``open type for class with used static member is not reported unused`` () =
+
+    let fileName1 = Path.ChangeExtension(getTemporaryFileName (), ".fs")
+    let base2 = getTemporaryFileName ()
+    let dllName = Path.ChangeExtension(base2, ".dll")
+    let projFileName = Path.ChangeExtension(base2, ".fsproj")
+    let fileSource1Text = """
+module Module
+
+module Helpers =
+    type View() =
+        static member Button(label: string) = label
+
+open type Helpers.View
+
+let label = Button "hello"
+"""
+    let fileSource1 = SourceText.ofString fileSource1Text
+    FileSystem.OpenFileForWriteShim(fileName1).Write(fileSource1Text)
+
+    let fileNames = [|fileName1|]
+    let args = mkProjectCommandLineArgs (dllName, [])
+    let keepAssemblyContentsChecker = FSharpChecker.Create(keepAssemblyContents=true, useTransparentCompiler=CompilerAssertHelpers.UseTransparentCompiler)
+    let options = { keepAssemblyContentsChecker.GetProjectOptionsFromCommandLineArgs (projFileName, args) with SourceFiles = fileNames }
+
+    let fileCheckResults =
+        keepAssemblyContentsChecker.ParseAndCheckFileInProject(fileName1, 0, fileSource1, options)  |> Async.RunImmediate
+        |> function
+            | _, FSharpCheckFileAnswer.Succeeded(res) -> res
+            | _ -> failwithf "Parsing aborted unexpectedly..."
+
+    let lines = FileSystem.OpenFileForReadShim(fileName1).ReadAllLines()
+    let unusedOpens = UnusedOpens.getUnusedOpens (fileCheckResults, (fun i -> lines[i-1])) |> Async.RunImmediate
+    let unusedOpensData = [ for uo in unusedOpens -> tups uo, lines[uo.StartLine-1] ]
+
+    let openTypeOnLine8 = unusedOpensData |> List.exists (fun ((_, _), text) -> text.Contains("open type Helpers.View"))
+    Assert.False(
+        openTypeOnLine8,
+        sprintf "Expected `open type Helpers.View` to be reported USED. Actual unused opens: %A" unusedOpensData)
+
 [<Fact>]
 let ``Unused opens smoke test auto open`` () =
 


### PR DESCRIPTION
Fixes #19905

- `Type.Method<int>()` / `new T<args>(...)` / `T<args>.M(...)` no longer classify `<…>` as Function/Type; span narrows to the identifier.
- `list[0..]` trailing `]` no longer classified as Function.
- CE builder name inside `[ for .. do builder { } ]` classified as ComputationExpression, not Value.
- `open type T` no longer always reported as unused.