### PR TITLE
Parser: recover on missing 'when' conditions

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -113,8 +113,8 @@
 * Fix signature conformance: overloaded member with unit parameter `M(())` now matches sig `member M: unit -> unit`. ([Issue #19596](https://github.com/dotnet/fsharp/issues/19596), [PR #19615](https://github.com/dotnet/fsharp/pull/19615))
 * Fix `--quiet` not suppressing NuGet restore output on stdout in F# Interactive ([Issue #18086](https://github.com/dotnet/fsharp/issues/18086))
 * Reference assembly MVIDs are now deterministic across compiler invocations. Previously, `--refout` / `<ProduceReferenceAssembly>true</ProduceReferenceAssembly>` produced a different MVID every build because the implied signature hash used .NET's randomized `String.GetHashCode()`. ([Issue #19751](https://github.com/dotnet/fsharp/issues/19751), [PR #19801](https://github.com/dotnet/fsharp/pull/19801))
-* Parser: recover on unfinished if and binary expressions
-([PR #19724](https://github.com/dotnet/fsharp/pull/19724))
+* Parser: recover on unfinished if and binary expressions ([PR #19724](https://github.com/dotnet/fsharp/pull/19724))
+* Parser: recover on missing 'when' conditions ([PR ##20071](https://github.com/dotnet/fsharp/pull/#20071))
 * Fix `SynExpr.shouldBeParenthesizedInContext` to report parentheses as required around `SynExpr.Sequential` expressions used as record or anonymous-record field values, so the IDE "remove unnecessary parentheses" analyzer no longer breaks code like `{| A = ((); B = 3) |}`. ([Issue #17826](https://github.com/dotnet/fsharp/issues/17826), [PR #19850](https://github.com/dotnet/fsharp/pull/19850))
 * Fix semantic classification of `IDisposable` and other interface types in type-occurrence positions being incorrectly classified as `DisposableType` instead of `Interface`. ([Issue #16268](https://github.com/dotnet/fsharp/issues/16268), [PR #19809](https://github.com/dotnet/fsharp/pull/19809))
 * Fix missing semantic classification on second and later type qualifiers in nested copy-and-update expressions like `{ p with Person.Info.X = 1; Person.Info.Y = 2 }`. ([Issue #17428](https://github.com/dotnet/fsharp/issues/17428), [PR #19878](https://github.com/dotnet/fsharp/pull/19878))

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1258,3 +1258,33 @@ let mkAbstractMember
     [
         SynMemberDefn.AbstractSlot(valSpfn, mkFlags (getSetAdjuster arity), mWhole, trivia)
     ]
+
+let mkMatchClauses patternAndGuard patternResult (mNextBar: range option) nextClauses mLastOuter =
+    let (pat: SynPat), guard = patternAndGuard
+    let (mArrow: range option), (resultExpr: SynExpr) = patternResult
+    fun mBar ->
+        let m = unionRanges resultExpr.Range pat.Range
+        let clause = SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = mArrow; BarRange = mBar })
+
+        let clauses, mLast =
+            match nextClauses with
+            | Some patternClauses ->
+                let clauses, mLast = patternClauses mNextBar
+                clause :: clauses, mLast
+
+            | _ -> [clause], resultExpr.Range
+
+        clauses, mLastOuter |> Option.defaultValue mLast
+
+let mkMatchClausesRecoverMissingResult (patternAndGuard: SynPat * SynExpr option) exprDebugString (mExpr: range option) (mNextBar: range option) nextClauses mLastOuter =
+    let pat, guard = patternAndGuard
+    let mBeforeResult =
+        match mExpr with
+        | Some m -> m
+        | _ ->
+
+        match guard with
+        | Some expr -> expr.Range
+        | _ -> pat.Range
+    let patternResult = None, arbExpr (exprDebugString, mBeforeResult.EndRange)
+    mkMatchClauses patternAndGuard patternResult (mNextBar: range option) nextClauses mLastOuter

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -1262,9 +1262,12 @@ let mkAbstractMember
 let mkMatchClauses patternAndGuard patternResult (mNextBar: range option) nextClauses mLastOuter =
     let (pat: SynPat), guard = patternAndGuard
     let (mArrow: range option), (resultExpr: SynExpr) = patternResult
+
     fun mBar ->
         let m = unionRanges resultExpr.Range pat.Range
-        let clause = SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = mArrow; BarRange = mBar })
+
+        let clause =
+            SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = mArrow; BarRange = mBar })
 
         let clauses, mLast =
             match nextClauses with
@@ -1272,19 +1275,28 @@ let mkMatchClauses patternAndGuard patternResult (mNextBar: range option) nextCl
                 let clauses, mLast = patternClauses mNextBar
                 clause :: clauses, mLast
 
-            | _ -> [clause], resultExpr.Range
+            | _ -> [ clause ], resultExpr.Range
 
         clauses, mLastOuter |> Option.defaultValue mLast
 
-let mkMatchClausesRecoverMissingResult (patternAndGuard: SynPat * SynExpr option) exprDebugString (mExpr: range option) (mNextBar: range option) nextClauses mLastOuter =
+let mkMatchClausesRecoverMissingResult
+    (patternAndGuard: SynPat * SynExpr option)
+    exprDebugString
+    (mExpr: range option)
+    (mNextBar: range option)
+    nextClauses
+    mLastOuter
+    =
     let pat, guard = patternAndGuard
+
     let mBeforeResult =
         match mExpr with
         | Some m -> m
         | _ ->
 
-        match guard with
-        | Some expr -> expr.Range
-        | _ -> pat.Range
+            match guard with
+            | Some expr -> expr.Range
+            | _ -> pat.Range
+
     let patternResult = None, arbExpr (exprDebugString, mBeforeResult.EndRange)
     mkMatchClauses patternAndGuard patternResult (mNextBar: range option) nextClauses mLastOuter

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -298,3 +298,20 @@ val mkAbstractMember:
         typeWithConstraints: SynType * SynValInfo ->
             accessors: range option * (SynMemberKind * GetSetKeywords option * SynAccess option * SynAccess option) ->
                 SynMemberDefn list
+
+val mkMatchClauses:
+    patternAndGuard: SynPat * SynExpr option ->
+    patternResult: range option * SynExpr ->
+    mNextBar: range option ->
+    nextClauses: (range option -> SynMatchClause list * range) option ->
+    mLastOuter: range option ->
+        (range option -> SynMatchClause list * range)
+
+val mkMatchClausesRecoverMissingResult:
+    patternAndGuard: SynPat * SynExpr option ->
+    exprDebugString: string ->
+    mExpr: range option ->
+    mNextBar: range option ->
+    nextClauses: (range option -> SynMatchClause list * range) option ->
+    mLastOuter: range option ->
+        (range option -> SynMatchClause list * range)

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -301,17 +301,17 @@ val mkAbstractMember:
 
 val mkMatchClauses:
     patternAndGuard: SynPat * SynExpr option ->
-    patternResult: range option * SynExpr ->
-    mNextBar: range option ->
-    nextClauses: (range option -> SynMatchClause list * range) option ->
-    mLastOuter: range option ->
-        (range option -> SynMatchClause list * range)
+        patternResult: range option * SynExpr ->
+            mNextBar: range option ->
+            nextClauses: (range option -> SynMatchClause list * range) option ->
+            mLastOuter: range option ->
+                (range option -> SynMatchClause list * range)
 
 val mkMatchClausesRecoverMissingResult:
     patternAndGuard: SynPat * SynExpr option ->
-    exprDebugString: string ->
-    mExpr: range option ->
-    mNextBar: range option ->
-    nextClauses: (range option -> SynMatchClause list * range) option ->
-    mLastOuter: range option ->
-        (range option -> SynMatchClause list * range)
+        exprDebugString: string ->
+        mExpr: range option ->
+        mNextBar: range option ->
+        nextClauses: (range option -> SynMatchClause list * range) option ->
+        mLastOuter: range option ->
+            (range option -> SynMatchClause list * range)

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -164,7 +164,7 @@ let parse_error_rich = Some(fun (ctxt: ParseErrorContext<_>) ->
 %type <SynTypeDefnSig list> tyconSpfnList
 %type <SynArgPats * Range> atomicPatsOrNamePatPairs
 %type <SynPat list> atomicPatterns
-%type <Range * SynExpr> patternResult
+%type <range option * SynExpr> patternResult
 %type <SynExpr> declExpr
 %type <SynExpr> minusExpr
 %type <SynExpr> appExpr
@@ -5072,66 +5072,64 @@ patternAndGuard:
 
 patternClauses:
   | patternAndGuard patternResult %prec prec_pat_pat_action
-     { let pat, guard = $1
-       let mArrow, resultExpr = $2
-       let mLast = resultExpr.Range
-       let m = unionRanges resultExpr.Range pat.Range
-       fun mBar ->
-           [SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar })], mLast }
+     { mkMatchClauses $1 $2 None None None }
 
   | patternAndGuard patternResult barCanBeRightBeforeNull patternClauses
-     { let pat, guard = $1
-       let mArrow, resultExpr = $2
-       let mNextBar = rhs parseState 3 |> Some
-       let clauses, mLast = $4 mNextBar
-       let m = unionRanges resultExpr.Range pat.Range
-       fun mBar ->
-           (SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar }) :: clauses), mLast }
+     { let mNextBar = rhs parseState 3 |> Some
+       mkMatchClauses $1 $2 mNextBar (Some $4) None }
 
   | patternAndGuard patternResult BAR barCanBeRightBeforeNull patternClauses
-     { let pat, guard = $1
-       let mArrow, resultExpr = $2
+     { let mNextBar = rhs parseState 3 |> Some
        let mBar1 = rhs parseState 3
        let mBar2 = rhs parseState 4
        reportParseErrorAt mBar2 (FSComp.SR.parsExpectingPattern ())
-       let clauses, mLast = Some mBar1 |> $5
-       let clauses = addEmptyMatchClause mBar1 mBar2 clauses
+       let patternClauses =
+           fun mNextBar ->
+               let clauses, mLast = Some mBar1 |> $5
+               let clauses = addEmptyMatchClause mBar1 mBar2 clauses
+               clauses, mLast
 
-       fun mBar ->
-           let m = unionRanges resultExpr.Range pat.Range
-           let trivia = { ArrowRange = Some mArrow; BarRange = mBar }
-           SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, trivia) :: clauses, mLast }
+       mkMatchClauses $1 $2 mNextBar (Some patternClauses) None }
 
   | patternAndGuard error barCanBeRightBeforeNull patternClauses
-     { let pat, guard = $1
-       let mNextBar = rhs parseState 3 |> Some
-       let clauses, mLast = $4 mNextBar
-       let patm = pat.Range
-       let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
-       fun _mBar ->
-           (SynMatchClause(pat, guard, arbExpr ("patternClauses1", m.EndRange), m, DebugPointAtTarget.Yes, SynMatchClauseTrivia.Zero) :: clauses), mLast }
+     { let mNextBar = rhs parseState 3 |> Some
+       mkMatchClausesRecoverMissingResult $1 "patternClauses1" None mNextBar (Some $4) None }
 
   | patternAndGuard patternResult barCanBeRightBeforeNull recover
-     { let pat, guard = $1
-       let mArrow, resultExpr = $2
-       let mLast = rhs parseState 3
-       let m = unionRanges resultExpr.Range pat.Range
-       fun mBar ->
-           [SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar })], mLast }
+     { let mLast = rhs parseState 3 |> Some
+       mkMatchClauses $1 $2 None None mLast }
 
   | patternAndGuard patternResult recover
-     { let pat, guard = $1
-       let mArrow, resultExpr = $2
-       let m = unionRanges resultExpr.Range pat.Range
-       fun mBar ->
-           [SynMatchClause(pat, guard, resultExpr, m, DebugPointAtTarget.Yes, { ArrowRange = Some mArrow; BarRange = mBar })], m }
+     { mkMatchClauses $1 $2 None None None }
 
   | patternAndGuard recover
-     { let pat, guard = $1
-       let patm = pat.Range
-       let m = guard |> Option.map (fun e -> unionRanges patm e.Range) |> Option.defaultValue patm
-       fun mBar ->
-           [SynMatchClause(pat, guard, arbExpr ("patternClauses2", m.EndRange), m, DebugPointAtTarget.Yes, { ArrowRange = None; BarRange = mBar })], m }
+     { mkMatchClausesRecoverMissingResult $1 "patternClauses2" None None None None }
+
+  | parenPattern WHEN patternResult %prec prec_recover
+     { let patternAndGuard = $1, None
+       let mWhen = rhs parseState 2
+       reportParseErrorAt mWhen (FSComp.SR.parsExpectingExpression ())
+       mkMatchClauses patternAndGuard $3 None None None }
+
+  | parenPattern WHEN %prec prec_recover
+     { let patternAndGuard = $1, None
+       let mWhen = rhs parseState 2
+       reportParseErrorAt mWhen (FSComp.SR.parsExpectingExpression ())
+       mkMatchClausesRecoverMissingResult patternAndGuard "patternClauses3" (Some mWhen) None None None }
+
+  | parenPattern WHEN barCanBeRightBeforeNull patternClauses %prec prec_recover
+     { let patternAndGuard = $1, None
+       let mWhen = rhs parseState 2
+       reportParseErrorAt mWhen (FSComp.SR.parsExpectingExpression ())
+       let mNextBar = rhs parseState 3 |> Some
+       mkMatchClausesRecoverMissingResult patternAndGuard "patternClauses4" (Some mWhen) mNextBar (Some $4) None }
+
+  | parenPattern WHEN barCanBeRightBeforeNull %prec prec_recover
+     { let patternAndGuard = $1, None
+       let mWhen = rhs parseState 2
+       reportParseErrorAt mWhen (FSComp.SR.parsExpectingExpression ())
+       let mLast = rhs parseState 3 |> Some
+       mkMatchClausesRecoverMissingResult patternAndGuard "patternClauses5" (Some mWhen) None None mLast }
 
 patternGuard:
   | WHEN declExpr
@@ -5144,7 +5142,7 @@ patternResult:
   | RARROW typedSequentialExprBlockR
       { let mArrow = rhs parseState 1
         let expr = $2 mArrow
-        mArrow, expr }
+        Some mArrow, expr }
 
 ifExprCases:
   | ifExprThen ifExprElifs

--- a/tests/service/data/SyntaxTree/Expression/Match - When 01.fs
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+match () with
+| _ when true -> ()

--- a/tests/service/data/SyntaxTree/Expression/Match - When 01.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 01.fs.bsl
@@ -1,0 +1,21 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Match - When 01.fs", false, QualifiedNameOfFile Module,
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Wild (4,2--4,3), Some (Const (Bool true, (4,9--4,13))),
+                     Const (Unit, (4,17--4,19)), (4,2--4,19), Yes,
+                     { ArrowRange = Some (4,14--4,16)
+                       BarRange = Some (4,0--4,1) })], (3,0--4,19),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--4,19))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,19), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))

--- a/tests/service/data/SyntaxTree/Expression/Match - When 02.fs
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+match () with
+| _ when -> ()

--- a/tests/service/data/SyntaxTree/Expression/Match - When 02.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 02.fs.bsl
@@ -1,0 +1,22 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Match - When 02.fs", false, QualifiedNameOfFile Module,
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Wild (4,2--4,3), None, Const (Unit, (4,12--4,14)),
+                     (4,2--4,14), Yes, { ArrowRange = Some (4,9--4,11)
+                                         BarRange = Some (4,0--4,1) })],
+                 (3,0--4,14), { MatchKeyword = (3,0--3,5)
+                                WithKeyword = (3,9--3,13) }), (3,0--4,14))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--4,14), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(4,4)-(4,8) parse error Expecting expression

--- a/tests/service/data/SyntaxTree/Expression/Match - When 03.fs
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 03.fs
@@ -1,0 +1,5 @@
+module Module
+
+match () with
+| a when
+| b -> ()

--- a/tests/service/data/SyntaxTree/Expression/Match - When 03.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 03.fs.bsl
@@ -1,0 +1,28 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Match - When 03.fs", false, QualifiedNameOfFile Module,
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Named (SynIdent (a, None), false, None, (4,2--4,3)), None,
+                     ArbitraryAfterError ("patternClauses4", (4,8--4,8)),
+                     (4,2--4,8), Yes, { ArrowRange = None
+                                        BarRange = Some (4,0--4,1) });
+                  SynMatchClause
+                    (Named (SynIdent (b, None), false, None, (5,2--5,3)), None,
+                     Const (Unit, (5,7--5,9)), (5,2--5,9), Yes,
+                     { ArrowRange = Some (5,4--5,6)
+                       BarRange = Some (5,0--5,1) })], (3,0--5,9),
+                 { MatchKeyword = (3,0--3,5)
+                   WithKeyword = (3,9--3,13) }), (3,0--5,9))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--5,9), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(4,4)-(4,8) parse error Expecting expression

--- a/tests/service/data/SyntaxTree/Expression/Match - When 04.fs
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 04.fs
@@ -1,0 +1,7 @@
+module Module
+
+match () with
+| a when
+|
+
+()

--- a/tests/service/data/SyntaxTree/Expression/Match - When 04.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Match - When 04.fs.bsl
@@ -1,0 +1,24 @@
+ImplFile
+  (ParsedImplFileInput
+     ("/root/Expression/Match - When 04.fs", false, QualifiedNameOfFile Module,
+      [],
+      [SynModuleOrNamespace
+         ([Module], false, NamedModule,
+          [Expr
+             (Match
+                (Yes (3,0--3,13), Const (Unit, (3,6--3,8)),
+                 [SynMatchClause
+                    (Named (SynIdent (a, None), false, None, (4,2--4,3)), None,
+                     ArbitraryAfterError ("patternClauses5", (4,8--4,8)),
+                     (4,2--4,8), Yes, { ArrowRange = None
+                                        BarRange = Some (4,0--4,1) })],
+                 (3,0--5,1), { MatchKeyword = (3,0--3,5)
+                               WithKeyword = (3,9--3,13) }), (3,0--5,1));
+           Expr (Const (Unit, (7,0--7,2)), (7,0--7,2))],
+          PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
+          (1,0--7,2), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
+      { ConditionalDirectives = []
+        WarnDirectives = []
+        CodeComments = [] }, set []))
+
+(4,4)-(4,8) parse error Expecting expression

--- a/tests/service/data/SyntaxTree/Expression/Try - With 09.fs.bsl
+++ b/tests/service/data/SyntaxTree/Expression/Try - With 09.fs.bsl
@@ -12,15 +12,21 @@ ImplFile
                     (None, SynValInfo ([], SynArgInfo ([], false, None)), None),
                   Wild (3,4--3,5), None,
                   TryWith
-                    (Const (Int32 1, (4,8--4,9)), [], (4,4--5,8), Yes (4,4--4,7),
-                     Yes (5,4--5,8), { TryKeyword = (4,4--4,7)
-                                       TryToWithRange = (4,4--5,8)
-                                       WithKeyword = (5,4--5,8)
-                                       WithToEndRange = (5,4--5,8) }),
-                  (3,4--3,5), NoneAtLet, { LeadingKeyword = Let (3,0--3,3)
-                                           InlineKeyword = None
-                                           EqualsRange = Some (3,6--3,7) })],
-              (3,0--5,8), { InKeyword = None });
+                    (Const (Int32 1, (4,8--4,9)),
+                     [SynMatchClause
+                        (Wild (5,9--5,10), None,
+                         ArbitraryAfterError ("patternClauses3", (5,15--5,15)),
+                         (5,9--5,15), Yes, { ArrowRange = None
+                                             BarRange = None })], (4,4--5,15),
+                     Yes (4,4--4,7), Yes (5,4--5,8),
+                     { TryKeyword = (4,4--4,7)
+                       TryToWithRange = (4,4--5,8)
+                       WithKeyword = (5,4--5,8)
+                       WithToEndRange = (5,4--5,15) }), (3,4--3,5), NoneAtLet,
+                  { LeadingKeyword = Let (3,0--3,3)
+                    InlineKeyword = None
+                    EqualsRange = Some (3,6--3,7) })], (3,0--5,15),
+              { InKeyword = None });
            Expr (Const (Int32 3, (7,0--7,1)), (7,0--7,1))],
           PreXmlDoc ((1,0), FSharp.Compiler.Xml.XmlDocCollector), [], None,
           (1,0--7,1), { LeadingKeyword = Module (1,0--1,6) })], (true, true),
@@ -28,4 +34,4 @@ ImplFile
         WarnDirectives = []
         CodeComments = [] }, set []))
 
-(7,0)-(7,1) parse error Incomplete structured construct at or before this point in expression
+(5,11)-(5,15) parse error Expecting expression

--- a/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CompletionProviderTests.fs
@@ -2102,7 +2102,7 @@ match { A = 1; B = 2 } with
 | { f = () }
 """
 
-        VerifyCompletionList(fileContents, "| { f = ()", [ "A"; "B"; "C"; "D" ], [])
+        VerifyCompletionList(fileContents, "| { f = ()", [ "A"; "B" ], [ "C"; "D" ])
 
     [<Fact>]
     let ``issue #16260 [TO-BE-IMPROVED] operators are fumbling for now`` () =


### PR DESCRIPTION
Fixes parsing of missing `when` clause expressions, like the following:

```fsharp
match () with
| _ when -> ()
```

```fsharp
match () with
| a when
| b -> ()
```