### PR TITLE
Move SDL/TSA validation to 1ES templates after Arcade 11 upgrade

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -65,8 +65,6 @@ variables:
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
   - name: Codeql.Enabled
     value: true
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-FSharp-SDLValidation-Params
   - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - name: RunningAsPullRequest
       value: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,6 @@ variables:
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
   - name: Codeql.Enabled
     value: "true"
-  - group: DotNet-FSharp-SDLValidation-Params
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:
@@ -68,6 +67,7 @@ extends:
         enabled: true
       policheck:
         enabled: true
+        exclusionsFile: '$(Build.SourcesDirectory)/eng/policheck_exclusions.xml'
       sbom:
         enabled: false # VS SBOM is generated with other steps
         justificationForDisabling: 'SBOM for F# is generated via build process. Will be migrated at later date.'
@@ -219,23 +219,8 @@ extends:
         enableSymbolValidation: false
         # SourceLink improperly looks for generated files.  See https://github.com/dotnet/arcade/issues/3069
         enableSourceLinkValidation: false
-        # Enable SDL validation, passing through values from the 'DotNet-FSharp-SDLValidation-Params' group.
-        SDLValidationParameters:
-          enable: true
-          params: >-
-            -SourceToolsList @("policheck","credscan")
-            -ArtifactToolsList @("binskim")
-            -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True")
-            -TsaInstanceURL $(_TsaInstanceURL)
-            -TsaProjectName $(_TsaProjectName)
-            -TsaNotificationEmail $(_TsaNotificationEmail)
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-            -TsaBugAreaPath $(_TsaBugAreaPath)
-            -TsaIterationPath $(_TsaIterationPath)
-            -TsaRepositoryName "FSharp"
-            -TsaCodebaseName "FSharp-GitHub"
-            -TsaPublish $True
-            -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/policheck_exclusions.xml")
+        # SDL validation (PoliCheck, CredScan, BinSkim) and TSA reporting are handled by the 1ES Pipeline
+        # Templates via the 'sdl:' block in the 'extends' section above; TSA config lives in eng/TSAConfig.gdntsa.
 
     #---------------------------------------------------------------------------------------------------------------------#
     #                                                   VS Insertion                                                      #


### PR DESCRIPTION
The .NET 11 / Arcade 11 upgrade regenerated `eng/common` and removed the SDL post-build scripts, so the official build failed with `Unexpected parameter 'SDLValidationParameters'`. SDL/TSA (PoliCheck, CredScan, BinSkim, TSA reporting) is now handled by the 1ES Pipeline Templates, so the PoliCheck exclusions move into the existing `sdl:` block and the obsolete post-build parameter and its now-unused variable group are removed.
