### PR TITLE
Optimizer: fix accessing captured values when skipping inlining

### DIFF
--- a/src/Compiler/Optimize/Optimizer.fs
+++ b/src/Compiler/Optimize/Optimizer.fs
@@ -3570,11 +3570,11 @@ and TryInlineApplication cenv env finfo (valExpr: Expr) (tyargs: TType list, arg
             let specLambda = MakeApplicationAndBetaReduce g (f2R, origLambdaTy, [tyargs], [], m)
             let specLambdaTy = tyOfExpr g specLambda
 
-            // Typars that flow in from the enclosing scope when tyargs are non-concrete.
-            // specLambdaTy is closed over the vref's typars after beta-reduction, so its free
-            // typars are exactly the ones carried in by tyargs.
+            // Typars that flow in from the enclosing scope when tyargs are non-concrete. A tyarg can reach
+            // only the body, and typars left unabstracted below are erased to 'object'.
             let freeTypars =
-                (freeInType CollectTyparsNoCaching specLambdaTy).FreeTypars
+                (freeInExpr CollectTyparsAndLocalsNoCaching specLambda).FreeTyvars.FreeTypars
+                |> Zset.union (freeInType CollectTyparsNoCaching specLambdaTy).FreeTypars
                 |> Zset.elements
 
             let allTyargsAreConcrete = List.isEmpty freeTypars
@@ -3618,6 +3618,27 @@ and TryInlineApplication cenv env finfo (valExpr: Expr) (tyargs: TType list, arg
             let freeTyparsNeedWitnesses =
                 GetTraitWitnessInfosOfTypars g 0 freeTypars |> List.isEmpty |> not
 
+            // A static method would resolve values captured from the enclosing method against the caller's
+            // storage, so lift them into a leading argument group. The closure form captures them itself.
+            let specLambdaRFvs = freeInExpr CollectLocals specLambdaR
+
+            let capturedVals =
+                specLambdaRFvs.FreeLocals
+                |> Zset.elements
+                |> List.filter (fun v -> not v.IsCompiledAsTopLevel)
+
+            let capturedArgGroups = if List.isEmpty capturedVals then [] else [ capturedVals ]
+
+            // Captured values are passed by value, so writes to a mutable local would be lost -
+            // LowerLocalMutables promotes those to reference cells only after this loop. 'base' calls and
+            // protected fields cannot leave their member at all.
+            let cannotLiftCapturedVals =
+                usesMethodLocalConstructsOrProtectedField cenv specLambdaRFvs specLambdaR
+                || capturedVals |> List.exists (fun v -> v.IsMutable)
+
+            if not (List.isEmpty capturedVals) && cannotLiftCapturedVals then
+                Some(MakeApplicationAndBetaReduce g (specLambdaR, specLambdaTy, [], argsR, m), info) else
+
             let debugValName = $"<{vref.LogicalName}>__debug"
 
             // The closure form wraps tupled args in a reference Tuple<> and cannot hold byrefs.
@@ -3645,10 +3666,11 @@ and TryInlineApplication cenv env finfo (valExpr: Expr) (tyargs: TType list, arg
             // a method with flattened arguments rather than a closure that wraps args in Tuple<>.
             // Closure path (witnesses needed, no byref): keep the body as-is; witnesses from the
             // enclosing scope flow through the closure, so no typar abstraction is needed.
-            let debugValTy, debugValBody, valReprInfo, typeInstForCall =
+            let debugValTy, debugValBody, valReprInfo, typeInstForCall, capturedArgs =
                 if not freeTyparsNeedWitnesses then
-                    let ty = mkForallTyIfNeeded freeTypars specLambdaTy
-                    let body = mkTypeLambda m freeTypars (specLambdaR, specLambdaTy)
+                    let liftedBody, liftedTy = mkMultiLambdasCore g m capturedArgGroups (specLambdaR, specLambdaTy)
+                    let ty = mkForallTyIfNeeded freeTypars liftedTy
+                    let body = mkTypeLambda m freeTypars (liftedBody, liftedTy)
                     let argInfos, retInfo =
                         match vref.ValReprInfo with
                         | Some(ValReprInfo(_, argInfos, retInfo)) -> argInfos, retInfo
@@ -3656,17 +3678,20 @@ and TryInlineApplication cenv env finfo (valExpr: Expr) (tyargs: TType list, arg
                             let (ValReprInfo(_, a, r)) =
                                 InferValReprInfoOfExpr g AllowTypeDirectedDetupling.No specLambdaTy [] [] specLambdaR
                             a, r
-                    let reprInfo = ValReprInfo(ValReprInfo.InferTyparInfo freeTypars, argInfos, retInfo)
-                    ty, body, Some reprInfo, [List.map mkTyparTy freeTypars]
+                    let capturedArgInfos =
+                        capturedArgGroups
+                        |> List.map (List.map (fun (v: Val) -> { ValReprInfo.unnamedTopArg1 with Name = Some v.Id }))
+                    let reprInfo = ValReprInfo(ValReprInfo.InferTyparInfo freeTypars, capturedArgInfos @ argInfos, retInfo)
+                    ty, body, Some reprInfo, [List.map mkTyparTy freeTypars], List.map (mkRefTupledVars g m) capturedArgGroups
                 else
-                    specLambdaTy, specLambdaR, None, []
+                    specLambdaTy, specLambdaR, None, [], []
 
             let debugVal =
                 Construct.NewVal(debugValName, m, None, debugValTy, Immutable, true, valReprInfo, taccessPublic, ValNotInRecScope, None,
                     NormalVal, [], ValInline.InlinedDefinition, XmlDoc.Empty, true, false, false, false, false, false, None,
                     ParentNone)
 
-            let callExpr = mkApps g ((exprForVal m debugVal, debugValTy), typeInstForCall, argsR, m)
+            let callExpr = mkApps g ((exprForVal m debugVal, debugValTy), typeInstForCall, capturedArgs @ argsR, m)
             Some(mkCompGenLet m debugVal debugValBody callExpr, info)
 
         | _ -> None

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall.fs
@@ -1076,6 +1076,182 @@ let main _ =
         |> verifySequencePoints
 
     [<Fact>]
+    let ``SRTP 30 - Capture of enclosing local`` () =
+        FSharp """
+let f () =
+    let x = 42
+    let inline g y = x + int y
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if f () = 43 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 31 - Capture used in nested closure`` () =
+        FSharp """
+let f () =
+    let xs = [ 1; 2; 3 ]
+    let inline g y = xs |> List.map (fun v -> v + int y) |> List.sum
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if f () = 9 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 32 - Capture of mutable local`` () =
+        // A captured mutable local cannot be passed by value, so the body is inlined at the callsite.
+        FSharp """
+let f () =
+    let mutable x = 10
+    let inline g y = x <- x + int y
+    g 5uy
+    x
+
+[<EntryPoint>]
+let main _ =
+    if f () = 15 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 33 - Capture of this`` () =
+        FSharp """
+type C(n: int) =
+    member _.M(b: byte) =
+        let inline g y = n + int y
+        g b
+
+[<EntryPoint>]
+let main _ =
+    if C(42).M(5uy) = 47 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 34 - Capture of enclosing inline function parameter`` () =
+        FSharp """
+let inline outer (a: int) =
+    let inline g y = a + int y
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if outer 42 = 43 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 35 - Capture of enclosing inline function parameter - Different assembly`` () =
+        let library =
+            FSharp """
+module MyLib
+
+let inline outer (a: int) =
+    let inline g y = a + int y
+    g 1uy
+"""
+            |> withDebug
+            |> withNoOptimize
+            |> asLibrary
+
+        FSharp """
+open MyLib
+
+[<EntryPoint>]
+let main _ =
+    if outer 42 = 43 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> withReferences [library]
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 36 - Capture at two instantiations`` () =
+        FSharp """
+let f () =
+    let x = 100
+    let inline g y = x + int y
+    g 1uy + g 2s
+
+[<EntryPoint>]
+let main _ =
+    if f () = 203 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 37 - Captured value with enclosing typar`` () =
+        FSharp """
+let f<'a> (v: 'a) =
+    let xs = [ v; v ]
+    let inline g y = List.length xs + int y
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if f "a" = 3 && f 1 = 3 && f 1.5 = 3 && f System.DateTime.Now = 3 then 0 else 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
+    let ``SRTP 38 - Free typar only in body`` () =
+        FSharp """
+let inline mk< 'T, ^U when ^U : (static member op_Explicit: ^U -> int) > (y: ^U) : obj =
+    let arr : 'T[] = Array.zeroCreate (int y)
+    box arr
+
+let outer<'a> () = mk<'a, byte> 3uy
+
+[<EntryPoint>]
+let main _ =
+    match outer<System.DateTime> () with
+    | :? (System.DateTime[]) as a when a.Length = 3 -> 0
+    | o -> printfn "Unexpected %s" (o.GetType().FullName); 1
+"""
+        |> withDebug
+        |> withNoOptimize
+        |> asExe
+        |> compileAndRun
+        |> verifySequencePoints
+
+    [<Fact>]
     let ``Member 01 - Non-generic`` () =
         FSharp """
 type T() =

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 30 - Capture of enclosing local.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 30 - Capture of enclosing local.bsl
@@ -1,0 +1,57 @@
+let f () =
+    let x = 42
+    let inline g y = x + int y
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if f () = 43 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::f
+  (3,5-3,15)  let x = 42
+    IL_0000:  ldc.i4.s 42
+    IL_0002:  stloc.0
+    IL_0003:  ldloc.0
+    IL_0004:  newobj g@4::.ctor
+    IL_0009:  stloc.1
+
+  (5,5-5,10)  g 1uy
+    IL_000a:  ldloc.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  tail.
+    IL_000e:  call Test::<g>__debug@5
+    IL_0013:  ret
+
+Test::main
+  (9,5-9,22)  if f () = 43 then
+    IL_0000:  call Test::f
+    IL_0005:  ldc.i4.s 43
+    IL_0007:  bne.un.s IL_000b
+
+  (9,23-9,24)  0
+    IL_0009:  ldc.i4.0
+    IL_000a:  ret
+
+  (9,30-9,31)  1
+    IL_000b:  ldc.i4.1
+    IL_000c:  ret
+
+Test::<g>__debug@5
+  (4,22-4,31)  x + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  conv.i4
+    IL_0003:  add
+    IL_0004:  ret
+
+g@4-1::Invoke
+  (4,22-4,31)  x + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld x
+    IL_0006:  ldarg.1
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  call LanguagePrimitives::ExplicitDynamic
+    IL_000e:  add
+    IL_000f:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 31 - Capture used in nested closure.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 31 - Capture used in nested closure.bsl
@@ -1,0 +1,172 @@
+let f () =
+    let xs = [ 1; 2; 3 ]
+    let inline g y = xs |> List.map (fun v -> v + int y) |> List.sum
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if f () = 9 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::f
+  (3,5-3,25)  let xs = [ 1; 2; 3 ]
+    IL_0000:  ldc.i4.1
+    IL_0001:  ldc.i4.2
+    IL_0002:  ldc.i4.3
+    IL_0003:  call get_Empty
+    IL_0008:  call Cons
+    IL_000d:  call Cons
+    IL_0012:  call Cons
+    IL_0017:  stloc.0
+    IL_0018:  ldloc.0
+    IL_0019:  newobj g@4::.ctor
+    IL_001e:  stloc.1
+
+  (5,5-5,10)  g 1uy
+    IL_001f:  ldloc.0
+    IL_0020:  ldc.i4.1
+    IL_0021:  tail.
+    IL_0023:  call Test::<g>__debug@5
+    IL_0028:  ret
+
+Test::main
+  (9,5-9,21)  if f () = 9 then
+    IL_0000:  call Test::f
+    IL_0005:  ldc.i4.s 9
+    IL_0007:  bne.un.s IL_000b
+
+  (9,22-9,23)  0
+    IL_0009:  ldc.i4.0
+    IL_000a:  ret
+
+  (9,29-9,30)  1
+    IL_000b:  ldc.i4.1
+    IL_000c:  ret
+
+Test::<sum>__debug@4
+  <hidden>
+    IL_0000:  ldarg.0
+    IL_0001:  call get_TailOrNull
+    IL_0006:  brtrue.s IL_000a
+
+  <hidden>
+    IL_0008:  ldc.i4.0
+    IL_0009:  ret
+
+  <hidden>
+    IL_000a:  ldc.i4.0
+    IL_000b:  stloc.0
+    IL_000c:  ldarg.0
+    IL_000d:  stloc.1
+    IL_000e:  ldloc.1
+    IL_000f:  call get_TailOrNull
+    IL_0014:  stloc.2
+    IL_0015:  br.s IL_002b
+    IL_0017:  ldloc.1
+    IL_0018:  call get_HeadOrDefault
+    IL_001d:  stloc.3
+    IL_001e:  ldloc.0
+    IL_001f:  ldloc.3
+    IL_0020:  add.ovf
+    IL_0021:  stloc.0
+    IL_0022:  ldloc.2
+    IL_0023:  stloc.1
+    IL_0024:  ldloc.1
+    IL_0025:  call get_TailOrNull
+    IL_002a:  stloc.2
+    IL_002b:  ldloc.2
+    IL_002c:  brtrue.s IL_0017
+    IL_002e:  ldloc.0
+    IL_002f:  ret
+
+Test::<sum>__debug@4-1
+  <hidden>
+    IL_0000:  ldarg.0
+    IL_0001:  call get_TailOrNull
+    IL_0006:  brtrue.s IL_000a
+
+  <hidden>
+    IL_0008:  ldc.i4.0
+    IL_0009:  ret
+
+  <hidden>
+    IL_000a:  ldc.i4.0
+    IL_000b:  stloc.0
+    IL_000c:  ldarg.0
+    IL_000d:  stloc.1
+    IL_000e:  ldloc.1
+    IL_000f:  call get_TailOrNull
+    IL_0014:  stloc.2
+    IL_0015:  br.s IL_002b
+    IL_0017:  ldloc.1
+    IL_0018:  call get_HeadOrDefault
+    IL_001d:  stloc.3
+    IL_001e:  ldloc.0
+    IL_001f:  ldloc.3
+    IL_0020:  add.ovf
+    IL_0021:  stloc.0
+    IL_0022:  ldloc.2
+    IL_0023:  stloc.1
+    IL_0024:  ldloc.1
+    IL_0025:  call get_TailOrNull
+    IL_002a:  stloc.2
+    IL_002b:  ldloc.2
+    IL_002c:  brtrue.s IL_0017
+    IL_002e:  ldloc.0
+    IL_002f:  ret
+
+Test::<g>__debug@5
+  (4,22-4,24)  xs
+    IL_0000:  ldarg.0
+    IL_0001:  stloc.0
+
+  (4,28-4,57)  List.map (fun v -> v + int y)
+    IL_0002:  ldarg.1
+    IL_0003:  newobj Pipe #1 stage #1 at line 4@4-1::.ctor
+    IL_0008:  ldloc.0
+    IL_0009:  call ListModule::Map
+    IL_000e:  stloc.1
+
+  (4,61-4,69)  List.sum
+    IL_000f:  ldloc.1
+    IL_0010:  call Test::<sum>__debug@4-1
+    IL_0015:  ret
+
+g@4-1::Invoke
+  (4,22-4,24)  xs
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld xs
+    IL_0006:  stloc.0
+
+  (4,28-4,57)  List.map (fun v -> v + int y)
+    IL_0007:  ldarg.1
+    IL_0008:  newobj .ctor
+    IL_000d:  ldloc.0
+    IL_000e:  call ListModule::Map
+    IL_0013:  stloc.1
+
+  (4,61-4,69)  List.sum
+    IL_0014:  ldloc.1
+    IL_0015:  tail.
+    IL_0017:  call Test::<sum>__debug@4
+    IL_001c:  ret
+
+Pipe #1 stage #1 at line 4@4::Invoke
+  (4,47-4,56)  v + int y
+    IL_0000:  ldarg.1
+    IL_0001:  ldarg.0
+    IL_0002:  ldfld y
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  call LanguagePrimitives::ExplicitDynamic
+    IL_000e:  add
+    IL_000f:  ret
+
+Pipe #1 stage #1 at line 4@4-1::Invoke
+  (4,47-4,56)  v + int y
+    IL_0000:  ldarg.1
+    IL_0001:  ldarg.0
+    IL_0002:  ldfld Pipe #1 stage #1 at line 4@4-1::y
+    IL_0007:  conv.i4
+    IL_0008:  add
+    IL_0009:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 32 - Capture of mutable local.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 32 - Capture of mutable local.bsl
@@ -1,0 +1,67 @@
+let f () =
+    let mutable x = 10
+    let inline g y = x <- x + int y
+    g 5uy
+    x
+
+[<EntryPoint>]
+let main _ =
+    if f () = 15 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::f
+  (3,5-3,23)  let mutable x = 10
+    IL_0000:  ldc.i4.s 10
+    IL_0002:  newobj .ctor
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  newobj g@4::.ctor
+    IL_000e:  stloc.1
+
+  (5,5-5,10)  g 5uy
+    IL_000f:  ldc.i4.5
+    IL_0010:  stloc.2
+
+  (4,22-4,36)  x <- x + int y
+    IL_0011:  ldloc.0
+    IL_0012:  ldloc.0
+    IL_0013:  call get_contents
+    IL_0018:  ldloc.2
+    IL_0019:  conv.i4
+    IL_001a:  add
+    IL_001b:  call set_contents
+
+  (6,5-6,6)  x
+    IL_0020:  ldloc.0
+    IL_0021:  call get_contents
+    IL_0026:  ret
+
+Test::main
+  (10,5-10,22)  if f () = 15 then
+    IL_0000:  call Test::f
+    IL_0005:  ldc.i4.s 15
+    IL_0007:  bne.un.s IL_000b
+
+  (10,23-10,24)  0
+    IL_0009:  ldc.i4.0
+    IL_000a:  ret
+
+  (10,30-10,31)  1
+    IL_000b:  ldc.i4.1
+    IL_000c:  ret
+
+g@4-1::Invoke
+  (4,22-4,36)  x <- x + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld x
+    IL_0006:  ldarg.0
+    IL_0007:  ldfld x
+    IL_000c:  call get_contents
+    IL_0011:  ldarg.1
+    IL_0012:  stloc.0
+    IL_0013:  ldloc.0
+    IL_0014:  call LanguagePrimitives::ExplicitDynamic
+    IL_0019:  add
+    IL_001a:  call set_contents
+    IL_001f:  ldnull
+    IL_0020:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 33 - Capture of this.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 33 - Capture of this.bsl
@@ -1,0 +1,71 @@
+type C(n: int) =
+    member _.M(b: byte) =
+        let inline g y = n + int y
+        g b
+
+[<EntryPoint>]
+let main _ =
+    if C(42).M(5uy) = 47 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::main
+  (9,5-9,30)  if C(42).M(5uy) = 47 then
+    IL_0000:  ldc.i4.s 42
+    IL_0002:  newobj C::.ctor
+    IL_0007:  ldc.i4.5
+    IL_0008:  callvirt C::M
+    IL_000d:  ldc.i4.s 47
+    IL_000f:  bne.un.s IL_0013
+
+  (9,31-9,32)  0
+    IL_0011:  ldc.i4.0
+    IL_0012:  ret
+
+  (9,38-9,39)  1
+    IL_0013:  ldc.i4.1
+    IL_0014:  ret
+
+C::.ctor
+  (2,6-2,7)  C
+    IL_0000:  ldarg.0
+    IL_0001:  callvirt Object::.ctor
+    IL_0006:  ldarg.0
+    IL_0007:  pop
+    IL_0008:  ldarg.0
+    IL_0009:  ldarg.1
+    IL_000a:  stfld C::n
+    IL_000f:  ret
+
+C::M
+  <hidden>
+    IL_0000:  ldarg.0
+    IL_0001:  newobj g@4::.ctor
+    IL_0006:  stloc.0
+
+  (5,9-5,12)  g b
+    IL_0007:  ldarg.0
+    IL_0008:  ldarg.1
+    IL_0009:  tail.
+    IL_000b:  call C::<g>__debug@5
+    IL_0010:  ret
+
+C::<g>__debug@5
+  (4,26-4,35)  n + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld C::n
+    IL_0006:  ldarg.1
+    IL_0007:  conv.i4
+    IL_0008:  add
+    IL_0009:  ret
+
+g@4-1::Invoke
+  (4,26-4,35)  n + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld _
+    IL_0006:  ldfld C::n
+    IL_000b:  ldarg.1
+    IL_000c:  stloc.0
+    IL_000d:  ldloc.0
+    IL_000e:  call LanguagePrimitives::ExplicitDynamic
+    IL_0013:  add
+    IL_0014:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 34 - Capture of enclosing inline function parameter.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 34 - Capture of enclosing inline function parameter.bsl
@@ -1,0 +1,55 @@
+let inline outer (a: int) =
+    let inline g y = a + int y
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if outer 42 = 43 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::outer
+  <hidden>
+    IL_0000:  ldarg.0
+    IL_0001:  newobj g@3::.ctor
+    IL_0006:  stloc.0
+
+  (4,5-4,10)  g 1uy
+    IL_0007:  ldarg.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  tail.
+    IL_000b:  call Test::<g>__debug@4
+    IL_0010:  ret
+
+Test::main
+  (8,5-8,26)  if outer 42 = 43 then
+    IL_0000:  ldc.i4.s 42
+    IL_0002:  call Test::outer
+    IL_0007:  ldc.i4.s 43
+    IL_0009:  bne.un.s IL_000d
+
+  (8,27-8,28)  0
+    IL_000b:  ldc.i4.0
+    IL_000c:  ret
+
+  (8,34-8,35)  1
+    IL_000d:  ldc.i4.1
+    IL_000e:  ret
+
+Test::<g>__debug@4
+  (3,22-3,31)  a + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  conv.i4
+    IL_0003:  add
+    IL_0004:  ret
+
+g@3-1::Invoke
+  (3,22-3,31)  a + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld a
+    IL_0006:  ldarg.1
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  call LanguagePrimitives::ExplicitDynamic
+    IL_000e:  add
+    IL_000f:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 35 - Capture of enclosing inline function parameter - Different assembly.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 35 - Capture of enclosing inline function parameter - Different assembly.bsl
@@ -1,0 +1,21 @@
+open MyLib
+
+[<EntryPoint>]
+let main _ =
+    if outer 42 = 43 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::main
+  (6,5-6,26)  if outer 42 = 43 then
+    IL_0000:  ldc.i4.s 42
+    IL_0002:  call MyLib::outer
+    IL_0007:  ldc.i4.s 43
+    IL_0009:  bne.un.s IL_000d
+
+  (6,27-6,28)  0
+    IL_000b:  ldc.i4.0
+    IL_000c:  ret
+
+  (6,34-6,35)  1
+    IL_000d:  ldc.i4.1
+    IL_000e:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 36 - Capture at two instantiations.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 36 - Capture at two instantiations.bsl
@@ -1,0 +1,67 @@
+let f () =
+    let x = 100
+    let inline g y = x + int y
+    g 1uy + g 2s
+
+[<EntryPoint>]
+let main _ =
+    if f () = 203 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::f
+  (3,5-3,16)  let x = 100
+    IL_0000:  ldc.i4.s 100
+    IL_0002:  stloc.0
+    IL_0003:  ldloc.0
+    IL_0004:  newobj g@4::.ctor
+    IL_0009:  stloc.1
+
+  (5,5-5,17)  g 1uy + g 2s
+    IL_000a:  ldloc.0
+    IL_000b:  ldc.i4.1
+    IL_000c:  call Test::<g>__debug@5
+    IL_0011:  ldloc.0
+    IL_0012:  ldc.i4.2
+    IL_0013:  call Test::<g>__debug@5-1
+    IL_0018:  add
+    IL_0019:  ret
+
+Test::main
+  (9,5-9,23)  if f () = 203 then
+    IL_0000:  call Test::f
+    IL_0005:  ldc.i4 203
+    IL_000a:  bne.un.s IL_000e
+
+  (9,24-9,25)  0
+    IL_000c:  ldc.i4.0
+    IL_000d:  ret
+
+  (9,31-9,32)  1
+    IL_000e:  ldc.i4.1
+    IL_000f:  ret
+
+Test::<g>__debug@5
+  (4,22-4,31)  x + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  conv.i4
+    IL_0003:  add
+    IL_0004:  ret
+
+Test::<g>__debug@5-1
+  (4,22-4,31)  x + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  add
+    IL_0003:  ret
+
+g@4-1::Invoke
+  (4,22-4,31)  x + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld x
+    IL_0006:  ldarg.1
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  call LanguagePrimitives::ExplicitDynamic
+    IL_000e:  add
+    IL_000f:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 37 - Captured value with enclosing typar.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 37 - Captured value with enclosing typar.bsl
@@ -1,0 +1,118 @@
+let f<'a> (v: 'a) =
+    let xs = [ v; v ]
+    let inline g y = List.length xs + int y
+    g 1uy
+
+[<EntryPoint>]
+let main _ =
+    if f "a" = 3 && f 1 = 3 && f 1.5 = 3 && f System.DateTime.Now = 3 then 0 else 1
+--------------------------------------------------------------------------------
+
+Test::f
+  (3,5-3,22)  let xs = [ v; v ]
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.0
+    IL_0002:  call get_Empty
+    IL_0007:  call Cons
+    IL_000c:  call Cons
+    IL_0011:  stloc.0
+    IL_0012:  ldloc.0
+    IL_0013:  newobj .ctor
+    IL_0018:  stloc.1
+
+  (5,5-5,10)  g 1uy
+    IL_0019:  ldloc.0
+    IL_001a:  ldc.i4.1
+    IL_001b:  tail.
+    IL_001d:  call Test::<g>__debug@5
+    IL_0022:  ret
+
+Test::main
+  (9,5-9,75)  if f "a" = 3 && f 1 = 3 && f 1.5 = 3 && f System.DateTime.Now = 3 then
+    IL_0000:  nop
+
+  (9,8-9,17)  f "a" = 3
+    IL_0001:  ldstr "a"
+    IL_0006:  call Test::f
+    IL_000b:  ldc.i4.3
+    IL_000c:  bne.un.s IL_001a
+
+  (9,21-9,28)  f 1 = 3
+    IL_000e:  ldc.i4.1
+    IL_000f:  call Test::f
+    IL_0014:  ldc.i4.3
+    IL_0015:  ceq
+
+  <hidden>
+    IL_0017:  nop
+    IL_0018:  br.s IL_001c
+
+  <hidden>
+    IL_001a:  ldc.i4.0
+
+  <hidden>
+    IL_001b:  nop
+    IL_001c:  brfalse.s IL_0032
+
+  (9,32-9,41)  f 1.5 = 3
+    IL_001e:  ldc.r8 1.500000
+    IL_0027:  call Test::f
+    IL_002c:  ldc.i4.3
+    IL_002d:  ceq
+
+  <hidden>
+    IL_002f:  nop
+    IL_0030:  br.s IL_0034
+
+  <hidden>
+    IL_0032:  ldc.i4.0
+
+  <hidden>
+    IL_0033:  nop
+    IL_0034:  brfalse.s IL_0046
+
+  (9,45-9,70)  f System.DateTime.Now = 3
+    IL_0036:  call DateTime::get_Now
+    IL_003b:  call Test::f
+    IL_0040:  ldc.i4.3
+    IL_0041:  ceq
+
+  <hidden>
+    IL_0043:  nop
+    IL_0044:  br.s IL_0048
+
+  <hidden>
+    IL_0046:  ldc.i4.0
+
+  <hidden>
+    IL_0047:  nop
+    IL_0048:  brfalse.s IL_004c
+
+  (9,76-9,77)  0
+    IL_004a:  ldc.i4.0
+    IL_004b:  ret
+
+  (9,83-9,84)  1
+    IL_004c:  ldc.i4.1
+    IL_004d:  ret
+
+Test::<g>__debug@5
+  (4,22-4,44)  List.length xs + int y
+    IL_0000:  ldarg.0
+    IL_0001:  call ListModule::Length
+    IL_0006:  ldarg.1
+    IL_0007:  conv.i4
+    IL_0008:  add
+    IL_0009:  ret
+
+g@4-1::Invoke
+  (4,22-4,44)  List.length xs + int y
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld xs
+    IL_0006:  call ListModule::Length
+    IL_000b:  ldarg.1
+    IL_000c:  stloc.0
+    IL_000d:  ldloc.0
+    IL_000e:  call LanguagePrimitives::ExplicitDynamic
+    IL_0013:  add
+    IL_0014:  ret

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 38 - Free typar only in body.bsl
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DebugInlineAsCall/SRTP 38 - Free typar only in body.bsl
@@ -1,0 +1,112 @@
+let inline mk< 'T, ^U when ^U : (static member op_Explicit: ^U -> int) > (y: ^U) : obj =
+    let arr : 'T[] = Array.zeroCreate (int y)
+    box arr
+
+let outer<'a> () = mk<'a, byte> 3uy
+
+[<EntryPoint>]
+let main _ =
+    match outer<System.DateTime> () with
+    | :? (System.DateTime[]) as a when a.Length = 3 -> 0
+    | o -> printfn "Unexpected %s" (o.GetType().FullName); 1
+--------------------------------------------------------------------------------
+
+Test::mk
+  (3,5-3,46)  let arr : 'T[] = Array.zeroCreate (int y)
+    IL_0000:  ldarg.0
+    IL_0001:  stloc.1
+    IL_0002:  ldloc.1
+    IL_0003:  call LanguagePrimitives::ExplicitDynamic
+    IL_0008:  call ArrayModule::ZeroCreate
+    IL_000d:  stloc.0
+
+  (4,5-4,12)  box arr
+    IL_000e:  ldloc.0
+    IL_000f:  box 0x1b000001
+    IL_0014:  ret
+
+Test::mk$W
+  (3,5-3,46)  let arr : 'T[] = Array.zeroCreate (int y)
+    IL_0000:  ldarg.1
+    IL_0001:  stloc.1
+    IL_0002:  ldarg.0
+    IL_0003:  ldloc.1
+    IL_0004:  callvirt Invoke
+    IL_0009:  call ArrayModule::ZeroCreate
+    IL_000e:  stloc.0
+
+  (4,5-4,12)  box arr
+    IL_000f:  ldloc.0
+    IL_0010:  box 0x1b000001
+    IL_0015:  ret
+
+Test::outer
+  (6,20-6,36)  mk<'a, byte> 3uy
+    IL_0000:  ldc.i4.3
+    IL_0001:  tail.
+    IL_0003:  call Test::<mk>__debug@6
+    IL_0008:  ret
+
+Test::main
+  (10,5-10,41)  match outer<System.DateTime> () with
+    IL_0000:  call Test::outer
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  isinst 0x1b000003
+    IL_000c:  stloc.1
+    IL_000d:  ldloc.1
+    IL_000e:  brfalse.s IL_001c
+    IL_0010:  ldloc.1
+    IL_0011:  stloc.2
+
+  (11,40-11,52)  a.Length = 3
+    IL_0012:  ldloc.2
+    IL_0013:  ldlen
+    IL_0014:  conv.i4
+    IL_0015:  ldc.i4.3
+    IL_0016:  ceq
+    IL_0018:  brfalse.s IL_0025
+    IL_001a:  br.s IL_0021
+
+  <hidden>
+    IL_001c:  ldloc.0
+    IL_001d:  stloc.s 4
+    IL_001f:  br.s IL_0028
+
+  <hidden>
+    IL_0021:  ldloc.1
+    IL_0022:  stloc.3
+
+  (11,56-11,57)  0
+    IL_0023:  ldc.i4.0
+    IL_0024:  ret
+
+  <hidden>
+    IL_0025:  ldloc.0
+    IL_0026:  stloc.s 4
+
+  (12,12-12,58)  printfn "Unexpected %s" (o.GetType().FullName)
+    IL_0028:  ldstr "Unexpected %s"
+    IL_002d:  newobj .ctor
+    IL_0032:  call ExtraTopLevelOperators::PrintFormatLine
+    IL_0037:  ldloc.s 4
+    IL_0039:  callvirt Object::GetType
+    IL_003e:  callvirt Type::get_FullName
+    IL_0043:  callvirt Invoke
+    IL_0048:  pop
+
+  (12,60-12,61)  1
+    IL_0049:  ldc.i4.1
+    IL_004a:  ret
+
+Test::<mk>__debug@6
+  (3,5-3,46)  let arr : 'T[] = Array.zeroCreate (int y)
+    IL_0000:  ldarg.0
+    IL_0001:  conv.i4
+    IL_0002:  call ArrayModule::ZeroCreate
+    IL_0007:  stloc.0
+
+  (4,5-4,12)  box arr
+    IL_0008:  ldloc.0
+    IL_0009:  box 0x1b000001
+    IL_000e:  ret


### PR DESCRIPTION
Fixes the captured values repro from #20063.

```fsharp
let f () =
    let x = 42
    let inline g y = x + int y
    g 1uy

printfn "%A (expected 43)" (f ())
```

```fsharp
let f2 () =
    let xs = [ 1; 2; 3 ]
    let inline g y = xs |> List.map (fun v -> v + int y) |> List.sum
    g 1uy

printfn "%A (expected 9)" (f2 ())
```