### PR TITLE
Fix StructLayout Size for struct discriminated unions

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -1,5 +1,6 @@
 ### Fixed
 
+* Fix `StructLayout` `Size` for struct discriminated unions so emitted IL matches the computed layout size. ([Issue #18125](https://github.com/dotnet/fsharp/issues/18125), [PR #19946](https://github.com/dotnet/fsharp/pull/19946))
 * Fix internal error (FS0193) when calling an indexed property setter with a named argument that matches an indexer parameter. ([Issue #16034](https://github.com/dotnet/fsharp/issues/16034), [PR #19851](https://github.com/dotnet/fsharp/pull/19851))
 * Fix missing FS1182 ("unused binding") warning for unused `let` function bindings inside class types. ([Issue #13849](https://github.com/dotnet/fsharp/issues/13849), [PR #19805](https://github.com/dotnet/fsharp/pull/19805))
 * Fix inner mutually-recursive `let rec ... and ...` functions under `--realsig+` not being lifted to top-level static methods (TLR), causing `FSharpFunc` closure allocations and loss of `tail.` opcodes — the large struct-mutual-recursion perf regression reported in [Issue #17607](https://github.com/dotnet/fsharp/issues/17607). ([PR #19882](https://github.com/dotnet/fsharp/pull/19882))

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -12019,6 +12019,7 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) : ILTypeRef option 
                                 // Structs with no instance fields get size 1, pack 0
                                 if
                                     tycon.AllFieldsArray |> Array.exists (fun f -> not f.IsStatic)
+                                    || tycon.IsUnionTycon
                                     ||
                                     // Reflection emit doesn't let us emit 'pack' and 'size' for generic structs.
                                     // In that case we generate a dummy field instead

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Structure/StructUnionLayout18125.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Structure/StructUnionLayout18125.fs
@@ -1,0 +1,12 @@
+// Regression test for https://github.com/dotnet/fsharp/issues/18125
+module StructUnionLayout18125
+
+[<Struct>]
+type ABC = A | B | C
+
+let verifySize () =
+    // Struct DU has a compiler-generated _tag field; sizeof must not be 1.
+    if sizeof<ABC> <> 4 then
+        failwith $"Expected sizeof<ABC> = 4, got {sizeof<ABC>}"
+
+verifySize ()

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Structure/Structure.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Structure/Structure.fs
@@ -235,3 +235,10 @@ module Structure =
         compilation
         |> getCompilation
         |> verifyExecution
+
+    // SOURCE=StructUnionLayout18125.fs SCFLAGS="-r:CodeGenHelper.dll" # StructUnionLayout18125.fs
+    [<Theory; FileInlineData("StructUnionLayout18125.fs")>]
+    let ``StructUnionLayout18125_fs`` compilation =
+        compilation
+        |> getCompilation
+        |> verifyExecution


### PR DESCRIPTION
Fixes #18125

Struct unions get a compiler-generated `_tag` field but `defaultLayout` was still emitting `StructLayout(..., Size = 1)` when there are no declared instance fields.

This adds `tycon.IsUnionTycon` to the condition that omits an explicit size, matching what we already do for structs with instance fields.

Added `StructUnionLayout18125.fs` which checks `sizeof<ABC> = 4` for a three-case struct DU.