### PR TITLE
Avoid per-instance lock object in InterruptibleLazy and DelayInitArrayMap

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -133,6 +133,7 @@
 * Parser: recover on unfinished abstract members ([PR #20070](https://github.com/dotnet/fsharp/pull/20070))
 * Fix #5795: Allow attributes defined in a `module rec` / `namespace rec` scope to be used on union cases, record fields, and generic type parameters of types in the same recursive scope. ([Issue #5795](https://github.com/dotnet/fsharp/issues/5795), [PR #19744](https://github.com/dotnet/fsharp/pull/19744))
 * Import: Don't walk non-F# assemblies when labelling trait constraint sources (PR [#20090](https://github.com/dotnet/fsharp/pull/20090))
+* Avoid per-instance lock object in InterruptibleLazy and DelayInitArrayMap (PR [#20088](https://github.com/dotnet/fsharp/pull/20088))
 
 ### Added
 

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -15,8 +15,6 @@ open FSharp.Compiler.Caches
 
 [<Class>]
 type InterruptibleLazy<'T> private (value, valueFactory: unit -> 'T) =
-    let syncObj = obj ()
-
     [<VolatileField>]
     // TODO nullness - this is boxed to obj because of an attribute targets bug fixed in main, but not yet shipped (needs shipped 8.0.400)
     let mutable valueFactory: objnull = valueFactory
@@ -34,7 +32,7 @@ type InterruptibleLazy<'T> private (value, valueFactory: unit -> 'T) =
         match valueFactory with
         | null -> value
         | _ ->
-            Monitor.Enter(syncObj)
+            Monitor.Enter(this)
 
             try
                 match valueFactory with
@@ -44,7 +42,7 @@ type InterruptibleLazy<'T> private (value, valueFactory: unit -> 'T) =
                     value <- (valueFactory |> unbox<unit -> 'T>) ()
                     valueFactory <- Unchecked.defaultof<_>
             finally
-                Monitor.Exit(syncObj)
+                Monitor.Exit(this)
 
             value
 
@@ -151,8 +149,6 @@ module internal PervasiveAutoOpens =
 
 [<AbstractClass>]
 type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
-    let syncObj = obj ()
-
     let mutable arrayStore: (_ array | null) = null
     let mutable dictStore: (_ | null) = null
 
@@ -162,7 +158,7 @@ type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
         match arrayStore with
         | NonNull value -> value
         | _ ->
-            Monitor.Enter(syncObj)
+            Monitor.Enter(this)
 
             try
                 match arrayStore with
@@ -174,14 +170,14 @@ type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
                     func <- Unchecked.defaultof<_>
                     freshArray
             finally
-                Monitor.Exit(syncObj)
+                Monitor.Exit(this)
 
     member this.GetDictionary() =
         match dictStore with
         | NonNull value -> value
         | _ ->
             let array = this.GetArray()
-            Monitor.Enter(syncObj)
+            Monitor.Enter(this)
 
             try
                 match dictStore with
@@ -191,7 +187,7 @@ type DelayInitArrayMap<'T, 'TDictKey, 'TDictValue>(f: unit -> 'T[]) =
                     dictStore <- dict
                     dict
             finally
-                Monitor.Exit(syncObj)
+                Monitor.Exit(this)
 
     abstract CreateDictionary: 'T[] -> IDictionary<'TDictKey, 'TDictValue>
 

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -8,6 +8,7 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Runtime.CompilerServices
 
+/// Do not lock on these objects.
 [<Class>]
 type InterruptibleLazy<'T> =
     new: valueFactory: (unit -> 'T) -> InterruptibleLazy<'T>


### PR DESCRIPTION
I've been measuring memory allocations on some my changes and found out that these sync objects retail a lot of memory due to usages like in `ImportILTypeDef`. This is a debatable change: it makes things more dangerous (an issue could be if someone locks on the lazy itself) but at the same it's an implementation detail inside the compiler which is fairly advanced, so I hope that it can be used responsibly.