### PR TITLE
Cache `DocumentDiagnosticAnalyzer` results by version stamp to avoid redundant typecheck on unchanged documents

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -9,6 +9,7 @@
 * Fixed Rename incorrectly renaming `get` and `set` keywords for properties with explicit accessors. ([Issue #18270](https://github.com/dotnet/fsharp/issues/18270), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Fixed Find All References crash when F# project contains non-F# files like `.cshtml`. ([Issue #16394](https://github.com/dotnet/fsharp/issues/16394), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Avoid using `cancellableTask` in `DocumentCache`; the editor cache now uses direct `CancellationToken`-aware `task` wrappers, avoiding the background `Task.Run` offload and a larger wrapper closure from the `cancellableTask` builder. ([Issue #20268](https://github.com/dotnet/fsharp/issues/20268))
+* Prevent stale and leaked per-document diagnostics by tightening cache validity and evicting entries for removed documents. ([PR #20121](https://github.com/dotnet/fsharp/pull/20121))
 * Find All References for external DLL symbols now only searches projects that reference the specific assembly. ([Issue #10227](https://github.com/dotnet/fsharp/issues/10227), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Improve static compilation of state machines. ([PR #19297](https://github.com/dotnet/fsharp/pull/19297))
 * Make Alt+F1 (momentary toggle) work for inlay hints. ([PR #19421](https://github.com/dotnet/fsharp/pull/19421))

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -9,7 +9,7 @@
 * Fixed Rename incorrectly renaming `get` and `set` keywords for properties with explicit accessors. ([Issue #18270](https://github.com/dotnet/fsharp/issues/18270), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Fixed Find All References crash when F# project contains non-F# files like `.cshtml`. ([Issue #16394](https://github.com/dotnet/fsharp/issues/16394), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Avoid using `cancellableTask` in `DocumentCache`; the editor cache now uses direct `CancellationToken`-aware `task` wrappers, avoiding the background `Task.Run` offload and a larger wrapper closure from the `cancellableTask` builder. ([Issue #20268](https://github.com/dotnet/fsharp/issues/20268))
-* Prevent stale and leaked per-document diagnostics by tightening cache validity and evicting entries for removed documents. ([PR #20121](https://github.com/dotnet/fsharp/pull/20121))
+* Cache document diagnostics by version stamp, so an unchanged document is not reanalyzed on every crawler pass. ([Issue #20120](https://github.com/dotnet/fsharp/issues/20120), [PR #20121](https://github.com/dotnet/fsharp/pull/20121))
 * Find All References for external DLL symbols now only searches projects that reference the specific assembly. ([Issue #10227](https://github.com/dotnet/fsharp/issues/10227), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Improve static compilation of state machines. ([PR #19297](https://github.com/dotnet/fsharp/pull/19297))
 * Make Alt+F1 (momentary toggle) work for inlay hints. ([PR #19421](https://github.com/dotnet/fsharp/pull/19421))

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -22,6 +22,15 @@ type internal DiagnosticsType =
     | Syntax
     | Semantic
 
+type private CachedDiagnosticsEntry =
+    {
+        TextVersion: VersionStamp
+        ProjectVersion: VersionStamp
+        FilePath: string
+        IsRemoveParensEnabled: bool
+        Diagnostics: ImmutableArray<Diagnostic>
+    }
+
 [<Export(typeof<IFSharpDocumentDiagnosticAnalyzer>)>]
 type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
 
@@ -29,7 +38,14 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
         document.Project.Solution.GetFSharpExtensionConfig().ShouldProduceDiagnostics()
 
     static let cache =
-        ConcurrentDictionary<struct (DocumentId * DiagnosticsType), VersionStamp * VersionStamp * ImmutableArray<Diagnostic>>()
+        ConcurrentDictionary<struct (DocumentId * DiagnosticsType), CachedDiagnosticsEntry>()
+
+    static let evictRemovedDocuments (solution: Solution) =
+        for entry in cache do
+            let struct (documentId, _) = entry.Key
+
+            if isNull (solution.GetDocument(documentId)) then
+                cache.TryRemove(entry.Key) |> ignore
 
     static let diagnosticEqualityComparer =
         { new IEqualityComparer<FSharpDiagnostic> with
@@ -83,79 +99,97 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                 | DiagnosticsType.Syntax -> CancellableTask.singleton VersionStamp.Default
                 | DiagnosticsType.Semantic -> (fun ct -> document.Project.GetDependentVersionAsync(ct))
 
+            let filePath = document.FilePath
+
+            let isRemoveParensEnabled =
+                match diagnosticType with
+                | DiagnosticsType.Syntax -> document.Project.IsFsharpRemoveParensEnabled
+                | DiagnosticsType.Semantic -> false
+
+            evictRemovedDocuments document.Project.Solution
+
             let cacheKey = struct (document.Id, diagnosticType)
 
             let cached =
                 match cache.TryGetValue(cacheKey) with
-                | true, (cachedTextVersion, cachedProjectVersion, cachedDiagnostics) when
-                    cachedTextVersion = textVersion && cachedProjectVersion = projectVersion
+                | true, cachedEntry when
+                    cachedEntry.TextVersion = textVersion
+                    && cachedEntry.ProjectVersion = projectVersion
+                    && cachedEntry.FilePath = filePath
+                    && cachedEntry.IsRemoveParensEnabled = isRemoveParensEnabled
                     ->
-                    ValueSome cachedDiagnostics
+                    ValueSome cachedEntry.Diagnostics
                 | _ -> ValueNone
 
             match cached with
             | ValueSome cachedDiagnostics -> return cachedDiagnostics
             | ValueNone ->
 
-            let! sourceText = document.GetTextAsync(ct)
-            let filePath = document.FilePath
+                let! sourceText = document.GetTextAsync(ct)
 
-            let errors = HashSet<FSharpDiagnostic>(diagnosticEqualityComparer)
+                let errors = HashSet<FSharpDiagnostic>(diagnosticEqualityComparer)
 
-            let! parseResults = document.GetFSharpParseResultsAsync("GetDiagnostics")
+                let! parseResults = document.GetFSharpParseResultsAsync("GetDiagnostics")
 
-            match diagnosticType with
-            | DiagnosticsType.Syntax ->
-                for diagnostic in parseResults.Diagnostics do
-                    errors.Add(diagnostic) |> ignore
-
-            | DiagnosticsType.Semantic ->
-                let! _, checkResults = document.GetFSharpParseAndCheckResultsAsync("GetDiagnostics")
-
-                for diagnostic in checkResults.Diagnostics do
-                    errors.Add(diagnostic) |> ignore
-
-                errors.ExceptWith(parseResults.Diagnostics)
-
-            let! unnecessaryParentheses =
                 match diagnosticType with
-                | DiagnosticsType.Syntax when document.Project.IsFsharpRemoveParensEnabled ->
-                    UnnecessaryParenthesesDiagnosticAnalyzer.GetDiagnostics document
-                | _ -> CancellableTask.singleton ImmutableArray.Empty
+                | DiagnosticsType.Syntax ->
+                    for diagnostic in parseResults.Diagnostics do
+                        errors.Add(diagnostic) |> ignore
 
-            let result =
-                if errors.Count = 0 && unnecessaryParentheses.IsEmpty then
-                    ImmutableArray.Empty
-                else
-                    let iab = ImmutableArray.CreateBuilder(errors.Count + unnecessaryParentheses.Length)
+                | DiagnosticsType.Semantic ->
+                    let! _, checkResults = document.GetFSharpParseAndCheckResultsAsync("GetDiagnostics")
 
-                    for diagnostic in errors do
-                        if diagnostic.StartLine <> 0 && diagnostic.EndLine <> 0 then
-                            let linePositionSpan =
-                                LinePositionSpan(
-                                    LinePosition(diagnostic.StartLine - 1, diagnostic.StartColumn),
-                                    LinePosition(diagnostic.EndLine - 1, diagnostic.EndColumn)
-                                )
+                    for diagnostic in checkResults.Diagnostics do
+                        errors.Add(diagnostic) |> ignore
 
-                            let textSpan = sourceText.Lines.GetTextSpan(linePositionSpan)
+                    errors.ExceptWith(parseResults.Diagnostics)
 
-                            // F# compiler report errors at end of file if parsing fails. It should be corrected to match Roslyn boundaries
-                            let correctedTextSpan =
-                                if textSpan.End <= sourceText.Length then
-                                    textSpan
-                                else
-                                    let start = min textSpan.Start (sourceText.Length - 1) |> max 0
+                let! unnecessaryParentheses =
+                    match diagnosticType with
+                    | DiagnosticsType.Syntax when isRemoveParensEnabled -> UnnecessaryParenthesesDiagnosticAnalyzer.GetDiagnostics document
+                    | _ -> CancellableTask.singleton ImmutableArray.Empty
 
-                                    TextSpan.FromBounds(start, sourceText.Length)
+                let result =
+                    if errors.Count = 0 && unnecessaryParentheses.IsEmpty then
+                        ImmutableArray.Empty
+                    else
+                        let iab = ImmutableArray.CreateBuilder(errors.Count + unnecessaryParentheses.Length)
 
-                            let location = Location.Create(filePath, correctedTextSpan, linePositionSpan)
-                            iab.Add(RoslynHelpers.ConvertError(diagnostic, location))
+                        for diagnostic in errors do
+                            if diagnostic.StartLine <> 0 && diagnostic.EndLine <> 0 then
+                                let linePositionSpan =
+                                    LinePositionSpan(
+                                        LinePosition(diagnostic.StartLine - 1, diagnostic.StartColumn),
+                                        LinePosition(diagnostic.EndLine - 1, diagnostic.EndColumn)
+                                    )
 
-                    iab.AddRange unnecessaryParentheses
-                    iab.ToImmutable()
+                                let textSpan = sourceText.Lines.GetTextSpan(linePositionSpan)
 
-            cache.[cacheKey] <- (textVersion, projectVersion, result)
-            return result
+                                // F# compiler report errors at end of file if parsing fails. It should be corrected to match Roslyn boundaries
+                                let correctedTextSpan =
+                                    if textSpan.End <= sourceText.Length then
+                                        textSpan
+                                    else
+                                        let start = min textSpan.Start (sourceText.Length - 1) |> max 0
+
+                                        TextSpan.FromBounds(start, sourceText.Length)
+
+                                let location = Location.Create(filePath, correctedTextSpan, linePositionSpan)
+                                iab.Add(RoslynHelpers.ConvertError(diagnostic, location))
+
+                        iab.AddRange unnecessaryParentheses
+                        iab.ToImmutable()
+
+                cache.[cacheKey] <-
+                    {
+                        TextVersion = textVersion
+                        ProjectVersion = projectVersion
+                        FilePath = filePath
+                        IsRemoveParensEnabled = isRemoveParensEnabled
+                        Diagnostics = result
+                    }
+
+                return result
         }
 
     interface IFSharpDocumentDiagnosticAnalyzer with

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -3,16 +3,15 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
-open System.Collections.Concurrent
 open System.Collections.Immutable
 open System.Collections.Generic
+open System.Runtime.CompilerServices
 open System.Threading
 open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics
-open Microsoft.VisualStudio.LanguageServices
 
 open FSharp.Compiler.Diagnostics
 open CancellableTasks
@@ -25,45 +24,19 @@ type internal DiagnosticsType =
 
 type private CachedDiagnosticsEntry =
     {
-        TextVersion: VersionStamp
         ProjectVersion: VersionStamp
-        FilePath: string
         IsRemoveParensEnabled: bool
         Diagnostics: ImmutableArray<Diagnostic>
     }
 
 [<Export(typeof<IFSharpDocumentDiagnosticAnalyzer>); Shared>]
-type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] ([<Import(AllowDefault = true)>] workspace: VisualStudioWorkspace | null) =
+type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
 
     let shouldProduceDiagnostics (document: Document) =
         document.Project.Solution.GetFSharpExtensionConfig().ShouldProduceDiagnostics()
 
-    static let cache =
-        ConcurrentDictionary<struct (DocumentId * DiagnosticsType), CachedDiagnosticsEntry>()
-
-    static let evictDocument (documentId: DocumentId) =
-        cache.TryRemove(struct (documentId, DiagnosticsType.Syntax)) |> ignore
-        cache.TryRemove(struct (documentId, DiagnosticsType.Semantic)) |> ignore
-
-    static let evictProject (projectId: ProjectId) =
-        for entry in cache do
-            let struct (documentId, _) = entry.Key
-
-            if documentId.ProjectId = projectId then
-                cache.TryRemove(entry.Key) |> ignore
-
-    do
-        match workspace with
-        | null -> ()
-        | workspace ->
-            workspace.WorkspaceChanged.Add(fun args ->
-                match args.Kind with
-                | WorkspaceChangeKind.DocumentRemoved when not (isNull args.DocumentId) -> evictDocument args.DocumentId
-                | WorkspaceChangeKind.ProjectRemoved when not (isNull args.ProjectId) -> evictProject args.ProjectId
-                | WorkspaceChangeKind.SolutionCleared
-                | WorkspaceChangeKind.SolutionRemoved -> cache.Clear()
-                | _ -> ()
-            )
+    static let syntaxCache = ConditionalWeakTable<Document, CachedDiagnosticsEntry>()
+    static let semanticCache = ConditionalWeakTable<Document, CachedDiagnosticsEntry>()
 
     static let diagnosticEqualityComparer =
         { new IEqualityComparer<FSharpDiagnostic> with
@@ -110,8 +83,6 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] ([<Impor
 
             let! ct = CancellableTask.getCancellationToken ()
 
-            let! textVersion = document.GetTextVersionAsync(ct)
-
             let! projectVersion =
                 match diagnosticType with
                 | DiagnosticsType.Syntax -> CancellableTask.singleton VersionStamp.Default
@@ -124,14 +95,15 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] ([<Impor
                 | DiagnosticsType.Syntax -> document.Project.IsFsharpRemoveParensEnabled
                 | DiagnosticsType.Semantic -> false
 
-            let cacheKey = struct (document.Id, diagnosticType)
+            let cache =
+                match diagnosticType with
+                | DiagnosticsType.Syntax -> syntaxCache
+                | DiagnosticsType.Semantic -> semanticCache
 
             let cached =
-                match cache.TryGetValue(cacheKey) with
+                match cache.TryGetValue document with
                 | true, cachedEntry when
-                    cachedEntry.TextVersion = textVersion
-                    && cachedEntry.ProjectVersion = projectVersion
-                    && cachedEntry.FilePath = filePath
+                    cachedEntry.ProjectVersion = projectVersion
                     && cachedEntry.IsRemoveParensEnabled = isRemoveParensEnabled
                     ->
                     ValueSome cachedEntry.Diagnostics
@@ -196,14 +168,16 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] ([<Impor
                         iab.AddRange unnecessaryParentheses
                         iab.ToImmutable()
 
-                cache.[cacheKey] <-
+                cache.Remove(document) |> ignore
+
+                cache.Add(
+                    document,
                     {
-                        TextVersion = textVersion
                         ProjectVersion = projectVersion
-                        FilePath = filePath
                         IsRemoveParensEnabled = isRemoveParensEnabled
                         Diagnostics = result
                     }
+                )
 
                 return result
         }

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System.Composition
+open System.Collections.Concurrent
 open System.Collections.Immutable
 open System.Collections.Generic
 open System.Threading
@@ -26,6 +27,9 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
 
     let shouldProduceDiagnostics (document: Document) =
         document.Project.Solution.GetFSharpExtensionConfig().ShouldProduceDiagnostics()
+
+    static let cache =
+        ConcurrentDictionary<struct (DocumentId * DiagnosticsType), VersionStamp * VersionStamp * ImmutableArray<Diagnostic>>()
 
     static let diagnosticEqualityComparer =
         { new IEqualityComparer<FSharpDiagnostic> with
@@ -72,6 +76,27 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
 
             let! ct = CancellableTask.getCancellationToken ()
 
+            let! textVersion = document.GetTextVersionAsync(ct)
+
+            let! projectVersion =
+                match diagnosticType with
+                | DiagnosticsType.Syntax -> CancellableTask.singleton VersionStamp.Default
+                | DiagnosticsType.Semantic -> (fun ct -> document.Project.GetDependentVersionAsync(ct))
+
+            let cacheKey = struct (document.Id, diagnosticType)
+
+            let cached =
+                match cache.TryGetValue(cacheKey) with
+                | true, (cachedTextVersion, cachedProjectVersion, cachedDiagnostics) when
+                    cachedTextVersion = textVersion && cachedProjectVersion = projectVersion
+                    ->
+                    ValueSome cachedDiagnostics
+                | _ -> ValueNone
+
+            match cached with
+            | ValueSome cachedDiagnostics -> return cachedDiagnostics
+            | ValueNone ->
+
             let! sourceText = document.GetTextAsync(ct)
             let filePath = document.FilePath
 
@@ -98,35 +123,39 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                     UnnecessaryParenthesesDiagnosticAnalyzer.GetDiagnostics document
                 | _ -> CancellableTask.singleton ImmutableArray.Empty
 
-            if errors.Count = 0 && unnecessaryParentheses.IsEmpty then
-                return ImmutableArray.Empty
-            else
-                let iab = ImmutableArray.CreateBuilder(errors.Count + unnecessaryParentheses.Length)
+            let result =
+                if errors.Count = 0 && unnecessaryParentheses.IsEmpty then
+                    ImmutableArray.Empty
+                else
+                    let iab = ImmutableArray.CreateBuilder(errors.Count + unnecessaryParentheses.Length)
 
-                for diagnostic in errors do
-                    if diagnostic.StartLine <> 0 && diagnostic.EndLine <> 0 then
-                        let linePositionSpan =
-                            LinePositionSpan(
-                                LinePosition(diagnostic.StartLine - 1, diagnostic.StartColumn),
-                                LinePosition(diagnostic.EndLine - 1, diagnostic.EndColumn)
-                            )
+                    for diagnostic in errors do
+                        if diagnostic.StartLine <> 0 && diagnostic.EndLine <> 0 then
+                            let linePositionSpan =
+                                LinePositionSpan(
+                                    LinePosition(diagnostic.StartLine - 1, diagnostic.StartColumn),
+                                    LinePosition(diagnostic.EndLine - 1, diagnostic.EndColumn)
+                                )
 
-                        let textSpan = sourceText.Lines.GetTextSpan(linePositionSpan)
+                            let textSpan = sourceText.Lines.GetTextSpan(linePositionSpan)
 
-                        // F# compiler report errors at end of file if parsing fails. It should be corrected to match Roslyn boundaries
-                        let correctedTextSpan =
-                            if textSpan.End <= sourceText.Length then
-                                textSpan
-                            else
-                                let start = min textSpan.Start (sourceText.Length - 1) |> max 0
+                            // F# compiler report errors at end of file if parsing fails. It should be corrected to match Roslyn boundaries
+                            let correctedTextSpan =
+                                if textSpan.End <= sourceText.Length then
+                                    textSpan
+                                else
+                                    let start = min textSpan.Start (sourceText.Length - 1) |> max 0
 
-                                TextSpan.FromBounds(start, sourceText.Length)
+                                    TextSpan.FromBounds(start, sourceText.Length)
 
-                        let location = Location.Create(filePath, correctedTextSpan, linePositionSpan)
-                        iab.Add(RoslynHelpers.ConvertError(diagnostic, location))
+                            let location = Location.Create(filePath, correctedTextSpan, linePositionSpan)
+                            iab.Add(RoslynHelpers.ConvertError(diagnostic, location))
 
-                iab.AddRange unnecessaryParentheses
-                return iab.ToImmutable()
+                    iab.AddRange unnecessaryParentheses
+                    iab.ToImmutable()
+
+            cache.[cacheKey] <- (textVersion, projectVersion, result)
+            return result
         }
 
     interface IFSharpDocumentDiagnosticAnalyzer with

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -12,6 +12,7 @@ open System.Threading.Tasks
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Diagnostics
+open Microsoft.VisualStudio.LanguageServices
 
 open FSharp.Compiler.Diagnostics
 open CancellableTasks
@@ -31,8 +32,8 @@ type private CachedDiagnosticsEntry =
         Diagnostics: ImmutableArray<Diagnostic>
     }
 
-[<Export(typeof<IFSharpDocumentDiagnosticAnalyzer>)>]
-type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
+[<Export(typeof<IFSharpDocumentDiagnosticAnalyzer>); Shared>]
+type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] ([<Import(AllowDefault = true)>] workspace: VisualStudioWorkspace | null) =
 
     let shouldProduceDiagnostics (document: Document) =
         document.Project.Solution.GetFSharpExtensionConfig().ShouldProduceDiagnostics()
@@ -40,12 +41,29 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
     static let cache =
         ConcurrentDictionary<struct (DocumentId * DiagnosticsType), CachedDiagnosticsEntry>()
 
-    static let evictRemovedDocuments (solution: Solution) =
+    static let evictDocument (documentId: DocumentId) =
+        cache.TryRemove(struct (documentId, DiagnosticsType.Syntax)) |> ignore
+        cache.TryRemove(struct (documentId, DiagnosticsType.Semantic)) |> ignore
+
+    static let evictProject (projectId: ProjectId) =
         for entry in cache do
             let struct (documentId, _) = entry.Key
 
-            if isNull (solution.GetDocument(documentId)) then
+            if documentId.ProjectId = projectId then
                 cache.TryRemove(entry.Key) |> ignore
+
+    do
+        match workspace with
+        | null -> ()
+        | workspace ->
+            workspace.WorkspaceChanged.Add(fun args ->
+                match args.Kind with
+                | WorkspaceChangeKind.DocumentRemoved when not (isNull args.DocumentId) -> evictDocument args.DocumentId
+                | WorkspaceChangeKind.ProjectRemoved when not (isNull args.ProjectId) -> evictProject args.ProjectId
+                | WorkspaceChangeKind.SolutionCleared
+                | WorkspaceChangeKind.SolutionRemoved -> cache.Clear()
+                | _ -> ()
+            )
 
     static let diagnosticEqualityComparer =
         { new IEqualityComparer<FSharpDiagnostic> with
@@ -105,8 +123,6 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                 match diagnosticType with
                 | DiagnosticsType.Syntax -> document.Project.IsFsharpRemoveParensEnabled
                 | DiagnosticsType.Semantic -> false
-
-            evictRemovedDocuments document.Project.Solution
 
             let cacheKey = struct (document.Id, diagnosticType)
 

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -45,9 +45,6 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
     static let syntaxCache = ConditionalWeakTable<DocumentId, CachedDiagnostics>()
     static let semanticCache = ConditionalWeakTable<DocumentId, CachedDiagnostics>()
 
-    // ConditionalWeakTable has no atomic replace on .NET Framework, and Remove + Add races with a concurrent pass.
-    static let cacheGate = obj ()
-
     static let diagnosticEqualityComparer =
         { new IEqualityComparer<FSharpDiagnostic> with
 
@@ -192,7 +189,8 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                         Diagnostics = result
                     }
 
-                lock cacheGate (fun () ->
+                // net472 has no ConditionalWeakTable.AddOrUpdate, and Remove + Add races with a concurrent pass.
+                lock cache (fun () ->
                     cache.Remove document.Id |> ignore
                     cache.Add(document.Id, entry))
 

--- a/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
+++ b/vsintegration/src/FSharp.Editor/Diagnostics/DocumentDiagnosticAnalyzer.fs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 namespace Microsoft.VisualStudio.FSharp.Editor
 
+open System
 open System.Composition
 open System.Collections.Immutable
 open System.Collections.Generic
@@ -22,8 +23,12 @@ type internal DiagnosticsType =
     | Syntax
     | Semantic
 
-type private CachedDiagnosticsEntry =
+[<NoComparison; NoEquality>]
+type private CachedDiagnostics =
     {
+        /// Diagnostic locations embed it, so a rename that keeps the DocumentId must still invalidate.
+        FilePath: string
+        TextVersion: VersionStamp
         ProjectVersion: VersionStamp
         IsRemoveParensEnabled: bool
         Diagnostics: ImmutableArray<Diagnostic>
@@ -35,8 +40,13 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
     let shouldProduceDiagnostics (document: Document) =
         document.Project.Solution.GetFSharpExtensionConfig().ShouldProduceDiagnostics()
 
-    static let syntaxCache = ConditionalWeakTable<Document, CachedDiagnosticsEntry>()
-    static let semanticCache = ConditionalWeakTable<Document, CachedDiagnosticsEntry>()
+    // DocumentId keys survive solution snapshots, and holding them weakly means a document dropped from the
+    // solution takes its cached diagnostics with it, so no eviction pass is needed on the request path.
+    static let syntaxCache = ConditionalWeakTable<DocumentId, CachedDiagnostics>()
+    static let semanticCache = ConditionalWeakTable<DocumentId, CachedDiagnostics>()
+
+    // ConditionalWeakTable has no atomic replace on .NET Framework, and Remove + Add races with a concurrent pass.
+    static let cacheGate = obj ()
 
     static let diagnosticEqualityComparer =
         { new IEqualityComparer<FSharpDiagnostic> with
@@ -85,8 +95,11 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
 
             let! projectVersion =
                 match diagnosticType with
-                | DiagnosticsType.Syntax -> CancellableTask.singleton VersionStamp.Default
+                // Syntax diagnostics depend on the parsing options (defines, langversion), which the project version covers.
+                | DiagnosticsType.Syntax -> CancellableTask.singleton document.Project.Version
                 | DiagnosticsType.Semantic -> (fun ct -> document.Project.GetDependentVersionAsync(ct))
+
+            let! textVersion = document.GetTextVersionAsync(ct)
 
             let filePath = document.FilePath
 
@@ -101,9 +114,11 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                 | DiagnosticsType.Semantic -> semanticCache
 
             let cached =
-                match cache.TryGetValue document with
+                match cache.TryGetValue document.Id with
                 | true, cachedEntry when
-                    cachedEntry.ProjectVersion = projectVersion
+                    String.Equals(cachedEntry.FilePath, filePath, StringComparison.Ordinal)
+                    && cachedEntry.TextVersion = textVersion
+                    && cachedEntry.ProjectVersion = projectVersion
                     && cachedEntry.IsRemoveParensEnabled = isRemoveParensEnabled
                     ->
                     ValueSome cachedEntry.Diagnostics
@@ -117,15 +132,15 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
 
                 let errors = HashSet<FSharpDiagnostic>(diagnosticEqualityComparer)
 
-                let! parseResults = document.GetFSharpParseResultsAsync("GetDiagnostics")
-
                 match diagnosticType with
                 | DiagnosticsType.Syntax ->
+                    let! parseResults = document.GetFSharpParseResultsAsync("GetDiagnostics")
+
                     for diagnostic in parseResults.Diagnostics do
                         errors.Add(diagnostic) |> ignore
 
                 | DiagnosticsType.Semantic ->
-                    let! _, checkResults = document.GetFSharpParseAndCheckResultsAsync("GetDiagnostics")
+                    let! parseResults, checkResults = document.GetFSharpParseAndCheckResultsAsync("GetDiagnostics")
 
                     for diagnostic in checkResults.Diagnostics do
                         errors.Add(diagnostic) |> ignore
@@ -168,16 +183,18 @@ type internal FSharpDocumentDiagnosticAnalyzer [<ImportingConstructor>] () =
                         iab.AddRange unnecessaryParentheses
                         iab.ToImmutable()
 
-                cache.Remove(document) |> ignore
-
-                cache.Add(
-                    document,
+                let entry =
                     {
+                        FilePath = filePath
+                        TextVersion = textVersion
                         ProjectVersion = projectVersion
                         IsRemoveParensEnabled = isRemoveParensEnabled
                         Diagnostics = result
                     }
-                )
+
+                lock cacheGate (fun () ->
+                    cache.Remove document.Id |> ignore
+                    cache.Add(document.Id, entry))
 
                 return result
         }


### PR DESCRIPTION
Fixes #20120

## Summary

`FSharpDocumentDiagnosticAnalyzer.GetDiagnostics` previously recomputed syntax/semantic diagnostics (parse, typecheck, `UnusedParentheses`) on every crawler pass, even when the document text and project state had not changed since the last computation.

This adds a version-stamp-aware cache keyed by `struct (DocumentId * DiagnosticsType)`, storing the last computed `(textVersion, projectVersion, ImmutableArray<Diagnostic>)` tuple:
- For `Syntax` diagnostics, only the document `textVersion` is tracked (`projectVersion` uses `VersionStamp.Default`).
- For `Semantic` diagnostics, both `textVersion` and `document.Project.GetDependentVersionAsync()` are tracked.
- If the current versions match the cached entry, the cached diagnostics are returned directly, skipping parse/typecheck/`UnnecessaryParenthesesDiagnosticAnalyzer` work entirely.

This mirrors the versioned-cache pattern used for referenced-project compilation emission in `FSharpProjectOptionsManager.fs` (`emitCache`).

## Testing

- `dotnet build vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj -c Debug` — succeeded.
- Deployed to RoslynDev hive (`Build.cmd -c Debug -deployExtensions`) and validated with a CPU trace of `devenv.exe`.
