### PR TITLE
Restore write permission for release-notes check comment

### DIFF
--- a/.github/workflows/check_release_notes.yml
+++ b/.github/workflows/check_release_notes.yml
@@ -307,6 +307,8 @@ jobs:
     # Keep one bot comment current without evaluating pull request content as JavaScript.
     - name: Create or update comment
       if: ${{ (success() || failure()) && steps.release_notes_changes.outputs.release-notes-check-message != '' }}
+      # The comment is informational; never let posting it fail the release-notes verdict.
+      continue-on-error: true
       uses: actions/github-script@v9
       env:
         COMMENT_BODY: ${{ steps.release_notes_changes.outputs.release-notes-check-message }}

--- a/.github/workflows/check_release_notes.yml
+++ b/.github/workflows/check_release_notes.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 concurrency:
   group: release-notes-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -314,29 +314,36 @@ jobs:
         github-token: ${{ github.token }}
         script: |
             const marker = '<!-- DO_NOT_REMOVE: release_notes_check -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                per_page: 100
-            });
-            const existing = comments.find(comment =>
-                comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
-
-            if (existing) {
-                const comment = await github.rest.issues.updateComment({
+            try {
+                const comments = await github.paginate(github.rest.issues.listComments, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    comment_id: existing.id,
+                    issue_number: context.issue.number,
+                    per_page: 100
+                });
+                const existing = comments.find(comment =>
+                    comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker));
+
+                if (existing) {
+                    const comment = await github.rest.issues.updateComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        comment_id: existing.id,
+                        body: process.env.COMMENT_BODY
+                    });
+                    return comment.data.id;
+                }
+
+                const comment = await github.rest.issues.createComment({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
                     body: process.env.COMMENT_BODY
                 });
                 return comment.data.id;
+            } catch (error) {
+                // The comment is informational only. The release-notes verdict is enforced by the
+                // "Check for release notes changes" step, so never fail the job if posting fails
+                // (e.g. a read-only token on some pull requests).
+                core.warning(`Unable to post release-notes comment: ${error.message}`);
             }
-
-            const comment = await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: process.env.COMMENT_BODY
-            });
-            return comment.data.id;


### PR DESCRIPTION
Posting the `check_release_notes` bot comment requires `pull-requests: write`,
but the token was reduced to `read`, so `createComment` failed with
`Resource not accessible by integration` and turned the check red even when no
release notes were required (e.g. the automated dotnet/arcade dependency-update
PRs). Restored the write scope and made the comment step best-effort so the
check reflects the release-notes verdict rather than the comment API result.

## Expected check state

`check_release_notes` on this PR is expected to stay red. `pull_request_target`
loads its workflow from the default branch, so this PR runs the old workflow
still on `main` and hits the same read-only-token failure before the fix can
apply to itself. Subsequent pull request events use the fixed workflow once this
merges.
