### PR TITLE
Remove always-on RelaxWhitespace language feature flag

### DIFF
--- a/src/Compiler/FSComp.txt
+++ b/src/Compiler/FSComp.txt
@@ -1565,7 +1565,6 @@ nativeResourceHeaderMalformed,"Resource header beginning at offset %s is malform
 formatDashItem," - %s"
 featureSingleUnderscorePattern,"single underscore pattern"
 featureWildCardInForLoop,"wild card in for loop"
-featureRelaxWhitespace,"whitespace relaxation"
 featureNameOf,"nameof"
 featureImplicitYield,"implicit yield"
 featureDotlessFloat32Literal,"dotless float32 literal"

--- a/src/Compiler/Facilities/LanguageFeatures.fs
+++ b/src/Compiler/Facilities/LanguageFeatures.fs
@@ -18,7 +18,6 @@ module internal FSharp.Compiler.Features
 type LanguageFeature =
     | SingleUnderscorePattern
     | WildCardInForLoop
-    | RelaxWhitespace
     | RelaxWhitespace2
     | NameOf
     | ImplicitYield
@@ -153,7 +152,6 @@ type LanguageVersion(versionText, ?disabledFeaturesArray: LanguageFeature array)
                 // F# 4.7
                 LanguageFeature.SingleUnderscorePattern, languageVersion47
                 LanguageFeature.WildCardInForLoop, languageVersion47
-                LanguageFeature.RelaxWhitespace, languageVersion47
                 LanguageFeature.ImplicitYield, languageVersion47
 
                 // F# 5.0
@@ -365,7 +363,6 @@ type LanguageVersion(versionText, ?disabledFeaturesArray: LanguageFeature array)
         match feature with
         | LanguageFeature.SingleUnderscorePattern -> FSComp.SR.featureSingleUnderscorePattern ()
         | LanguageFeature.WildCardInForLoop -> FSComp.SR.featureWildCardInForLoop ()
-        | LanguageFeature.RelaxWhitespace -> FSComp.SR.featureRelaxWhitespace ()
         | LanguageFeature.RelaxWhitespace2 -> FSComp.SR.featureRelaxWhitespace2 ()
         | LanguageFeature.NameOf -> FSComp.SR.featureNameOf ()
         | LanguageFeature.ImplicitYield -> FSComp.SR.featureImplicitYield ()

--- a/src/Compiler/Facilities/LanguageFeatures.fsi
+++ b/src/Compiler/Facilities/LanguageFeatures.fsi
@@ -8,7 +8,6 @@ module internal FSharp.Compiler.Features
 type LanguageFeature =
     | SingleUnderscorePattern
     | WildCardInForLoop
-    | RelaxWhitespace
     | RelaxWhitespace2
     | NameOf
     | ImplicitYield

--- a/src/Compiler/SyntaxTree/LexFilter.fs
+++ b/src/Compiler/SyntaxTree/LexFilter.fs
@@ -964,7 +964,6 @@ type LexFilterImpl (
             | _, CtxtSeqBlock _ :: CtxtParen(LPAREN, _) :: (CtxtMemberHead _ as limitCtxt) :: _
             // 'static member P with get() = ' limited by 'static', likewise others
             | _, CtxtWithAsLet _ :: (CtxtMemberHead _ as limitCtxt) :: _
-                 when lexbuf.SupportsFeature LanguageFeature.RelaxWhitespace
                  -> PositionWithColumn(limitCtxt.StartPos, limitCtxt.StartCol + 1)
 
             // REVIEW: document these

--- a/src/Compiler/xlf/FSComp.txt.cs.xlf
+++ b/src/Compiler/xlf/FSComp.txt.cs.xlf
@@ -617,11 +617,6 @@
         <target state="translated">informační zprávy související s referenčními buňkami</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">relaxace whitespace v2</target>

--- a/src/Compiler/xlf/FSComp.txt.de.xlf
+++ b/src/Compiler/xlf/FSComp.txt.de.xlf
@@ -617,11 +617,6 @@
         <target state="translated">Informationsmeldungen im Zusammenhang mit Bezugszellen</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">whitespace relaxation v2</target>

--- a/src/Compiler/xlf/FSComp.txt.es.xlf
+++ b/src/Compiler/xlf/FSComp.txt.es.xlf
@@ -617,11 +617,6 @@
         <target state="translated">mensajes informativos relacionados con las celdas de referencia</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">relajación de espacios en blanco v2</target>

--- a/src/Compiler/xlf/FSComp.txt.fr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.fr.xlf
@@ -617,11 +617,6 @@
         <target state="translated">messages d’information liés aux cellules de référence</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">relaxation des espaces blancs v2</target>

--- a/src/Compiler/xlf/FSComp.txt.it.xlf
+++ b/src/Compiler/xlf/FSComp.txt.it.xlf
@@ -617,11 +617,6 @@
         <target state="translated">messaggi informativi relativi alle celle di riferimento</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">uso meno restrittivo degli spazi vuoti v2</target>

--- a/src/Compiler/xlf/FSComp.txt.ja.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ja.xlf
@@ -617,11 +617,6 @@
         <target state="translated">参照セルに関連する情報メッセージ</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">whitespace relaxation v2</target>

--- a/src/Compiler/xlf/FSComp.txt.ko.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ko.xlf
@@ -617,11 +617,6 @@
         <target state="translated">참조 셀과 관련된 정보 메시지</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">공백 relaxation v2</target>

--- a/src/Compiler/xlf/FSComp.txt.pl.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pl.xlf
@@ -617,11 +617,6 @@
         <target state="translated">komunikaty informacyjne związane z odwołaniami do komórek</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">łagodzenie odstępów wer 2</target>

--- a/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
+++ b/src/Compiler/xlf/FSComp.txt.pt-BR.xlf
@@ -617,11 +617,6 @@
         <target state="translated">mensagens informativas relacionadas a células de referência</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">relaxamento de espaço em branco v2</target>

--- a/src/Compiler/xlf/FSComp.txt.ru.xlf
+++ b/src/Compiler/xlf/FSComp.txt.ru.xlf
@@ -617,11 +617,6 @@
         <target state="translated">информационные сообщения, связанные с ссылочными ячейками</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">смягчение требований по использованию пробелов, версия 2</target>

--- a/src/Compiler/xlf/FSComp.txt.tr.xlf
+++ b/src/Compiler/xlf/FSComp.txt.tr.xlf
@@ -617,11 +617,6 @@
         <target state="translated">başvuru hücreleriyle ilgili bilgi mesajları</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">boşluk ilişkilendirme v2</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hans.xlf
@@ -617,11 +617,6 @@
         <target state="translated">与引用单元格相关的信息性消息</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">空格放空 v2</target>

--- a/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
+++ b/src/Compiler/xlf/FSComp.txt.zh-Hant.xlf
@@ -617,11 +617,6 @@
         <target state="translated">與參考儲存格相關的資訊訊息</target>
         <note />
       </trans-unit>
-      <trans-unit id="featureRelaxWhitespace">
-        <source>whitespace relaxation</source>
-        <target state="new">whitespace relaxation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="featureRelaxWhitespace2">
         <source>whitespace relaxation v2</source>
         <target state="translated">空格鍵放鬆 v2</target>


### PR DESCRIPTION
Fixes #20140

The `RelaxWhitespace` (F# 4.7) feature has been on for every supported language version, so its `SupportsFeature` gate was dead. Removed the flag and kept the whitespace-relaxation behavior it guarded unconditionally.
