### PR TITLE
Adopt ordered multi-caret markers in FCS tests (no behaviour change)

### DIFF
--- a/tests/FSharp.Compiler.Service.Tests/BreakpointLocationTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/BreakpointLocationTests.fs
@@ -5,53 +5,51 @@ open FSharp.Compiler.Text.Range
 open FSharp.Test.Assert
 open Xunit
 
-let assertBreakpointRange ((startLine, startCol), (endLine, endCol)) markedSource =
+let assertBreakpointRange markedSource =
     let context, parseResults = Checker.getParseResultsWithContext markedSource
     let breakpointRange = parseResults.ValidateBreakpointLocation(context.CaretPos).Value
-
-    let startPos = Position.mkPos startLine startCol
-    let endPod = Position.mkPos endLine endCol
-    let expectedRange = mkFileIndexRange breakpointRange.FileIndex startPos endPod
+    let selected = context.SelectedRange.Value
+    let expectedRange = mkFileIndexRange breakpointRange.FileIndex selected.Start selected.End
 
     breakpointRange |> shouldEqual expectedRange
 
 [<Fact>]
 let ``Let - Function - Body 01`` () =
-    assertBreakpointRange ((3, 4), (3, 5)) """
+    assertBreakpointRange """
 let f () =
-    1{caret}
+    {selstart}1{selend}
 """
 
 [<Fact>]
 let ``Seq 01`` () =
-    assertBreakpointRange ((3, 4), (3, 5)) """
+    assertBreakpointRange """
 do
-    1{caret}
+    {selstart}1{selend}
     2
 """
 
 [<Fact>]
 let ``Seq 02`` () =
-    assertBreakpointRange ((4, 4), (4, 5)) """
+    assertBreakpointRange """
 do
     1
-    2{caret}
+    {selstart}2{selend}
 """
 
 [<Fact>]
 let ``Lambda 01`` () =
-    assertBreakpointRange ((2, 27), (2, 35)) """
-[""] |> List.map (fun s -> s.Lenght{caret}) 
+    assertBreakpointRange """
+[""] |> List.map (fun s -> {selstart}s.Lenght{selend}) 
 """
 
 [<Fact>]
 let ``Dot lambda 01`` () =
-    assertBreakpointRange ((2, 17), (2, 25)) """
-[""] |> List.map _.Lenght{caret} 
+    assertBreakpointRange """
+[""] |> List.map {selstart}_.Lenght{selend} 
 """
 
 [<Fact>]
 let ``Dot lambda 02`` () =
-    assertBreakpointRange ((2, 17), (2, 36)) """
-[""] |> List.map _.ToString().Length{caret} 
+    assertBreakpointRange """
+[""] |> List.map {selstart}_.ToString().Length{selend} 
 """

--- a/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.Functions.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.Functions.fs
@@ -34,36 +34,20 @@ let test3 = fffff ggggg ggggg"""
 
     assertHasItemWithNames [ "fffff" ] info
 
-[<Theory>]
-[<InlineData("""let fffff x y = 1
+[<Fact>]
+let ``CurriedArguments.Regression`` () =
+    let sources =
+        SourceContext.extractOrderedMarkedSources
+            """let fffff x y = 1
 let ggggg  = 1
-let test1 = f{caret}ffff "a" ggggg
-let test2 = fffff 1 ggggg
-let test3 = fffff ggggg ggggg""", "fffff")>]
-[<InlineData("""let fffff x y = 1
-let ggggg  = 1
-let test1 = fffff "a" gg{caret}ggg
-let test2 = fffff 1 ggggg
-let test3 = fffff ggggg ggggg""", "ggggg")>]
-[<InlineData("""let fffff x y = 1
-let ggggg  = 1
-let test1 = fffff "a" ggggg
-let test2 = fffff 1 gg{caret}ggg
-let test3 = fffff ggggg ggggg""", "ggggg")>]
-[<InlineData("""let fffff x y = 1
-let ggggg  = 1
-let test1 = fffff "a" ggggg
-let test2 = fffff 1 ggggg
-let test3 = fffff gg{caret}ggg ggggg""", "ggggg")>]
-[<InlineData("""let fffff x y = 1
-let ggggg  = 1
-let test1 = fffff "a" ggggg
-let test2 = fffff 1 ggggg
-let test3 = fffff ggggg gg{caret}ggg""", "ggggg")>]
-let ``CurriedArguments.Regression`` (markedSource: string) (expected: string) =
-    let info = Checker.getCompletionInfo markedSource
+let test1 = f{caret1}ffff "a" gg{caret2}ggg
+let test2 = fffff 1 gg{caret3}ggg
+let test3 = fffff gg{caret4}ggg gg{caret5}ggg"""
 
-    assertHasItemWithNames [ expected ] info
+    List.iter2
+        (fun expected source -> assertHasItemWithNames [ expected ] (Checker.getCompletionInfo source))
+        [ "fffff"; "ggggg"; "ggggg"; "ggggg"; "ggggg" ]
+        sources
 
 [<Fact>]
 let ``StringFunctions`` () =

--- a/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.Generics.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.Generics.fs
@@ -48,24 +48,17 @@ type Foo() as this =
 
     assertHasItemWithNames [ "this" ] info
 
-[<Theory>]
-[<InlineData("""
+[<Fact>]
+let ``GenericType.Self.Bug69673_1.CtrlSpaceForThis`` () =
+    """
 type Base(o:obj) = class end
 type Foo() as this =
     inherit Base(this) // this
-    let o = th{caret}is // this ok
-    do this.Bar() // this ok, dotting ok
-    member this.Bar() = ()""")>]
-[<InlineData("""
-type Base(o:obj) = class end
-type Foo() as this =
-    inherit Base(this) // this
-    let o = this // this ok
-    do th{caret}is.Bar() // this ok, dotting ok
-    member this.Bar() = ()""")>]
-let ``GenericType.Self.Bug69673_1.CtrlSpaceForThis`` (markedSource: string) =
-    let info = Checker.getCompletionInfo markedSource
-    assertHasItemWithNames [ "this" ] info
+    let o = th{caret1}is // this ok
+    do th{caret2}is.Bar() // this ok, dotting ok
+    member this.Bar() = ()"""
+    |> SourceContext.extractOrderedMarkedSources
+    |> List.iter (fun source -> assertHasItemWithNames [ "this" ] (Checker.getCompletionInfo source))
 
 [<Fact>]
 let ``GenericType.Self.Bug69673_1.04`` () =

--- a/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.IndexingSlicing.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.IndexingSlicing.fs
@@ -59,26 +59,15 @@ let test1 = strs.[1].{caret}"""
 
     assertHasItemWithNames [ "Substring"; "GetHashCode" ] info
 
-[<Theory>]
-[<InlineData("""let string_of_int (x:int) = x.ToString()
+[<Fact>]
+let ``DotOff.ArraySliceNotation`` () =
+    """let string_of_int (x:int) = x.ToString()
 let strs = Array.init 10 string_of_int
-let test2 = strs.[1..].{caret}
-let test3 = strs.[..1].
-let test4 = strs.[1..1].""")>]
-[<InlineData("""let string_of_int (x:int) = x.ToString()
-let strs = Array.init 10 string_of_int
-let test2 = strs.[1..].
-let test3 = strs.[..1].{caret}
-let test4 = strs.[1..1].""")>]
-[<InlineData("""let string_of_int (x:int) = x.ToString()
-let strs = Array.init 10 string_of_int
-let test2 = strs.[1..].
-let test3 = strs.[..1].
-let test4 = strs.[1..1].{caret}""")>]
-let ``DotOff.ArraySliceNotation`` (source: string) =
-    let info = Checker.getCompletionInfo source
-
-    assertHasItemWithNames [ "Length" ] info
+let test2 = strs.[1..].{caret1}
+let test3 = strs.[..1].{caret2}
+let test4 = strs.[1..1].{caret3}"""
+    |> SourceContext.extractOrderedMarkedSources
+    |> List.iter (fun source -> assertHasItemWithNames [ "Length" ] (Checker.getCompletionInfo source))
 
 [<Fact>]
 let ``DotOff.DictionaryIndexer`` () =

--- a/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.PatternMatching.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Completion/CompletionTests.PatternMatching.fs
@@ -6,33 +6,12 @@ open Xunit
 
 [<Fact>]
 let ``TupledArgsInLambda.Completion.Bug312557_2`` () =
-    let assertOffersTupleArgs (markedSource: string) =
-        let info = Checker.getCompletionInfo markedSource
-        assertHasItemWithNames [ "aaa"; "bbb" ] info
-
-    assertOffersTupleArgs
-        """(1,2) |> (fun (aaa,bbb) ->
+    """(1,2) |> (fun (aaa,bbb) ->
     printfn "hi"
-    printfn "%d%d" b{caret} a
-    printfn "%d%d" a b   ) """
-
-    assertOffersTupleArgs
-        """(1,2) |> (fun (aaa,bbb) ->
-    printfn "hi"
-    printfn "%d%d" b a
-    printfn "%d%d" a{caret} b   ) """
-
-    assertOffersTupleArgs
-        """(1,2) |> (fun (aaa,bbb) ->
-    printfn "hi"
-    printfn "%d%d" b a{caret}
-    printfn "%d%d" a b   ) """
-
-    assertOffersTupleArgs
-        """(1,2) |> (fun (aaa,bbb) ->
-    printfn "hi"
-    printfn "%d%d" b a
-    printfn "%d%d" a b{caret}   ) """
+    printfn "%d%d" b{caret1} a{caret3}
+    printfn "%d%d" a{caret2} b{caret4}   ) """
+    |> SourceContext.extractOrderedMarkedSources
+    |> List.iter (fun source -> assertHasItemWithNames [ "aaa"; "bbb" ] (Checker.getCompletionInfo source))
 
 [<Fact>]
 let ``DotCompletionInPatternsPartOfLambda`` () =

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.ActivePatterns.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.ActivePatterns.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionActivePatternsTests
 
-open System
 open Xunit
 
 let private overlapSource =
@@ -10,13 +9,13 @@ let private overlapSource =
           "  type Parity = Even | Odd"
           "  let (|Even{caret1}|Odd|) x = (*loc-59*)"
           "    if x % 0 = 0"
-          "       then Even{caret2} (*loc-60*)"
+          "       then Even{caret2}"
           "       else Odd"
           "  let foo (x : int) ="
           "    match x with"
-          "    | Even{caret3} -> 1 (*loc-61*)"
+          "    | Even{caret3} -> 1"
           "    | Odd  -> 0"
-          "  let patval = (|Even{caret4}|Odd|) (*loc-61b*)" ]
+          "  let patval = (|Even{caret4}|Odd|)" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.ActivePat`` () =

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Classes.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Classes.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionClassesTests
 
-open System
 open Xunit
 
 let private classFieldSource =
@@ -23,7 +22,7 @@ let private classSource =
           "  member c.Method () = () (*loc-63*)"
           "  static member Foo () = () (*loc-64*)"
           "let _ ="
-          "  let c = Class{caret2} () (*loc-65*)"
+          "  let c = Class{caret2} ()"
           "  c.Method () (*loc-66*)"
           "  Class.Foo () (*loc-67*)" ]
 

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.DiscriminatedUnions.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.DiscriminatedUnions.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionDiscriminatedUnionsTests
 
-open System
 open Xunit
 
 let private discUnionSource =
@@ -11,7 +10,7 @@ let private discUnionSource =
                     | Gamma
 
                 let valueX = Beta{caret2}(1.0M, ())(*GotoTypeDef*)
-                let valueY = valueX{caret1} (*GotoValDef*)
+                let valueY = valueX{caret1}
                 """
 
 [<Fact>]
@@ -25,20 +24,20 @@ let private simpleDatatypeSource =
     String.concat
         "\n"
         [ "type Zero = (*loc-13*)"
-          "let foo (_ : Zero{caret1}) : 'a = failwith \"hi\" (*loc-14*)"
+          "let foo (_ : Zero{caret1}) : 'a = failwith \"hi\""
           "type One{caret3} = (*loc-16*)"
           "  One{caret2} (*loc-15*)"
-          "let f (x : One{caret5}) = (*loc-17*)"
-          "  One{caret4} (*loc-18*)"
+          "let f (x : One{caret5}) ="
+          "  One{caret4}"
           "type Nat{caret6} = (*loc-19*)"
           "  | Suc of Nat{caret7} (*loc-20*)"
           "  | Zro (*loc-21*)"
           "let rec plus m n = (*loc-23*)"
           "  match m with (*loc-22*)"
-          "  | Zro{caret8}   -> (*loc-24*)"
+          "  | Zro{caret8}   ->"
           "      n"
           "  | Suc{caret9} m -> (*loc-25*)"
-          "      Suc (plus m{caret10} n{caret11}) (*loc-26*)" ]
+          "      Suc (plus m{caret10} n{caret11})" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.Datatype`` () =

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.LetBindings.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.LetBindings.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionLetBindingsTests
 
-open System
 open Xunit
 
 [<Fact>]
@@ -27,7 +26,7 @@ let private trivialLetSource =
         "\n"
         [ "let _ ="
           "  let x{caret2} = () (*loc-2*)"
-          "  x{caret1} (*loc-1*)" ]
+          "  x{caret1}" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.Binding.TrivialLet`` () =
@@ -40,7 +39,7 @@ let private nestedSameNameSource =
         [ "let _ ="
           "  let x{caret3} = () (*loc-5*)"
           "  let x{caret2} = () (*loc-3*)"
-          "  x{caret1} (*loc-4*)" ]
+          "  x{caret1}" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.Binding.NestedLetWithSameName`` () =
@@ -56,7 +55,7 @@ let private nestedXIsXSource =
         [ "let _ ="
           "  let x = () (*loc-7*)"
           "  let x ="
-          "    x{caret} (*loc-6*)"
+          "    x{caret}"
           "  ()" ]
 
 [<Fact>]

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Members.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Members.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionMembersTests
 
-open System
 open Xunit
 
 [<Fact>]
@@ -19,7 +18,7 @@ let private orPatSource =
           "  let f x ="
           "    match x with"
           "    | Suc x{caret1} (*loc-44*)"
-          "    | x{caret2} (*loc-45*) -> "
+          "    | x{caret2} -> "
           "        x"
           "  ()" ]
 
@@ -36,7 +35,7 @@ let private consPatSource =
           "    match xs with"
           "    | x :: xs (*loc-54*)"
           "      when xs <> [] -> (*loc-52*)"
-          "        x{caret1} :: xs{caret2} (*loc-53*)"
+          "        x{caret1} :: xs{caret2}"
           "  ()" ]
 
 [<Fact>]
@@ -49,7 +48,7 @@ let private inStringSource =
         "\n"
         [ "let _ ="
           "  let x = 2"
-          "  \"x{caret}(*loc-72*)\"" ]
+          "  \"x{caret}\"" ]
 
 [<Fact(Skip = "non-FCS: goto-def suppression inside a string literal is an IDE editor-layer (tokenizer) decision; FCS GetDeclarationLocation is string-unaware and navigates the supplied island regardless.")>]
 let ``GotoDefinition.Simple.Tricky.InStringFails`` () =
@@ -61,7 +60,7 @@ let private inMultiLineStringSource =
         [ "let _ ="
           "  let x = 2"
           "  \"this is a string"
-          "    x{caret}(*loc-73*)"
+          "    x{caret}"
           "  \"" ]
 
 [<Fact(Skip = "non-FCS: goto-def suppression inside a string literal is an IDE editor-layer (tokenizer) decision; FCS GetDeclarationLocation is string-unaware and navigates the supplied island regardless.")>]
@@ -70,7 +69,7 @@ let ``GotoDefinition.Simple.Tricky.InMultiLineStringFails`` () =
 
 [<Fact(Skip = "This is currently broken for dev enlistments.")>]
 let ``GotoDefinition.Library.InitialTest`` () =
-    let source = "let _ = List.map{caret} (*loc-1*)"
+    let source = "let _ = List.map{caret}"
 
     assertGoToDefinitionToExternalLine "map" source
 
@@ -82,8 +81,8 @@ let private ooClassSource =
           "  static member Foo{caret3} () = () (*loc-64*)"
           "let _ ="
           "  let c = Class () (*loc-65*)"
-          "  c.Method{caret4} () (*loc-66*)"
-          "  Class.Foo{caret5} () (*loc-67*)" ]
+          "  c.Method{caret4} ()"
+          "  Class.Foo{caret5} ()" ]
 
 [<Fact>]
 let ``GotoDefinition.ObjectOriented`` () =
@@ -103,11 +102,11 @@ let private ooClassPrimeSource =
           "  static member Foo () = () (*loc-64*)"
           "type Class' () ="
           "  member c.Method  () = c.Method{caret1} () (*loc-68*)"
-          "  member c.Method1 () = c.Method2{caret2} () (*loc-69*)"
+          "  member c.Method1 () = c.Method2{caret2} ()"
           "  member c.Method2 () = c.Method1 () (*loc-70*)"
           "  member c.Method3  () ="
           "    let c = Class ()"
-          "    c{caret3}.Method{caret4} () (*loc-71*)" ]
+          "    c{caret3}.Method{caret4} ()" ]
 
 [<Fact>]
 let ``GotoDefinition.ObjectOriented.Prime`` () =
@@ -130,10 +129,10 @@ let private overloadedPropertiesSource =
           "    with get (s:string) = 1"
           "    and  set (s:string) v = ()"
           ""
-          "D().Foo{caret1} 1 (*loc-u1*)"
-          "D().Foo{caret2} 1 <- 2 (*loc-u2*)"
-          "D().Foo{caret3} \"abc\" (*loc-u3*)"
-          "D().Foo{caret4} \"abc\" <- 2 (*loc-u4*)" ]
+          "D().Foo{caret1} 1"
+          "D().Foo{caret2} 1 <- 2"
+          "D().Foo{caret3} \"abc\""
+          "D().Foo{caret4} \"abc\" <- 2" ]
 
 [<Fact>]
 let ``GotoDefinition.OverloadResolutionForProperties`` () =
@@ -158,8 +157,8 @@ let private overloadedMethodsSource =
           "   override this.Method (i:int) = () (*loc-d1*)"
           ""
           "let d = new Derived()"
-          "d.Method{caret1} 12 (*loc-u1*)"
-          "d.Method{caret2}() (*loc-u2*)" ]
+          "d.Method{caret1} 12"
+          "d.Method{caret2}()" ]
 
 [<Fact>]
 let ``GotoDefinition.OverloadResolutionWithOverrides`` () =
@@ -180,8 +179,8 @@ let private inheritedMembersSource =
           "   override this.Method () = ()"
           "   override this.Property = 1"
           "let b = Bar()"
-          "b.Method{caret1}(*loc-1*)()"
-          "b.Property{caret2}(*loc-2*)" ]
+          "b.Method{caret1}()"
+          "b.Property{caret2}" ]
 
 [<Fact>]
 let ``GotoDefinition.InheritedMembers`` () =

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Misc.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Misc.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionMiscTests
 
-open System
 open Xunit
 
 let private nestedLetRecSource =
@@ -10,7 +9,7 @@ let private nestedLetRecSource =
           "  let     x = ()"
           "  let rec x = (*loc-9*)"
           "    fun y -> (*loc-10*)"
-          "      x{caret} y (*loc-8*)"
+          "      x{caret} y"
           "  ()" ]
 
 [<Fact>]
@@ -25,7 +24,7 @@ let private asPatternSource =
         [ "let _ ="
           "  let foo          = ()"
           "  let f (_ as foo{caret1}) = (*loc-35*)"
-          "    foo{caret2} (*loc-36*)"
+          "    foo{caret2}"
           "  ()" ]
 
 [<Fact>]
@@ -103,6 +102,6 @@ let ``GotoDefinition.UnitOfMeasure.Bug193064`` () =
     let source =
         """
             open Microsoft.FSharp.Data.UnitSystems.SI
-            UnitSymbols.A{caret}(*Marker*)"""
+            UnitSymbols.A{caret}"""
 
     assertGoToDefinitionToExternalLine "type A = ampere" source

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Modules.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Modules.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionModulesTests
 
-open System
 open Xunit
 
 let private moduleDefSource =
@@ -22,8 +21,8 @@ let private moduleSource =
         [ "module Too{caret1} = (*loc-55*)"
           "  let foo{caret2} = 0 (*loc-56*)"
           "module Bar ="
-          "  open Too{caret5} (*loc-57*)"
-          "let _ = Too{caret3}.foo{caret4} (*loc-58*)" ]
+          "  open Too{caret5}"
+          "let _ = Too{caret3}.foo{caret4}" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.Module`` () =

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.PatternMatching.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.PatternMatching.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionPatternMatchingTests
 
-open System
 open Xunit
 
 let private nestedLetSource =
@@ -10,7 +9,7 @@ let private nestedLetSource =
           "  let     x = ()"
           "  let rec x = (*loc-9*)"
           "    fun y -> (*loc-10*)"
-          "      x y{caret} (*loc-8*)"
+          "      x y{caret}"
           "  ()" ]
 
 [<Fact>]
@@ -25,7 +24,7 @@ let private lambdaMultiBindSource =
         [ "let _ ="
           "  fun x (*loc-37*)"
           "      x{caret1} -> (*loc-38*)"
-          "    x{caret2} (*loc-39*)" ]
+          "    x{caret2}" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.Tricky.LambdaMultBind`` () =
@@ -39,7 +38,7 @@ let private functionPatternSource =
           "  let f = () (*loc-40*)"
           "  let f = (*loc-41*)"
           "    function f{caret1} -> (*loc-42*)"
-          "      f{caret2} (*loc-43*)"
+          "      f{caret2}"
           "  ()" ]
 
 [<Fact>]
@@ -55,7 +54,7 @@ let private andPatternSource =
           "  let f x ="
           "    match x with"
           "    | Suc y & z -> (*loc-47*)"
-          "        y{caret} (*loc-46*)"
+          "        y{caret}"
           "  ()" ]
 
 [<Fact>]
@@ -71,7 +70,7 @@ let private consPatternSource =
           "  let f xs ="
           "    match xs with"
           "    | x :: xs -> (*loc-49*)"
-          "        x{caret} (*loc-48*)"
+          "        x{caret}"
           "    | _       -> []"
           "  ()" ]
 
@@ -88,7 +87,7 @@ let private pairPatternSource =
           "  let f x ="
           "    match x with"
           "    | (y : int, z) -> (*loc-51*)"
-          "         y{caret} (*loc-50*)"
+          "         y{caret}"
           "  ()" ]
 
 [<Fact>]
@@ -104,7 +103,7 @@ let private consWhenSource =
           "  let f xs ="
           "    match xs with"
           "    | x :: xs (*loc-54*)"
-          "      when xs{caret} <> [] -> (*loc-52*)"
+          "      when xs{caret} <> [] ->"
           "        x :: xs (*loc-53*)"
           "  ()" ]
 

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Records.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.Records.fs
@@ -1,6 +1,5 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionRecordsTests
 
-open System
 open Xunit
 
 let private simpleRecordSource =
@@ -11,10 +10,10 @@ let private simpleRecordSource =
           "    myY{caret3} : int (*loc-29*)"
           "  }"
           "let rDefault ="
-          "  { myX{caret4} = 2 (*loc-30*)"
-          "    myY{caret5} = 3 (*loc-31*)"
+          "  { myX{caret4} = 2"
+          "    myY{caret5} = 3"
           "  }"
-          "let _ = { rDefault with myX{caret6} = 7 } (*loc-32*)" ]
+          "let _ = { rDefault with myX{caret6} = 7 }" ]
 
 [<Fact>]
 let ``GotoDefinition.Simple.Datatype.Record`` () =

--- a/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.TypeAnnotations.fs
+++ b/tests/FSharp.Compiler.Service.Tests/GotoDefinition/GotoDefinitionTests.TypeAnnotations.fs
@@ -1,13 +1,12 @@
 module FSharp.Compiler.Service.Tests.GotoDefinitionTypeAnnotationsTests
 
-open System
 open Xunit
 
 let private bug2516SpacedSource =
     """
                 //regression test for bug 2516
                 type One{caret1} (*Marker1*) = One
-                let f (x : One{caret2} (*Marker2*)) = 2
+                let f (x : One{caret2}) = 2
                 """
 
 [<Fact>]
@@ -26,10 +25,10 @@ let private overloadResolutionSource =
           "   member this.Foo(x) (*#2#*) = ()"
           ""
           "let d = new D()"
-          "d.Foo{caret1}() (*$1$*)"
-          "d.Foo{caret2}(1) (*$2$*)"
-          "d.ToString{caret3}() (*$3$*)"
-          "d.ToString{caret4}(\"aaa\") (*$4$*)" ]
+          "d.Foo{caret1}()"
+          "d.Foo{caret2}(1)"
+          "d.ToString{caret3}()"
+          "d.ToString{caret4}(\"aaa\")" ]
 
 [<Fact>]
 let ``GotoDefinition.OverloadResolution`` () =
@@ -47,8 +46,8 @@ let private overloadStaticsSource =
           "   static member Foo(i : int) (*#1#*) = ()"
           "   static member Foo(s : string) (*#2#*) = ()"
           ""
-          "T.Foo{caret1} 1 (*$1$*)"
-          "T.Foo{caret2} \"abc\" (*$2$*)" ]
+          "T.Foo{caret1} 1"
+          "T.Foo{caret2} \"abc\"" ]
 
 [<Fact>]
 let ``GotoDefinition.OverloadResolutionStatics`` () =
@@ -68,26 +67,26 @@ let private constructorsSource =
           "B(1)"
           "B(\"abc\")"
           ""
-          "new B{caret1}() (*$1b$*)"
-          "new B{caret2}(1) (*$2b$*)"
-          "new B{caret3}(\"abc\") (*$3b$*)"
+          "new B{caret1}()"
+          "new B{caret2}(1)"
+          "new B{caret3}(\"abc\")"
           ""
           "type D1() ="
-          "    inherit B{caret4}() (*$1c$*)"
+          "    inherit B{caret4}()"
           ""
           "type D2() ="
-          "    inherit B{caret5}(1) (*$2c$*)"
+          "    inherit B{caret5}(1)"
           ""
           "type D3() ="
-          "    inherit B{caret6}(\"abc\") (*$3c$*)"
+          "    inherit B{caret6}(\"abc\")"
           ""
-          "let o1 = { new B{caret7}() (*$1d$*) with"
+          "let o1 = { new B{caret7}() with"
           "             override this.ToString() = \"\""
           "         }"
-          "let o2 = { new B{caret8}(1) (*$2d$*) with"
+          "let o2 = { new B{caret8}(1) with"
           "             override this.ToString() = \"\""
           "         }"
-          "let o3 = { new B{caret9}(\"aaa\") (*$3d$*) with"
+          "let o3 = { new B{caret9}(\"aaa\") with"
           "             override this.ToString() = \"\""
           "         }" ]
 
@@ -111,7 +110,7 @@ let private simplePolymorphSource =
         [ "let _ ="
           "  let a = 2"
           "  let id (x : 'a{caret1}) (*loc-33*)"
-          "    : 'a{caret2} = x (*loc-34*)"
+          "    : 'a{caret2} = x"
           "  ()" ]
 
 [<Fact>]
@@ -123,7 +122,7 @@ let private bug2516ModuleSource =
     """
             module GotoDefinition
             type One{caret1}(*Mark1*) = One
-            let f (x : One{caret2}(*Mark2*)) = 2"""
+            let f (x : One{caret2}) = 2"""
 
 [<Fact>]
 let ``Identifier.Bug2516`` () =

--- a/tests/FSharp.Compiler.Service.Tests/Symbols.fs
+++ b/tests/FSharp.Compiler.Service.Tests/Symbols.fs
@@ -1190,68 +1190,24 @@ let f (r: {| A: int; C: int |}) =
         | _ -> failwith "Symbol was not FSharpField"
 
     [<Fact>]
-    let ``Nested copy-and-update 01`` () =
-        checkFieldUsage "Zoo" "RecordA`1" ((4, 44), (4, 47)) """
+    let ``Nested copy-and-update`` () =
+        let cases =
+            [ "Zoo", ((4, 44), (4, 47))
+              "Foo", ((4, 48), (4, 51))
+              "Zoo", ((4, 57), (4, 60))
+              "Zoo", ((4, 61), (4, 64))
+              "Bar", ((4, 65), (4, 68))
+              "Zoo", ((4, 74), (4, 77))
+              "Bar", ((4, 78), (4, 81))
+              "Foo", ((4, 87), (4, 90)) ]
+
+        """
 type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
 
-let nestedFunc (a: RecordA<int>) = { a with Zo{caret}o.Foo = 1; Zoo.Zoo.Bar = 2; Zoo.Bar = 3; Foo = 4 }
+let nestedFunc (a: RecordA<int>) = { a with Zo{caret1}o.Fo{caret2}o = 1; Z{caret3}oo.Zo{caret4}o.B{caret5}ar = 2; Z{caret6}oo.B{caret7}ar = 3; Fo{caret8}o = 4 }
 """
-
-    [<Fact>]
-    let ``Nested copy-and-update 02`` () =
-        checkFieldUsage "Foo" "RecordA`1" ((4, 48), (4, 51)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Fo{caret}o = 1; Zoo.Zoo.Bar = 2; Zoo.Bar = 3; Foo = 4 }
-"""
-
-    [<Fact>]
-    let ``Nested copy-and-update 03`` () =
-        checkFieldUsage "Zoo" "RecordA`1" ((4, 57), (4, 60)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Foo = 1; Z{caret}oo.Zoo.Bar = 2; Zoo.Bar = 3; Foo = 4 }
-"""
-
-    [<Fact>]
-    let ``Nested copy-and-update 04`` () =
-        checkFieldUsage "Zoo" "RecordA`1" ((4, 61), (4, 64)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Foo = 1; Zoo.Zo{caret}o.Bar = 2; Zoo.Bar = 3; Foo = 4 }
-"""
-
-    [<Fact>]
-    let ``Nested copy-and-update 05`` () =
-        checkFieldUsage "Bar" "RecordA`1" ((4, 65), (4, 68)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Foo = 1; Zoo.Zoo.B{caret}ar = 2; Zoo.Bar = 3; Foo = 4 }
-"""
-
-    [<Fact>]
-    let ``Nested copy-and-update 06`` () =
-        checkFieldUsage "Zoo" "RecordA`1" ((4, 74), (4, 77)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Foo = 1; Zoo.Zoo.Bar = 2; Z{caret}oo.Bar = 3; Foo = 4 }
-"""
-
-    [<Fact>]
-    let ``Nested copy-and-update 07`` () =
-        checkFieldUsage "Bar" "RecordA`1" ((4, 78), (4, 81)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Foo = 1; Zoo.Zoo.Bar = 2; Zoo.B{caret}ar = 3; Foo = 4 }
-"""
-
-    [<Fact>]
-    let ``Nested copy-and-update 08`` () =
-        checkFieldUsage "Foo" "RecordA`1" ((4, 87), (4, 90)) """
-type RecordA<'a> = { Foo: 'a; Bar: int; Zoo: RecordA<'a> }
-
-let nestedFunc (a: RecordA<int>) = { a with Zoo.Foo = 1; Zoo.Zoo.Bar = 2; Zoo.Bar = 3; Fo{caret}o = 4 }
-"""
+        |> SourceContext.extractOrderedMarkedSources
+        |> List.iter2 (fun (name, range) source -> checkFieldUsage name "RecordA`1" range source) cases
 
 module ComputationExpressions =
     [<Fact>]


### PR DESCRIPTION
Follow-up to #20033, building on @auduchinok's #20077. Adopts the ordered multi-caret / selection markers (`SourceContext.extractOrderedMarkedSources` + `{selstart}/{selend}`) to remove **copy-pasted test sources** and **magic coordinates**.

**No behaviour change** — every migrated test keeps identical assertions (each commit rubber-duck-verified byte-for-byte; tests green on net472 + net10.0).

Reductions:
- [x] Goto-def tests: drop unused `open System` + now-redundant caret-anchor `(*loc-N*)` comments
- [x] Completion `ArraySliceNotation` (3 source copies → 1), `CurriedArguments` (5 → 1), `Bug312557_2` (4 → 1), `Bug69673_1` (2 → 1)
- [x] Symbols `Nested copy-and-update` (8 Facts sharing a copied source → 1)
- [x] BreakpointLocation: magic `((line,col),(line,col))` tuples → `{selstart}/{selend}` markers in the source

Deliberately **not** migrated (it would make the code *worse*, not better):
- Tooltip/Completion tests using `markAtStartOfMarker`/`markAtEndOfMarker` on a **shared** source — they already reuse the source, with heterogeneous asserts per position; `{caretN}` there is 0 reduction and messier.
- `$` / direct-column low-level marker tests (IdentifierIsland, QuickParse, …) — `$` is more compact than `{caret}`; migrating adds indirection + a ±1 column risk for no reduction.
