### PR TITLE
Add regression test for cross-assembly private-constructor record equality

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/Conformance/GeneratedEqualityHashingComparison/Basic/Basic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/GeneratedEqualityHashingComparison/Basic/Basic.fs
@@ -229,7 +229,8 @@ module Basic =
 
     // Regression for https://github.com/dotnet/fsharp/issues/17773: a record with a private constructor whose
     // generated structural-equality/comparison members are consumed from another assembly must not throw
-    // MethodAccessException. Equals(R, IEqualityComparer) / CompareTo(R, IComparer) are emitted at the record
+    // MethodAccessException. Cross-assembly `a = b` emits a direct call to the typed `R::Equals(R, IEqualityComparer)`
+    // (the member that threw in #17773) and `compare a c` to `R::CompareTo(R)`; both must be emitted at the record
     // type's accessibility (public), not the private representation's.
     let private issue17773Lib =
         FSharp """
@@ -246,15 +247,12 @@ module Make =
         FSharp """
 module Consumer
 open Issue17773.Lib
-open System.Collections
 [<EntryPoint>]
 let main _ =
     let a = Make.r 1
     let b = Make.r 1
     let c = Make.r 2
-    let eqWithComparer = (a :> IStructuralEquatable).Equals(b, StructuralComparisons.StructuralEqualityComparer)
-    let cmpWithComparer = (a :> IStructuralComparable).CompareTo(c, StructuralComparisons.StructuralComparer)
-    if a = b && eqWithComparer && cmpWithComparer < 0 && compare a c < 0 then 0 else 1
+    if a = b && compare a c < 0 then 0 else 1
 """
         |> withReferences [issue17773Lib]
         |> asExe

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/GeneratedEqualityHashingComparison/Basic/Basic.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/GeneratedEqualityHashingComparison/Basic/Basic.fs
@@ -226,3 +226,37 @@ module Basic =
         |> shouldSucceed
 
     // SOURCE=E_CustomEqualityEquals01.fs SCFLAGS="--test:ErrorRanges"          # E_CustomEqualityEquals01.fs
+
+    // Regression for https://github.com/dotnet/fsharp/issues/17773: a record with a private constructor whose
+    // generated structural-equality/comparison members are consumed from another assembly must not throw
+    // MethodAccessException. Equals(R, IEqualityComparer) / CompareTo(R, IComparer) are emitted at the record
+    // type's accessibility (public), not the private representation's.
+    let private issue17773Lib =
+        FSharp """
+namespace Issue17773.Lib
+type R = private { X: int }
+module Make =
+    let r v : R = { X = v }
+"""
+        |> withName "Issue17773Lib"
+        |> asLibrary
+
+    [<Fact>]
+    let ``Private-constructor record equality and comparison work across assemblies (issue 17773)`` () =
+        FSharp """
+module Consumer
+open Issue17773.Lib
+open System.Collections
+[<EntryPoint>]
+let main _ =
+    let a = Make.r 1
+    let b = Make.r 1
+    let c = Make.r 2
+    let eqWithComparer = (a :> IStructuralEquatable).Equals(b, StructuralComparisons.StructuralEqualityComparer)
+    let cmpWithComparer = (a :> IStructuralComparable).CompareTo(c, StructuralComparisons.StructuralComparer)
+    if a = b && eqWithComparer && cmpWithComparer < 0 && compare a c < 0 then 0 else 1
+"""
+        |> withReferences [issue17773Lib]
+        |> asExe
+        |> compileAndRun
+        |> shouldSucceed


### PR DESCRIPTION
Fixes #17773

A record with a private constructor, equated or compared from another assembly, threw
`MethodAccessException` at runtime (a regression first seen in SDK 8.0.4) — the failing member was
`Equals(_, IEqualityComparer)`. On current main the generated structural `Equals`/`CompareTo` members
are emitted at the record type's accessibility, so this no longer reproduces; the change locks that in
with a cross-assembly regression test.
