### PR TITLE
Add computation-expression tests for warning 20 range

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/ErrorMessages/WarnExpressionTests.fs
@@ -285,6 +285,34 @@ while x < 3 do
                                  "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
 
     [<Fact>]
+    let ``Warn On Last Expression Inside async Computation Expression - highlights only offending expression``() =
+        FSharp """
+let _ =
+    async {
+        for _ in [1] do
+            let x = 1
+            x
+    }
+        """
+        |> typecheck
+        |> shouldFail
+        |> withSingleDiagnostic (Warning 20, Line 6, Col 13, Line 6, Col 14,
+                                 "The result of this expression has type 'int' and is implicitly ignored. Consider using 'ignore' to discard this value explicitly, e.g. 'expr |> ignore', or 'let' to bind the result to a name, e.g. 'let result = expr'.")
+
+    [<Fact>]
+    let ``No Warning 20 For Trailing Non-unit Expression In seq Computation Expression (implicit yield)``() =
+        FSharp """
+let _ =
+    seq {
+        for _ in [1] do
+            let x = 1
+            x
+    }
+        """
+        |> typecheck
+        |> shouldSucceed
+
+    [<Fact>]
     let ``Warn If Possible Property Setter``() =
         FSharp """
 type MyClass(property1 : int) =


### PR DESCRIPTION
Test-only follow-up to #19896, adding the computation-expression coverage requested in review.

Inside a CE the loop body is desugared per-statement, so the trailing expression reaches `TcStmt` on its own and warning 20 highlights only the offending expression. `async`/`task` warn on the value alone; `seq` treats it as an implicit yield, so it doesn't warn at all.
