### PR TITLE
Remove always-on WildCardInForLoop language feature flag

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -163,7 +163,6 @@
 * Lower string-typed interpolated strings to `System.String.Concat` rather than the reflection-based `printf` engine, making them trim- and NativeAOT-compatible. This generalizes and ungates the previous all-string `String.Concat` optimization, so it now applies to every string-typed interpolation. ([Language suggestion #1108](https://github.com/fsharp/fslang-suggestions/issues/1108), [PR #19971](https://github.com/dotnet/fsharp/pull/19971))
 * Stabilized several `preview` language features into F# 11.0 (`--langversion:11.0`, enabled by default with a .NET 11 SDK): `MethodOverloadsCache`, `ErrorOnMissingSignatureAttribute`, `DirectDelegateConstruction`, `AccessProtectedBaseFieldFromClosure`, and `RecordSpreads`. `FromEndSlicing` intentionally remains in `preview`. ([PR #20199](https://github.com/dotnet/fsharp/pull/20199))
 * Interpolated string holes (e.g. `$"{x}"`) are now formatted with invariant culture (via the `string` operator) instead of the current thread culture. ([PR #19971](https://github.com/dotnet/fsharp/pull/19971))
-* Removed the always-on `WildCardInForLoop` language feature flag; `--disableLanguageFeature:WildCardInForLoop` is no longer a recognised feature name. ([Issue #20142](https://github.com/dotnet/fsharp/issues/20142), [PR #20221](https://github.com/dotnet/fsharp/pull/20221))
 
 ### Breaking Changes
 

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -163,6 +163,7 @@
 * Lower string-typed interpolated strings to `System.String.Concat` rather than the reflection-based `printf` engine, making them trim- and NativeAOT-compatible. This generalizes and ungates the previous all-string `String.Concat` optimization, so it now applies to every string-typed interpolation. ([Language suggestion #1108](https://github.com/fsharp/fslang-suggestions/issues/1108), [PR #19971](https://github.com/dotnet/fsharp/pull/19971))
 * Stabilized several `preview` language features into F# 11.0 (`--langversion:11.0`, enabled by default with a .NET 11 SDK): `MethodOverloadsCache`, `ErrorOnMissingSignatureAttribute`, `DirectDelegateConstruction`, `AccessProtectedBaseFieldFromClosure`, and `RecordSpreads`. `FromEndSlicing` intentionally remains in `preview`. ([PR #20199](https://github.com/dotnet/fsharp/pull/20199))
 * Interpolated string holes (e.g. `$"{x}"`) are now formatted with invariant culture (via the `string` operator) instead of the current thread culture. ([PR #19971](https://github.com/dotnet/fsharp/pull/19971))
+* Removed the always-on `WildCardInForLoop` language feature flag; `--disableLanguageFeature:WildCardInForLoop` is no longer a recognised feature name. ([Issue #20142](https://github.com/dotnet/fsharp/issues/20142), [PR #20221](https://github.com/dotnet/fsharp/pull/20221))
 
 ### Breaking Changes
 

--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1564,7 +1564,6 @@ nativeResourceFormatError,"Stream does not begin with a null resource and is not
 nativeResourceHeaderMalformed,"Resource header beginning at offset %s is malformed."
 formatDashItem," - %s"
 featureSingleUnderscorePattern,"single underscore pattern"
-featureWildCardInForLoop,"wild card in for loop"
 featureRelaxWhitespace,"whitespace relaxation"
 featureNameOf,"nameof"
 featureImplicitYield,"implicit yield"

--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -17,7 +17,6 @@ module internal FSharp.Compiler.Features
 [<RequireQualifiedAccess>]
 type LanguageFeature =
     | SingleUnderscorePattern
-    | WildCardInForLoop
     | RelaxWhitespace
     | RelaxWhitespace2
     | NameOf
@@ -153,7 +152,6 @@ type LanguageVersion(versionText, ?disabledFeaturesArray: LanguageFeature array)
             [
                 // F# 4.7
                 LanguageFeature.SingleUnderscorePattern, languageVersion47
-                LanguageFeature.WildCardInForLoop, languageVersion47
                 LanguageFeature.RelaxWhitespace, languageVersion47
                 LanguageFeature.ImplicitYield, languageVersion47
 
@@ -365,7 +363,6 @@ type LanguageVersion(versionText, ?disabledFeaturesArray: LanguageFeature array)
     static member GetFeatureString feature =
         match feature with
         | LanguageFeature.SingleUnderscorePattern -> FSComp.SR.featureSingleUnderscorePattern ()
-        | LanguageFeature.WildCardInForLoop -> FSComp.SR.featureWildCardInForLoop ()
         | LanguageFeature.RelaxWhitespace -> FSComp.SR.featureRelaxWhitespace ()
         | LanguageFeature.RelaxWhitespace2 -> FSComp.SR.featureRelaxWhitespace2 ()
         | LanguageFeature.NameOf -> FSComp.SR.featureNameOf ()

--- a/src/Compiler/Facilities/LanguageFeatures.fsi
+++ b/src/Compiler/Facilities/LanguageFeatures.fsi
@@ -7,7 +7,6 @@ module internal FSharp.Compiler.Features
 [<RequireQualifiedAccess>]
 type LanguageFeature =
     | SingleUnderscorePattern
-    | WildCardInForLoop
     | RelaxWhitespace
     | RelaxWhitespace2
     | NameOf

--- a/src/Compiler/SyntaxTree/ParseHelpers.fs
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fs
@@ -978,9 +978,9 @@ let mkDefnBindings (mWhole, BindingSetPreAttrs(_, isRec, isUse, declsPreAttrs, _
 
     attrDecls @ letDecls
 
-let idOfPat (parseState: IParseState) m p =
+let idOfPat m p =
     match p with
-    | SynPat.Wild r when parseState.LexBuffer.SupportsFeature LanguageFeature.WildCardInForLoop -> mkSynId r "_"
+    | SynPat.Wild r -> mkSynId r "_"
     | SynPat.Named(SynIdent(id, _), false, _, _) -> id
     | SynPat.LongIdent(longDotId = SynLongIdent([ id ], _, _); typarDecls = None; argPats = SynArgPats.Pats []; accessibility = None) -> id
     | _ -> raiseParseErrorAt m (FSComp.SR.parsIntegerForLoopRequiresSimpleIdentifier ())

--- a/src/Compiler/SyntaxTree/ParseHelpers.fsi
+++ b/src/Compiler/SyntaxTree/ParseHelpers.fsi
@@ -229,7 +229,7 @@ val mkDefnBindings:
     mWhole: range * BindingSet * attrs: SynAttributes * vis: SynAccess option * attrsm: range * mIn: range option ->
         SynModuleDecl list
 
-val idOfPat: parseState: IParseState -> m: range -> p: SynPat -> Ident
+val idOfPat: m: range -> p: SynPat -> Ident
 
 val checkForMultipleAugmentations: m: range -> a1: 'a list -> a2: 'a list -> 'a list
 

--- a/src/Compiler/pars.fsy
+++ b/src/Compiler/pars.fsy
@@ -5750,7 +5750,7 @@ forLoopRange:
   | parenPattern EQUALS declExpr forLoopDirection declExpr
       { let mEquals = rhs parseState 2
         let spTo = DebugPointAtInOrTo.Yes(rhs parseState 4)
-        idOfPat parseState (rhs parseState 1) $1, Some mEquals, $3, $4, $5, spTo }
+        idOfPat (rhs parseState 1) $1, Some mEquals, $3, $4, $5, spTo }
 
 forLoopDirection:
   | TO { true }

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -747,11 +747,6 @@
         <target state="translated">Výraz „while!“</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">zástupný znak ve smyčce for</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Předávání kopie clusteru pro omezení vlastností v uvozovkách v jazyce F#</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -747,11 +747,6 @@
         <target state="translated">while!-Ausdruck</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">Platzhalter in for-Schleife</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Zeugenübergabe für Merkmalseinschränkungen in F#-Zitaten</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -747,11 +747,6 @@
         <target state="translated">expresión “while!”</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">carácter comodín en bucle for</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Paso de testigo para las restricciones de rasgos en las expresiones de código delimitadas de F#</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -747,11 +747,6 @@
         <target state="translated">'alors que!' expression</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">caractère générique dans une boucle for</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Passage de témoin pour les contraintes de trait dans les quotations F#</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -747,11 +747,6 @@
         <target state="translated">Espressione "while!"</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">carattere jolly nel ciclo for</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Passaggio del testimone per vincoli di tratto in quotation F#</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -747,11 +747,6 @@
         <target state="translated">'while!' 式</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">for ループのワイルド カード</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">F# 引用での特性制約に対する監視の引き渡し</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -747,11 +747,6 @@
         <target state="translated">'while!' 식</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">for 루프의 와일드카드</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">F# 인용의 특성 제약 조건에 대한 감시 전달</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -747,11 +747,6 @@
         <target state="translated">Wyrażenie „while!”</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">symbol wieloznaczny w pętli for</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">monitor, który przekazuje ograniczenia cech języka F#</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -747,11 +747,6 @@
         <target state="translated">expressão "while!"</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">curinga para loop</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Passagem de testemunha para restrições de característica nas citações do F#</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -747,11 +747,6 @@
         <target state="translated">выражение "while!"</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">подстановочный знак в цикле for</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">Передача свидетеля для ограничений признаков в цитированиях F#</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -747,11 +747,6 @@
         <target state="translated">'while!' ifadesi</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">for döngüsünde joker karakter</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">F# alıntılarındaki nitelik kısıtlamaları için tanık geçirme</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -747,11 +747,6 @@
         <target state="translated">"while!" 表达式</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">for 循环中的通配符</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">F# 引号中特征约束的见证传递</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -747,11 +747,6 @@
         <target state="translated">'while!' 運算式</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureWildCardInForLoop">
-        <source>wild card in for loop</source>
-        <target state="translated">for 迴圈中的萬用字元</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureWitnessPassing">
         <source>witness passing for trait constraints in F# quotations</source>
         <target state="translated">見證 F# 引號中特徵條件約束的傳遞</target>


### PR DESCRIPTION
Fixes #20142

`LanguageFeature.WildCardInForLoop` has shipped since F# 4.7 and is enabled for every accepted `--langversion` (minimum 8.0), so the flag could never be turned off. Removed the dead flag and collapsed the guarded parse of `for _ = … to …` to its enabled behaviour. `--disableLanguageFeature:WildCardInForLoop` is no longer a recognised feature name.
