### PR TITLE
Enable Central Package Management with transitive pinning

### DIFF
--- a/.github/skills/fsharp-diagnostics/server/Directory.Build.props
+++ b/.github/skills/fsharp-diagnostics/server/Directory.Build.props
@@ -3,6 +3,8 @@
        Also blocks Directory.Build.targets import. -->
   <PropertyGroup>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+    <!-- Standalone tool consuming shipped FSharp.Compiler.Service/FSharp.Core; keep off repo CPM. -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
     <BaseOutputPath>$(MSBuildThisFileDirectory)../../../../.tools/fsharp-diag/bin/</BaseOutputPath>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)../../../../.tools/fsharp-diag/obj/</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,20 +25,17 @@
     <FsYaccPath>$(ArtifactsDir)/bin/fsyacc/$(Configuration)/$(FSharpNetCoreProductTargetFramework)/$(NETCoreSdkPortableRuntimeIdentifier)/fsyacc.dll</FsYaccPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DesignTimeBuild)' == 'true'">
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(UnitTestType)' == 'xunit'">
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
   <!-- We want to restore ALL the MIBCs when we build anything, since in the future it will contain different profiles, not only the FSC one we got from building Giraffe -->
   <Import Project="$(MSBuildThisFileDirectory)\eng\restore\optimizationData.targets"/>
-  <!-- CPM: reference the MIBC optimization packages by identity only; their versions come from
-       eng/Packages.props. @(MIBCPackage) carries Version metadata (needed by CopyMIBC to locate the
-       restored .mibc under the package cache), which must not appear on a PackageReference under
-       Central Package Management (NU1008). Guarded by the same IgnoreMIBC switch as the item list. -->
+  <!-- @(MIBCPackage) carries Version item metadata (CopyMIBC needs it to locate the restored .mibc under
+       the package cache). Under CPM that Version must not sit on a PackageReference (NU1008), and neither
+       RemoveMetadata nor an identity transform strips it in an evaluation-phase ItemGroup, so list the
+       identities literally here; the central versions in eng/Packages.props apply. Opt-out subtrees
+       (ImportDirectoryPackagesProps=false) are not under CPM and keep the inline Version from @(MIBCPackage). -->
   <ItemGroup Condition="'$(IgnoreMIBC)' != 'true' and '$(ManagePackageVersionsCentrally)' == 'true'">
     <PackageReference Include="optimization.windows_nt-x86.mibc.runtime" />
     <PackageReference Include="optimization.windows_nt-x64.mibc.runtime" />
@@ -46,8 +43,6 @@
     <PackageReference Include="optimization.linux-x64.mibc.runtime" />
     <PackageReference Include="optimization.linux-arm64.mibc.runtime" />
   </ItemGroup>
-  <!-- Opt-out subtrees (ImportDirectoryPackagesProps=false) are not under CPM, so their MIBC references
-       must carry the Version metadata from @(MIBCPackage) directly (otherwise NU1015). -->
   <ItemGroup Condition="'$(IgnoreMIBC)' != 'true' and '$(ManagePackageVersionsCentrally)' != 'true'">
     <PackageReference Include="@(MIBCPackage)" />
   </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,10 +25,6 @@
     <FsYaccPath>$(ArtifactsDir)/bin/fsyacc/$(Configuration)/$(FSharpNetCoreProductTargetFramework)/$(NETCoreSdkPortableRuntimeIdentifier)/fsyacc.dll</FsYaccPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(UnitTestType)' == 'xunit'">
-    <PackageReference Include="xunit.v3.mtp-v2" />
-  </ItemGroup>
-
   <!-- We want to restore ALL the MIBCs when we build anything, since in the future it will contain different profiles, not only the FSC one we got from building Giraffe -->
   <Import Project="$(MSBuildThisFileDirectory)\eng\restore\optimizationData.targets"/>
   <!-- @(MIBCPackage) carries Version item metadata (CopyMIBC needs it to locate the restored .mibc under

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,11 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DesignTimeBuild)' == 'true'">
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="17.14.2120" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UnitTestType)' == 'xunit'">
-    <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
   <!-- We want to restore ALL the MIBCs when we build anything, since in the future it will contain different profiles, not only the FSC one we got from building Giraffe -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,8 +28,16 @@
 
   <!-- We want to restore ALL the MIBCs when we build anything, since in the future it will contain different profiles, not only the FSC one we got from building Giraffe -->
   <Import Project="$(MSBuildThisFileDirectory)\eng\restore\optimizationData.targets"/>
-  <ItemGroup>
-    <PackageReference Include="@(MIBCPackage)" />
+  <!-- CPM: reference the MIBC optimization packages by identity only; their versions come from
+       eng/Packages.props. @(MIBCPackage) carries Version metadata (needed by CopyMIBC to locate the
+       restored .mibc under the package cache), which must not appear on a PackageReference under
+       Central Package Management (NU1008). Guarded by the same IgnoreMIBC switch as the item list. -->
+  <ItemGroup Condition="'$(IgnoreMIBC)' != 'true'">
+    <PackageReference Include="optimization.windows_nt-x86.mibc.runtime" />
+    <PackageReference Include="optimization.windows_nt-x64.mibc.runtime" />
+    <PackageReference Include="optimization.windows_nt-arm64.mibc.runtime" />
+    <PackageReference Include="optimization.linux-x64.mibc.runtime" />
+    <PackageReference Include="optimization.linux-arm64.mibc.runtime" />
   </ItemGroup>
 
   <Target Name="CopyMIBCWrapper" AfterTargets="Restore" BeforeTargets="Build;Pack">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,12 +32,17 @@
        eng/Packages.props. @(MIBCPackage) carries Version metadata (needed by CopyMIBC to locate the
        restored .mibc under the package cache), which must not appear on a PackageReference under
        Central Package Management (NU1008). Guarded by the same IgnoreMIBC switch as the item list. -->
-  <ItemGroup Condition="'$(IgnoreMIBC)' != 'true'">
+  <ItemGroup Condition="'$(IgnoreMIBC)' != 'true' and '$(ManagePackageVersionsCentrally)' == 'true'">
     <PackageReference Include="optimization.windows_nt-x86.mibc.runtime" />
     <PackageReference Include="optimization.windows_nt-x64.mibc.runtime" />
     <PackageReference Include="optimization.windows_nt-arm64.mibc.runtime" />
     <PackageReference Include="optimization.linux-x64.mibc.runtime" />
     <PackageReference Include="optimization.linux-arm64.mibc.runtime" />
+  </ItemGroup>
+  <!-- Opt-out subtrees (ImportDirectoryPackagesProps=false) are not under CPM, so their MIBC references
+       must carry the Version metadata from @(MIBCPackage) directly (otherwise NU1015). -->
+  <ItemGroup Condition="'$(IgnoreMIBC)' != 'true' and '$(ManagePackageVersionsCentrally)' != 'true'">
+    <PackageReference Include="@(MIBCPackage)" />
   </ItemGroup>
 
   <Target Name="CopyMIBCWrapper" AfterTargets="Restore" BeforeTargets="Build;Pack">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,13 @@
   <Import Project="FSharpTests.Directory.Build.targets" Condition = " '$(FSharpTestCompilerVersion)' != '' "/>
   <Import Project="CoordinateXliff.targets" Condition = " '$(FSharpBuildAssemblyFile)' != '' and '$(XliffTasksAssembly)' != '' "/>
 
+  <!-- The repo restores from many NuGet sources (Maestro does not support package source mapping),
+       which triggers NU1507 under Central Package Management. Suppress it here, after the project
+       bodies (some of which reset NoWarn), so it is applied consistently across every CPM project. -->
+  <PropertyGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+
   <!-- Disable R2R when building source-only and not targeting the current SDK bundled TFM. -->
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(DotNetBuildSourceOnly)' == 'true' and

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <!-- Multiple package sources are not supported by Maestro; silence the CPM multi-source warning
+         (same as dotnet/sourcelink). -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+
+  <Import Project="eng/Packages.props" />
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <!-- Multiple package sources are not supported by Maestro; silence the CPM multi-source warning
-         (same as dotnet/sourcelink). -->
-    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <Import Project="eng/Packages.props" />

--- a/buildtools/AssemblyCheck/AssemblyCheck.fsproj
+++ b/buildtools/AssemblyCheck/AssemblyCheck.fsproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
 </Project>

--- a/buildtools/checkpackages/Directory.Build.props
+++ b/buildtools/checkpackages/Directory.Build.props
@@ -3,6 +3,8 @@
     <Import Project="$(MSBuildThisFileDirectory)..\..\eng\TargetFrameworks.props" />
 
     <PropertyGroup>
+        <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
+        <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <CachePath>$(MSBuildProjectDirectory)\..\..\artifacts\tmp\$([System.Guid]::NewGuid())</CachePath>
         <BaseIntermediateOutputPath>$(CachePath)\obj\</BaseIntermediateOutputPath>

--- a/buildtools/fslex/fslex.fsproj
+++ b/buildtools/fslex/fslex.fsproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
 </Project>

--- a/buildtools/fsyacc/fsyacc.fsproj
+++ b/buildtools/fsyacc/fsyacc.fsproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
 </Project>

--- a/docs/fcs-samples/Directory.Build.props
+++ b/docs/fcs-samples/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <!-- FCS sample projects consume shipped FCS/FSharp.Core packages; keep them off repo CPM. -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+</Project>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -75,14 +75,14 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageVersion Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableCentralVersion)" />
     <PackageVersion Include="System.Composition" Version="$(SystemCompositionVersion)" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageVersion Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataCentralVersion)" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlCentralVersion)" />
     <PackageVersion Include="xunit.v3.assert" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.v3.common" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,0 +1,89 @@
+<!-- Central Package Management version list. See Directory.Packages.props.
+     Versions flow via eng/Versions.props / eng/Version.Details.props (darc/Maestro).
+     Reference those $(...) properties here; use literals only for external one-offs. -->
+<Project>
+  <ItemGroup>
+    <!-- Optimization data (MIBC) — referenced via @(MIBCPackage) in Directory.Build.targets -->
+    <PackageVersion Include="optimization.windows_nt-x86.mibc.runtime" Version="$(optimizationwindows_ntx86MIBCRuntimeVersion)" />
+    <PackageVersion Include="optimization.windows_nt-x64.mibc.runtime" Version="$(optimizationwindows_ntx64MIBCRuntimeVersion)" />
+    <PackageVersion Include="optimization.windows_nt-arm64.mibc.runtime" Version="$(optimizationwindows_ntarm64MIBCRuntimeVersion)" />
+    <PackageVersion Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" />
+    <PackageVersion Include="optimization.linux-arm64.mibc.runtime" Version="$(optimizationlinuxarm64MIBCRuntimeVersion)" />
+
+    <PackageVersion Include="Dotnet.ProjInfo" Version="0.37.0" />
+    <PackageVersion Include="FsCheck" Version="$(FsCheckVersion)" />
+    <PackageVersion Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(MicrosoftCodeAnalysisExternalAccessFSharpVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+    <PackageVersion Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.13.0-3.24579.1" />
+    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
+    <PackageVersion Include="Microsoft.DotNet.NuGetRepack.Tasks" Version="$(MicrosoftDotNetNuGetRepackTasksVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
+    <PackageVersion Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" />
+    <PackageVersion Include="Microsoft.NETCore.ILDAsm" Version="$(MicrosoftNETCoreILDAsmVersion)" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="$(MicrosoftServiceHubFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
+    <PackageVersion Include="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" Version="$(MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Build" Version="17.13.39620" />
+    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="17.13.39620" />
+    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.6-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.13.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfacesVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="$(MicrosoftVisualStudioPackageLanguageService150Version)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="$(MicrosoftVisualStudioProjectSystemManagedVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Query" Version="17.13.66" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110Version)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="$(MicrosoftVisualStudioShellImmutable150Version)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="$(MicrosoftVisualStudioSolutionPersistenceVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
+    <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageVersion Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
+    <PackageVersion Include="Nullable" Version="1.3.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+    <PackageVersion Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageVersion Include="System.Composition" Version="$(SystemCompositionVersion)" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
+    <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageVersion Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <PackageVersion Include="xunit.v3.assert" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.v3.common" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
+    <PackageVersion Include="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
+  </ItemGroup>
+</Project>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -46,6 +46,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
+    <!-- Pinned to 17.13.9 (not the projects' 17.13.6-preview floor) because Protocol.Internal 17.13.9,
+         referenced by FSharp.VisualStudio.Extension, transitively requires Protocol >= 17.13.9. -->
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.6-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfacesVersion)" />
@@ -70,7 +70,8 @@
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageVersion Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
-    <PackageVersion Include="Nullable" Version="1.3.0" />
+    <!-- Raised from 1.3.0: Microsoft.VisualStudio.ComponentModelHost 18.9.453 (transitive via the VS SDK) requires >= 1.3.1. -->
+    <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
     <PackageVersion Include="System.Buffers" Version="$(SystemBuffersVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,6 +1,7 @@
 <!-- Central Package Management version list. See Directory.Packages.props.
-     Versions flow via eng/Versions.props / eng/Version.Details.props (darc/Maestro).
-     Reference those $(...) properties here; use literals only for external one-offs. -->
+     Darc/Maestro-flowed and repo-shared versions are referenced as $(...) properties from
+     eng/Versions.props / eng/Version.Details.props. Manually-pinned, single-use packages carry
+     their literal version here directly (no indirection through eng/Versions.props). -->
 <Project>
   <ItemGroup>
     <!-- Optimization data (MIBC) — referenced via @(MIBCPackage) in Directory.Build.targets -->
@@ -10,8 +11,7 @@
     <PackageVersion Include="optimization.linux-x64.mibc.runtime" Version="$(optimizationlinuxx64MIBCRuntimeVersion)" />
     <PackageVersion Include="optimization.linux-arm64.mibc.runtime" Version="$(optimizationlinuxarm64MIBCRuntimeVersion)" />
 
-    <PackageVersion Include="Dotnet.ProjInfo" Version="0.37.0" />
-    <PackageVersion Include="FsCheck" Version="$(FsCheckVersion)" />
+    <PackageVersion Include="FsCheck" Version="2.16.6" />
     <PackageVersion Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
@@ -21,61 +21,71 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(MicrosoftCodeAnalysisExternalAccessFSharpVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="2.0.28" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
     <PackageVersion Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.13.0-3.24579.1" />
-    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
+    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.6.0" />
     <PackageVersion Include="Microsoft.DotNet.NuGetRepack.Tasks" Version="$(MicrosoftDotNetNuGetRepackTasksVersion)" />
     <!-- Raised from 8.0.0 to 10.0.0: OpenTelemetry (in test/VS projects) pulls Microsoft.Extensions.Logging 10.0.0,
          which requires Microsoft.Extensions.DependencyInjection >= 10.0.0. FSharp.Compiler.LanguageServer (net8)
          keeps 8.0.0 via a VersionOverride. -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkVersion)" />
-    <PackageVersion Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
-    <PackageVersion Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" />
-    <PackageVersion Include="Microsoft.NETCore.ILDAsm" Version="$(MicrosoftNETCoreILDAsmVersion)" />
-    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="$(MicrosoftServiceHubFrameworkVersion)" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="18.0.2188-preview.1" />
+    <PackageVersion Include="Microsoft.Net.Compilers" Version="4.3.0-1.22220.8" />
+    <PackageVersion Include="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.7.20364.11" />
+    <PackageVersion Include="Microsoft.NETCore.ILDAsm" Version="5.0.0-preview.7.20364.11" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework" Version="4.10.128" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
-    <PackageVersion Include="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" Version="$(MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
+    <PackageVersion Include="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" Version="17.0.0" />
+    <!-- The 18.9.x Visual Studio SDK packages below (Interop/Shell/Editor) are pinned to the versions pulled
+         transitively by Microsoft.VisualStudio.SDK 18.9.496 (via Microsoft.CodeAnalysis.ExternalAccess.FSharp).
+         Under CPM transitive pinning the central pin must match that resolved version, otherwise NU1109 downgrades
+         and MSB3277 assembly-version conflicts break every vsintegration project. -->
+    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces" Version="18.9.438" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="$(VisualStudioEditorPackagesVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Build" Version="17.13.39620" />
     <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="17.13.39620" />
-    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator" Version="$(MicrosoftVisualStudioExtensibilityTestingVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(VisualStudioEditorPackagesVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VisualStudioEditorPackagesVersion)" />
     <!-- Pinned to 17.13.9 (not the projects' 17.13.6-preview floor) because Protocol.Internal 17.13.9,
          referenced by FSharp.VisualStudio.Extension, transitively requires Protocol >= 17.13.9. -->
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.13.9" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfacesVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="$(MicrosoftVisualStudioPackageLanguageService150Version)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="$(MicrosoftVisualStudioProjectSystemManagedVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces" Version="18.0.2077-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="18.9.438" />
+    <PackageVersion Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="18.9.493" />
+    <!-- Microsoft.VisualStudio.Platform.VSEditor is the runtime editor implementation. Unlike the other editor
+         packages it is not pulled transitively, so it is pinned explicitly to match the 18.9.123 Text.* interfaces;
+         otherwise the VsMocks MEF catalog throws ReflectionTypeLoadException and every legacy VS unit test fails. -->
+    <PackageVersion Include="Microsoft.VisualStudio.Platform.VSEditor" Version="18.9.123" />
+    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="18.0.1237-pre" />
+    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="2.3.6152103" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Query" Version="17.13.66" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110Version)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="$(MicrosoftVisualStudioShellImmutable150Version)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="$(MicrosoftVisualStudioSolutionPersistenceVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="18.9.453" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design" Version="18.9.493" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="10.0.30319" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="11.0.50727" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Interop" Version="18.9.438" />
+    <!-- Shell.15.0 references SolutionPersistence at runtime without declaring the NuGet dependency (it is expected
+         from the VS install). The standalone VS unit-test host loads Shell.15.0 into a MEF catalog, so the assembly
+         must be deployed next to it or Assembly.GetTypes throws and every legacy VS unit test fails. -->
+    <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
+    <PackageVersion Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(VisualStudioEditorPackagesVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.TextManager.Interop" Version="18.9.438" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="18.7.19" />
+    <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="18.7.1" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
-    <PackageVersion Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageVersion Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NuGet.VisualStudio" Version="17.14.0" />
     <!-- Raised from 1.3.0: Microsoft.VisualStudio.ComponentModelHost 18.9.453 (transitive via the VS SDK) requires >= 1.3.1. -->
     <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.26.5" />
     <PackageVersion Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableCentralVersion)" />
     <PackageVersion Include="System.Composition" Version="$(SystemCompositionVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -59,9 +59,9 @@
     <PackageVersion Include="Microsoft.VisualStudio.OLE.Interop" Version="18.9.438" />
     <PackageVersion Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="18.9.493" />
     <!-- Microsoft.VisualStudio.Platform.VSEditor is the runtime editor implementation. Unlike the other editor
-         packages it is not pulled transitively, so it is pinned explicitly to match the 18.9.123 Text.* interfaces;
-         otherwise the VsMocks MEF catalog throws ReflectionTypeLoadException and every legacy VS unit test fails. -->
-    <PackageVersion Include="Microsoft.VisualStudio.Platform.VSEditor" Version="18.9.123" />
+         packages it is not pulled transitively, so it is pinned explicitly to match the editor interfaces via the
+         shared property; otherwise the VsMocks MEF catalog throws ReflectionTypeLoadException and every legacy VS unit test fails. -->
+    <PackageVersion Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(VisualStudioEditorPackagesVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem" Version="18.0.1237-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="2.3.6152103" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Query" Version="17.13.66" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -26,7 +26,10 @@
     <PackageVersion Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.13.0-3.24579.1" />
     <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
     <PackageVersion Include="Microsoft.DotNet.NuGetRepack.Tasks" Version="$(MicrosoftDotNetNuGetRepackTasksVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <!-- Raised from 8.0.0 to 10.0.0: OpenTelemetry (in test/VS projects) pulls Microsoft.Extensions.Logging 10.0.0,
+         which requires Microsoft.Extensions.DependencyInjection >= 10.0.0. FSharp.Compiler.LanguageServer (net8)
+         keeps 8.0.0 via a VersionOverride. -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkVersion)" />
     <PackageVersion Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
     <PackageVersion Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -99,7 +99,7 @@
     <PackageVersion Include="xunit.v3.common" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
-    <PackageVersion Include="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
+    <PackageVersion Include="xunit.v3.runner.console" Version="$(XunitVersion)" />
     <PackageVersion Include="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,7 +105,10 @@
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <!-- Versions for package groups -->
-    <VisualStudioEditorPackagesVersion>18.0.404-preview</VisualStudioEditorPackagesVersion>
+    <!-- Editor packages resolve to 18.9.123 transitively via Microsoft.VisualStudio.SDK 18.9.496 (pulled by
+         Microsoft.CodeAnalysis.ExternalAccess.FSharp). Under CPM transitive pinning the central pin must match
+         that resolved version, otherwise NU1109 downgrades every vsintegration project. -->
+    <VisualStudioEditorPackagesVersion>18.9.123</VisualStudioEditorPackagesVersion>
     <MicrosoftVisualStudioShellPackagesVersion>18.0.2188-preview.1</MicrosoftVisualStudioShellPackagesVersion>
     <VisualStudioProjectSystemPackagesVersion>18.0.1237-pre</VisualStudioProjectSystemPackagesVersion>
     <VisualStudioShellProjectsPackages>18.0.2077-preview.1</VisualStudioShellProjectsPackages>
@@ -120,11 +123,14 @@
     <MicrosoftVisualStudioShellInteropVersion>18.9.438</MicrosoftVisualStudioShellInteropVersion>
     <MicrosoftVisualStudioTextManagerInteropVersion>18.9.438</MicrosoftVisualStudioTextManagerInteropVersion>
     <MicrosoftVisualStudioOLEInteropVersion>18.9.438</MicrosoftVisualStudioOLEInteropVersion>
-    <MicrosoftVisualStudioShellDesignVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellDesignVersion>
+    <!-- These shell packages are pulled higher transitively by Microsoft.VisualStudio.SDK 18.9.496 (via
+         Microsoft.CodeAnalysis.ExternalAccess.FSharp), so under CPM transitive pinning they must be pinned to
+         the required 18.9.x versions rather than the shell package group; otherwise NU1109. -->
+    <MicrosoftVisualStudioShellDesignVersion>18.9.493</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
-    <MicrosoftVisualStudioPackageLanguageService150Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioPackageLanguageService150Version>
+    <MicrosoftVisualStudioPackageLanguageService150Version>18.9.493</MicrosoftVisualStudioPackageLanguageService150Version>
     <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
-    <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
+    <MicrosoftVisualStudioDesignerInterfacesVersion>18.9.438</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioShellImmutable100Version>10.0.30319</MicrosoftVisualStudioShellImmutable100Version>
     <MicrosoftVisualStudioShellImmutable110Version>11.0.50727</MicrosoftVisualStudioShellImmutable110Version>
     <MicrosoftVisualStudioShellImmutable150Version>15.0.25123-Dev15Preview</MicrosoftVisualStudioShellImmutable150Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -102,9 +102,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-    <SystemSecurityCryptographyXmlCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemSecurityCryptographyXmlVersion)', '10.0.9'))">10.0.9</SystemSecurityCryptographyXmlCentralVersion>
-    <SystemCollectionsImmutableCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemCollectionsImmutableVersion)', '10.0.9'))">10.0.9</SystemCollectionsImmutableCentralVersion>
-    <SystemReflectionMetadataCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemReflectionMetadataVersion)', '10.0.9'))">10.0.9</SystemReflectionMetadataCentralVersion>
+    <!-- Minimum central version the MSBuild-pulled dotnet/runtime packages must meet (see comment above). -->
+    <SystemRuntimeCentralFloorVersion>10.0.9</SystemRuntimeCentralFloorVersion>
+    <SystemSecurityCryptographyXmlCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemSecurityCryptographyXmlVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemSecurityCryptographyXmlCentralVersion>
+    <SystemCollectionsImmutableCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemCollectionsImmutableVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemCollectionsImmutableCentralVersion>
+    <SystemReflectionMetadataCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemReflectionMetadataVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemReflectionMetadataCentralVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -116,9 +118,8 @@
     <!-- Shared version groups referenced by multiple PackageVersion entries in eng/Packages.props.
          (Single-use package versions are pinned inline there; only genuinely shared or Arcade-read
          versions live here.) -->
-    <!-- Editor packages resolve to 18.9.123 transitively via Microsoft.VisualStudio.SDK 18.9.496 (pulled by
-         Microsoft.CodeAnalysis.ExternalAccess.FSharp). Under CPM transitive pinning the central pin must match
-         that resolved version, otherwise NU1109 downgrades every vsintegration project. -->
+    <!-- Shared pin for the editor packages in eng/Packages.props; must match 18.9.123 (resolved transitively
+         via Microsoft.VisualStudio.SDK 18.9.496). Full NU1109 rationale lives there, next to the 18.9.x pins. -->
     <VisualStudioEditorPackagesVersion>18.9.123</VisualStudioEditorPackagesVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.800-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -115,9 +115,7 @@
     updated in years, you most likely DON'T need it, please exercise caution when adding it to the list. -->
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
 
-    <!-- Shared version groups referenced by multiple PackageVersion entries in eng/Packages.props.
-         (Single-use package versions are pinned inline there; only genuinely shared or Arcade-read
-         versions live here.) -->
+    <!-- Shared version groups referenced by multiple PackageVersion entries in eng/Packages.props. -->
     <!-- Shared pin for the editor packages in eng/Packages.props; must match 18.9.123 (resolved transitively
          via Microsoft.VisualStudio.SDK 18.9.496). Full NU1109 rationale lives there, next to the 18.9.x pins. -->
     <VisualStudioEditorPackagesVersion>18.9.123</VisualStudioEditorPackagesVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,7 +130,6 @@
     <MicrosoftTestPlatformVersion>17.14.1</MicrosoftTestPlatformVersion>
     <MicrosoftTestingExtensionsHangDumpVersion>2.0.2</MicrosoftTestingExtensionsHangDumpVersion>
     <XunitVersion>3.2.2</XunitVersion>
-    <XunitRunnerConsoleVersion>3.2.2</XunitRunnerConsoleVersion>
     <XunitXmlTestLoggerVersion>8.0.0</XunitXmlTestLoggerVersion>
   </PropertyGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,10 +90,12 @@
     <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.2</SystemRuntimeCompilerServicesUnsafeVersion>
     <!-- System.* packages from dotnet/runtime are managed in Version.Details.xml / Version.Details.props for source-build. -->
-    <!-- Product/PR builds consume MSBuild 18.10, which pulls System.Security.Cryptography.Xml >= 10.0.9
-         transitively. Raise the central pin to that floor so CPM transitive pinning doesn't report a
-         downgrade (NU1109). Source-build keeps the live runtime version flowed via Version.Details. -->
+    <!-- Product/PR builds consume MSBuild 18.10, which pulls these dotnet/runtime packages >= 10.0.9
+         transitively. Raise the central pins to that floor so CPM transitive pinning doesn't report a
+         downgrade (NU1109). Source-build keeps the live runtime versions flowed via Version.Details. -->
     <SystemSecurityCryptographyXmlVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemSecurityCryptographyXmlVersion>
+    <SystemCollectionsImmutableVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemCollectionsImmutableVersion>
+    <SystemReflectionMetadataVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemReflectionMetadataVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -129,6 +129,8 @@
     <!-- Visual Studio Shell packages -->
     <MicrosoftVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropVersion>
     <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
+    <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
+    <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
     <!-- Interop packages are pinned to the version required by Microsoft.VisualStudio.SDK (pulled transitively via Microsoft.CodeAnalysis.ExternalAccess.FSharp), which is newer than the other shell packages. -->
     <MicrosoftVisualStudioShellInteropVersion>18.9.438</MicrosoftVisualStudioShellInteropVersion>
     <MicrosoftVisualStudioTextManagerInteropVersion>18.9.438</MicrosoftVisualStudioTextManagerInteropVersion>
@@ -137,9 +139,7 @@
          Microsoft.CodeAnalysis.ExternalAccess.FSharp), so under CPM transitive pinning they must be pinned to
          the required 18.9.x versions rather than the shell package group; otherwise NU1109. -->
     <MicrosoftVisualStudioShellDesignVersion>18.9.493</MicrosoftVisualStudioShellDesignVersion>
-    <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioPackageLanguageService150Version>18.9.493</MicrosoftVisualStudioPackageLanguageService150Version>
-    <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>18.9.438</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioShellImmutable100Version>10.0.30319</MicrosoftVisualStudioShellImmutable100Version>
     <MicrosoftVisualStudioShellImmutable110Version>11.0.50727</MicrosoftVisualStudioShellImmutable110Version>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,91 +112,27 @@
     <!-- If a System.* package is stuck on version 4.3.x, targets .NET Standard 1.x and hasn't been
     updated in years, you most likely DON'T need it, please exercise caution when adding it to the list. -->
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
-    <MicrosoftDiaSymReaderPortablePdbVersion>1.6.0</MicrosoftDiaSymReaderPortablePdbVersion>
-    <!-- Versions for package groups -->
+
+    <!-- Shared version groups referenced by multiple PackageVersion entries in eng/Packages.props.
+         (Single-use package versions are pinned inline there; only genuinely shared or Arcade-read
+         versions live here.) -->
     <!-- Editor packages resolve to 18.9.123 transitively via Microsoft.VisualStudio.SDK 18.9.496 (pulled by
          Microsoft.CodeAnalysis.ExternalAccess.FSharp). Under CPM transitive pinning the central pin must match
          that resolved version, otherwise NU1109 downgrades every vsintegration project. -->
     <VisualStudioEditorPackagesVersion>18.9.123</VisualStudioEditorPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>18.0.2188-preview.1</MicrosoftVisualStudioShellPackagesVersion>
-    <VisualStudioProjectSystemPackagesVersion>18.0.1237-pre</VisualStudioProjectSystemPackagesVersion>
-    <VisualStudioShellProjectsPackages>18.0.2077-preview.1</VisualStudioShellProjectsPackages>
-    <MicrosoftVisualStudioThreadingPackagesVersion>18.7.19</MicrosoftVisualStudioThreadingPackagesVersion>
-  
-    <!-- Roslyn packages. Rest is managed by maestro bot and is in the imported .Details.props file -->
-    <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.28</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
-    <!-- Visual Studio Shell packages -->
-    <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
-    <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
-    <!-- Interop packages are pinned to the version required by Microsoft.VisualStudio.SDK (pulled transitively via Microsoft.CodeAnalysis.ExternalAccess.FSharp), which is newer than the other shell packages. -->
-    <MicrosoftVisualStudioShellInteropVersion>18.9.438</MicrosoftVisualStudioShellInteropVersion>
-    <MicrosoftVisualStudioTextManagerInteropVersion>18.9.438</MicrosoftVisualStudioTextManagerInteropVersion>
-    <MicrosoftVisualStudioOLEInteropVersion>18.9.438</MicrosoftVisualStudioOLEInteropVersion>
-    <!-- These shell packages are pulled higher transitively by Microsoft.VisualStudio.SDK 18.9.496 (via
-         Microsoft.CodeAnalysis.ExternalAccess.FSharp), so under CPM transitive pinning they must be pinned to
-         the required 18.9.x versions rather than the shell package group; otherwise NU1109. -->
-    <MicrosoftVisualStudioShellDesignVersion>18.9.493</MicrosoftVisualStudioShellDesignVersion>
-    <MicrosoftVisualStudioPackageLanguageService150Version>18.9.493</MicrosoftVisualStudioPackageLanguageService150Version>
-    <MicrosoftVisualStudioDesignerInterfacesVersion>18.9.438</MicrosoftVisualStudioDesignerInterfacesVersion>
-    <MicrosoftVisualStudioShellImmutable100Version>10.0.30319</MicrosoftVisualStudioShellImmutable100Version>
-    <MicrosoftVisualStudioShellImmutable110Version>11.0.50727</MicrosoftVisualStudioShellImmutable110Version>
-    <MicrosoftVisualStudioShellImmutable150Version>15.0.25123-Dev15Preview</MicrosoftVisualStudioShellImmutable150Version>
-
-    <!-- -->
-    <!-- Visual Studio Editor packages -->
-    <MicrosoftVisualStudioEditorVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioEditorVersion>
-    <MicrosoftVisualStudioLanguageStandardClassificationVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioLanguageStandardClassificationVersion>
-    <MicrosoftVisualStudioLanguageIntellisenseVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioLanguageIntellisenseVersion>
-    <!-- Microsoft.VisualStudio.Platform.VSEditor is the runtime implementation of the editor. Unlike the other editor
-         packages it is not pulled transitively by Microsoft.CodeAnalysis.ExternalAccess.FSharp, so it stays at the
-         explicit pin while Microsoft.VisualStudio.Text.* / .Editor get bumped to 18.9.123 transitively. Pin VSEditor to
-         the matching 18.9.123 so its implementation types load against the newer Text.Internal interfaces; otherwise the
-         VsMocks MEF catalog throws ReflectionTypeLoadException and every legacy VS unit test fails. -->
-    <MicrosoftVisualStudioPlatformVSEditorVersion>18.9.123</MicrosoftVisualStudioPlatformVSEditorVersion>
-    <MicrosoftVisualStudioTextUIWpfVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextUIWpfVersion>
-    <NuGetVisualStudioVersion>17.14.0</NuGetVisualStudioVersion>
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.800-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
-    <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>
 
-    <!-- Visual Studio Threading packages -->
-    <MicrosoftVisualStudioThreadingVersion>$(MicrosoftVisualStudioThreadingPackagesVersion)</MicrosoftVisualStudioThreadingVersion>
-
-    <!-- Transitive packages pinned to the versions required by Microsoft.CodeAnalysis.ExternalAccess.FSharp
-         (via Microsoft.VisualStudio.SDK 18.9.496), which are newer than the versions the Shell packages pull in.
-         Pinning them avoids MSB3277 assembly version conflicts across the vsintegration projects. -->
-    <MicrosoftVisualStudioValidationVersion>18.7.1</MicrosoftVisualStudioValidationVersion>
-    <MicrosoftVisualStudioRpcContractsVersion>18.9.453</MicrosoftVisualStudioRpcContractsVersion>
-    <MicrosoftServiceHubFrameworkVersion>4.10.128</MicrosoftServiceHubFrameworkVersion>
-    <StreamJsonRpcVersion>2.26.5</StreamJsonRpcVersion>
-
-    <!-- Microsoft.VisualStudio.Shell.15.0 18.9.x references Microsoft.VisualStudio.SolutionPersistence at runtime but
-         does not declare it as a NuGet dependency (it is expected to come from the VS install). The standalone VS unit
-         test host loads Shell.15.0 into a MEF catalog, so the assembly must be deployed next to it or Assembly.GetTypes
-         throws and every legacy VS unit test fails. -->
-    <MicrosoftVisualStudioSolutionPersistenceVersion>1.0.52</MicrosoftVisualStudioSolutionPersistenceVersion>
-
-    <!-- Visual Studio Project System packages-->
-    <MicrosoftVisualStudioProjectSystemVersion>$(VisualStudioProjectSystemPackagesVersion)</MicrosoftVisualStudioProjectSystemVersion>
-    <MicrosoftVisualStudioProjectSystemManagedVersion>2.3.6152103</MicrosoftVisualStudioProjectSystemManagedVersion>
-
-    <!-- Misc. Visual Studio packages -->
+    <!-- Read by name by the Arcade SDK (tools/VisualStudio.targets injects it into VSIX projects), so it must
+         stay a property rather than being inlined into eng/Packages.props. -->
     <MicrosoftVSSDKBuildToolsVersion>17.14.2120</MicrosoftVSSDKBuildToolsVersion>
-    <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
-    <!-- -->
+
     <!-- other packages -->
     <BenchmarkDotNetVersion>0.13.10</BenchmarkDotNetVersion>
-    <FsCheckVersion>2.16.6</FsCheckVersion>
-    <MicrosoftNetCompilersVersion>4.3.0-1.22220.8</MicrosoftNetCompilersVersion>
-     <!-- Making diff way too large, update separately later. e.g. to 6.0.0-rtm.21518.12 and 9.0.0-rc.2.24462.10 or via darc -->
-    <MicrosoftNETCoreILDAsmVersion>5.0.0-preview.7.20364.11</MicrosoftNETCoreILDAsmVersion>
-    <MicrosoftNETCoreILAsmVersion>5.0.0-preview.7.20364.11</MicrosoftNETCoreILAsmVersion>
     <MicrosoftTestPlatformVersion>17.14.1</MicrosoftTestPlatformVersion>
     <MicrosoftTestingExtensionsHangDumpVersion>2.0.2</MicrosoftTestingExtensionsHangDumpVersion>
-    <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
     <XunitVersion>3.2.2</XunitVersion>
     <XunitRunnerConsoleVersion>3.2.2</XunitRunnerConsoleVersion>
     <XunitXmlTestLoggerVersion>8.0.0</XunitXmlTestLoggerVersion>
-    <!-- -->
   </PropertyGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,6 @@
     <!-- FSharp.Core version -->
     <!-- For FSMajorVersion 10, use MinorVersion 1 to indicate breaking changes in FSharp.Core -->
     <FSMinorVersion Condition="'$(FSMajorVersion)' == '10'">1</FSMinorVersion>
-    <FSCoreProductVersion>$(FSMajorVersion).$(FSMinorVersion)</FSCoreProductVersion>
     <FSCorePackageVersionValue>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCorePackageVersionValue>
     <FSCoreVersionPrefix>$(FSMajorVersion).$(FSMinorVersion).$(FSBuildVersion)</FSCoreVersionPrefix>
     <FSCoreVersion>$(FSMajorVersion).$(FSMinorVersion).0.0</FSCoreVersion>
@@ -127,8 +126,6 @@
     <!-- Roslyn packages. Rest is managed by maestro bot and is in the imported .Details.props file -->
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.28</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <!-- Visual Studio Shell packages -->
-    <MicrosoftVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropVersion>
-    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
     <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioManagedInterfacesVersion>$(VisualStudioShellProjectsPackages)</MicrosoftVisualStudioManagedInterfacesVersion>
     <!-- Interop packages are pinned to the version required by Microsoft.VisualStudio.SDK (pulled transitively via Microsoft.CodeAnalysis.ExternalAccess.FSharp), which is newer than the other shell packages. -->
@@ -185,11 +182,6 @@
     <!-- Misc. Visual Studio packages -->
     <MicrosoftVSSDKBuildToolsVersion>17.14.2120</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>17.0.0</MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion>
-    <!-- -->
-    <!-- setup packages -->
-    <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
-    <MicroBuildCoreSentinelVersion>1.0.0</MicroBuildCoreSentinelVersion>
-    <MicroBuildPluginsSwixBuildVersion>1.1.87</MicroBuildPluginsSwixBuildVersion>
     <!-- -->
     <!-- other packages -->
     <BenchmarkDotNetVersion>0.13.10</BenchmarkDotNetVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,6 +90,10 @@
     <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.2</SystemRuntimeCompilerServicesUnsafeVersion>
     <!-- System.* packages from dotnet/runtime are managed in Version.Details.xml / Version.Details.props for source-build. -->
+    <!-- Product/PR builds consume MSBuild 18.10, which pulls System.Security.Cryptography.Xml >= 10.0.9
+         transitively. Raise the central pin to that floor so CPM transitive pinning doesn't report a
+         downgrade (NU1109). Source-build keeps the live runtime version flowed via Version.Details. -->
+    <SystemSecurityCryptographyXmlVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemSecurityCryptographyXmlVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,12 +90,22 @@
     <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.2</SystemRuntimeCompilerServicesUnsafeVersion>
     <!-- System.* packages from dotnet/runtime are managed in Version.Details.xml / Version.Details.props for source-build. -->
-    <!-- Product/PR builds consume MSBuild 18.10, which pulls these dotnet/runtime packages >= 10.0.9
-         transitively. Raise the central pins to that floor so CPM transitive pinning doesn't report a
-         downgrade (NU1109). Source-build keeps the live runtime versions flowed via Version.Details. -->
-    <SystemSecurityCryptographyXmlVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemSecurityCryptographyXmlVersion>
-    <SystemCollectionsImmutableVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemCollectionsImmutableVersion>
-    <SystemReflectionMetadataVersion Condition="'$(DotNetBuildSourceOnly)' != 'true'">10.0.9</SystemReflectionMetadataVersion>
+    <!-- Product/PR builds consume MSBuild 18.10 (via fsc/fsi and FSharp.Build.UnitTests), which pulls these
+         dotnet/runtime packages transitively at >= 10.0.9. CPM transitive pinning needs the *central* pin to
+         meet that floor, so define dedicated ...CentralVersion properties for eng/Packages.props. These do NOT
+         touch the darc-flowed $(System*Version) properties, which stay authoritative for source-build live
+         versions and for FSharp.Compiler.Service's shipped nuspec dependency metadata (FCS itself does not pull
+         MSBuild, so it must keep the darc version). The floor only raises when darc is below it; once darc flows
+         >= 10.0.9 the darc version wins, so this never freezes or downgrades the flow. -->
+    <SystemSecurityCryptographyXmlCentralVersion>$(SystemSecurityCryptographyXmlVersion)</SystemSecurityCryptographyXmlCentralVersion>
+    <SystemCollectionsImmutableCentralVersion>$(SystemCollectionsImmutableVersion)</SystemCollectionsImmutableCentralVersion>
+    <SystemReflectionMetadataCentralVersion>$(SystemReflectionMetadataVersion)</SystemReflectionMetadataCentralVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+    <SystemSecurityCryptographyXmlCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemSecurityCryptographyXmlVersion)', '10.0.9'))">10.0.9</SystemSecurityCryptographyXmlCentralVersion>
+    <SystemCollectionsImmutableCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemCollectionsImmutableVersion)', '10.0.9'))">10.0.9</SystemCollectionsImmutableCentralVersion>
+    <SystemReflectionMetadataCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemReflectionMetadataVersion)', '10.0.9'))">10.0.9</SystemReflectionMetadataCentralVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/setup/Swix/Directory.Build.props
+++ b/setup/Swix/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
     <UseVsMicroBuildAssemblyVersion>true</UseVsMicroBuildAssemblyVersion>
     <VisualStudioInsertionComponent>Microsoft.FSharp</VisualStudioInsertionComponent>
     <OutputArchitecture>neutral</OutputArchitecture>

--- a/src/Compiler/FSharp.Compiler.Service.fsproj
+++ b/src/Compiler/FSharp.Compiler.Service.fsproj
@@ -621,17 +621,17 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Reflection.Emit" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Buffers" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -82,16 +82,16 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/FSharp.Build/FSharp.Build.fsproj
@@ -89,9 +89,6 @@
     <PackageReference Include="Microsoft.Build.Framework" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
-    <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/src/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
+++ b/src/FSharp.Compiler.Interactive.Settings/FSharp.Compiler.Interactive.Settings.fsproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
+++ b/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
@@ -8,6 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Package References">
+		<!-- net8.0 host keeps DI 8.0.0; the central 10.0.0 is only needed by consumers that pull DI >= 10 transitively. -->
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
 		<!-- Pinned below the central versions: this LSP host targets the VS 17.x servicing baseline. -->

--- a/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
+++ b/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
@@ -10,8 +10,9 @@
 	<ItemGroup Label="Package References">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading" />
-		<PackageReference Include="StreamJsonRpc" />
+		<!-- Pinned below the central versions: this LSP host targets the VS 17.x servicing baseline. -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading" VersionOverride="17.12.21" />
+		<PackageReference Include="StreamJsonRpc" VersionOverride="2.25.29" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
+++ b/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
@@ -8,10 +8,10 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Package References">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.6-preview" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.21" />
-		<PackageReference Include="StreamJsonRpc" Version="2.25.29" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
+		<PackageReference Include="Microsoft.VisualStudio.Threading" />
+		<PackageReference Include="StreamJsonRpc" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -28,7 +28,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-		<PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+		<PackageReference Include="FSharp.Core" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
+++ b/src/FSharp.Compiler.LanguageServer/FSharp.Compiler.LanguageServer.fsproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Label="Package References">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="8.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
 		<!-- Pinned below the central versions: this LSP host targets the VS 17.x servicing baseline. -->
 		<PackageReference Include="Microsoft.VisualStudio.Threading" VersionOverride="17.12.21" />

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
@@ -51,13 +51,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.Reflection.Emit" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
+++ b/src/FSharp.DependencyManager.Nuget/FSharp.DependencyManager.Nuget.fsproj
@@ -54,10 +54,4 @@
     <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" />
-    <PackageReference Include="System.Reflection.Metadata" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-  </ItemGroup>
-
 </Project>

--- a/src/FSharp.VisualStudio.Extension/FSharp.VisualStudio.Extension.csproj
+++ b/src/FSharp.VisualStudio.Extension/FSharp.VisualStudio.Extension.csproj
@@ -16,7 +16,8 @@
 		<PackageReference Include="Microsoft.VisualStudio.Extensibility.Build" />
 		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" />
 		<PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading" />
+		<!-- Pinned below the central version to match this VS extension's 17.13 tooling baseline. -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading" VersionOverride="17.13.2" />
 		<!--<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" />
 		<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.Collector" />
 		<PackageReference Include="OpenTelemetry" />

--- a/src/FSharp.VisualStudio.Extension/FSharp.VisualStudio.Extension.csproj
+++ b/src/FSharp.VisualStudio.Extension/FSharp.VisualStudio.Extension.csproj
@@ -12,20 +12,20 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="17.13.39620" />
-		<PackageReference Include="Microsoft.VisualStudio.Extensibility.Build" Version="17.13.39620" />
-		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="17.13.9" />
-		<PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" Version="17.13.66" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.13.2" />
-		<!--<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" Version="0.1.718-beta" />
-		<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.Collector" Version="0.1.718-beta" />
-		<PackageReference Include="OpenTelemetry" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />-->
+		<PackageReference Include="Microsoft.VisualStudio.Extensibility.Sdk" />
+		<PackageReference Include="Microsoft.VisualStudio.Extensibility.Build" />
+		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" />
+		<PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
+		<PackageReference Include="Microsoft.VisualStudio.Threading" />
+		<!--<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" />
+		<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.Collector" />
+		<PackageReference Include="OpenTelemetry" />
+		<PackageReference Include="OpenTelemetry.Api" />
+		<PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" />-->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/FSharp.VisualStudio.Extension/FSharp.VisualStudio.Extension.csproj
+++ b/src/FSharp.VisualStudio.Extension/FSharp.VisualStudio.Extension.csproj
@@ -18,15 +18,15 @@
 		<PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
 		<!-- Pinned below the central version to match this VS extension's 17.13 tooling baseline. -->
 		<PackageReference Include="Microsoft.VisualStudio.Threading" VersionOverride="17.13.2" />
-		<!--<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" />
-		<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.Collector" />
-		<PackageReference Include="OpenTelemetry" />
-		<PackageReference Include="OpenTelemetry.Api" />
-		<PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
-		<PackageReference Include="OpenTelemetry.Exporter.Console" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />-->
+		<!--<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" Version="0.1.718-beta" />
+		<PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.Collector" Version="0.1.718-beta" />
+		<PackageReference Include="OpenTelemetry" Version="1.11.2" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
+		<PackageReference Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="1.11.2" />
+		<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />-->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Microsoft.CommonLanguageServerProtocol.Framework.Proxy/Microsoft.CommonLanguageServerProtocol.Framework.Proxy.csproj
+++ b/src/Microsoft.CommonLanguageServerProtocol.Framework.Proxy/Microsoft.CommonLanguageServerProtocol.Framework.Proxy.csproj
@@ -8,7 +8,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CommonLanguageServerProtocol.Framework" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading" />
+		<!-- Pinned below the central version to match the LSP framework's VS 17.x baseline. -->
+		<PackageReference Include="Microsoft.VisualStudio.Threading" VersionOverride="17.12.21" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Microsoft.CommonLanguageServerProtocol.Framework.Proxy/Microsoft.CommonLanguageServerProtocol.Framework.Proxy.csproj
+++ b/src/Microsoft.CommonLanguageServerProtocol.Framework.Proxy/Microsoft.CommonLanguageServerProtocol.Framework.Proxy.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CommonLanguageServerProtocol.Framework" PrivateAssets="all" Version="4.13.0-3.24579.1" />
-		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.21" />
+		<PackageReference Include="Microsoft.CommonLanguageServerProtocol.Framework" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.VisualStudio.Threading" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
+++ b/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.NuGetRepack.Tasks" Version="$(MicrosoftDotNetNuGetRepackTasksVersion)" />
+    <PackageReference Include="Microsoft.DotNet.NuGetRepack.Tasks" />
   </ItemGroup>
   <!-- TODO: Remove UsingTask when upgrading to Arcade 11: https://github.com/dotnet/fsharp/issues/19557 -->
   <PropertyGroup>

--- a/src/fsc/fsc.targets
+++ b/src/fsc/fsc.targets
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,14 +53,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
 </Project>

--- a/src/fsc/fsc.targets
+++ b/src/fsc/fsc.targets
@@ -58,9 +58,4 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Memory" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
-  </ItemGroup>
-
 </Project>

--- a/src/fsi/fsi.targets
+++ b/src/fsi/fsi.targets
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup>
@@ -65,9 +65,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
 </Project>

--- a/tests/AheadOfTime/Directory.Build.props
+++ b/tests/AheadOfTime/Directory.Build.props
@@ -6,9 +6,6 @@
   <PropertyGroup>
     <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
     <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <LocalFSharpBuildBinPath>$(MSBuildThisFileDirectory)/../../artifacts/bin/fsc/Release/$(FSharpNetCoreProductTargetFramework)</LocalFSharpBuildBinPath>    
   </PropertyGroup>
 

--- a/tests/AheadOfTime/Directory.Build.props
+++ b/tests/AheadOfTime/Directory.Build.props
@@ -4,6 +4,11 @@
   <Import Project="$(MSBuildThisFileDirectory)../../eng/TargetFrameworks.props" />
   
   <PropertyGroup>
+    <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LocalFSharpBuildBinPath>$(MSBuildThisFileDirectory)/../../artifacts/bin/fsc/Release/$(FSharpNetCoreProductTargetFramework)</LocalFSharpBuildBinPath>    
   </PropertyGroup>
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -25,7 +25,7 @@
        central list does not apply; supply the versions inline from the properties they define before this import. -->
   <ItemGroup Condition="'$(_IsTestRunnerProject)' == 'true' AND '$(ExcludeFromTestPackageReferences)' != 'true' AND '$(ImportDirectoryPackagesProps)' == 'false'">
     <PackageReference Update="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
-    <PackageReference Update="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
+    <PackageReference Update="xunit.v3.runner.console" Version="$(XunitVersion)" />
     <PackageReference Update="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
     <PackageReference Update="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
     <PackageReference Update="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -9,14 +9,14 @@
 
   <!-- xUnit3 packages for all test projects (except Test.Utilities which is a library) -->
   <ItemGroup Condition="($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))) AND '$(ExcludeFromTestPackageReferences)' != 'true'">
-    <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
+    <PackageReference Include="xunit.v3.runner.console" />
     <!-- MTP HangDump extension for hang detection (replaces VSTest blame-hang-timeout) -->
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <!-- Xunit XML test logger for CI-friendly xunit v2 format output -->
-    <PackageReference Include="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
+    <PackageReference Include="XunitXml.TestLogger" />
     <!-- ObjectModel is required at runtime by XunitXml.TestLogger but not declared as a transitive dependency -->
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
   </ItemGroup>
 
   <!-- Enable Microsoft.Testing.Platform runner for all test projects -->

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,10 +5,12 @@
   <PropertyGroup>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <DebugType>portable</DebugType>
+    <!-- True for the actual test-runner projects (*.Tests, *.ComponentTests, *.UnitTests), not generated fixtures. -->
+    <_IsTestRunnerProject Condition="$(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))">true</_IsTestRunnerProject>
   </PropertyGroup>
 
   <!-- xUnit3 packages for all test projects (except Test.Utilities which is a library) -->
-  <ItemGroup Condition="($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))) AND '$(ExcludeFromTestPackageReferences)' != 'true'">
+  <ItemGroup Condition="'$(_IsTestRunnerProject)' == 'true' AND '$(ExcludeFromTestPackageReferences)' != 'true'">
     <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.v3.runner.console" />
     <!-- MTP HangDump extension for hang detection (replaces VSTest blame-hang-timeout) -->
@@ -21,7 +23,7 @@
 
   <!-- Opt-out subtrees (ImportDirectoryPackagesProps=false, e.g. EndToEndBuildTests) are not under CPM, so the
        central list does not apply; supply the versions inline from the properties they define before this import. -->
-  <ItemGroup Condition="($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))) AND '$(ExcludeFromTestPackageReferences)' != 'true' AND '$(ImportDirectoryPackagesProps)' == 'false'">
+  <ItemGroup Condition="'$(_IsTestRunnerProject)' == 'true' AND '$(ExcludeFromTestPackageReferences)' != 'true' AND '$(ImportDirectoryPackagesProps)' == 'false'">
     <PackageReference Update="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
     <PackageReference Update="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
     <PackageReference Update="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
@@ -30,7 +32,7 @@
   </ItemGroup>
 
   <!-- Enable Microsoft.Testing.Platform runner for all test projects -->
-  <PropertyGroup Condition="($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))) AND '$(ExcludeFromTestPackageReferences)' != 'true'">
+  <PropertyGroup Condition="'$(_IsTestRunnerProject)' == 'true' AND '$(ExcludeFromTestPackageReferences)' != 'true'">
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
@@ -43,9 +45,8 @@
 
   <!-- Test-specific settings for xUnit3/MTP migration -->
   <!-- Force x64 for .NET Framework test executables to avoid OOM and sizeof issues.
-       Note: OutputType isn't available at props evaluation time, so we apply to all net472 test projects
-       Only apply to actual test runner projects (*.Tests, *.ComponentTests, *.UnitTests), not dynamically generated test fixtures -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472' AND ($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests')))">
+       OutputType isn't available at props evaluation time, so this applies to all net472 test-runner projects. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472' AND '$(_IsTestRunnerProject)' == 'true'">
     <PlatformTarget>x64</PlatformTarget>
     <!-- Clear RuntimeIdentifier(s) to avoid conflict with PlatformTarget -->
     <RuntimeIdentifier />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -19,6 +19,16 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
   </ItemGroup>
 
+  <!-- Opt-out subtrees (ImportDirectoryPackagesProps=false, e.g. EndToEndBuildTests) are not under CPM, so the
+       central list does not apply; supply the versions inline from the properties they define before this import. -->
+  <ItemGroup Condition="($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))) AND '$(ExcludeFromTestPackageReferences)' != 'true' AND '$(ImportDirectoryPackagesProps)' == 'false'">
+    <PackageReference Update="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
+    <PackageReference Update="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
+    <PackageReference Update="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
+    <PackageReference Update="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
+    <PackageReference Update="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
+  </ItemGroup>
+
   <!-- Enable Microsoft.Testing.Platform runner for all test projects -->
   <PropertyGroup Condition="($(MSBuildProjectName.EndsWith('.Tests')) OR $(MSBuildProjectName.EndsWith('.ComponentTests')) OR $(MSBuildProjectName.EndsWith('.UnitTests'))) AND '$(ExcludeFromTestPackageReferences)' != 'true'">
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>

--- a/tests/EndToEndBuildTests/Directory.Build.props
+++ b/tests/EndToEndBuildTests/Directory.Build.props
@@ -7,7 +7,6 @@
     <RollForward>LatestMajor</RollForward>
     <!-- xUnit3 package versions for EndToEndBuildTests - these must be defined before importing parent props -->
     <XunitVersion Condition="'$(XunitVersion)' == ''">3.2.2</XunitVersion>
-    <XunitRunnerConsoleVersion Condition="'$(XunitRunnerConsoleVersion)' == ''">3.2.2</XunitRunnerConsoleVersion>
     <MicrosoftTestingExtensionsHangDumpVersion Condition="'$(MicrosoftTestingExtensionsHangDumpVersion)' == ''">2.0.2</MicrosoftTestingExtensionsHangDumpVersion>
     <XunitXmlTestLoggerVersion Condition="'$(XunitXmlTestLoggerVersion)' == ''">8.0.0</XunitXmlTestLoggerVersion>
     <MicrosoftTestPlatformVersion Condition="'$(MicrosoftTestPlatformVersion)' == ''">17.14.1</MicrosoftTestPlatformVersion>

--- a/tests/EndToEndBuildTests/Directory.Build.props
+++ b/tests/EndToEndBuildTests/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
     <FSharpTestCompilerVersion Condition = " '$(FSharpTestCompilerVersion)' == '' ">net40</FSharpTestCompilerVersion>
     <RollForward>LatestMajor</RollForward>
     <!-- xUnit3 package versions for EndToEndBuildTests - these must be defined before importing parent props -->

--- a/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
+++ b/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
@@ -25,13 +25,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(FSharpNetCoreProductTargetFramework)'">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
 </Project>

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -547,7 +547,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
 

--- a/tests/FSharp.Compiler.LanguageServer.Tests/FSharp.Compiler.LanguageServer.Tests.fsproj
+++ b/tests/FSharp.Compiler.LanguageServer.Tests/FSharp.Compiler.LanguageServer.Tests.fsproj
@@ -25,7 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.13.6-preview" />
+		<PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -39,7 +39,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-		<PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+		<PackageReference Include="FSharp.Core" />
 	</ItemGroup>
 
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -93,9 +93,6 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dotnet.ProjInfo" />
-    <!-- Force a newer Newtonsoft.Json version to avoid conflicts. -->
-    <PackageReference Include="Newtonsoft.Json" />
 	<ProjectReference Include="..\..\src\Compiler\FSharp.Compiler.Service.fsproj">
 		<!-- If tests would use net10.0, the surface area changes because of different set of Assembly references -->
 		<SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -93,9 +93,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dotnet.ProjInfo" Version="0.37.0" />
+    <PackageReference Include="Dotnet.ProjInfo" />
     <!-- Force a newer Newtonsoft.Json version to avoid conflicts. -->
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
 	<ProjectReference Include="..\..\src\Compiler\FSharp.Compiler.Service.fsproj">
 		<!-- If tests would use net10.0, the surface area changes because of different set of Assembly references -->
 		<SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>

--- a/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core.UnitTests.fsproj
@@ -98,6 +98,6 @@
   <ItemGroup>
     <ProjectReference Include="$(FSharpSourcesRoot)\FSharp.Core\FSharp.Core.fsproj" />
     <ProjectReference Include="$(FSharpSourcesRoot)\..\tests\FSharp.Test.Utilities\FSharp.Test.Utilities.fsproj" />
-    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
+    <PackageReference Include="FsCheck" />
   </ItemGroup>
 </Project>

--- a/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
+++ b/tests/FSharp.Test.Utilities/FSharp.Test.Utilities.fsproj
@@ -54,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BUILDING_USING_DOTNET)' == 'true'">
@@ -65,19 +65,19 @@
 
   <!-- Runtime dependencies. Beware. -->
   <ItemGroup>
-	<PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(MicrosoftNETCoreILDAsmVersion)">
+	<PackageReference Include="Microsoft.NETCore.ILDAsm">
 		<IncludeAssets>runtime; native</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(MicrosoftNETCoreILAsmVersion)">
+	<PackageReference Include="Microsoft.NETCore.ILAsm">
 		<IncludeAssets>runtime; native</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)">
+	<PackageReference Include="Microsoft.Net.Compilers">
 		<IncludeAssets>runtime; native</IncludeAssets>
 		<PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)">
+	<PackageReference Include="Microsoft.DiaSymReader.PortablePdb">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
@@ -94,24 +94,24 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(FSharpNetCoreProductTargetFramework)'">
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 <PropertyGroup>
  <NoWarn>$(NoWarn);NU1510;44</NoWarn> <!-- NU1510: Project is explicitly referencing the runtime assembly 'System.Collections.Immutable', however, if we remove it, it tries to find it on the wrong path. Also, local NoWarn does not help - This is just me trying to enforce it -->
  <!-- 44: AssemblyName.CodeBase is deprecated but needed for assembly resolution in VS integration tests -->
 </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" Version="$(MicrosoftCodeAnalysisTestResourcesProprietaryVersion)" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="System.Collections.Immutable" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Test.Resources.Proprietary" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="Newtonsoft.Json" />
     <!-- xUnit3 extensibility packages for custom test utilities -->
-    <PackageReference Include="xunit.v3.common" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.v3.assert" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="$(XunitVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="xunit.v3.common" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.extensibility.core" GeneratePathProperty="true" />
   </ItemGroup>
 
   <!-- Explicit reference to xunit.v3.core.dll to ensure F# compiler finds types -->

--- a/tests/benchmarks/Directory.Build.props
+++ b/tests/benchmarks/Directory.Build.props
@@ -2,6 +2,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <TargetFramework>$(FSharpNetCoreProductTargetFramework)</TargetFramework>
   </PropertyGroup>

--- a/tests/fsharp/SDKTests/Directory.Build.props
+++ b/tests/fsharp/SDKTests/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- empty to prevent directory crawling -->
     <PropertyGroup>
+        <!-- Auxiliary/consumer-style projects keep their own inline package versions (not under repo CPM). -->
+        <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
         <NuGetAudit>false</NuGetAudit>
     </PropertyGroup>
 

--- a/tests/projects/CompilerCompat/Directory.Build.props
+++ b/tests/projects/CompilerCompat/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <!-- Compiler-compat test projects reference a local 1.0.* package; keep them off repo CPM. -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+</Project>

--- a/tests/service/data/TestTP/TestTP.fsproj
+++ b/tests/service/data/TestTP/TestTP.fsproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(FSHARPCORE_USE_PACKAGE)' == 'true'">
-    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/Directory.Build.targets
+++ b/vsintegration/Directory.Build.targets
@@ -3,22 +3,22 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="$(MicrosoftVisualStudioOLEInteropVersion)" PrivateAssets="compile" ExcludeAssets="compile" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="$(MicrosoftVisualStudioShellInteropVersion)" PrivateAssets="compile" ExcludeAssets="compile" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" Version="$(MicrosoftVisualStudioTextManagerInteropVersion)" PrivateAssets="compile" ExcludeAssets="compile" />
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.Build" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" PrivateAssets="compile" ExcludeAssets="compile" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" PrivateAssets="compile" ExcludeAssets="compile" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop" PrivateAssets="compile" ExcludeAssets="compile" />
+    <PackageReference Include="System.Buffers" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="System.Composition" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="System.Memory" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
     <!-- Pinned to match Microsoft.CodeAnalysis.ExternalAccess.FSharp's transitive versions and avoid MSB3277 conflicts. -->
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" Version="$(MicrosoftVisualStudioRpcContractsVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="Microsoft.ServiceHub.Framework" Version="$(MicrosoftServiceHubFrameworkVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
-    <PackageReference Include="StreamJsonRpc" Version="$(StreamJsonRpcVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.ServiceHub.Framework" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="StreamJsonRpc" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
   </ItemGroup>
 
   <!-- New VS does not allow embedded interop assemblies ... this turns off the target that turns it on -->

--- a/vsintegration/Vsix/VisualFSharpFull/VisualFSharp.Core.targets
+++ b/vsintegration/Vsix/VisualFSharpFull/VisualFSharp.Core.targets
@@ -260,8 +260,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -177,12 +177,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(MicrosoftCodeAnalysisEditorFeaturesTextVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(MicrosoftCodeAnalysisExternalAccessFSharpVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="$(MicrosoftVisualStudioProjectSystemManagedVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" Condition="'$(Configuration)' == 'Debug'" />    
+    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Text" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Condition="'$(Configuration)' == 'Debug'" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -182,7 +182,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Condition="'$(Configuration)' == 'Debug'" />    
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.LanguageService.Base/FSharp.LanguageService.Base.csproj
+++ b/vsintegration/src/FSharp.LanguageService.Base/FSharp.LanguageService.Base.csproj
@@ -46,9 +46,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="$(MicrosoftVisualStudioPackageLanguageService150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
+++ b/vsintegration/src/FSharp.LanguageService/FSharp.LanguageService.fsproj
@@ -56,14 +56,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(MicrosoftVisualStudioLanguageStandardClassificationVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.ProjectSystem.Base/FSharp.ProjectSystem.Base.csproj
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/FSharp.ProjectSystem.Base.csproj
@@ -39,12 +39,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" Version="$(MicrosoftVisualFSharpMicrosoftVisualStudioShellUIInternalVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
+    <PackageReference Include="Microsoft.VisualFSharp.Microsoft.VisualStudio.Shell.UI.Internal" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.ProjectSystem.Base/FSharp.ProjectSystem.Base.csproj
+++ b/vsintegration/src/FSharp.ProjectSystem.Base/FSharp.ProjectSystem.Base.csproj
@@ -44,7 +44,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/FSharp.ProjectSystem.FSharp.fsproj
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/FSharp.ProjectSystem.FSharp.fsproj
@@ -104,12 +104,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="$(MicrosoftVisualStudioShellImmutable150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
   </ItemGroup>
 
 </Project>

--- a/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.ProjectSystem.PropertyPages.vbproj
+++ b/vsintegration/src/FSharp.ProjectSystem.PropertyPages/FSharp.ProjectSystem.PropertyPages.vbproj
@@ -46,9 +46,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfacesVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" Version="$(MicrosoftVisualStudioShellImmutable110Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
@@ -57,9 +57,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" Version="$(MicrosoftVisualStudioPackageLanguageService150Version)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" />
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 

--- a/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
+++ b/vsintegration/src/FSharp.VS.FSI/FSharp.VS.FSI.fsproj
@@ -59,7 +59,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Editor" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.Package.LanguageService.15.0" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools" />
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 

--- a/vsintegration/tests/Directory.Build.targets
+++ b/vsintegration/tests/Directory.Build.targets
@@ -5,6 +5,6 @@
     <!-- Deploy Microsoft.VisualStudio.SolutionPersistence next to the VS unit-test host. Shell.15.0 18.9.x references
          it at runtime without declaring a NuGet dependency (it normally comes from the VS install), and the tests load
          Shell.15.0 into a MEF catalog, so it must be copied locally. Scoped to test projects to keep it out of the VSIX. -->
-    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="$(MicrosoftVisualStudioSolutionPersistenceVersion)" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" PrivateAssets="all" ExcludeAssets="contentFiles;analyzers;native" />
   </ItemGroup>
 </Project>

--- a/vsintegration/tests/FSharp.Editor.IntegrationTests/FSharp.Editor.IntegrationTests.csproj
+++ b/vsintegration/tests/FSharp.Editor.IntegrationTests/FSharp.Editor.IntegrationTests.csproj
@@ -27,12 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator" Version="$(MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(MicrosoftVisualStudioLanguageIntellisenseVersion)" />
-    <PackageReference Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
-    <PackageReference Include="Nullable" Version="1.3.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
+    <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.Xunit" />
+    <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
+    <PackageReference Include="NuGet.VisualStudio" />
+    <PackageReference Include="Nullable" />
   </ItemGroup>
 
   <Target Name="SyncXunitDesktopDll" AfterTargets="Build" Condition="'$(OutputType)' == 'Exe'">

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -92,12 +92,12 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 
-	<PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(MicrosoftCodeAnalysisExternalAccessFSharpVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
+	<PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
   </ItemGroup>
 
   <ItemGroup>
@@ -106,11 +106,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
-    <PackageReference Include="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
+    <PackageReference Include="xunit.v3.runner.console" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="XunitXml.TestLogger" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
   </ItemGroup>
 
 </Project>

--- a/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
+++ b/vsintegration/tests/Salsa/VisualFSharp.Salsa.fsproj
@@ -53,14 +53,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
-    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.v3.assert" Version="$(XunitVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" />
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="xunit.v3.assert" />
   </ItemGroup>
 
 </Project>

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -117,19 +117,19 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 
-	<PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(MicrosoftCodeAnalysisExternalAccessFSharpVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" Version="$(MicrosoftVisualStudioPlatformVSEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" Version="$(MicrosoftVisualStudioProjectSystemManagedVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="$(MicrosoftVisualStudioProjectSystemVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="$(MicrosoftVisualStudioShellImmutable100Version)" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.v3.runner.console" Version="$(XunitRunnerConsoleVersion)" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" />
-    <PackageReference Include="XunitXml.TestLogger" Version="$(XunitXmlTestLoggerVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformVersion)" />
+	<PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" />
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
+    <PackageReference Include="xunit.v3.runner.console" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="XunitXml.TestLogger" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Turn on NuGet Central Package Management with transitive pinning across the
repo: package versions now come from a single central list (`eng/Packages.props`),
and vulnerable transitive dependencies such as `System.Security.Cryptography.Xml`
are pinned repo-wide.

This unblocks removing the `-warnNotAsErrors` NuGet Audit workaround for fsharp
in the dotnet/dotnet VMR.
