### PR TITLE
Pin nonvulnerable version of MessagePack package

### DIFF
--- a/src/Microsoft.CommonLanguageServerProtocol.Framework.Proxy/Microsoft.CommonLanguageServerProtocol.Framework.Proxy.csproj
+++ b/src/Microsoft.CommonLanguageServerProtocol.Framework.Proxy/Microsoft.CommonLanguageServerProtocol.Framework.Proxy.csproj
@@ -9,6 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CommonLanguageServerProtocol.Framework" PrivateAssets="all" Version="4.13.0-3.24579.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.21" />
+		<PackageReference Include="MessagePack" Version="2.5.302" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Due to this https://github.com/advisories/GHSA-2f33-pr97-265q we need to bump to a patched version