### PR TITLE
Don't ReadyToRun-publish the proto tools on ppc64le (no crossgen2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,8 @@
   <PropertyGroup>
     <!-- Set PublishReadyToRun to speed up the build. -->
     <EnablePublishReadyToRun>true</EnablePublishReadyToRun>
+    <!-- Crossgen2 has no PowerPC backend, so it is not built for ppc64le. -->
+    <EnablePublishReadyToRun Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Ppc64le'">false</EnablePublishReadyToRun>
     <!-- Crossgen2 is not built with source-built Mono-based .NET SDKs. -->
     <EnablePublishReadyToRun Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">false</EnablePublishReadyToRun>
   </PropertyGroup>


### PR DESCRIPTION
PowerPC has no crossgen2 backend, so ReadyToRun publishing of the proto/bootstrap tools (fslex/fsyacc) fails to resolve a Microsoft.NETCore.App.Crossgen2.freebsd-ppc64le pack that does not exist.

`src/fsharp/Directory.Build.props` already disables R2R for the Mono runtime; this adds an equivalent carve-out for ppc64le. The condition uses RuntimeInformation.ProcessArchitecture == Ppc64le rather than an SDK-derived RID property, because the RID properties are not yet populated at Directory.Build.props evaluation time. Part of a FreeBSD/powerpc64le (ppc64le) port. Sibling PRs: dotnet/runtime (PAL/platform), dotnet/arcade (eng/common detection), dotnet/sdk, dotnet/fsharp.

I have signed (or will sign on the dnfadmin bot's prompt) the .NET Foundation CLA.