### PR TITLE
Bump FCSMinorVersion to 13

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <!-- -->
     <!-- FSharp.Compiler.Service version -->
     <FCSMajorVersion>43</FCSMajorVersion>
-    <FCSMinorVersion>12</FCSMinorVersion>
+    <FCSMinorVersion>13</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>
     <FSharpCompilerServicePackageVersion>$(FCSMajorVersion).$(FCSMinorVersion).$(FCSBuildVersion)</FSharpCompilerServicePackageVersion>


### PR DESCRIPTION
Bump FCS minor to 13 so main ships FSharp.Compiler.Service `43.13.x`.

Companion to the .NET 10.0.400 servicing line, which takes `43.12.400`. Keeps main above the servicing branch (and above the latest published `43.12.204`).
