### PR TITLE
Migrate devdiv/dotnet-core-internal-tooling to WIF service connection

### DIFF
--- a/eng/restore-internal-tools.yml
+++ b/eng/restore-internal-tools.yml
@@ -1,7 +1,9 @@
 steps:
   - task: NuGetAuthenticate@1
+    displayName: Authenticate devdiv/dotnet-core-internal-tooling feed (WIF)
     inputs:
-      nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
+      azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+      feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
       forceReinstallCredentialProvider: true
 
   - script: $(Build.SourcesDirectory)\eng\RestoreInternal.cmd


### PR DESCRIPTION
## Summary

Replace PAT-backed externalnugetfeed SC with WIF-based azureDevOpsServiceConnection for the devdiv/dotnet-core-internal-tooling NuGet feed.

## Motivation

Part of PAT disable policy migration ([dnceng WI 10124](https://dnceng.visualstudio.com/internal/_workitems/edit/10124)).

## Changes

- **Before:** nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling' (PAT-based ExternalNuGetFeed SC)
- **After:** azureDevOpsServiceConnection + feedUrl (WIF SC backed by Entra app)

## New Service Connection

- **Name:** dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
- **Type:** workloadidentityuser
- **Target:** https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json

Same pattern as the devdiv/engineering feed migration (dotnet/roslyn#83918, dotnet/dotnet#6902).
