### PR TITLE
Fix missing .NET 11 framework build issue

### DIFF
--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -241,6 +241,8 @@ function Make-BootstrapBuild() {
 
     # prepare FsLex and Fsyacc and AssemblyCheck
     $dotnetPath = InitializeDotNetCli
+    # Ensure apphosts spawned by this publish see the repo-local runtime even if the caller forgot DOTNET_ROOT.
+    $env:DOTNET_ROOT = $dotnetPath
     $dotnetExe = Join-Path $dotnetPath "dotnet.exe"
 
     # prepare compiler

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -384,6 +384,9 @@ trap TrapAndReportError EXIT
 
 InitializeDotNetCli $restore
 
+# Apphosts (bootstrap fsc, testhost, etc.) resolve runtimes via DOTNET_ROOT, not PATH.
+export DOTNET_ROOT="$DOTNET_INSTALL_DIR"
+
 # Resolve product TFM from centralized source of truth if not overridden via --tfm
 if [[ "$tfm" == "" ]]; then
   tfm=$("$DOTNET_INSTALL_DIR/dotnet" msbuild "$scriptroot/TargetFrameworks.props" -getProperty:FSharpNetCoreProductTargetFramework 2>/dev/null | tr -d '[:space:]')


### PR DESCRIPTION
## Description

Fixes .NET 11 SDK/runtime resolution during local and CI builds. Bootstrap apphosts (`fsc`, `fsi`, `testhost`, etc.) resolve the runtime via `DOTNET_ROOT`/multi-level lookup rather than `PATH`, so when a machine also has other .NET installations, the apphost could pick up an unexpected or missing runtime instead of the repo-local `.dotnet` install, causing build/test failures on machines where the .NET 11 framework isn't globally installed.

This change:
- Prefers the repo-local `.dotnet` host in `FSharpBuild.Directory.Build.props` so the compiler host and bootstrap runtime come from the same install.
- Sets `DOTNET_ROOT` and `DOTNET_MULTILEVEL_LOOKUP=0` in `eng/Build.ps1`, `eng/build-utils.ps1`, `eng/build.sh`, and `eng/test-determinism.ps1` right after `InitializeDotNetCli`, so every apphost spawned during bootstrap/build/test resolves the correct SDK/runtime instead of falling back to a machine-wide lookup.

Fixes # (issue, if applicable)

## Checklist

- [ ] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated:
    > Entry added to `docs/release-notes/.FSharp.Compiler.Service/11.0.100.md`:
    > * Fix missing .NET 11 framework build support by preferring the repo-local `.dotnet` host and setting `DOTNET_ROOT` with `DOTNET_MULTILEVEL_LOOKUP=0` for bootstrap toolchains, so apphosts and test hosts resolve the correct SDK/runtime instead of a stale machine-wide installation.
