### PR TITLE
Update test project to net11

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/CompilerService/EncMethodDebugInformationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerService/EncMethodDebugInformationTests.fs
@@ -286,10 +286,10 @@ let private buildCSharpScratchPdb () =
 
     File.WriteAllText(
         projPath,
-        """<Project Sdk="Microsoft.NET.Sdk">
+        $"""<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net11.0</TargetFramework>
+    <TargetFramework>{TestFramework.productTfm}</TargetFramework>
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
@@ -323,7 +323,7 @@ let private buildCSharpScratchPdb () =
     if p.ExitCode <> 0 then
         failwith $"dotnet build of the C# scratch library failed: {stdout}\n{stderr}"
 
-    let pdbPath = Path.Combine(workDir, "bin", "Debug", "net11.0", "scratch.pdb")
+    let pdbPath = Path.Combine(workDir, "bin", "Debug", TestFramework.productTfm, "scratch.pdb")
     Assert.True(File.Exists pdbPath, $"expected portable PDB at {pdbPath}")
     workDir, pdbPath
 

--- a/tests/FSharp.Compiler.ComponentTests/CompilerService/EncMethodDebugInformationTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerService/EncMethodDebugInformationTests.fs
@@ -289,7 +289,7 @@ let private buildCSharpScratchPdb () =
         """<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
@@ -323,7 +323,7 @@ let private buildCSharpScratchPdb () =
     if p.ExitCode <> 0 then
         failwith $"dotnet build of the C# scratch library failed: {stdout}\n{stderr}"
 
-    let pdbPath = Path.Combine(workDir, "bin", "Debug", "net10.0", "scratch.pdb")
+    let pdbPath = Path.Combine(workDir, "bin", "Debug", "net11.0", "scratch.pdb")
     Assert.True(File.Exists pdbPath, $"expected portable PDB at {pdbPath}")
     workDir, pdbPath
 


### PR DESCRIPTION
Internal CI was failing since the move to net11 because restoring this test project had to suddenly be done via network call to nuget.org