### PR TITLE
Opt out of IntelliSense-ready deferral for the F# editor factory

### DIFF
--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -189,7 +189,7 @@ type internal FSharpSettingsFactory
 [<ProvideEditorExtension(typeof<FSharpEditorFactory>, ".fsx", 64)>]
 [<ProvideEditorExtension(typeof<FSharpEditorFactory>, ".ml", 64)>]
 [<ProvideEditorExtension(typeof<FSharpEditorFactory>, ".mli", 64)>]
-[<ProvideEditorFactory(typeof<FSharpEditorFactory>, 101s, CommonPhysicalViewAttributes = Constants.FSharpEditorFactoryPhysicalViewAttributes)>]
+[<ProvideEditorFactory(typeof<FSharpEditorFactory>, 101s, false, CommonPhysicalViewAttributes = Constants.FSharpEditorFactoryPhysicalViewAttributes)>]
 [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".fs")>]
 [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".fsi")>]
 [<ProvideLanguageExtension(typeof<FSharpLanguageService>, ".fsx")>]


### PR DESCRIPTION
`deferUntilIntellisenseIsReady` defaults to `true` for editor factories, so F# files wait for IntelliSense readiness before the editor opens even though `FSharpEditorFactory` doesn't use the DTE CodeModel — it creates a plain text view and IntelliSense loads asynchronously afterward. This sets `deferUntilIntellisenseIsReady` to `false` on the `ProvideEditorFactory` registration so F# files open without the wait.

Part of a cross-repo sweep flipping non-CodeModel editor factories to opt out of the deferral.

*Cowritten with Copilot (Claude Opus 4.8)*