### PR TITLE
Restore pull-requests: write so release-note comments can post

### DIFF
--- a/.github/workflows/check_release_notes.yml
+++ b/.github/workflows/check_release_notes.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 concurrency:
   group: release-notes-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -314,29 +314,36 @@ jobs:
         github-token: ${{ github.token }}
         script: |
             const marker = '<!-- DO_NOT_REMOVE: release_notes_check -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                per_page: 100
-            });
-            const existing = comments.find(comment =>
-                comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
-
-            if (existing) {
-                const comment = await github.rest.issues.updateComment({
+            // Posting the status comment is best-effort and must never fail the check:
+            // the release-notes gate is enforced by the previous step's exit code.
+            try {
+                const comments = await github.paginate(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    comment_id: existing.id,
+                    issue_number: context.issue.number,
+                    per_page: 100
+                });
+                const existing = comments.find(comment =>
+                    comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
+
+                if (existing) {
+                    const comment = await github.rest.issues.updateComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        comment_id: existing.id,
+                        body: process.env.COMMENT_BODY
+                    });
+                    return comment.data.id;
+                }
+
+                const comment = await github.rest.issues.createComment({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
                     body: process.env.COMMENT_BODY
                 });
                 return comment.data.id;
+            } catch (error) {
+                core.warning(`Unable to post the release-notes status comment: ${error.message}`);
+                return '';
             }
-
-            const comment = await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: process.env.COMMENT_BODY
-            });
-            return comment.data.id;


### PR DESCRIPTION
`check_release_notes` (rewritten in #20081) reduced the token to
`pull-requests: read`. Creating a PR comment (`issues.createComment`, a POST)
requires `pull-requests: write`, so brand-new PRs with no existing bot comment —
such as the dependency updates dotnet-maestro opens (#20134) — failed with 403
`Resource not accessible by integration`. Only PRs that already had a comment
from before #20081 kept passing, because the `updateComment` (PATCH) path works
with `issues: write`.

The security fix in #20081 was removing the untrusted fork-head checkout; that
protection is unchanged. No untrusted code runs and the comment body is passed
via an environment variable, so restoring `pull-requests: write` does not
reintroduce the fork-checkout risk. The comment step is also wrapped in
try/catch so posting the informational comment can never fail the release-notes
gate.

This PR's own `check_release_notes` stays red: `pull_request_target` loads the
workflow from the base branch, so this PR runs the old `main` workflow and can't
validate its own replacement — the same expected exception noted in #20081.
