### PR TITLE
Add ResetCompilerGeneratedNameState to compiler-generated name generators

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -139,6 +139,7 @@
 * Debug: fix if and match condition sequence points ([PR #19932](https://github.com/dotnet/fsharp/pull/19932))
 * Checker: recover on checking language version ([PR ##19970](https://github.com/dotnet/fsharp/pull/19970))
 * Implied argument names for function-to-delegate coercions now fall back to the delegate's `Invoke` parameter names when the function has no recoverable names (e.g. a partial application like `System.Func<int, int>((+) 1)`), instead of synthetic `delegateArg0`, `delegateArg1`, … names. ([PR #20001](https://github.com/dotnet/fsharp/pull/20001))
+* Add internal `ResetCompilerGeneratedNameState` to `CompilerGlobalState` name generators so warm-checker re-compilation can produce fresh-process-identical generated names. ([PR #20017](https://github.com/dotnet/fsharp/pull/20017))
 
 ### Improved
 

--- a/src/Compiler/TypedTree/CompilerGlobalState.fs
+++ b/src/Compiler/TypedTree/CompilerGlobalState.fs
@@ -45,6 +45,11 @@ type NiceNameGenerator() =
         let count = incrementBucket basicName scopeFileIndex
         mkName basicName m count
 
+    /// Reset the per-(basicName, file) occurrence counters so a subsequent codegen run assigns the
+    /// same compiler-generated occurrence names a fresh process would. Callers must ensure no
+    /// concurrent codegen is using this generator when resetting.
+    member _.ResetCompilerGeneratedNameState() = basicNameCounts.Clear()
+
 /// Generates compiler-generated names marked up with a source code location, but if given the same unique value then
 /// return precisely the same name. Each name generated also includes the StartLine number of the range passed in
 /// at the point of first generation.
@@ -60,6 +65,12 @@ type StableNiceNameGenerator() =
         let basicName = GetBasicNameOfPossibleCompilerGeneratedName name
         let key = basicName, uniq
         niceNames.GetOrAddLazy(key, fun (basicName, _) -> innerGenerator.FreshCompilerGeneratedNameOfBasicName(basicName, m))
+
+    /// Reset the stable-name cache and inner occurrence counters, so both the cached stable names and
+    /// the underlying occurrence counters are cleared. See NiceNameGenerator.ResetCompilerGeneratedNameState.
+    member _.ResetCompilerGeneratedNameState() =
+        niceNames.Clear()
+        innerGenerator.ResetCompilerGeneratedNameState()
 
 [<Sealed>]
 type PerFileNamingScope internal (nng: NiceNameGenerator, fileIndex: int) =
@@ -85,6 +96,15 @@ type internal CompilerGlobalState () =
 
     member _.NewFileScope (fileRange: range) =
         PerFileNamingScope(globalNng, fileRange.FileIndex)
+
+    /// Reset all compiler-generated-name occurrence counters on this state, so successive in-process
+    /// codegen runs over the same source produce identical generated names (a fresh-process layout).
+    /// Callers must ensure no compilation is concurrently generating names (quiescence). Needed by
+    /// Edit-and-Continue style scenarios that re-emit from a warm checker.
+    member _.ResetCompilerGeneratedNameState() =
+        globalNng.ResetCompilerGeneratedNameState()
+        globalStableNameGenerator.ResetCompilerGeneratedNameState()
+        ilxgenGlobalNng.ResetCompilerGeneratedNameState()
 
 /// Unique name generator for stamps attached to lambdas and object expressions
 type Unique = int64

--- a/src/Compiler/TypedTree/CompilerGlobalState.fsi
+++ b/src/Compiler/TypedTree/CompilerGlobalState.fsi
@@ -18,6 +18,11 @@ type NiceNameGenerator =
     new: unit -> NiceNameGenerator
     member FreshCompilerGeneratedName: name: string * m: range -> string
 
+    /// Reset the per-(basicName, file) occurrence counters so a subsequent codegen run assigns the
+    /// same compiler-generated occurrence names a fresh process would. Callers must ensure no
+    /// concurrent codegen is using this generator when resetting.
+    member ResetCompilerGeneratedNameState: unit -> unit
+
 /// Generates compiler-generated names marked up with a source code location, but if given the same unique value then
 /// return precisely the same name. Each name generated also includes the StartLine number of the range passed in
 /// at the point of first generation.
@@ -28,6 +33,10 @@ type StableNiceNameGenerator =
 
     new: unit -> StableNiceNameGenerator
     member GetUniqueCompilerGeneratedName: name: string * m: range * uniq: int64 -> string
+
+    /// Reset the stable-name cache and inner occurrence counters, so both the cached stable names and
+    /// the underlying occurrence counters are cleared. See NiceNameGenerator.ResetCompilerGeneratedNameState.
+    member ResetCompilerGeneratedNameState: unit -> unit
 
 /// A compiler-generated-name allocation scope bound to a single ImplFile being optimized.
 /// Instances can only be obtained from CompilerGlobalState.NewFileScope so a call site can't
@@ -57,6 +66,12 @@ type internal CompilerGlobalState =
     /// through the returned scope are bucketed by that file's FileIndex, guaranteeing determinism
     /// under parallel optimization. See https://github.com/dotnet/fsharp/issues/19732.
     member NewFileScope: fileRange: range -> PerFileNamingScope
+
+    /// Reset all compiler-generated-name occurrence counters on this state, so successive in-process
+    /// codegen runs over the same source produce identical generated names (a fresh-process layout).
+    /// Callers must ensure no compilation is concurrently generating names (quiescence). Needed by
+    /// Edit-and-Continue style scenarios that re-emit from a warm checker.
+    member ResetCompilerGeneratedNameState: unit -> unit
 
 type Unique = int64
 

--- a/tests/FSharp.Compiler.Service.Tests/CompilerGlobalStateTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/CompilerGlobalStateTests.fs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+module FSharp.Compiler.Service.Tests.CompilerGlobalStateTests
+
+open FSharp.Compiler.CompilerGlobalState
+open FSharp.Compiler.Text.Range
+open FSharp.Test.Assert
+open Xunit
+
+[<Fact>]
+let ``NiceNameGenerator drifts across calls and ResetCompilerGeneratedNameState restores a fresh-process layout`` () =
+    let nng = NiceNameGenerator()
+    let r = rangeN "niceNameGenerator.fs" 10
+
+    // First batch: occurrence counters start from zero, so names drift f@10, f@10-1, f@10-2.
+    let batch1 = [ for _ in 1 .. 3 -> nng.FreshCompilerGeneratedName("f", r) ]
+    batch1 |> shouldEqual [ "f@10"; "f@10-1"; "f@10-2" ]
+
+    // Without a reset, further calls keep drifting from where the counters left off.
+    let keepsDriftingWithoutReset = [ for _ in 1 .. 2 -> nng.FreshCompilerGeneratedName("f", r) ]
+    keepsDriftingWithoutReset |> shouldEqual [ "f@10-3"; "f@10-4" ]
+
+    // Resetting clears the occurrence counters, so a subsequent run reproduces the very first batch.
+    nng.ResetCompilerGeneratedNameState()
+    let batch2 = [ for _ in 1 .. 3 -> nng.FreshCompilerGeneratedName("f", r) ]
+    batch2 |> shouldEqual batch1
+
+[<Fact>]
+let ``StableNiceNameGenerator caches by uniq and ResetCompilerGeneratedNameState clears both the cache and the counters`` () =
+    let gen = StableNiceNameGenerator()
+    let r = rangeN "stableNiceNameGenerator.fs" 20
+
+    // First occurrence of "h" for uniq 1.
+    let first = gen.GetUniqueCompilerGeneratedName("h", r, 1L)
+    first |> shouldEqual "h@20"
+
+    // A different uniq for the same basic name advances the shared occurrence counter.
+    let second = gen.GetUniqueCompilerGeneratedName("h", r, 2L)
+    second |> shouldEqual "h@20-1"
+
+    // Re-querying uniq 1 must return the cached name, not a recomputed (drifted) one, even though
+    // the shared occurrence counter for "h" has since advanced to produce `second`.
+    let cachedAgain = gen.GetUniqueCompilerGeneratedName("h", r, 1L)
+    cachedAgain |> shouldEqual first
+
+    gen.ResetCompilerGeneratedNameState()
+
+    // Replaying the exact same sequence of calls after a reset reproduces the exact same names
+    // ("h@20" then "h@20-1"), because both the stable-name cache and the shared occurrence
+    // counter were cleared: a fresh call for uniq 1 is once again the first-ever occurrence.
+    let afterResetForUniq1 = gen.GetUniqueCompilerGeneratedName("h", r, 1L)
+    afterResetForUniq1 |> shouldEqual first
+
+    let afterResetForUniq2 = gen.GetUniqueCompilerGeneratedName("h", r, 2L)
+    afterResetForUniq2 |> shouldEqual second
+
+    // The cache is fully functional again after reset: re-querying uniq 1 still returns the
+    // cached (post-reset) name rather than drifting further.
+    let cachedAgainAfterReset = gen.GetUniqueCompilerGeneratedName("h", r, 1L)
+    cachedAgainAfterReset |> shouldEqual afterResetForUniq1
+
+    // Prove the stable-name CACHE itself was cleared, not just the inner counters: after another
+    // reset, the same (name, uniq) key queried with a DIFFERENT range must be recomputed from the
+    // new range ("h@99"). A stale cache entry would instead return the pre-reset "h@20".
+    gen.ResetCompilerGeneratedNameState()
+    let differentRange = rangeN "stableNiceNameGenerator.fs" 99
+    let recomputedForUniq1 = gen.GetUniqueCompilerGeneratedName("h", differentRange, 1L)
+    recomputedForUniq1 |> shouldEqual "h@99"
+
+[<Fact>]
+let ``CompilerGlobalState.ResetCompilerGeneratedNameState resets all three generators together`` () =
+    let state = CompilerGlobalState()
+    let r = rangeN "compilerGlobalState.fs" 30
+
+    let niceName1 = state.NiceNameGenerator.FreshCompilerGeneratedName("f", r)
+    let ilxName1 = state.IlxGenNiceNameGenerator.FreshCompilerGeneratedName("g", r)
+    let stableName1 = state.StableNameGenerator.GetUniqueCompilerGeneratedName("h", r, 1L)
+
+    // Drift each generator away from its first-occurrence name before resetting.
+    state.NiceNameGenerator.FreshCompilerGeneratedName("f", r) |> ignore
+    state.IlxGenNiceNameGenerator.FreshCompilerGeneratedName("g", r) |> ignore
+    state.StableNameGenerator.GetUniqueCompilerGeneratedName("h", r, 2L) |> ignore
+
+    state.ResetCompilerGeneratedNameState()
+
+    let niceName2 = state.NiceNameGenerator.FreshCompilerGeneratedName("f", r)
+    let ilxName2 = state.IlxGenNiceNameGenerator.FreshCompilerGeneratedName("g", r)
+    // Replaying the same first call (uniq 1) after the aggregate reset reproduces the original
+    // stable name, confirming the reset reached the StableNameGenerator too. (StableNiceNameGenerator's
+    // own tests separately confirm that the reset actually clears its cache, rather than merely
+    // resetting the shared occurrence counter.)
+    let stableName2 = state.StableNameGenerator.GetUniqueCompilerGeneratedName("h", r, 1L)
+
+    niceName2 |> shouldEqual niceName1
+    ilxName2 |> shouldEqual ilxName1
+    stableName2 |> shouldEqual stableName1

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="XmlDocTests.fs" />
     <Compile Include="XmlDocTests - Units of Measure.fs" />
     <Compile Include="RangeTests.fs" />
+    <Compile Include="CompilerGlobalStateTests.fs" />
     <Compile Include="TooltipTests.fs" />
     <Compile Include="TokenizerTests.fs" />
     <Compile Include="QuickParseTests.fs" />


### PR DESCRIPTION
## Summary

Adds an internal `ResetCompilerGeneratedNameState` method to the compiler-generated name generators (`NiceNameGenerator`, `StableNiceNameGenerator`, and an aggregate on `CompilerGlobalState`) that restores the fresh-process generated-name layout.

## Why

Compiler-generated occurrence names (`name@line-N`) are allocated from counters on `CompilerGlobalState` that accumulate across compilations. When a warm checker re-emits the same project in-process, an unchanged closure gets a different occurrence suffix than the previous emit (for example `data@10` in one emit and `data@10-3` in the next). Consumers that need to align generated names across successive compilations then cannot match them.

The concrete consumer is F# hot reload (#19941): Edit-and-Continue delta emission from a warm checker needs each emit to lay out generated names exactly as a fresh process would, otherwise unchanged closures appear renamed and the delta mapping fails. Measured in the hot reload spike: a one-method edit produced an ambiguous synthesized-type mapping purely because of this drift.

There is intentionally no in-tree caller in this PR; the caller lands with the hot reload emit path in #19941. This PR carries the primitive plus tests so it can be reviewed on its own.

## What

- `NiceNameGenerator.ResetCompilerGeneratedNameState()` clears the per-`(name, file)` occurrence counters.
- `StableNiceNameGenerator.ResetCompilerGeneratedNameState()` clears the cached stable names and the inner generator's counters.
- `CompilerGlobalState.ResetCompilerGeneratedNameState()` resets all three generator fields.
- Callers must ensure no compilation is concurrently generating names (documented on the aggregate).

## Tests

`CompilerGlobalStateTests.fs` (new): proves names drift across repeated generation without reset; that replaying the same call sequence after reset reproduces the exact original names; that the stable-name cache itself is cleared (same `(name, uniq)` re-queried with a different range is recomputed, not served stale); and that the aggregate reset reaches all three generators.

Verified locally: `FSharp.Compiler.Service.fsproj` builds clean, the new test class passes 3/3, `fantomas --check` clean.

## Sequencing

This PR is part of splitting the F# hot reload work (#19941) into small, independently reviewable PRs. The planned order:

1. **Wave 1 (independent of each other, no cross dependencies):** #20017 (generated-name counter reset), #20018 (EnC CustomDebugInformation codec and method CDI emission), #20019 (EnC metadata delta writer), plus two upcoming slices: stable synthesized-name replay and the typed-tree differ with rude-edit classification.
2. **Wave 2:** baseline reading and recorded CDI state (depends on #20018 and the naming slice).
3. **Wave 3:** the delta emitter and symbol matcher.
4. **Wave 4:** the hot reload session, FCS surface, and the `--test:HotReloadDeltas` capture hook (#19941 in its final, much smaller form).
5. **Last, explicitly experimental:** #20031 (the flag-gated in-process compile perf path).

Each slice is rebased on current main, carries its own tests, and is flag-off zero-cost. Everything stays draft until reviewed in order.
Role in the train: warm-checker re-emission must produce fresh-process generated names; the hot reload session resets name counters before each in-process delta compile.

