### PR TITLE
Set the default F# language version to 11.0

### DIFF
--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -128,7 +128,7 @@ type LanguageVersion(versionText, ?disabledFeaturesArray: LanguageFeature array)
     static let languageVersion100 = 10.0m
     static let languageVersion110 = 11.0m
     static let previewVersion = 9999m // Language version when preview specified
-    static let defaultVersion = languageVersion100 // Language version when default specified
+    static let defaultVersion = languageVersion110 // Language version when default specified
     static let latestVersion = defaultVersion // Language version when latest specified
     static let latestMajorVersion = defaultVersion // Language version when latestmajor specified
 

--- a/tests/FSharp.Compiler.ComponentTests/Conformance/Signatures/SignatureEnforcedAttributes.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Conformance/Signatures/SignatureEnforcedAttributes.fs
@@ -16,6 +16,7 @@ module SignatureEnforcedAttributes =
         |> FS
         |> withAdditionalSourceFile (fs implSrc)
         |> asLibrary
+        |> withLangVersion10 // FS3888 is a warning pre-11 and an error at 11.0 (ErrorOnMissingSignatureAttribute); pin to the warning behavior
         |> ignoreWarnings
         |> compile
 
@@ -265,6 +266,7 @@ let inline f (x: int) = x + 1
         |> FS
         |> withAdditionalSourceFile (fs implSrc)
         |> asLibrary
+        |> withLangVersion10 // #nowarn suppresses FS3888 only while it is a warning (pre-11); at 11.0 it is an error
         |> compile
         |> shouldSucceed
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/DirectDelegates/DirectDelegates.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/DirectDelegates/DirectDelegates.fs
@@ -17,6 +17,7 @@ let private coreOptions compilation =
 let verifyCompilation compilation =
     compilation
     |> coreOptions
+    |> withLangVersion10 // default baseline captures the pre-11 closure IL; DirectDelegateConstruction (11.0) is covered by the preview twin
     |> compile
     |> shouldSucceed
     |> verifyPEFileWithSystemDlls
@@ -212,6 +213,7 @@ let main _ =
     if d.Method.Name <> "Invoke" then failwithf "expected closure Method.Name 'Invoke' but got '%s'" d.Method.Name
     0
         """
+    |> withLangVersion10 // "without the feature": DirectDelegateConstruction is off pre-11, so the delegate goes through a closure
     |> compileExeAndRun
     |> shouldSucceed
 

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/NullnessMetadata.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Nullness/NullnessMetadata.fs
@@ -70,6 +70,7 @@ module NullnessMetadata =
     let ``Nullable attr for exception types`` compilation =  
         compilation
         |> getCompilation
+        |> withLangVersion10 // ExceptionFieldSerializationSupport (11.0) changes exception IL; pin to pre-11 (nullness stays on, gated at 9.0)
         |> verifyCompilation DoNotOptimize
 
     [<Theory; FileInlineData("ReferenceDU.fs")>]

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/SerializableAttribute.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/SerializableAttribute/SerializableAttribute.fs
@@ -15,6 +15,7 @@ module SerializableAttribute =
         |> withEmbeddedPdb
         |> withEmbedAllSource
         |> ignoreWarnings
+        |> withLangVersion10 // baselines capture pre-11 serialization IL; ExceptionFieldSerializationSupport (11.0) is off here
         |> compile
         |> verifyILBaseline
 

--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/FsharpSuiteMigrated.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/FsharpSuiteMigrated.fs
@@ -86,6 +86,7 @@ module TestFrameworkAdapter =
         match version with 
         | LangVersion.V80 -> "8.0",bonusArgs
         | LangVersion.V90 -> "9.0",bonusArgs
+        | LangVersion.V10 -> "10.0",bonusArgs
         | LangVersion.Preview -> "preview",bonusArgs
         | LangVersion.Latest  -> "latest", bonusArgs
 

--- a/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedTypeCheckTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Miscellaneous/MigratedTypeCheckTests.fs
@@ -46,7 +46,9 @@ let ``type check neg10_a`` () = singleNegTest ( "typecheck/sigs") "neg10_a"
 let ``type check neg11`` () = singleNegTest ( "typecheck/sigs") "neg11"
 
 [<FactForDESKTOP>]
-let ``type check neg12`` () = singleNegTest ( "typecheck/sigs") "neg12"
+// Pinned to 10.0: at 11.0 AccessProtectedBaseFieldFromClosure lets the protected-member-from-closure
+// cases compile, dropping baseline errors. 11.0 behavior is covered by dedicated conformance tests.
+let ``type check neg12`` () = singleVersionedNegTest ("typecheck/sigs") LangVersion.V10 "neg12"
 
 [<FactForDESKTOP>]
 let ``type check neg13`` () = singleNegTest ( "typecheck/sigs") "neg13"

--- a/tests/FSharp.Test.Utilities/ScriptHelpers.fs
+++ b/tests/FSharp.Test.Utilities/ScriptHelpers.fs
@@ -16,6 +16,7 @@ open FSharp.Test
 type LangVersion =
     | V80
     | V90
+    | V10
     | Preview
     | Latest
 
@@ -40,6 +41,7 @@ type FSharpScript(?additionalArgs: string[], ?quiet: bool, ?langVersion: LangVer
         | LangVersion.Latest -> "--langversion:latest"
         | LangVersion.V80 -> "--langversion:8.0"
         | LangVersion.V90 -> "--langversion:9.0"
+        | LangVersion.V10 -> "--langversion:10.0"
         |]
 
     let argv = Array.append baseArgs additionalArgs

--- a/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
+++ b/tests/fsharp/Compiler/CodeGen/EmittedIL/StaticMember.fs
@@ -8,9 +8,13 @@ open Xunit
 
 module ``Static Member`` =
 
+    // The delegate-from-method cases below are pinned to --langversion:10.0: at F# 11.0 (now the default)
+    // DirectDelegateConstruction builds the delegate straight from the target method, dropping the closure
+    // class this IL expects. The 11.0 form is covered by EmittedIL/DirectDelegates.
+
     [<Fact>]
     let ``Action on Static Member``() =
-        CompilerAssert.CompileLibraryAndVerifyILRealSig(
+        CompilerAssert.CompileLibraryAndVerifyILWithOptions([| "--realsig+"; "--langversion:10.0" |],
             """
 module StaticMember01
 
@@ -74,7 +78,7 @@ type C =
 
     [<Fact>]
     let ``Action on Static Member with lambda``() =
-        CompilerAssert.CompileLibraryAndVerifyILRealSig(
+        CompilerAssert.CompileLibraryAndVerifyILWithOptions([| "--realsig+"; "--langversion:10.0" |],
             """
 module StaticMember02
 
@@ -247,7 +251,7 @@ let main _ =
 
     [<Fact>]
     let ``Func on Static Member``() =
-        CompilerAssert.CompileLibraryAndVerifyILRealSig(
+        CompilerAssert.CompileLibraryAndVerifyILWithOptions([| "--realsig+"; "--langversion:10.0" |],
             """
 module StaticMember04
 
@@ -313,7 +317,7 @@ type C =
 
     [<Fact>]
     let ``Func on Static Member with lambda``() =
-        CompilerAssert.CompileLibraryAndVerifyILRealSig(
+        CompilerAssert.CompileLibraryAndVerifyILWithOptions([| "--realsig+"; "--langversion:10.0" |],
             """
 module StaticMember05
 
@@ -434,7 +438,8 @@ let main _ =
 #if !FX_NO_WINFORMS
     [<Fact>]
     let ``EventHandler from Regression/83``() =
-        CompilerAssert.CompileLibraryAndVerifyILRealSig(
+        // Same pin as the cases above; WinForms-gated, so this one only runs on Windows CI.
+        CompilerAssert.CompileLibraryAndVerifyILWithOptions([| "--realsig+"; "--langversion:10.0" |],
             """
 module StaticMember07
 

--- a/tests/fsharp/tests.fs
+++ b/tests/fsharp/tests.fs
@@ -66,11 +66,14 @@ module CoreTests =
         exec cfg cfg.DotNetExe ($"msbuild {projectFile} /p:Configuration={cfg.BUILD_CONFIG} -property:FSharpRepositoryPath={FSharpRepositoryPath}")
 
 #if !NETCOREAPP
+    // Pinned to 10.0: at 11.0 ErrorOnMissingSignatureAttribute turns FS3888 (attribute on impl but
+    // not signature) from warning into error, which this test deliberately exercises. 11.0 behavior is
+    // covered by Conformance/Signatures/SignatureEnforcedAttributes.
     [<Fact>]
-    let ``attributes-FSC_OPTIMIZED`` () = singleTestBuildAndRun "core/attributes" FSC_OPTIMIZED
+    let ``attributes-FSC_OPTIMIZED`` () = singleTestBuildAndRunVersion "core/attributes" FSC_OPTIMIZED "10.0"
 
     [<Fact>]
-    let ``attributes-FSI`` () = singleTestBuildAndRun "core/attributes" FSI
+    let ``attributes-FSI`` () = singleTestBuildAndRunVersion "core/attributes" FSI "10.0"
 
     [<Fact>]
     let span () =


### PR DESCRIPTION
Bumps the default language version (`--langversion:default` / `latest` / `latestmajor`) from 10.0 to 11.0, so the features stabilized into F# 11.0 in #20199 are now on by default with a .NET 11 SDK. `FromEndSlicing` intentionally stays in `preview`.

A handful of EmittedIL/signature tests that capture the pre-11 behavior are pinned to `--langversion:10.0` so their existing baselines stay valid; the 11.0 behavior of those features is already covered by the existing preview twins.