### PR TITLE
IL: fix the per-reader string cache sizing

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -178,6 +178,7 @@
 * Add symbol and type highlighting to F# diagnostics ([PR #20097](https://github.com/dotnet/fsharp/pull/20097))
 * IL: hold custom attributes in fields rather than a union case ([PR #20287](https://github.com/dotnet/fsharp/pull/20287))
 * IL: reuse the cached ILTypeRef in ILTypeInfo.FromType ([PR #20255](https://github.com/dotnet/fsharp/pull/20255))
+* IL: fix the per-reader string cache sizing ([PR #20261](https://github.com/dotnet/fsharp/pull/20261))
 * Name resolution: group C#-style extension members per `open` and extended type ([PR #20298](https://github.com/dotnet/fsharp/pull/20298))
 
 ### Improved

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -1109,7 +1109,6 @@ type ILMetadataReader =
         blobsStreamPhysicalLoc: int32
         blobsStreamSize: int32
         readUserStringHeap: int32 -> string
-        memoizeString: string -> string
         readStringHeap: int32 -> string
         readBlobHeap: int32 -> byte[]
         guidsStreamPhysicalLoc: int32
@@ -2084,7 +2083,7 @@ and readBlobHeapAsTypeName ctxt (nameIdx, namespaceIdx) =
 
     match nspace with
     | None -> name
-    | Some ns -> ctxt.memoizeString (ns + "." + name)
+    | Some ns -> ns + "." + name
 
 and seekReadTypeDefRowExtents (ctxt: ILMetadataReader) _info (idx: int) =
     if idx >= ctxt.getNumRows TableNames.TypeDef then
@@ -4254,7 +4253,7 @@ let openMetadataReader
                 let firstStreamLength = seekReadInt32 mdv (streamHeadersStart + 4)
                 firstStreamOffset, firstStreamLength
 
-    let stringsStreamPhysicalLoc, stringsStreamSize =
+    let stringsStreamPhysicalLoc, _stringsStreamSize =
         findStream [| 0x23; 0x53; 0x74; 0x72; 0x69; 0x6e; 0x67; 0x73 |] (* #Strings *)
 
     let userStringsStreamPhysicalLoc, userStringsStreamSize =
@@ -4530,8 +4529,9 @@ let openMetadataReader
     let cacheUserStringHeap =
         mkCacheGeneric reduceMemoryUsage inbase "UserStringHeap" (userStringsStreamSize / 20 + 1)
     // nb. Lots and lots of cache hits on this cache, hence never optimize cache away
-    let cacheStringHeap =
-        mkCacheGeneric false inbase "string heap" (stringsStreamSize / 50 + 1)
+    // Sized to grow rather than from the stream length: only a small fraction of a #Strings heap is ever
+    // read, so sizing from it left the table around 11% full, one nearly-empty table per reference.
+    let cacheStringHeap = mkCacheGeneric false inbase "string heap" 0
 
     let cacheBlobHeap =
         mkCacheGeneric reduceMemoryUsage inbase "blob heap" (blobsStreamSize / 50 + 1)
@@ -4575,7 +4575,6 @@ let openMetadataReader
             stringsStreamPhysicalLoc = stringsStreamPhysicalLoc
             blobsStreamPhysicalLoc = blobsStreamPhysicalLoc
             blobsStreamSize = blobsStreamSize
-            memoizeString = Tables.memoize id
             readUserStringHeap = cacheUserStringHeap (readUserStringHeapUncached ctxtH)
             readStringHeap = cacheStringHeap (readStringHeapUncached ctxtH)
             readBlobHeap = cacheBlobHeap (readBlobHeapUncached ctxtH)


### PR DESCRIPTION
`ILMetadataReader` keeps two string tables per referenced assembly. Both were sized from something
unrelated to how many strings are actually read.

`cacheStringHeap` was sized `stringsStreamSize / 50 + 1`, i.e. from the length of the `#Strings` stream.
Only a small fraction of a `#Strings` heap is ever read, so the table sat around 11% full — one
nearly-empty table per reference. It is now sized to grow.

`memoizeString` interned one computed string: the `ns + "." + name` concatenation in
`readBlobHeapAsTypeName`. Every caller of that function is already cached or one-shot per row
(`typeDefReader`, `seekReadTypeDefAsTypeRefUncached`, `seekReadTypeRefUncached`, and the exported-type
readers), so the table could only pay when two different rows produce identical text. It went through
`Tables.memoize`, whose fixed 1000-entry capacity cost about 3.0 MB in buckets across a large reference
set while collapsing at most 0.24 MB of duplicate names — so the table is removed rather than resized.
`Tables.memoize` keeps its `ilmorph.fs` caller.

Retained memory after `ParseAndCheckProject`, mean of 3 runs in fresh processes per project:

| Project | Before | After | Retained |
|---|--:|--:|--:|
| consoleapp | 33.25 MB | 31.11 MB | **-2.14 MB (-6.4%)** |
| Oxpecker | 69.65 MB | 65.77 MB | **-3.88 MB (-5.6%)** |
| IcedTasks | 47.10 MB | 44.93 MB | **-2.17 MB (-4.6%)** |
| FsToolkit | 69.97 MB | 67.86 MB | **-2.11 MB (-3.0%)** |
| Fantomas.Benchmarks | 64.26 MB | 61.33 MB | **-2.93 MB (-4.6%)** |
| Prime | 100.99 MB | 99.44 MB | **-1.55 MB (-1.5%)** |
| Fantomas.Core | 107.74 MB | 106.21 MB | **-1.53 MB (-1.4%)** |
| Fantomas.Core.Tests | 140.20 MB | 137.61 MB | **-2.59 MB (-1.8%)** |
| FSharp.Common | 261.81 MB | 251.68 MB | **-10.13 MB (-3.9%)** |
| fcs | 1226.73 MB | 1223.99 MB | **-2.74 MB (-0.2%)** |

The saving is two tables per reader, so it scales with the number of referenced assemblies rather than
project size: the smallest subject gains most in relative terms, and FSharp.Common, with 489 references,
most in absolute terms. Total allocation drops 1-34 MB per project. Analysis time is unchanged within
measurement noise.

Without the intern table, ~2,077 duplicate name strings survive per FSharp.Common analysis (~0.24 MB,
an upper bound). 98% are one structural pair: the same type def read once as `ILTypeDef.Name` and once
as `ILTypeRef.Name`. That is the 0.24 MB the table used to collapse, and it is well below what the table
itself cost.
