### PR TITLE
Restore source-build overridable prop names for runtime packages

### DIFF
--- a/.github/instructions/EngVersioning.instructions.md
+++ b/.github/instructions/EngVersioning.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo:
+  - "eng/Packages.props"
+  - "eng/Versions.props"
+  - "eng/Version.Details.xml"
+  - "eng/Version.Details.props"
+---
+
+These files feed the VMR source-build. The `System.*` dotnet/runtime packages marked *"Necessary for source-build"* in `eng/Version.Details.xml` are overridden at build time by the VMR's generated `PackageVersions.fsharp.props`, which replaces the darc-named `$(System*Version)` properties (e.g. `$(SystemCollectionsImmutableVersion)`) with the live source-built runtime version.
+
+Rules:
+
+- Consume those packages in `eng/Packages.props` through `$(System*Version)` **directly**. Never route them through a renamed or computed alias (e.g. a `$(System*CentralVersion)`) or a version floor — source-build overrides the darc-named property, and a renamed/eagerly-computed intermediate freezes the value so the override never reaches CPM, causing prebuilt packages and `NU1109` downgrades in the source-only build.
+- When a transitive consumer (MSBuild, Roslyn) requires a higher minimum than the flowed baseline, raise the declared version in `eng/Version.Details.{xml,props}` instead of adding a floor. Source-build overrides it back down to the live runtime version; product/PR restore uses the declared value.
+- fsharp PR/CI does **not** run the VMR source-only prebuilt gate (`SB_CentOSStream10_Online_MsftSdk_x64`), so a green PR restore does not prove source-build correctness. Reason about these edits against source-build.
+
+See `docs/postmortems/regression-sourcebuild-cpm-runtime-version-floor.md` for why.

--- a/docs/postmortems/README.md
+++ b/docs/postmortems/README.md
@@ -8,3 +8,4 @@ These are referenced from [agentic instructions](../../.github/instructions/) an
 
 - [`regression-fs0229-bstream-misalignment.md`](regression-fs0229-bstream-misalignment.md) — a conditional write with an unconditional read shifted the pickle B-stream, producing `FS0229` when reading older metadata.
 - [`regression-legacy-inline-metadata-dynamic-invocation.md`](regression-legacy-inline-metadata-dynamic-invocation.md) — a new inline-flag case reused a serialized bit pattern that already meant "required inline" in F# 5 binaries, breaking cross-assembly SRTP at runtime.
+- [`regression-sourcebuild-cpm-runtime-version-floor.md`](regression-sourcebuild-cpm-runtime-version-floor.md) — renaming the CPM runtime-package pins to computed `$(System*CentralVersion)` aliases with a floor defeated source-build's `$(System*Version)` override, causing prebuilt/`NU1109` failures in the VMR that fsharp CI could not see.

--- a/docs/postmortems/regression-sourcebuild-cpm-runtime-version-floor.md
+++ b/docs/postmortems/regression-sourcebuild-cpm-runtime-version-floor.md
@@ -1,0 +1,76 @@
+# Regression: renamed CPM runtime-package pins broke VMR source-build
+
+## Summary
+
+To satisfy CPM transitive pinning, the central versions of the dotnet/runtime packages that MSBuild and Roslyn pull (`System.Collections.Immutable`, `System.Reflection.Metadata`, `System.Composition`, `System.Diagnostics.DiagnosticSource`, `System.Security.Cryptography.Xml`) were routed through computed `$(System*CentralVersion)` properties with a version floor, instead of the darc-named `$(System*Version)` properties. Source-build injects live runtime versions by overriding the darc-named properties, so the renamed, eagerly-floored pins froze at the floor value and the override never reached CPM. In the .NET 11 RC1 VMR the floor demanded `10.0.10` while source-build supplied the live `10.0.9`, producing prebuilt packages and `NU1109` downgrade errors that blocked the fsharp forward-flow (dotnet/dotnet#8413, #8414, #8415). Caught at the VMR source-only gate; it never shipped.
+
+## Error Manifestation
+
+The `VMR Source-Only Build SB_CentOSStream10_Online_MsftSdk_x64` leg failed two ways.
+
+Prebuilt detection:
+
+```text
+eng/finish-source-only.proj(141,5): error : Prebuilt packages are not allowed in source-only builds.
+Detected 1 prebuilt package(s):
+ - System.Diagnostics.DiagnosticSource.10.0.10
+```
+
+And, once the floor was partially relaxed, a downgrade in `fsc`/`fsi`:
+
+```text
+error NU1109: Detected package downgrade: System.Collections.Immutable from 10.0.10 to centrally defined 10.0.9.
+  fsi -> Microsoft.Build.Framework 18.11.0-1.26417.9 -> System.Collections.Immutable (>= 10.0.10)
+  fsi -> System.Collections.Immutable (>= 10.0.9)
+```
+
+fsharp's own PR/CI legs were green throughout — the failure appeared only downstream in dotnet/dotnet.
+
+## Root Cause
+
+fsharp declares these `System.*` packages in `eng/Version.Details.xml` with an empty `<Sha>` and the note *"Necessary for source-build. This allows the live version of the package to be used by source-build."* When the VMR builds fsharp it passes `/p:DotNetPackageVersionPropsPath=…/PackageVersions.fsharp.props`, a generated file that **unconditionally overrides the darc-named properties** — `$(SystemCollectionsImmutableVersion)`, etc. — with the live runtime version it just source-built. Whatever CPM reads must be that exact property for the override to take effect.
+
+The CPM-transitive-pinning work introduced an indirection instead:
+
+```xml
+<!-- eng/Versions.props (removed) -->
+<SystemCollectionsImmutableCentralVersion>$(SystemCollectionsImmutableVersion)</SystemCollectionsImmutableCentralVersion>
+<SystemCollectionsImmutableCentralVersion
+    Condition="...VersionLessThan($(SystemCollectionsImmutableVersion), $(SystemRuntimeCentralFloorVersion))">
+  $(SystemRuntimeCentralFloorVersion)   <!-- floor, e.g. 10.0.10 -->
+</SystemCollectionsImmutableCentralVersion>
+```
+
+`eng/Packages.props` then pinned `Version="$(SystemCollectionsImmutableCentralVersion)"`. Two mistakes combined:
+
+1. **Rename.** Source-build overrides `$(SystemCollectionsImmutableVersion)`, not `$(...CentralVersion)`. The alias is a different property that source-build has no knowledge of.
+2. **Eager floor.** `$(...CentralVersion)` is computed once, before arcade imports `PackageVersions.fsharp.props`, and is `max(flowed, floor)`. Even in source-build it evaluated to the floor.
+
+So the central pin froze at the floor (`10.0.10`). Source-build only produces the live runtime (`10.0.9`), which cannot satisfy a `10.0.10` pin from within the source tree, so restore reached an external feed → prebuilt; and where the graph also carried a `10.0.9` constraint, `NU1109` downgrade.
+
+The violated assumption: **a source-build "live version" package must be consumed through the exact darc-named `$(System*Version)` property; any renamed or computed intermediate silently defeats the override.** roslyn's `eng/Packages.props` does the correct thing — it references `$(SystemCollectionsImmutableVersion)` directly.
+
+## Why It Escaped
+
+fsharp's PR/CI restores are allowed to pull from nuget.org, where `10.0.10` exists. The floored pin resolved cleanly there, so every fsharp leg — including its own `Source-Build (Managed)` legs — was green. The only environment that rejects an out-of-tree package is the VMR source-**only** prebuilt gate (`SB_CentOSStream10_Online_MsftSdk_x64`), which fsharp CI does not run. The defect was therefore structurally invisible until the change forward-flowed into dotnet/dotnet, roughly a day later.
+
+It also recurred: the same source-build/runtime coherency was fought three times — the MSBuild pin (#20073), the CPM floor (#20084, extended by #20100), and the MSBuild unpin (#20278) — before the direct-property pattern fixed it.
+
+## Fix
+
+[#20290](https://github.com/dotnet/fsharp/pull/20290): reference `$(System*Version)` directly in `eng/Packages.props` (matching roslyn), delete the `$(...CentralVersion)`/`SystemRuntimeCentralFloorVersion` scaffolding from `eng/Versions.props`, and declare the packages at `10.0.10` in `eng/Version.Details.{xml,props}` so product/PR restore meets the MSBuild 18.11 / Roslyn 5.11 transitive minimum. In source-build, `PackageVersions.fsharp.props` overrides those same properties down to the live runtime version, so the pin always tracks what the VMR actually builds. Verified by feeding a simulated `PackageVersions.fsharp.props` through `/p:DotNetPackageVersionPropsPath`: with the fix CPM resolves the injected `10.0.9`; with the old alias it stayed frozen at `10.0.10`.
+
+## Timeline
+
+| Date (2026) | PR | Event |
+| --- | --- | --- |
+| 08-04 | #20084 | CPM + transitive pinning introduces `$(System*CentralVersion)` + floor (latent). |
+| 08-13 | #20073 | MSBuild pinned at `18.10.0-1.26370.18` (kept net10 assets for the then-net10 product). |
+| 08-18 | #20100 | Floor extended to the Roslyn-pulled `System.*` packages. |
+| 08-18 | #20278 | MSBuild unpinned to `18.11` line; floor bumped to `10.0.10`, expanded to 5 packages. |
+| 08-19 | dotnet/dotnet#8413/#8414/#8415 | Forward-flow source-only build fails: prebuilt `DiagnosticSource 10.0.10` + `NU1109`. |
+| 08-19 | #20290 | Direct `$(System*Version)`, floor removed, declared `10.0.10`. |
+
+## Prevention
+
+`.github/instructions/EngVersioning.instructions.md` scoped to `eng/Packages.props`, `eng/Versions.props`, and `eng/Version.Details.{xml,props}` encodes the rule: consume source-build "live version" packages through the darc-named `$(System*Version)` property directly; never route them through a renamed or computed central alias/floor. When a transitive consumer (MSBuild, Roslyn) needs a higher minimum than the flowed baseline, raise the declared version in `eng/Version.Details.*` rather than adding a floor — source-build overrides it back down to the live runtime version. fsharp CI cannot reproduce the VMR source-only prebuilt gate, so these files must be reasoned about against source-build, not just a green PR restore.

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -94,14 +94,14 @@
     <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="System.Buffers" Version="$(SystemBuffersVersion)" />
-    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableCentralVersion)" />
-    <PackageVersion Include="System.Composition" Version="$(SystemCompositionCentralVersion)" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceCentralVersion)" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageVersion Include="System.Composition" Version="$(SystemCompositionVersion)" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageVersion Include="System.Reflection.Emit" Version="$(SystemReflectionEmitVersion)" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataCentralVersion)" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlCentralVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
     <PackageVersion Include="xunit.v3.assert" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.v3.common" Version="$(XunitVersion)" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitVersion)" />

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -28,10 +28,10 @@ This file should be imported by eng/Versions.props
     <MicrosoftVisualStudioLanguageServicesPackageVersion>5.11.0-1.26415.2</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <MicrosoftVisualStudioLanguageServicesExternalAccessPackageVersion>5.11.0-1.26415.2</MicrosoftVisualStudioLanguageServicesExternalAccessPackageVersion>
     <!-- dotnet-runtime dependencies -->
-    <SystemCollectionsImmutablePackageVersion>10.0.8</SystemCollectionsImmutablePackageVersion>
-    <SystemCompositionPackageVersion>10.0.8</SystemCompositionPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.8</SystemDiagnosticsDiagnosticSourcePackageVersion>
-    <SystemReflectionMetadataPackageVersion>10.0.8</SystemReflectionMetadataPackageVersion>
+    <SystemCollectionsImmutablePackageVersion>10.0.10</SystemCollectionsImmutablePackageVersion>
+    <SystemCompositionPackageVersion>10.0.10</SystemCompositionPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.10</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemReflectionMetadataPackageVersion>10.0.10</SystemReflectionMetadataPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -51,25 +51,25 @@
       <Sha>0280f7f9457d50a46cd523ce0082807b5d70b236</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Collections.Immutable" Version="10.0.8">
+    <Dependency Name="System.Collections.Immutable" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Composition" Version="10.0.8">
+    <Dependency Name="System.Composition" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="10.0.8">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Reflection.Metadata" Version="10.0.8">
+    <Dependency Name="System.Reflection.Metadata" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,26 +88,6 @@
     <SystemBuffersVersion>4.6.1</SystemBuffersVersion>
     <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.1.2</SystemRuntimeCompilerServicesUnsafeVersion>
-    <!-- System.* packages from dotnet/runtime flow via Version.Details (darc). MSBuild 18.10 (fsc/fsi +
-         FSharp.Build.UnitTests) and Roslyn 5.11 (System.Composition, System.Diagnostics.DiagnosticSource) both
-         pull dotnet/runtime packages transitively at >= 10.0.10, in product/PR and source-build. CPM transitive
-         pinning needs the *central* pin to meet that floor, hence these ...CentralVersion properties. They don't
-         touch the darc-flowed $(System*Version) (authoritative for FCS's nuspec); the floor only raises, never downgrades. -->
-    <SystemSecurityCryptographyXmlCentralVersion>$(SystemSecurityCryptographyXmlVersion)</SystemSecurityCryptographyXmlCentralVersion>
-    <SystemCollectionsImmutableCentralVersion>$(SystemCollectionsImmutableVersion)</SystemCollectionsImmutableCentralVersion>
-    <SystemReflectionMetadataCentralVersion>$(SystemReflectionMetadataVersion)</SystemReflectionMetadataCentralVersion>
-    <SystemCompositionCentralVersion>$(SystemCompositionVersion)</SystemCompositionCentralVersion>
-    <SystemDiagnosticsDiagnosticSourceCentralVersion>$(SystemDiagnosticsDiagnosticSourceVersion)</SystemDiagnosticsDiagnosticSourceCentralVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Floor for the MSBuild/Roslyn-pulled dotnet/runtime packages: 10.0.10 (Roslyn 5.11) also covers MSBuild's >= 10.0.9. -->
-    <SystemRuntimeCentralFloorVersion>10.0.10</SystemRuntimeCentralFloorVersion>
-    <SystemSecurityCryptographyXmlCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemSecurityCryptographyXmlVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemSecurityCryptographyXmlCentralVersion>
-    <SystemCollectionsImmutableCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemCollectionsImmutableVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemCollectionsImmutableCentralVersion>
-    <SystemReflectionMetadataCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemReflectionMetadataVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemReflectionMetadataCentralVersion>
-    <SystemCompositionCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemCompositionVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemCompositionCentralVersion>
-    <SystemDiagnosticsDiagnosticSourceCentralVersion Condition="$([MSBuild]::VersionLessThan('$(SystemDiagnosticsDiagnosticSourceVersion)', '$(SystemRuntimeCentralFloorVersion)'))">$(SystemRuntimeCentralFloorVersion)</SystemDiagnosticsDiagnosticSourceCentralVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Follow-up to #20278. The CPM central pins for the MSBuild/Roslyn-pulled dotnet/runtime packages were routed through intermediate `...CentralVersion` properties with a `10.0.10` floor. Source-build injects live runtime versions by overriding `$(System*Version)` (via `PackageVersions.fsharp.props`), but the renamed `...CentralVersion` pins were evaluated before that override and could not be set by source-build — so the floor forced `10.0.10` while source-build supplied `10.0.9`, producing prebuilts and NU1109 downgrades in the VMR (dotnet/dotnet#8413, dotnet/dotnet#8414, dotnet/dotnet#8415).

`eng/Packages.props` now references `$(System*Version)` directly (matching roslyn), the floor scaffolding is gone, and the packages are declared at `10.0.10` in `Version.Details` so product/PR restore satisfies MSBuild `18.11` / Roslyn `5.11` without a downgrade. Source-build overrides these to its live runtime version.