### PR TITLE
IL: fix leaking binary view

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -134,6 +134,7 @@
 * Fix #5795: Allow attributes defined in a `module rec` / `namespace rec` scope to be used on union cases, record fields, and generic type parameters of types in the same recursive scope. ([Issue #5795](https://github.com/dotnet/fsharp/issues/5795), [PR #19744](https://github.com/dotnet/fsharp/pull/19744))
 * Import: Don't walk non-F# assemblies when labelling trait constraint sources (PR [#20090](https://github.com/dotnet/fsharp/pull/20090))
 * Avoid per-instance lock object in InterruptibleLazy and DelayInitArrayMap (PR [#20088](https://github.com/dotnet/fsharp/pull/20088))
+* IL: fix leaking binary view ([PR #20250](https://github.com/dotnet/fsharp/pull/20250))
 
 ### Added
 

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -2190,7 +2190,7 @@ and typeDefReader ctxtH : ILTypeDefStored =
         let fdefs = seekReadFields ctxt (numTypars, hasLayout) fieldsIdx endFieldsIdx
         let nested = seekReadNestedTypeDefs ctxt idx
 
-        let impls = seekReadInterfaceImpls ctxt mdv numTypars idx
+        let impls = seekReadInterfaceImpls ctxt numTypars idx
 
         let mimpls = seekReadMethodImpls ctxt numTypars idx
         let props = seekReadProperties ctxt numTypars idx
@@ -2246,8 +2246,10 @@ and seekReadNestedTypeDefs (ctxt: ILMetadataReader) tidx =
                 yield mkILPreTypeDefRead (nameIdx, i, ctxt.typeDefReader)
         |])
 
-and seekReadInterfaceImpls (ctxt: ILMetadataReader) mdv numTypars tidx =
+and seekReadInterfaceImpls (ctxt: ILMetadataReader) numTypars tidx =
     InterruptibleLazy(fun () ->
+        let mdv = ctxt.mdfile.GetView()
+
         seekReadIndexedRows (
             ctxt.getNumRows TableNames.InterfaceImpl,
             id,

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.Tests.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="AssemblyReaderShim.fs" />
     <Compile Include="ModuleReaderCancellationTests.fs" />
     <Compile Include="ModuleReaderNamespaceTests.fs" />
+    <Compile Include="ILBinaryReaderMemoryTests.fs" />
     <Compile Include="EditorTests.fs" />
     <Compile Include="Symbols.fs" />
     <Compile Include="RecordConstructorTests.fs" />

--- a/tests/FSharp.Compiler.Service.Tests/ILBinaryReaderMemoryTests.fs
+++ b/tests/FSharp.Compiler.Service.Tests/ILBinaryReaderMemoryTests.fs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+module FSharp.Compiler.Service.Tests.ILBinaryReaderMemoryTests
+
+open System
+open System.Collections.Generic
+open System.IO
+open System.Reflection
+open FSharp.Compiler.AbstractIL.ILBinaryReader
+open FSharp.Compiler.IO
+open Xunit
+
+let private instanceFields =
+    BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic
+
+let rec private allFields (ty: Type | null) =
+    match ty with
+    | Null -> Seq.empty
+    | NonNull ty -> Seq.append (ty.GetFields instanceFields) (allFields ty.BaseType)
+
+/// The metadata of a stable file is held weakly (see `WeakByteFile`) so that it can be dropped under memory
+/// pressure and re-read on demand. Capturing a view over it, for example in a lazy value, defeats that.
+/// Weakly held data is not reported: a weak reference has no field pointing to its target.
+let private assertDoesNotRetainMetadata (root: obj) =
+    let visited = HashSet<obj>(HashIdentity.Reference)
+    let queue = Queue<obj * string>()
+
+    let enqueue path (value: objnull) =
+        match value with
+        | NonNull value when not (value.GetType().IsPrimitive) && visited.Add value -> queue.Enqueue(value, path)
+        | _ -> ()
+
+    enqueue (root.GetType().Name) root
+
+    while queue.Count > 0 do
+        match queue.Dequeue() with
+        | (:? ByteMemory), path -> failwith $"The metadata view is retained by: {path}"
+        | (:? Array as array), path -> array |> Seq.cast<obj> |> Seq.iteri (fun i o -> enqueue $"{path}[{i}]" o)
+        | value, path ->
+            for field in allFields (value.GetType()) do
+                enqueue $"{path}.{field.Name}" (field.GetValue value)
+
+let private readerOptions =
+    {
+        pdbDirPath = None
+        reduceMemoryUsage = ReduceMemoryFlag.Yes
+        metadataOnly = MetadataOnlyFlag.Yes
+        tryGetMetadataSnapshot = fun _ -> None
+    }
+
+[<Fact>]
+let ``Reading type defs does not retain the metadata view`` () =
+    // The bytes are only held weakly for files that look stable, which is decided by location (`IsStableFileHeuristic`).
+    let directory =
+        Path.Combine(FileSystem.GetTempPathShim(), "packages", Guid.NewGuid().ToString())
+        |> FileSystem.DirectoryCreateShim
+
+    let path = Path.Combine(directory, "TestAssembly.dll")
+    FileSystem.CopyShim(typeof<FactAttribute>.Assembly.Location, path, false)
+
+    try
+        let reader = OpenILModuleReader path readerOptions
+
+        // The lazily read parts of the type defs, such as the interface impls, are left unforced on purpose.
+        assertDoesNotRetainMetadata (reader.ILModuleDef.TypeDefs.AsArray())
+    finally
+        FileSystem.FileDeleteShim path
+        FileSystem.DirectoryDeleteShim directory


### PR DESCRIPTION
Fixes binary view is kept instead of getting it in the lambda.

For non-framework assemblies a weak reference is used for metadata. However, `seekReadInterfaceImpls` captured the metadata view, so the metadata was kept in memory. For project with many non-framework references it retained a lot of memory.

Retained memory after `ParseAndCheckProject`:
| Project | Before (MB) | After (MB) | Diff (%) |
|---|---|---|---|
| Console app | 33.89 | 33.83 | −0.17% |
| FCS | 1270.99 | 1270.45 | −0.04% |
| Fantomas.Core | 111.50 | 109.44 | −1.85% |
| Fantomas.Core.Tests | 144.48 | 141.93 | −1.77% |
| Fantomas.Benchmarks | 75.57 | 64.83 | −14.21% |
| FSharp.Common | 445.02 | 297.69 | −33.10% |

References distribution:
| Project | `WeakByteFile` (`.nuget\packages`) | strong `ByteFile` |
|---|---|---|
| Console app | 0 refs / 0.0 MB | 167 refs / 5.8 MB |
| FCS | 0 refs / 0.0 MB | 178 refs / 8.5 MB |
| FSharp.Common | 487 refs / 287.2 MB | 2 refs / 0.3 MB |
| Fantomas.Core | 120 refs / 6.7 MB | 1 ref / 3.9 MB |
| Fantomas.Core.Tests | 26 refs / 7.9 MB | 169 refs / 10.8 MB |
| Fantomas.Benchmarks | 25 refs / 20.0 MB | 169 refs / 10.8 MB |
