### PR TITLE
Enable MSBuild node reuse defaults in the F# build scripts

### DIFF
--- a/eng/Build.ps1
+++ b/eng/Build.ps1
@@ -165,8 +165,6 @@ function Process-Arguments() {
         $script:useGlobalNugetCache = $False
     }
 
-    $script:nodeReuse = $False;
-
     if ($testAll) {
         $script:testDesktop = $True
         $script:testCoreClr = $True

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -303,9 +303,6 @@ function BuildSolution {
     quiet_restore=true
   fi
 
-  # Node reuse fails because multiple different versions of FSharp.Build.dll get loaded into MSBuild nodes
-  node_reuse=false
-
   # build bootstrap tools
   # source_build=In source build proto does no work, except cause sourcebuild in wrapper to build
   bootstrap_dir=$artifacts_dir/Bootstrap


### PR DESCRIPTION
Fixes #20217

`eng/Build.ps1` and `eng/build.sh` both hard-disabled MSBuild node reuse for every build, overriding Arcade's default (reuse on locally, off on CI). The overrides were added together in March 2019 as a workaround for `FSharp.Build.dll` version conflicts when the proto compiler and the freshly built one land in reused MSBuild nodes during F#'s self-bootstrap — not, as the issue assumed, a PowerShell-only template leftover.

Removing both restores node reuse for the inner loop and unblocks MSBuild Server. Whether that 2019 `FSharp.Build.dll` conflict still reproduces is the open question, so this leans on full CI to answer it — in particular the Windows `EndToEndBuildTests` job, which builds without `-ci` and now exercises node reuse end to end.
