### PR TITLE
Record spreads: off-by-default shadowing warnings

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -141,7 +141,7 @@
 * Add diagnostic FS3889 when a namespace and a type have the same fully-qualified name in the same assembly, replacing the misleading FS0247 "namespace and a module" error. ([Issue #17827](https://github.com/dotnet/fsharp/issues/17827), [PR #19802](https://github.com/dotnet/fsharp/pull/19802))
 * Debug: rework for expressions stepping ([PR #19894](https://github.com/dotnet/fsharp/pull/19894))
 * Debug: rework conditional erasure, fix stepping over literals ([PR #19897](https://github.com/dotnet/fsharp/pull/19897))
-* Spread operator for records ([RFC FS-1151](https://github.com/fsharp/fslang-design/pull/805), [PR #18927](https://github.com/dotnet/fsharp/pull/18927))
+* Record spreads ([RFC FS-1151](https://github.com/fsharp/fslang-design/pull/805), [PR #18927](https://github.com/dotnet/fsharp/pull/18927), [PR #20206](https://github.com/dotnet/fsharp/pull/20206))
 * Debug: fix if and match condition sequence points ([PR #19932](https://github.com/dotnet/fsharp/pull/19932))
 * Under `--reflectionfree`, discriminated unions, records and anonymous records now get a [generated `ToString`](../../reflectionfree-printing.md) (rendering each field like `Option` does) instead of falling back to the namespace-qualified type name. ([PR #19976](https://github.com/dotnet/fsharp/pull/19976))
 * Support common types of `NotNullIfNotNullAttribute` usage. If a method parameter is marked with `NotNullIfNotNullAttribute`, the compiler will now honor this attribute and mark the return type as non-null. ([PR #19977](https://github.com/dotnet/fsharp/pull/19977))

--- a/src/Compiler/Checking/CheckDeclarations.fs
+++ b/src/Compiler/Checking/CheckDeclarations.fs
@@ -2712,7 +2712,7 @@ module EstablishTypeDefinitionCores =
           | SynTypeDefnSimpleRepr.Record (_, fieldsAndSpreads, _) ->
               let tcField (SynField (fieldType = ty; range = m)) =
                   let tyR, _ = TcTypeAndRecover cenv NoNewTypars NoCheckCxs ItemOccurrence.UseInType WarnOnIWSAM.Yes env tpenv ty
-                  (tyR, m), ignore
+                  (tyR, m), ignore, ignore
   
               let tcSpread (SynTypeSpread (ty = ty; range = m)) =
                   let spreadSrcTy, _ = TcTypeAndRecover cenv NoNewTypars NoCheckCxs ItemOccurrence.UseInType WarnOnIWSAM.Yes env tpenv ty
@@ -2721,11 +2721,11 @@ module EstablishTypeDefinitionCores =
                       spreadSrcTys.Add spreadSrcTy
                       ResolveRecordOrClassFieldsOfType cenv.nameResolver m ad spreadSrcTy false
                       |> List.choose (function
-                          | Item.RecdField field -> Some (field.RecdField.Id.idText, (field.FieldType, m), ignore)
+                          | Item.RecdField field -> Some (field.RecdField.Id.idText, (field.FieldType, m), ignore, ignore)
                           | _ -> None)
                   else
                       match tryDestAnonRecdTy g spreadSrcTy with
-                      | ValueSome (anonInfo, tys) -> tys |> List.mapi (fun i ty -> (anonInfo.SortedNames[i], (ty, m), ignore))
+                      | ValueSome (anonInfo, tys) -> tys |> List.mapi (fun i ty -> (anonInfo.SortedNames[i], (ty, m), ignore, ignore))
                       | ValueNone -> []
   
               // We must apply the spread shadowing logic here
@@ -3731,7 +3731,12 @@ module EstablishTypeDefinitionCores =
                             let tcField synField =
                                 let field = TcRecdUnionAndEnumDeclarations.TcNamedFieldDecl cenv envinner innerParent false tpenv addFixup synField |> Option.get
                                 let errorAmbiguousShadowing () = if firstPass then errorR (Duplicate ("field", field.Id.idText, field.Id.idRange))
-                                field, errorAmbiguousShadowing
+                                let infoExplicitShadowing () =
+                                    if firstPass then
+                                        let fmtedSpreadField = NicePrint.stringOfRecdField envinner.DisplayEnv cenv.infoReader thisTyconRef field
+                                        informationalWarning (Error (FSComp.SR.tcRecordExplicitFieldShadowsSpreadField fmtedSpreadField, field.Id.idRange))
+
+                                field, errorAmbiguousShadowing, infoExplicitShadowing
 
                             let tcSpread (SynTypeSpread (ty = ty; range = m)) =
                                 let mTy = ty.Range
@@ -3789,7 +3794,12 @@ module EstablishTypeDefinitionCores =
                                                 let fmtedSpreadSrcTy = NicePrint.stringOfTy envinner.DisplayEnv spreadSrcTy
                                                 warning (Error (FSComp.SR.tcRecordTypeDefinitionSpreadFieldShadowsExplicitField (fmtedSpreadField, fmtedSpreadSrcTy), m))
 
-                                            Some (fieldInfo.RecdField.Id.idText, recdField, warnAmbiguousShadowing)
+                                            let infoSpreadShadowing () =
+                                                let fmtedSpreadField = NicePrint.stringOfRecdField envinner.DisplayEnv cenv.infoReader fieldInfo.TyconRef recdField
+                                                let fmtedSpreadSrcTy = NicePrint.stringOfTy envinner.DisplayEnv spreadSrcTy
+                                                informationalWarning (Error (FSComp.SR.tcRecordTypeDefinitionSpreadFieldShadowsSpreadField (fmtedSpreadField, fmtedSpreadSrcTy), m))
+
+                                            Some (fieldInfo.RecdField.Id.idText, recdField, warnAmbiguousShadowing, infoSpreadShadowing)
 
                                         | Item.AnonRecdField (anonInfo, tys, fieldIndex, _) ->
                                             let fieldId =
@@ -3815,7 +3825,13 @@ module EstablishTypeDefinitionCores =
                                                 let fmtedSpreadSrcTy = NicePrint.stringOfTy envinner.DisplayEnv spreadSrcTy
                                                 warning (Error (FSComp.SR.tcRecordTypeDefinitionSpreadFieldShadowsExplicitField (fmtedSpreadField, fmtedSpreadSrcTy), m))
 
-                                            Some (fieldId.idText, field, warnAmbiguousShadowing)
+                                            let infoSpreadShadowing () =
+                                                let typars = tryAppTy g ty |> ValueOption.map (snd >> List.choose (tryDestTyparTy g >> ValueOption.toOption)) |> ValueOption.defaultValue []
+                                                let fmtedSpreadField = LayoutRender.showL (NicePrint.prettyLayoutOfMemberSig envinner.DisplayEnv ([], fieldId.idText, typars, [], ty))
+                                                let fmtedSpreadSrcTy = NicePrint.stringOfTy envinner.DisplayEnv spreadSrcTy
+                                                informationalWarning (Error (FSComp.SR.tcRecordTypeDefinitionSpreadFieldShadowsSpreadField (fmtedSpreadField, fmtedSpreadSrcTy), m))
+
+                                            Some (fieldId.idText, field, warnAmbiguousShadowing, infoSpreadShadowing)
 
                                         | _ -> None)
                                 elif not firstPass then

--- a/src/Compiler/Checking/Spreads.fs
+++ b/src/Compiler/Checking/Spreads.fs
@@ -67,7 +67,7 @@ module Types =
                 | SynFieldOrSpread.Field(SynField(idOpt = None)) :: fieldsAndSpreads -> loop fields i fieldsAndSpreads
 
                 | SynFieldOrSpread.Field(SynField(idOpt = Some fieldId) as synField) :: fieldsAndSpreads ->
-                    let field, errorAmbiguousShadowing = tcField synField
+                    let field, errorAmbiguousShadowing, infoExplicitShadowing = tcField synField
 
                     let fields =
                         fields
@@ -76,7 +76,9 @@ module Types =
                             | Some(LeftwardExplicit, dupes) ->
                                 errorAmbiguousShadowing ()
                                 Some(LeftwardExplicit, (i, field) :: dupes)
-                            | Some(NoLeftwardExplicit, _dupes) -> Some(LeftwardExplicit, [ i, field ]))
+                            | Some(NoLeftwardExplicit, _dupes) ->
+                                infoExplicitShadowing ()
+                                Some(LeftwardExplicit, [ i, field ]))
 
                     loop fields (i + 1) fieldsAndSpreads
 
@@ -86,7 +88,7 @@ module Types =
                     let rec collectFieldsFromSpread fields i fieldsFromSpread =
                         match fieldsFromSpread with
                         | [] -> fields, i
-                        | (fieldId, field, warnAmbiguousShadowing) :: fieldsFromSpread ->
+                        | (fieldId, field, warnAmbiguousShadowing, infoSpreadShadowing) :: fieldsFromSpread ->
                             let fields =
                                 fields
                                 |> Map.change fieldId (function
@@ -94,7 +96,9 @@ module Types =
                                     | Some(LeftwardExplicit, _dupes) ->
                                         warnAmbiguousShadowing ()
                                         Some(LeftwardExplicit, [ i, field ])
-                                    | Some(NoLeftwardExplicit, _dupes) -> Some(NoLeftwardExplicit, [ i, field ]))
+                                    | Some(NoLeftwardExplicit, _dupes) ->
+                                        infoSpreadShadowing ()
+                                        Some(NoLeftwardExplicit, [ i, field ]))
 
                             collectFieldsFromSpread fields (i + 1) fieldsFromSpread
 
@@ -132,7 +136,7 @@ module Values =
                     let interveningSpreadSrc =
                         interveningSpreadSrcs |> Map.tryFind (textOfId (List.head synLongId.LongIdent))
 
-                    let fieldId, path, fieldExpr, errorAmbiguousShadowing =
+                    let fieldId, path, fieldExpr, errorAmbiguousShadowing, infoExplicitShadowing =
                         tcField interveningSpreadSrc synLongId fieldExpr m
 
                     let fields =
@@ -156,6 +160,7 @@ module Values =
 
                                 Some(LeftwardExplicit, fieldExpr, (i, (fieldId, ExplicitOrSpread.Explicit(path, fieldExpr))) :: dupes)
                             | Some(NoLeftwardExplicit, _dupeExpr, _dupes) ->
+                                infoExplicitShadowing ()
                                 Some(LeftwardExplicit, fieldExpr, [ i, (fieldId, ExplicitOrSpread.Explicit(path, fieldExpr)) ]))
 
                     loop fields (i + 1) spreadSrcTys spreadSrcExprs interveningSpreadSrcs fieldsAndSpreads
@@ -168,7 +173,7 @@ module Values =
                         let rec collectFieldsFromSpread fields i interveningSpreadSrcs fieldsFromSpread =
                             match fieldsFromSpread with
                             | [] -> fields, i, interveningSpreadSrcs
-                            | (fieldId, field, warnAmbiguousShadowing) :: fieldsFromSpread ->
+                            | (fieldId, field, warnAmbiguousShadowing, infoSpreadShadowing) :: fieldsFromSpread ->
                                 let tys =
                                     fields
                                     |> Map.change (textOfId fieldId) (function
@@ -177,6 +182,7 @@ module Values =
                                             warnAmbiguousShadowing ()
                                             Some(LeftwardExplicit, Some spreadSrcSynExpr, [ i, (fieldId, field) ])
                                         | Some(NoLeftwardExplicit, _existingExpr, _dupes) ->
+                                            infoSpreadShadowing ()
                                             Some(NoLeftwardExplicit, Some spreadSrcSynExpr, [ i, (fieldId, field) ]))
 
                                 let interveningSpreadSrcs =
@@ -236,7 +242,11 @@ module Values =
                     if not isFromNestedUpdate || isFromSpread then
                         errorR (Error(FSComp.SR.tcMultipleFieldsInRecord fieldId.idText, m))
 
-                fieldId, path, field, errorAmbiguousShadowing
+                let infoExplicitShadowing () =
+                    if not isFromNestedUpdate then
+                        informationalWarning (Error(FSComp.SR.tcRecordExplicitFieldShadowsSpreadField fieldId.idText, m))
+
+                fieldId, path, field, errorAmbiguousShadowing, infoExplicitShadowing
 
             let tcSpread (SynExprSpread(expr = expr; range = m)) =
                 let mExpr = expr.Range
@@ -306,7 +316,13 @@ module Values =
 
                                     warning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsExplicitField fmtedSpreadField, m))
 
-                                Some(fieldId, ExplicitOrSpread.Spread(ty, fieldExpr), warnAmbiguousShadowing)
+                                let infoSpreadShadowing () =
+                                    let fmtedSpreadField =
+                                        NicePrint.stringOfRecdField env.DisplayEnv cenv.infoReader fieldInfo.TyconRef fieldInfo.RecdField
+
+                                    informationalWarning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsSpreadField fmtedSpreadField, m))
+
+                                Some(fieldId, ExplicitOrSpread.Spread(ty, fieldExpr), warnAmbiguousShadowing, infoSpreadShadowing)
 
                             | Item.AnonRecdField(anonInfo, tys, fieldIndex, _) ->
                                 let fieldExpr =
@@ -315,20 +331,25 @@ module Values =
                                 let fieldId = anonInfo.SortedIds[fieldIndex]
                                 let ty = tys[fieldIndex]
 
-                                let warnAmbiguousShadowing () =
+                                let getFmtedSpreadField () =
                                     let typars =
                                         tryAppTy g ty
                                         |> ValueOption.map (snd >> List.choose (tryDestTyparTy g >> ValueOption.toOption))
                                         |> ValueOption.defaultValue []
 
-                                    let fmtedSpreadField =
-                                        LayoutRender.showL (
-                                            NicePrint.prettyLayoutOfMemberSig env.DisplayEnv ([], fieldId.idText, typars, [], ty)
-                                        )
+                                    LayoutRender.showL (
+                                        NicePrint.prettyLayoutOfMemberSig env.DisplayEnv ([], fieldId.idText, typars, [], ty)
+                                    )
 
-                                    warning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsExplicitField fmtedSpreadField, m))
+                                let warnAmbiguousShadowing () =
+                                    warning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsExplicitField (getFmtedSpreadField ()), m))
 
-                                Some(fieldId, ExplicitOrSpread.Spread(ty, fieldExpr), warnAmbiguousShadowing)
+                                let infoSpreadShadowing () =
+                                    informationalWarning (
+                                        Error(FSComp.SR.tcRecordExprSpreadFieldShadowsSpreadField (getFmtedSpreadField ()), m)
+                                    )
+
+                                Some(fieldId, ExplicitOrSpread.Spread(ty, fieldExpr), warnAmbiguousShadowing, infoSpreadShadowing)
 
                             | _ -> None)
 
@@ -398,7 +419,7 @@ module Values =
                     let interveningSpreadSrc =
                         interveningSpreadSrcs |> Map.tryFind (textOfId (List.head synLongId.LongIdent))
 
-                    let fieldId, fieldTy, transformedFieldExpr, mkTcField, errorAmbiguousShadowing =
+                    let fieldId, fieldTy, transformedFieldExpr, mkTcField, errorAmbiguousShadowing, infoExplicitShadowing =
                         tcField interveningSpreadSrc synExprAnonRecordField
 
                     let fields =
@@ -417,6 +438,7 @@ module Values =
                                     (i, (fieldId, fieldTy, mkTcField transformedFieldExpr)) :: dupes
                                 )
                             | Some(NoLeftwardExplicit, _dupeExpr, _dupes) ->
+                                infoExplicitShadowing ()
                                 Some(LeftwardExplicit, transformedFieldExpr, [ i, (fieldId, fieldTy, mkTcField transformedFieldExpr) ]))
 
                     loop fields (i + 1) spreadSrcExprs interveningSpreadSrcs fieldsAndSpreads
@@ -429,7 +451,7 @@ module Values =
                         let rec collectFieldsFromSpread fields i interveningSpreadSrcs fieldsFromSpread =
                             match fieldsFromSpread with
                             | [] -> fields, i, interveningSpreadSrcs
-                            | (fieldId, fieldTy, tcField, warnAmbiguousShadowing) :: fieldsFromSpread ->
+                            | (fieldId, fieldTy, tcField, warnAmbiguousShadowing, infoSpreadShadowing) :: fieldsFromSpread ->
                                 let tys =
                                     fields
                                     |> Map.change (textOfId fieldId) (function
@@ -438,6 +460,7 @@ module Values =
                                             warnAmbiguousShadowing ()
                                             Some(LeftwardExplicit, spreadSrcSynExpr, [ i, (fieldId, fieldTy, tcField) ])
                                         | Some(NoLeftwardExplicit, _existingExpr, _dupes) ->
+                                            infoSpreadShadowing ()
                                             Some(NoLeftwardExplicit, spreadSrcSynExpr, [ i, (fieldId, fieldTy, tcField) ]))
 
                                 let interveningSpreadSrcs =
@@ -519,7 +542,11 @@ module Values =
                     if not isFromNestedUpdate then
                         errorR (Error(FSComp.SR.tcAnonRecdDuplicateFieldId fieldId.idText, m))
 
-                fieldId, fieldTy, transformedFieldExpr, tcField, errorAmbiguousShadowing
+                let infoExplicitShadowing () =
+                    if not isFromNestedUpdate then
+                        informationalWarning (Error(FSComp.SR.tcRecordExplicitFieldShadowsSpreadField fieldId.idText, m))
+
+                fieldId, fieldTy, transformedFieldExpr, tcField, errorAmbiguousShadowing, infoExplicitShadowing
 
             let tcSpread (expr: SynExpr) m =
                 errorRIfSpreadUsedWithWith m
@@ -599,7 +626,13 @@ module Values =
 
                                     warning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsExplicitField fmtedSpreadField, m))
 
-                                Some(fieldId, ty, tcField, warnAmbiguousShadowing)
+                                let infoSpreadShadowing () =
+                                    let fmtedSpreadField =
+                                        NicePrint.stringOfRecdField env.DisplayEnv cenv.infoReader fieldInfo.TyconRef fieldInfo.RecdField
+
+                                    informationalWarning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsSpreadField fmtedSpreadField, m))
+
+                                Some(fieldId, ty, tcField, warnAmbiguousShadowing, infoSpreadShadowing)
 
                             | Item.AnonRecdField(anonInfo, tys, fieldIndex, _) ->
                                 let fieldId = anonInfo.SortedIds[fieldIndex]
@@ -621,20 +654,25 @@ module Values =
                                     let fieldExpr = mkCoerceIfNeeded g ty (tyOfExpr g fieldExpr) fieldExpr
                                     fieldExpr
 
-                                let warnAmbiguousShadowing () =
+                                let getFmtedSpreadField () =
                                     let typars =
                                         tryAppTy g ty
                                         |> ValueOption.map (snd >> List.choose (tryDestTyparTy g >> ValueOption.toOption))
                                         |> ValueOption.defaultValue []
 
-                                    let fmtedSpreadField =
-                                        LayoutRender.showL (
-                                            NicePrint.prettyLayoutOfMemberSig env.DisplayEnv ([], fieldId.idText, typars, [], ty)
-                                        )
+                                    LayoutRender.showL (
+                                        NicePrint.prettyLayoutOfMemberSig env.DisplayEnv ([], fieldId.idText, typars, [], ty)
+                                    )
 
-                                    warning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsExplicitField fmtedSpreadField, m))
+                                let warnAmbiguousShadowing () =
+                                    warning (Error(FSComp.SR.tcRecordExprSpreadFieldShadowsExplicitField (getFmtedSpreadField ()), m))
 
-                                Some(fieldId, ty, tcField, warnAmbiguousShadowing)
+                                let infoSpreadShadowing () =
+                                    informationalWarning (
+                                        Error(FSComp.SR.tcRecordExprSpreadFieldShadowsSpreadField (getFmtedSpreadField ()), m)
+                                    )
+
+                                Some(fieldId, ty, tcField, warnAmbiguousShadowing, infoSpreadShadowing)
 
                             | _ -> None)
 

--- a/src/Compiler/Driver/CompilerDiagnostics.fs
+++ b/src/Compiler/Driver/CompilerDiagnostics.fs
@@ -402,6 +402,9 @@ type PhasedDiagnostic with
         | 3582 -> false // infoIfFunctionShadowsUnionCase - off by default
         | 3570 -> false // tcAmbiguousDiscardDotLambda - off by default
         | 3878 -> false // tcAttributeIsNotValidForUnionCaseWithFields - off by default
+        | 3905 -> false // tcRecordTypeDefinitionSpreadFieldShadowsSpreadField - off by default
+        | 3906 -> false // tcRecordExplicitFieldShadowsSpreadField - off by default
+        | 3907 -> false // tcRecordExprSpreadFieldShadowsSpreadField - off by default
         | _ ->
             match x.Exception with
             | DiagnosticEnabledWithLanguageFeature(_, _, _, enabled) -> enabled

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1841,4 +1841,7 @@ featureImprovedImpliedArgumentNamesPartTwo,"Improved implied argument names with
 3902,parsSpreadNotSupported,"Spreading is not supported in this construct."
 3903,parsSpreadNotSupportedBeforeWith,"Spreading is not supported in this position. Use one of the forms {{ ...expr1; A = expr2 }} or {{ expr1 with A = expr2 }} instead."
 3904,tcRecordExprSpreadWithCannotBeUsedWithSpreads,"Spread expressions and 'with' cannot be used together in the same copy-and-update expression."
+3905,tcRecordTypeDefinitionSpreadFieldShadowsSpreadField,"Spread field '%s' from type '%s' shadows a field with the same name from an earlier spread."
+3906,tcRecordExplicitFieldShadowsSpreadField,"Explicit field '%s' shadows a field with the same name from an earlier spread."
+3907,tcRecordExprSpreadFieldShadowsSpreadField,"Spread field '%s' shadows a field with the same name from an earlier spread."
 featureRecordSpreads,"record type and expression spreads"

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -1802,6 +1802,21 @@
         <target state="new">You can remove this `nonNull` assertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="tcRecordExplicitFieldShadowsSpreadField">
+        <source>Explicit field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Explicit field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordExprSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="tcRecordTypeDefinitionSpreadFieldShadowsSpreadField">
+        <source>Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</source>
+        <target state="new">Spread field '{0}' from type '{1}' shadows a field with the same name from an earlier spread.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="tcRecursiveInlineNotAllowed">
         <source>The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</source>
         <target state="new">The value or member '{0}' has been marked 'inline' but is part of a recursive binding group. F# does not support recursive 'inline' values. Either remove the 'inline' modifier or refactor the recursion.</target>

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Spreads/RecordSpreadsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Spreads/RecordSpreadsTests.fs
@@ -24,5 +24,16 @@ let verifyCompileAndRun compilation =
 let ``RecordSpreads_fsx`` compilation =
     compilation
     |> withReferences [inlineLib]
+    |> ignoreWarnings
     |> verifyCompileAndRun
     |> shouldSucceed
+    |> withDiagnostics [
+        Information 3906, Line 13, Col 64, Line 13, Col 72, "Explicit field 'D' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 29, Col 58, Line 29, Col 63, "Explicit field 'Y' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 33, Col 50, Line 33, Col 55, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 35, Col 57, Line 35, Col 62, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 36, Col 55, Line 36, Col 60, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 58, Col 65, Line 58, Col 71, "Explicit field 'M' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 62, Col 60, Line 62, Col 65, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+        Information 3906, Line 70, Col 32, Line 70, Col 37, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+    ]

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Spreads/RecordSpreadsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Spreads/RecordSpreadsTests.fs
@@ -24,16 +24,5 @@ let verifyCompileAndRun compilation =
 let ``RecordSpreads_fsx`` compilation =
     compilation
     |> withReferences [inlineLib]
-    |> ignoreWarnings
     |> verifyCompileAndRun
     |> shouldSucceed
-    |> withDiagnostics [
-        Information 3906, Line 13, Col 64, Line 13, Col 72, "Explicit field 'D' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 29, Col 58, Line 29, Col 63, "Explicit field 'Y' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 33, Col 50, Line 33, Col 55, "Explicit field 'A' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 35, Col 57, Line 35, Col 62, "Explicit field 'A' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 36, Col 55, Line 36, Col 60, "Explicit field 'A' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 58, Col 65, Line 58, Col 71, "Explicit field 'M' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 62, Col 60, Line 62, Col 65, "Explicit field 'A' shadows a field with the same name from an earlier spread."
-        Information 3906, Line 70, Col 32, Line 70, Col 37, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-    ]

--- a/tests/FSharp.Compiler.ComponentTests/Language/RecordSpreadsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/RecordSpreadsTests.fs
@@ -322,8 +322,12 @@ module NominalAndAnonymousRecords =
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3906, Line 3, Col 40, Line 3, Col 41, "Explicit field 'A: string' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward spread field shadows leftward spread field.
             [<Fact>]
@@ -341,8 +345,13 @@ module NominalAndAnonymousRecords =
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3905, Line 4, Col 40, Line 4, Col 45, "Spread field 'A: string' from type 'R2' shadows a field with the same name from an earlier spread."
+                    Information 3905, Line 5, Col 40, Line 5, Col 45, "Spread field 'A: int' from type 'R1' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward spread field shadows leftward explicit field with warning.
             [<Fact>]
@@ -395,6 +404,7 @@ module NominalAndAnonymousRecords =
                 |> typecheck
                 |> shouldFail
                 |> withDiagnostics [
+                    Information 3906, Line 4, Col 40, Line 4, Col 41, "Explicit field 'A: string' shadows a field with the same name from an earlier spread."
                     Warning 3897, Line 4, Col 52, Line 4, Col 57, "Spread field 'A: int' from type 'R1' shadows an explicitly declared field with the same name."
                     Error 37, Line 4, Col 59, Line 4, Col 60, "Duplicate definition of field 'A'"
                 ]
@@ -1104,8 +1114,13 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3907, Line 6, Col 84, Line 6, Col 89, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 6, Col 84, Line 6, Col 89, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward explicit duplicate field shadows field from spread.
             [<Fact>]
@@ -1119,8 +1134,12 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3906, Line 4, Col 68, Line 4, Col 75, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward spread field shadows leftward spread field.
             [<Fact>]
@@ -1136,8 +1155,13 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3907, Line 5, Col 68, Line 5, Col 73, "Spread field 'A: string' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 6, Col 65, Line 6, Col 70, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward spread field shadows leftward explicit field with warning.
             [<Fact>]
@@ -1191,6 +1215,7 @@ but here has type
                 |> typecheck
                 |> shouldFail
                 |> withDiagnostics [
+                    Information 3906, Line 5, Col 40, Line 5, Col 47, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                     Warning 3898, Line 5, Col 49, Line 5, Col 54, "Spread field 'A: int' shadows an explicitly declared field with the same name."
                     Error 3522, Line 5, Col 56, Line 5, Col 64, "The field 'A' appears multiple times in this record expression."
                 ]
@@ -1507,8 +1532,11 @@ but here has type
 
                 Fsx src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
+                |> withDiagnostics [
+                ]
 
         module Effects =
             [<Fact>]
@@ -1530,8 +1558,17 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3907, Line 6, Col 41, Line 6, Col 48, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 6, Col 41, Line 6, Col 48, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 6, Col 50, Line 6, Col 57, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 6, Col 50, Line 6, Col 57, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 6, Col 59, Line 6, Col 66, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 6, Col 68, Line 6, Col 75, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                ]
 
         module BackCompat =
             [<Fact>]
@@ -1902,8 +1939,15 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3907, Line 9, Col 40, Line 9, Col 45, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 9, Col 40, Line 9, Col 45, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 14, Col 42, Line 14, Col 47, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 14, Col 42, Line 14, Col 47, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward explicit duplicate field shadows field from spread.
             [<Fact>]
@@ -1922,8 +1966,12 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3906, Line 7, Col 40, Line 7, Col 46, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward spread field shadows leftward spread field.
             [<Fact>]
@@ -1942,8 +1990,12 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3907, Line 7, Col 40, Line 7, Col 55, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                ]
 
             /// Rightward spread field shadows leftward explicit field with warning.
             [<Fact>]
@@ -2230,8 +2282,17 @@ but here has type
 
                 FSharp src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3907, Line 8, Col 40, Line 8, Col 47, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 8, Col 40, Line 8, Col 47, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 8, Col 49, Line 8, Col 56, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 8, Col 49, Line 8, Col 56, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Information 3907, Line 8, Col 58, Line 8, Col 65, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 8, Col 67, Line 8, Col 74, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                ]
 
         module Conversions =
             [<Fact>]
@@ -2391,8 +2452,19 @@ but here has type
 
                 Fsx src
                 |> withLangVersion SupportedLangVersion
+                |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
+                |> withDiagnostics [
+                    Information 3906, Line 10, Col 111, Line 10, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 11, Col 111, Line 11, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 12, Col 114, Line 12, Col 119, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 13, Col 114, Line 13, Col 119, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 14, Col 108, Line 14, Col 113, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 15, Col 108, Line 15, Col 113, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 16, Col 111, Line 16, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Information 3906, Line 17, Col 111, Line 17, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                ]
 
         module WithAndSpreads =
             [<Fact>]
@@ -2412,6 +2484,7 @@ but here has type
                 |> shouldFail
                 |> withDiagnostics [
                     Error 3904, Line 6, Col 40, Line 6, Col 45, "Spread expressions and 'with' cannot be used together in the same copy-and-update expression."
+                    Information 3906, Line 6, Col 47, Line 6, Col 52, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                 ]
 
         module NestedUpdates =

--- a/tests/FSharp.Compiler.ComponentTests/Language/RecordSpreadsTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Language/RecordSpreadsTests.fs
@@ -8,6 +8,12 @@ open Xunit
 module NominalAndAnonymousRecords =
     let [<Literal>] SupportedLangVersion = "preview"
 
+    let withOptionalInfoWarningsEnabled compilationUnit =
+        compilationUnit
+        |> withWarnOn 3905 // tcRecordTypeDefinitionSpreadFieldShadowsSpreadField, "Spread field '%s' from type '%s' shadows a field with the same name from an earlier spread."
+        |> withWarnOn 3906 // tcRecordTypeDefinitionSpreadFieldShadowsSpreadField, "Spread field '%s' from type '%s' shadows a field with the same name from an earlier spread."
+        |> withWarnOn 3907 // tcRecordExprSpreadFieldShadowsSpreadField,           "Spread field '%s' shadows a field with the same name from an earlier spread."
+
     module LangVersion =
         [<Fact>]
         let ``10 → error`` () =
@@ -20,6 +26,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion10
             |> typecheck
             |> shouldFail
@@ -39,6 +46,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldSucceed
@@ -57,6 +65,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -79,6 +88,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -100,6 +110,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -134,6 +145,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -159,6 +171,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -184,6 +197,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -214,6 +228,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -236,6 +251,7 @@ module NominalAndAnonymousRecords =
                 """
 
             FSharp src
+            |> withOptionalInfoWarningsEnabled
             |> withLangVersion SupportedLangVersion
             |> typecheck
             |> shouldFail
@@ -257,6 +273,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -272,6 +289,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -288,6 +306,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -305,6 +324,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -321,12 +341,13 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3906, Line 3, Col 40, Line 3, Col 41, "Explicit field 'A: string' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 3, Col 40, Line 3, Col 41, "Explicit field 'A: string' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward spread field shadows leftward spread field.
@@ -344,13 +365,14 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3905, Line 4, Col 40, Line 4, Col 45, "Spread field 'A: string' from type 'R2' shadows a field with the same name from an earlier spread."
-                    Information 3905, Line 5, Col 40, Line 5, Col 45, "Spread field 'A: int' from type 'R1' shadows a field with the same name from an earlier spread."
+                    Warning 3905, Line 4, Col 40, Line 4, Col 45, "Spread field 'A: string' from type 'R2' shadows a field with the same name from an earlier spread."
+                    Warning 3905, Line 5, Col 40, Line 5, Col 45, "Spread field 'A: int' from type 'R1' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward spread field shadows leftward explicit field with warning.
@@ -365,6 +387,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -382,6 +405,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -400,11 +424,12 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
                 |> withDiagnostics [
-                    Information 3906, Line 4, Col 40, Line 4, Col 41, "Explicit field 'A: string' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 4, Col 40, Line 4, Col 41, "Explicit field 'A: string' shadows a field with the same name from an earlier spread."
                     Warning 3897, Line 4, Col 52, Line 4, Col 57, "Spread field 'A: int' from type 'R1' shadows an explicitly declared field with the same name."
                     Error 37, Line 4, Col 59, Line 4, Col 60, "Duplicate definition of field 'A'"
                 ]
@@ -433,6 +458,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -450,6 +476,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -467,6 +494,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -483,6 +511,7 @@ module NominalAndAnonymousRecords =
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -505,6 +534,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -521,6 +551,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -536,6 +567,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -551,6 +583,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -573,6 +606,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -594,6 +628,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -611,6 +646,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -627,6 +663,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -646,6 +683,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -663,6 +701,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -683,6 +722,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -701,6 +741,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -718,6 +759,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -731,6 +773,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -744,6 +787,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -781,6 +825,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -797,6 +842,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -814,6 +860,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -834,6 +881,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -856,6 +904,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -888,6 +937,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -916,6 +966,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -933,6 +984,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -951,6 +1003,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -969,6 +1022,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -986,6 +1040,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1003,6 +1058,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1021,6 +1077,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> withCheckNulls
                 |> typecheck
@@ -1041,6 +1098,7 @@ but here has type
                     """
 
                 Fsi src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> withCheckNulls
                 |> typecheck
@@ -1064,6 +1122,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -1081,6 +1140,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1096,6 +1156,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1113,13 +1174,14 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3907, Line 6, Col 84, Line 6, Col 89, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 6, Col 84, Line 6, Col 89, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 84, Line 6, Col 89, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 84, Line 6, Col 89, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward explicit duplicate field shadows field from spread.
@@ -1133,12 +1195,13 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3906, Line 4, Col 68, Line 4, Col 75, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 4, Col 68, Line 4, Col 75, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward spread field shadows leftward spread field.
@@ -1154,13 +1217,14 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3907, Line 5, Col 68, Line 5, Col 73, "Spread field 'A: string' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 6, Col 65, Line 6, Col 70, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 5, Col 68, Line 5, Col 73, "Spread field 'A: string' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 65, Line 6, Col 70, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward spread field shadows leftward explicit field with warning.
@@ -1174,6 +1238,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1192,6 +1257,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1211,11 +1277,12 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
                 |> withDiagnostics [
-                    Information 3906, Line 5, Col 40, Line 5, Col 47, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 5, Col 40, Line 5, Col 47, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                     Warning 3898, Line 5, Col 49, Line 5, Col 54, "Spread field 'A: int' shadows an explicitly declared field with the same name."
                     Error 3522, Line 5, Col 56, Line 5, Col 64, "The field 'A' appears multiple times in this record expression."
                 ]
@@ -1230,6 +1297,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1246,6 +1314,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -1264,6 +1333,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1281,6 +1351,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1302,6 +1373,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1317,6 +1389,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1329,6 +1402,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1341,6 +1415,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1358,6 +1433,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1384,6 +1460,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1404,6 +1481,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1429,6 +1507,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1444,6 +1523,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1459,6 +1539,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1474,6 +1555,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -1498,6 +1580,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1531,6 +1614,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
@@ -1557,17 +1641,18 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3907, Line 6, Col 41, Line 6, Col 48, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 6, Col 41, Line 6, Col 48, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 6, Col 50, Line 6, Col 57, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 6, Col 50, Line 6, Col 57, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 6, Col 59, Line 6, Col 66, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 6, Col 68, Line 6, Col 75, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 41, Line 6, Col 48, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 41, Line 6, Col 48, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 50, Line 6, Col 57, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 50, Line 6, Col 57, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 6, Col 59, Line 6, Col 66, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 6, Col 68, Line 6, Col 75, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                 ]
 
         module BackCompat =
@@ -1595,6 +1680,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -1619,6 +1705,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldSucceed
@@ -1644,6 +1731,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldSucceed
@@ -1658,6 +1746,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1682,6 +1771,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1696,6 +1786,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> withCheckNulls
                 |> typecheck
@@ -1716,6 +1807,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -1755,6 +1847,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -1770,6 +1863,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -1787,6 +1881,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -1809,6 +1904,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
@@ -1836,6 +1932,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
@@ -1853,6 +1950,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile
@@ -1870,6 +1968,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile
@@ -1893,6 +1992,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1913,6 +2013,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -1938,15 +2039,16 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3907, Line 9, Col 40, Line 9, Col 45, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 9, Col 40, Line 9, Col 45, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 14, Col 42, Line 14, Col 47, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 14, Col 42, Line 14, Col 47, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 9, Col 40, Line 9, Col 45, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 9, Col 40, Line 9, Col 45, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 14, Col 42, Line 14, Col 47, "Spread field 'C: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 14, Col 42, Line 14, Col 47, "Spread field 'D: int' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward explicit duplicate field shadows field from spread.
@@ -1965,12 +2067,13 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3906, Line 7, Col 40, Line 7, Col 46, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 7, Col 40, Line 7, Col 46, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward spread field shadows leftward spread field.
@@ -1989,12 +2092,13 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3907, Line 7, Col 40, Line 7, Col 55, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 7, Col 40, Line 7, Col 55, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
                 ]
 
             /// Rightward spread field shadows leftward explicit field with warning.
@@ -2009,6 +2113,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2025,6 +2130,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2047,6 +2153,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -2067,6 +2174,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -2086,6 +2194,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2115,6 +2224,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2138,6 +2248,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2166,6 +2277,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2184,6 +2296,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2202,6 +2315,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2223,6 +2337,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -2250,6 +2365,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldFail
@@ -2281,17 +2397,18 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3907, Line 8, Col 40, Line 8, Col 47, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 8, Col 40, Line 8, Col 47, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 8, Col 49, Line 8, Col 56, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 8, Col 49, Line 8, Col 56, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
-                    Information 3907, Line 8, Col 58, Line 8, Col 65, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 8, Col 67, Line 8, Col 74, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 8, Col 40, Line 8, Col 47, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 8, Col 40, Line 8, Col 47, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 8, Col 49, Line 8, Col 56, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 8, Col 49, Line 8, Col 56, "Spread field 'B: int' shadows a field with the same name from an earlier spread."
+                    Warning 3907, Line 8, Col 58, Line 8, Col 65, "Spread field 'A: int' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 8, Col 67, Line 8, Col 74, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                 ]
 
         module Conversions =
@@ -2309,6 +2426,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> typecheck
                 |> shouldSucceed
@@ -2333,6 +2451,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> typecheck
@@ -2354,6 +2473,7 @@ but here has type
                     """
 
                 FSharp src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> withCheckNulls
                 |> typecheck
@@ -2401,6 +2521,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compileExeAndRun
                 |> shouldSucceed
@@ -2417,6 +2538,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -2451,19 +2573,20 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
                 |> shouldSucceed
                 |> withDiagnostics [
-                    Information 3906, Line 10, Col 111, Line 10, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 11, Col 111, Line 11, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 12, Col 114, Line 12, Col 119, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 13, Col 114, Line 13, Col 119, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 14, Col 108, Line 14, Col 113, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 15, Col 108, Line 15, Col 113, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 16, Col 111, Line 16, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
-                    Information 3906, Line 17, Col 111, Line 17, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 10, Col 111, Line 10, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 11, Col 111, Line 11, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 12, Col 114, Line 12, Col 119, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 13, Col 114, Line 13, Col 119, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 14, Col 108, Line 14, Col 113, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 15, Col 108, Line 15, Col 113, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 16, Col 111, Line 16, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 17, Col 111, Line 17, Col 116, "Explicit field 'B' shadows a field with the same name from an earlier spread."
                 ]
 
         module WithAndSpreads =
@@ -2479,12 +2602,13 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
                 |> withDiagnostics [
                     Error 3904, Line 6, Col 40, Line 6, Col 45, "Spread expressions and 'with' cannot be used together in the same copy-and-update expression."
-                    Information 3906, Line 6, Col 47, Line 6, Col 52, "Explicit field 'A' shadows a field with the same name from an earlier spread."
+                    Warning 3906, Line 6, Col 47, Line 6, Col 52, "Explicit field 'A' shadows a field with the same name from an earlier spread."
                 ]
 
         module NestedUpdates =
@@ -2501,6 +2625,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -2522,6 +2647,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> compile
                 |> shouldFail
@@ -2548,6 +2674,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
@@ -2574,6 +2701,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compileExeAndRun
@@ -2595,6 +2723,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile
@@ -2615,6 +2744,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile
@@ -2638,6 +2768,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile
@@ -2657,6 +2788,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile
@@ -2676,6 +2808,7 @@ but here has type
                     """
 
                 Fsx src
+                |> withOptionalInfoWarningsEnabled
                 |> withLangVersion SupportedLangVersion
                 |> ignoreWarnings
                 |> compile


### PR DESCRIPTION
## Description

Follows https://github.com/dotnet/fsharp/pull/18927.

- Add additional, off-by-default informational shadowing warnings for record spreads. These are intended more as optional refactoring tools than as a fundamental part of everyday spreads usage. They can be enabled via `--warnon`/`<WarnOn>`, and turned into errors via `--warnaserror`/`<WarningsAsErrors>`.

## Checklist

- [x] Test cases added
- [x] Release notes updated