### PR TITLE
Stop merging main into the retired .NET 11 scouting branch

### DIFF
--- a/.config/service-branch-merge.json
+++ b/.config/service-branch-merge.json
@@ -26,18 +26,6 @@
                 "azure-pipelines.yml",
                 "azure-pipelines-PR.yml"
             ]
-        },
-        "main": {
-            "MergeToBranch": "feature/net11-scouting",
-            "ExtraSwitches": "-QuietComments",
-            "ResetToTargetPaths": [
-                "global.json",
-                "eng/Version.Details.xml",
-                "eng/Version.Details.props",
-                "eng/Versions.props",
-                "eng/common/**",
-                "eng/TargetFrameworks.props"
-            ]
         }
     }
 }


### PR DESCRIPTION
Remove the obsolete intra-branch merge configuration now that feature/net11-scouting has been retired.
