### PR TITLE
Add Chiron to the compiler regression-test matrix

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -845,3 +845,9 @@ stages:
           displayName: FSharpDataGraphQL_DesignTimeProvider_Packaging
           useVmImage: $(LinuxMachineQueueName)
           usePool: $(DncEngPublicBuildPool)
+        # Chiron (chiron-6) exercises Aether 8.2.0 inline SRTP optics, reproducing the SDK 10.0.400 legacy inline-metadata
+        # regression (#20253, fixed by #20260): the miscompile throws NotSupportedException at run time, so run the tests.
+        - repo: xyncro/chiron
+          commit: 94cf9db1793a1bd0e6e0b69efadcfb37368a6428
+          buildScript: dotnet test tests/Chiron.Tests/Chiron.Tests.fsproj -c Release -p:AssetTargetFallback=net461 -p:RollForward=Major --filter FullyQualifiedName~Optic
+          displayName: Chiron_Aether_Inline_SRTP


### PR DESCRIPTION
Adds Chiron to the compiler regression-test matrix. Chiron's chiron-6 branch serializes through Aether 8.2.0's `inline` SRTP optics, reproducing the runtime-only SDK 10.0.400 regression (#20253, fixed by #20260): a compiler that misreads the legacy pickled `inline` flag drops the inline body and calls the dynamic-invocation stub, so the build stays clean but `System.NotSupportedException` is thrown at run time. A build-only check would pass, so the entry runs Chiron's own xunit suite, filtered to the Aether `Optic` tests that hit the miscompiled path.

Runs on the default Windows image as a single `dotnet test` — no source edits. `AssetTargetFallback=net461` lets Chiron's old net452 leg restore, and `RollForward=Major` runs its netcoreapp2.0 tests on a current runtime.

Verified locally: the `Optic` tests fail with 4 × `System.NotSupportedException` on the SDK 10.0.400 compiler, and all 6 pass with the compiler built from this branch.

@panesofglass — is this OK with you? We'll be testing Chiron's build on every compiler PR, as we caused a regression in the 10.0.400 SDK.