### PR TITLE
Make AI expert-review post file+line anchored inline comments, not a prose wall

### DIFF
--- a/.github/agents/expert-reviewer.md
+++ b/.github/agents/expert-reviewer.md
@@ -476,34 +476,36 @@ Execute review in five waves, each building on the previous.
 
 ### Wave 5: Deliver Review as Inline Comments
 
-**This wave is mandatory.** Analysis without posting is worthless — the review MUST appear on the PR as posted inline comments at the correct file and line.
+**This wave is mandatory.** Analysis without posting is worthless — the review MUST appear on the PR as inline comments anchored to the exact file and line. A prose review body is the failure this wave exists to prevent: the author wrote the diff, so narrating it back is noise. Every review body and every comment begins with the robot+detective disclosure `🤖🕵️`.
 
-1. **Deduplicate first.** Check existing reviews to avoid duplicate content:
+1. **Deduplicate first.**
    ```bash
    gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq 'length'
    ```
    If reviews from automated accounts already exist, skip posting and apply the label only.
 
-2. **Post findings as a review with inline comments** at the best-fitting file and line. Use the GitHub API to create a single review with all comments:
+2. **Findings exist → one review, inline comments only.** Every finding — *including minor and "nice to have" ones* — is its own inline comment anchored to a file+line, so each becomes an independent, resolvable thread. Never collect findings into the body.
    ```bash
    gh api repos/{owner}/{repo}/pulls/{number}/reviews \
      --method POST \
      --field event=COMMENT \
-     --field body='' \
+     --field 'body=🤖🕵️ AI review — verify independently.' \
      --field 'comments=[
-      {"path":"src/Compiler/Checking/CheckDeclarations.fs","line":2750,"body":"**[Test Coverage]** This code path lacks a test. Add a test exercising this branch."},
-      {"path":"src/Compiler/CodeGen/IlxGen.fs","line":1234,"body":"**[IL Emission]** Call `stripTyEqns` before this match to handle type abbreviations."}
+      {"path":"src/Compiler/CodeGen/IlxGen.fs","line":1234,"body":"🤖🕵️ Type abbreviation slips past the match — wrong branch taken.\n```fsharp\ntype Alias = int\nlet f (x: Alias) = ()  // reaches this case, mishandled\n```"}
      ]'
    ```
-   Each comment needs:
-   - `path`: file path relative to repo root (from the diff)
-   - `line`: line number in the **new** version of the file (right side of diff)
-   - `body`: severity tag in `**[Dimension]**` format, the issue, and suggested fix
+   - Review **`body` = one short line**, the `🤖🕵️` disclosure. Never a summary, never a finding list.
+   - `path`: file path from the diff. `line`: line in the **new** file (right side of diff); use `start_line`+`line` for a range.
+   - Comment body: `🤖🕵️` + one fragment naming the **consequence** (what breaks), then a fenced **user-code** sample — the input/usage that triggers it, or the fix. Show how the problem looks in *user* code; do not restate the product diff.
+   - **Validated, not guessed.** If you have not run it and seen the result, drop the finding. "Would allocate" / "could box" / "may cancel" without a repro → drop.
+   - At most ~6–10 comments, ranked Behavioral > Quality > Nitpick.
 
-3. **If no significant issues found**, post an approving review:
+3. **No significant issues → approve.** Body is the disclosure plus, optionally, a collapsed list of what was covered — the ONE permitted multi-line body:
    ```bash
-   gh pr review {number} --repo {owner}/{repo} --approve --body "LGTM"
+   gh pr review {number} --repo {owner}/{repo} --approve \
+     --body $'🤖🕵️ LGTM ✅\n\n<details>\n<summary>Dimensions covered (expand)</summary>\n\n- IL emission\n- Binary compatibility\n- Concurrency\n</details>'
    ```
+   The `<details>` block is a bare list of the dimensions/subagents that ran — no prose, no per-dimension write-up.
 
 4. **Apply the label and request human review:**
    ```bash
@@ -511,12 +513,12 @@ Execute review in five waves, each building on the previous.
    ```
 
 **Delivery rules:**
-- The review body MUST begin with an AI disclosure note (the `🤖` line above). This is non-negotiable — readers must know this is AI-generated, not human-written.
-- At most 10 inline comments — prioritize Behavioral over Quality over Nitpick.
-- Every comment must reference a specific file and line from the diff.
+- Every review body and every inline comment begins with `🤖🕵️`. Non-negotiable — readers must know this is AI-generated.
+- The review **body** is only ever: the one-line `🤖🕵️` disclosure (findings present), or `🤖🕵️ LGTM ✅` + the optional collapsed dimensions list (no findings). Anything else in the body — a summary, a numbered list of notes, praise, "two tiny things" — is a bug.
+- Every finding is an inline comment anchored to a specific file+line from the diff. No exception for "minor" or "nice" notes: if it is worth saying, anchor it.
+- Each comment carries a concrete **user-code** sample and describes **validated** behavior, not a guess.
+- **Banned in any body or comment:** prose summary, restating what the PR does, `**[Dimension]**`/`file:LINE` as a text header in the body, hedge/filler ("consider", "might want to", "non-blocking nit", "for consistency"), and any finding lacking a file+line or a concrete code sample.
 - Never post duplicate content if reviews already exist on the PR.
-- If the PR is too large to review fully, note skipped areas in the review body.
-- **NEVER write a wall-of-text review body.** The body is either `LGTM` (approve) or empty (with inline findings). All analysis stays in your context — only actionable findings get posted as inline comments. A review body longer than 10 characters (other than `LGTM`) is a bug.
 
 ## Folder Hotspot Mapping
 


### PR DESCRIPTION
### Problem

The automated `expert-reviewer` keeps posting **wall-of-text `COMMENTED` reviews with zero inline comments**, instead of file+line anchored, individually-resolvable findings. Recent examples:

- https://github.com/dotnet/fsharp/pull/20254#pullrequestreview-4949735328 (1759-char prose body, 0 anchors)
- https://github.com/dotnet/fsharp/pull/20273#pullrequestreview-4949775414 (3288-char prose body, 0 anchors)

### Root cause

`Wave 5` in `.github/agents/expert-reviewer.md` contradicted itself:

- the example posts `--field body=''` (empty),
- one delivery rule says *"body MUST begin with an AI disclosure note (the `🤖` line above)"* — but no such line exists in the example,
- the next rule says *"body is either `LGTM` or empty … longer than 10 characters is a bug."*

"Must start with a disclosure line" vs "must be empty/≤10 chars" is irreconcilable, so the model writes a body — and once it is writing a body it writes prose, and skips the `comments[]` array entirely.

### Fix

Rewrite Wave 5 into one coherent contract:

- **Findings → inline `comments[]` only**, each anchored to a file+line so each is an independent, resolvable thread. Minor / "nice to have" notes are anchored too — no friendly-prose middle path.
- **Review body** is only ever: a one-line `🤖🕵️` disclosure (findings present), or `🤖🕵️ LGTM ✅` + an optional collapsed `<details>` list of dimensions covered (the one permitted multi-line body).
- Every body and comment is prefixed with the robot+detective disclosure `🤖🕵️`.
- Each comment must carry a **user-code** sample (how the problem looks in user code, not a restatement of the diff) and describe **validated** behavior, not a guess.
- The self-contradictory disclosure/empty-body rules are removed.