### PR TITLE
Switch from Newtonsoft to MessagePack restore in fsi tests

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
@@ -85,10 +85,24 @@ module FsiCliTests =
         finally
             try System.IO.File.Delete(scriptPath) with _ -> ()
 
+    // The FSI #r "nuget:" restore below must request a package version that is guaranteed to be in
+    // the offline restore cache on the internal signed build (which cannot restore online). Central
+    // package management + transitive pinning means only the centrally-pinned version (eng/Packages.props)
+    // is ever restored into that cache, and it changes whenever the pin is bumped. Rather than hardcode
+    // a version that would silently drift, read the exact pinned version baked into this test assembly
+    // at build time via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj).
+    let private centralNewtonsoftJsonVersion =
+        System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(typeof<System.Reflection.AssemblyMetadataAttribute>, false)
+        |> Array.tryPick (fun a ->
+            let m = a :?> System.Reflection.AssemblyMetadataAttribute
+            if m.Key = "NewtonsoftJsonCentralVersion" && not (System.String.IsNullOrWhiteSpace m.Value) then Some m.Value else None)
+        |> Option.defaultWith (fun () ->
+            failwith "AssemblyMetadata 'NewtonsoftJsonCentralVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central Newtonsoft.Json PackageVersion.")
+
     [<Fact>]
     let ``FSI quiet mode suppresses NuGet restore output from stdout`` () =
-        let script = """
-#r "nuget: Newtonsoft.Json, 13.0.3"
+        let script = $"""
+#r "nuget: Newtonsoft.Json, {centralNewtonsoftJsonVersion}"
 printfn "RESULT_MARKER_18086"
 """
         let result = runFsiScript ["--quiet"] script
@@ -100,8 +114,8 @@ printfn "RESULT_MARKER_18086"
 
     [<Fact>]
     let ``FSI default (non-quiet) mode still evaluates script and prints user output`` () =
-        let script = """
-#r "nuget: Newtonsoft.Json, 13.0.3"
+        let script = $"""
+#r "nuget: Newtonsoft.Json, {centralNewtonsoftJsonVersion}"
 printfn "RESULT_MARKER_18086_DEFAULT"
 """
         let result = runFsiScript [] script

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
@@ -90,19 +90,23 @@ module FsiCliTests =
     // package management + transitive pinning means only the centrally-pinned version (eng/Packages.props)
     // is ever restored into that cache, and it changes whenever the pin is bumped. Rather than hardcode
     // a version that would silently drift, read the exact pinned version baked into this test assembly
-    // at build time via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj).
-    let private centralNewtonsoftJsonVersion =
+    // at build time via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj). The package id
+    // (FsCheck) is kept in sync with that project; any centrally-pinned standalone package would do.
+    [<Literal>]
+    let private restoreTestPackageId = "FsCheck"
+
+    let private restoreTestPackageVersion =
         System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(typeof<System.Reflection.AssemblyMetadataAttribute>, false)
         |> Array.tryPick (fun a ->
             let m = a :?> System.Reflection.AssemblyMetadataAttribute
-            if m.Key = "NewtonsoftJsonCentralVersion" && not (System.String.IsNullOrWhiteSpace m.Value) then Some m.Value else None)
+            if m.Key = "FsiRestoreTestPackageVersion" && not (System.String.IsNullOrWhiteSpace m.Value) then Some m.Value else None)
         |> Option.defaultWith (fun () ->
-            failwith "AssemblyMetadata 'NewtonsoftJsonCentralVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central Newtonsoft.Json PackageVersion.")
+            failwith "AssemblyMetadata 'FsiRestoreTestPackageVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central FsCheck PackageVersion.")
 
     [<Fact>]
     let ``FSI quiet mode suppresses NuGet restore output from stdout`` () =
         let script = $"""
-#r "nuget: Newtonsoft.Json, {centralNewtonsoftJsonVersion}"
+#r "nuget: {restoreTestPackageId}, {restoreTestPackageVersion}"
 printfn "RESULT_MARKER_18086"
 """
         let result = runFsiScript ["--quiet"] script
@@ -115,7 +119,7 @@ printfn "RESULT_MARKER_18086"
     [<Fact>]
     let ``FSI default (non-quiet) mode still evaluates script and prints user output`` () =
         let script = $"""
-#r "nuget: Newtonsoft.Json, {centralNewtonsoftJsonVersion}"
+#r "nuget: {restoreTestPackageId}, {restoreTestPackageVersion}"
 printfn "RESULT_MARKER_18086_DEFAULT"
 """
         let result = runFsiScript [] script

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
@@ -91,9 +91,9 @@ module FsiCliTests =
     // is ever restored into that cache, and it changes whenever the pin is bumped. Rather than hardcode
     // a version that would silently drift, read the exact pinned version baked into this test assembly
     // at build time via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj). The package id
-    // (FsCheck) is kept in sync with that project; any centrally-pinned standalone package would do.
+    // (MessagePack) is kept in sync with that project; any centrally-pinned standalone package would do.
     [<Literal>]
-    let private restoreTestPackageId = "FsCheck"
+    let private restoreTestPackageId = "MessagePack"
 
     let private restoreTestPackageVersion =
         System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(typeof<System.Reflection.AssemblyMetadataAttribute>, false)
@@ -101,7 +101,7 @@ module FsiCliTests =
             let m = a :?> System.Reflection.AssemblyMetadataAttribute
             if m.Key = "FsiRestoreTestPackageVersion" && not (System.String.IsNullOrWhiteSpace m.Value) then Some m.Value else None)
         |> Option.defaultWith (fun () ->
-            failwith "AssemblyMetadata 'FsiRestoreTestPackageVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central FsCheck PackageVersion.")
+            failwith "AssemblyMetadata 'FsiRestoreTestPackageVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central MessagePack PackageVersion.")
 
     [<Fact>]
     let ``FSI quiet mode suppresses NuGet restore output from stdout`` () =

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -562,15 +562,19 @@
     <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
-  <!-- Bake the centrally-pinned Newtonsoft.Json version (eng/Packages.props via central package
-       management) into the test assembly so FsiCliTests can request exactly the version that is
-       present in the offline restore cache on the internal signed build, with no manual sync when
-       the central pin is bumped. -->
+  <!-- FsiCliTests spawns FSI and does `#r "nuget: <pkg>, <version>"` to verify that quiet mode
+       suppresses NuGet restore chatter. On the internal signed build NuGet restore is offline, so the
+       requested version must be one that is already in the restore cache. Under central package
+       management with transitive pinning, that is exactly the centrally-pinned version
+       (eng/Packages.props). Bake that version into the test assembly so the test can request it at
+       runtime with no manual sync when the central pin is bumped. FsCheck is used (rather than a
+       general-purpose JSON package) because it is an F#-owned standalone leaf library that is centrally
+       pinned and restored by the build; keep the package id here in sync with the id in FsiCliTests.fs. -->
   <PropertyGroup>
-    <NewtonsoftJsonCentralVersion>@(PackageVersion->WithMetadataValue('Identity','Newtonsoft.Json')->'%(Version)')</NewtonsoftJsonCentralVersion>
+    <FsiRestoreTestPackageVersion>@(PackageVersion->WithMetadataValue('Identity','FsCheck')->'%(Version)')</FsiRestoreTestPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <AssemblyMetadata Include="NewtonsoftJsonCentralVersion" Value="$(NewtonsoftJsonCentralVersion)" />
+    <AssemblyMetadata Include="FsiRestoreTestPackageVersion" Value="$(FsiRestoreTestPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -567,11 +567,12 @@
        requested version must be one that is already in the restore cache. Under central package
        management with transitive pinning, that is exactly the centrally-pinned version
        (eng/Packages.props). Bake that version into the test assembly so the test can request it at
-       runtime with no manual sync when the central pin is bumped. FsCheck is used (rather than a
-       general-purpose JSON package) because it is an F#-owned standalone leaf library that is centrally
-       pinned and restored by the build; keep the package id here in sync with the id in FsiCliTests.fs. -->
+       runtime with no manual sync when the central pin is bumped. MessagePack is used (rather than a
+       general-purpose JSON package) because it is an actively-maintained, non-system standalone library
+       that is centrally pinned and restored transitively by the product (StreamJsonRpc); keep the
+       package id here in sync with the id in FsiCliTests.fs. -->
   <PropertyGroup>
-    <FsiRestoreTestPackageVersion>@(PackageVersion->WithMetadataValue('Identity','FsCheck')->'%(Version)')</FsiRestoreTestPackageVersion>
+    <FsiRestoreTestPackageVersion>@(PackageVersion->WithMetadataValue('Identity','MessagePack')->'%(Version)')</FsiRestoreTestPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyMetadata Include="FsiRestoreTestPackageVersion" Value="$(FsiRestoreTestPackageVersion)" />

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -562,5 +562,15 @@
     <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
+  <!-- Bake the centrally-pinned Newtonsoft.Json version (eng/Packages.props via central package
+       management) into the test assembly so FsiCliTests can request exactly the version that is
+       present in the offline restore cache on the internal signed build, with no manual sync when
+       the central pin is bumped. -->
+  <PropertyGroup>
+    <NewtonsoftJsonCentralVersion>@(PackageVersion->WithMetadataValue('Identity','Newtonsoft.Json')->'%(Version)')</NewtonsoftJsonCentralVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <AssemblyMetadata Include="NewtonsoftJsonCentralVersion" Value="$(NewtonsoftJsonCentralVersion)" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Signed build fails because (I think) it tries to resolve offline and the previous Newtonsoft version is no longer cached.

Switching to MessagePack instead of Newtonsoft and using a centrally managed version to avoid future regressions of this kind.