### PR TITLE
Backport #20210: switch fsi restore tests to FsCheck

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>400</FSBuildVersion>
+    <FSBuildVersion>401</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
@@ -85,15 +85,35 @@ module FsiCliTests =
         finally
             try System.IO.File.Delete(scriptPath) with _ -> ()
 
-    // The FSI #r "nuget:" restore below must request a package version that is guaranteed to be in
-    // the offline restore cache on the internal signed build (which cannot restore online). Central
-    // package management + transitive pinning means only the centrally-pinned version (eng/Packages.props)
-    // is ever restored into that cache, and it changes whenever the pin is bumped. Rather than hardcode
-    // a version that would silently drift, read the exact pinned version baked into this test assembly
-    // at build time via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj). The package id
-    // (MessagePack) is kept in sync with that project; any centrally-pinned standalone package would do.
+    // On failure, surface the FSI subprocess output so CI logs show what actually happened (e.g. a
+    // NuGet restore error) instead of a bare "Expected 0, Actual 1". xunit's Assert.Equal/Contains do
+    // not include the process stdout/stderr, so these wrappers append it to the failure message.
+    let private fsiDiagnostics (result: ProcessResult) =
+        $"FSI exit code: %d{result.ExitCode}\n--- FSI STDOUT ---\n%s{result.StdOut}\n--- FSI STDERR ---\n%s{result.StdErr}\n--- end FSI output ---"
+
+    let private assertFsiExitCode (expected: int) (result: ProcessResult) =
+        if result.ExitCode <> expected then
+            Assert.Fail($"Expected FSI exit code %d{expected} but got %d{result.ExitCode}.\n%s{fsiDiagnostics result}")
+
+    let private assertStdOutContains (expected: string) (result: ProcessResult) =
+        if not (result.StdOut.Contains(expected)) then
+            Assert.Fail($"Expected FSI stdout to contain '%s{expected}'.\n%s{fsiDiagnostics result}")
+
+    let private assertStdOutDoesNotContain (unexpected: string) (result: ProcessResult) =
+        if result.StdOut.Contains(unexpected) then
+            Assert.Fail($"Expected FSI stdout NOT to contain '%s{unexpected}'.\n%s{fsiDiagnostics result}")
+
+    // The FSI #r "nuget:" restore below must request a package (and closure) already in the offline
+    // restore cache on the internal signed build (which cannot restore online), and it must be a genuine
+    // third-party assembly (not in the shared framework) so that on .NET Core it resolves to a restored
+    // package rather than the framework (which would emit NU1510 and skip real nuget resolution). FsCheck
+    // fits: a real third-party library whose only dependency (FSharp.Core) is always cached and filtered
+    // from fsx resolution, centrally pinned (eng/Packages.props) and restored by FSharp.Core.UnitTests, so
+    // it restores offline-clean on both net472 and .NET Core. Read the exact pinned version baked into this
+    // test assembly via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj) so the request never
+    // drifts from the pin; keep the package id below in sync with that project.
     [<Literal>]
-    let private restoreTestPackageId = "MessagePack"
+    let private restoreTestPackageId = "FsCheck"
 
     let private restoreTestPackageVersion =
         System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(typeof<System.Reflection.AssemblyMetadataAttribute>, false)
@@ -101,7 +121,7 @@ module FsiCliTests =
             let m = a :?> System.Reflection.AssemblyMetadataAttribute
             if m.Key = "FsiRestoreTestPackageVersion" && not (System.String.IsNullOrWhiteSpace m.Value) then Some m.Value else None)
         |> Option.defaultWith (fun () ->
-            failwith "AssemblyMetadata 'FsiRestoreTestPackageVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central MessagePack PackageVersion.")
+            failwith "AssemblyMetadata 'FsiRestoreTestPackageVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central FsCheck PackageVersion.")
 
     [<Fact>]
     let ``FSI quiet mode suppresses NuGet restore output from stdout`` () =
@@ -110,11 +130,11 @@ module FsiCliTests =
 printfn "RESULT_MARKER_18086"
 """
         let result = runFsiScript ["--quiet"] script
-        Assert.Equal(0, result.ExitCode)
-        Assert.Contains("RESULT_MARKER_18086", result.StdOut)
-        Assert.DoesNotContain("Determining projects to restore", result.StdOut)
-        Assert.DoesNotContain("Restored ", result.StdOut)
-        Assert.DoesNotContain("NU1", result.StdOut)
+        assertFsiExitCode 0 result
+        assertStdOutContains "RESULT_MARKER_18086" result
+        assertStdOutDoesNotContain "Determining projects to restore" result
+        assertStdOutDoesNotContain "Restored " result
+        assertStdOutDoesNotContain "NU1" result
 
     [<Fact>]
     let ``FSI default (non-quiet) mode still evaluates script and prints user output`` () =
@@ -123,12 +143,12 @@ printfn "RESULT_MARKER_18086"
 printfn "RESULT_MARKER_18086_DEFAULT"
 """
         let result = runFsiScript [] script
-        Assert.Equal(0, result.ExitCode)
-        Assert.Contains("RESULT_MARKER_18086_DEFAULT", result.StdOut)
+        assertFsiExitCode 0 result
+        assertStdOutContains "RESULT_MARKER_18086_DEFAULT" result
 
     [<Fact>]
     let ``FSI quiet mode still prints user printfn output to stdout`` () =
         let script = """printfn "hello from quiet script" """
         let result = runFsiScript ["--quiet"] script
-        Assert.Equal(0, result.ExitCode)
-        Assert.Contains("hello from quiet script", result.StdOut)
+        assertFsiExitCode 0 result
+        assertStdOutContains "hello from quiet script" result

--- a/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
+++ b/tests/FSharp.Compiler.ComponentTests/CompilerOptions/fsi/FsiCliTests.fs
@@ -85,10 +85,28 @@ module FsiCliTests =
         finally
             try System.IO.File.Delete(scriptPath) with _ -> ()
 
+    // The FSI #r "nuget:" restore below must request a package version that is guaranteed to be in
+    // the offline restore cache on the internal signed build (which cannot restore online). Central
+    // package management + transitive pinning means only the centrally-pinned version (eng/Packages.props)
+    // is ever restored into that cache, and it changes whenever the pin is bumped. Rather than hardcode
+    // a version that would silently drift, read the exact pinned version baked into this test assembly
+    // at build time via AssemblyMetadata (see FSharp.Compiler.ComponentTests.fsproj). The package id
+    // (MessagePack) is kept in sync with that project; any centrally-pinned standalone package would do.
+    [<Literal>]
+    let private restoreTestPackageId = "MessagePack"
+
+    let private restoreTestPackageVersion =
+        System.Reflection.Assembly.GetExecutingAssembly().GetCustomAttributes(typeof<System.Reflection.AssemblyMetadataAttribute>, false)
+        |> Array.tryPick (fun a ->
+            let m = a :?> System.Reflection.AssemblyMetadataAttribute
+            if m.Key = "FsiRestoreTestPackageVersion" && not (System.String.IsNullOrWhiteSpace m.Value) then Some m.Value else None)
+        |> Option.defaultWith (fun () ->
+            failwith "AssemblyMetadata 'FsiRestoreTestPackageVersion' is missing. It should be emitted by FSharp.Compiler.ComponentTests.fsproj from the central MessagePack PackageVersion.")
+
     [<Fact>]
     let ``FSI quiet mode suppresses NuGet restore output from stdout`` () =
-        let script = """
-#r "nuget: Newtonsoft.Json, 13.0.3"
+        let script = $"""
+#r "nuget: {restoreTestPackageId}, {restoreTestPackageVersion}"
 printfn "RESULT_MARKER_18086"
 """
         let result = runFsiScript ["--quiet"] script
@@ -100,8 +118,8 @@ printfn "RESULT_MARKER_18086"
 
     [<Fact>]
     let ``FSI default (non-quiet) mode still evaluates script and prints user output`` () =
-        let script = """
-#r "nuget: Newtonsoft.Json, 13.0.3"
+        let script = $"""
+#r "nuget: {restoreTestPackageId}, {restoreTestPackageVersion}"
 printfn "RESULT_MARKER_18086_DEFAULT"
 """
         let result = runFsiScript [] script

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -564,15 +564,17 @@
 
   <!-- FsiCliTests spawns FSI and does `#r "nuget: <pkg>, <version>"` to verify that quiet mode
        suppresses NuGet restore chatter. On the internal signed build NuGet restore is offline, so the
-       requested version must be one that is already in the restore cache. Under central package
-       management with transitive pinning, that is exactly the centrally-pinned version
-       (eng/Packages.props). Bake that version into the test assembly so the test can request it at
-       runtime with no manual sync when the central pin is bumped. MessagePack is used (rather than a
-       general-purpose JSON package) because it is an actively-maintained, non-system standalone library
-       that is centrally pinned and restored transitively by the product (StreamJsonRpc); keep the
-       package id here in sync with the id in FsiCliTests.fs. -->
+       requested package AND ITS ENTIRE TRANSITIVE CLOSURE must already be in the restore cache. The
+       package must also be a genuine third-party assembly (NOT in the shared framework), otherwise on
+       .NET Core it resolves to the framework (NU1510) instead of a restored package and the test no
+       longer exercises real nuget resolution. FsCheck fits: a real third-party library whose only
+       dependency is FSharp.Core (always cached, and filtered from fsx resolution), centrally pinned
+       (eng/Packages.props) and restored by FSharp.Core.UnitTests, so its closure is cached and it
+       restores offline-clean on both net472 and .NET Core. Bake the centrally-pinned version into the
+       test assembly so the test can request exactly the cached version with no manual sync when the pin
+       is bumped; keep the package id here in sync with the id in FsiCliTests.fs. -->
   <PropertyGroup>
-    <FsiRestoreTestPackageVersion>@(PackageVersion->WithMetadataValue('Identity','MessagePack')->'%(Version)')</FsiRestoreTestPackageVersion>
+    <FsiRestoreTestPackageVersion>@(PackageVersion->WithMetadataValue('Identity','FsCheck')->'%(Version)')</FsiRestoreTestPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyMetadata Include="FsiRestoreTestPackageVersion" Value="$(FsiRestoreTestPackageVersion)" />

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -562,5 +562,20 @@
     <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
+  <!-- FsiCliTests spawns FSI and does `#r "nuget: <pkg>, <version>"` to verify that quiet mode
+       suppresses NuGet restore chatter. On the internal signed build NuGet restore is offline, so the
+       requested version must be one that is already in the restore cache. Under central package
+       management with transitive pinning, that is exactly the centrally-pinned version
+       (eng/Packages.props). Bake that version into the test assembly so the test can request it at
+       runtime with no manual sync when the central pin is bumped. MessagePack is used (rather than a
+       general-purpose JSON package) because it is an actively-maintained, non-system standalone library
+       that is centrally pinned and restored transitively by the product (StreamJsonRpc); keep the
+       package id here in sync with the id in FsiCliTests.fs. -->
+  <PropertyGroup>
+    <FsiRestoreTestPackageVersion>@(PackageVersion->WithMetadataValue('Identity','MessagePack')->'%(Version)')</FsiRestoreTestPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <AssemblyMetadata Include="FsiRestoreTestPackageVersion" Value="$(FsiRestoreTestPackageVersion)" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Backports #20210 (and its prerequisite #20205) to release/10.0.4xx.

The FSI `#r "nuget:"` restore tests must restore offline-clean on the internal signed build. FsCheck is centrally pinned and its only dependency (FSharp.Core) is already cached via FSharp.Core.UnitTests, so its closure restores offline on both net472 and .NET Core — unlike MessagePack (uncached net472 deps) and the previous hardcoded Newtonsoft.Json version.
