### PR TITLE
Add grounded folder-scoped Copilot instructions for compiler internals

### DIFF
--- a/.github/instructions/abstract-il.instructions.md
+++ b/.github/instructions/abstract-il.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: 'src/Compiler/AbstractIL/**'
+---
+
+In-memory IL model and binary/PDB I/O: il.fs (model), ilread.fs (lazy metadata reader), ilwrite.fs (PE writer), ilwritepdb.fs (portable PDB emit).
+
+- Enforce the `maximumMethodsPerDotNetType` cap before writing type defs; overflowing the method count must fail early instead of producing an invalid table layout.
+- Any instruction-expanding morphism must remap `ILCode` labels and exception clauses together; changing instructions alone leaves branch targets and handler clauses stale.
+- Treat `LazyOrderedMultiMap` as order-preserving infrastructure; add or filter by creating a new map rather than mutating the cached list.
+- Keep `ReadResFile` two-pass resource parse aligned with the actual resource tree shape, including the `RT_DLGINCLUDE` skip, so node counts and payload reads stay in sync.
+- Keep `getBinaryFile` `safeHolder` ownership intact so the mapped bytes stay alive until the finalizer disposes the underlying stream.
+- Keep `SequencePoint.orderBySource`, `SequencePoint.orderByOffset`, and `scopeSorter` consistent with PDB traversal, because debug info is serialized in sorted source/offset order.
+- Keep `splitILTypeNameWithPossibleStaticArguments` and `splitTypeNameRight` behavior stable, because IL type-name parsing feeds metadata lookup and provided-type mangling.
+- When rewriting shadowed locals, sort child scopes with `scopeSorter` before splitting scopes so nested ranges stay valid and deterministic.
+- Keep `PEFile.GetView` and the weak `BinaryFile` cache lifetime pattern, because `PEReader.Dispose` is owned by finalization and the cache avoids holding duplicate buffers.

--- a/.github/instructions/checking.instructions.md
+++ b/.github/instructions/checking.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: 'src/Compiler/Checking/**'
+---
+
+Type inference and declaration checking: CheckExpressions, ConstraintSolver, NameResolution, CheckDeclarations.
+
+- `NameResolver` must be constructed with the right `TcGlobals`, `ImportMap`, `InfoReader`, and instantiation generator because lookup caches and generic instantiation depend on them.
+- Run `escapeDotnetFormatString` before parsing format specifiers; the lexer strips brace escapes, so the checker must re-double them to keep .NET formatting semantics.
+- Keep `BindSubExprOfInput` and `GetSubExprOfInput` threading the generalized typars and instantiation together; pattern compilation must not lose the dummy type substitution needed for polymorphic matches.
+- Keep `MutRecShapes` and the `MutRecDefnsPhase*` data flow intact; nested modules, tycons, and `Lets` must stay grouped in the declared recursive shape.
+- Always remap signature attributes with `sigToImplRemap` before comparing or propagating them; signature/implementation identity is not stable without that rename layer.
+- Only enable `TryFindRelevantImplicitConversion` when required and actual types are known precisely and no feasible subtype match exists; otherwise implicit conversions steal normal overloads.
+- Keep `ConstraintSolver`'s resolution order deterministic; overload and SRTP solving rely on fixed sequencing and only limited backtracking.
+- Preserve `CombineTwoLimits` scope/flag normalization, especially the stack-referring span-like case forcing scope 1; otherwise byref escaping checks miss method-level violations.

--- a/.github/instructions/driver.instructions.md
+++ b/.github/instructions/driver.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: 'src/Compiler/Driver/**'
+---
+
+Compiler front-end orchestration: ParseAndCheckInputs, fsc, GetInitialTcState, CheckClosedInputSet.
+
+- Keep `TryResolveFileUsingPaths` path-order sensitive and stop at the first existing candidate; later probes must not override earlier search roots.
+- Preserve the `ArtificialImplFile` remapping so signature dependencies are duplicated into `TcEnvFromImpls` only for graph prerequisites, not for the real implementation node.
+- `TypeCheck` must build the initial `TcState` and then call `CheckClosedInputSet`; do not bypass the closed-input-set path for normal compilation.
+- `CheckClosedInputSet` must reject any `tcsRootSigs` entry without a matching implementation before final CCU contents are produced.
+- `AdjustForScriptCompile` should only normalize inputs and append script closure references before checking; it must not mix with type-checking logic.
+- `optimizeFilesInParallel` must derive each node from both the previous phase and the previous file task; dropping either dependency breaks the phase/file pipeline.
+- When static-linking, partition resources by signature/optimization markers before appending the rest, and keep provider-generated resources filtered out of that copy step.
+- Keep `GetInitialTcState` and `AddCheckResultsToTcState` in sync so `tcsTcSigEnv` and `tcsTcImplEnv` reflect the same file history the driver expects.

--- a/.github/instructions/expressions.instructions.md
+++ b/.github/instructions/expressions.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: 'src/Compiler/Checking/Expressions/**'
+---
+
+Expression and computation-expression elaboration: CheckExpressions (left-to-right checking, generalization), CheckComputationExpressions (builder desugaring).
+
+- `CheckExpressions` must preserve left-to-right checking and generalization points; expression order is part of the typechecker contract.
+- Keep the real `Expr.Let` for discard/unit bindings when the RHS is byref-like; `PostInferenceChecks` relies on that node to enforce byref scope rules.
+- Call `requireBuilderMethod` before translating each computation-expression form, so translation fails early when the builder lacks `Bind`, `Delay`, or `Using` rather than emitting a broken shape.

--- a/.github/instructions/facilities.instructions.md
+++ b/.github/instructions/facilities.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: 'src/Compiler/Facilities/**'
+---
+
+Compiler infrastructure helpers for diagnostics and reference resolution: DiagnosticsLogger, ReferenceResolver, BuildGraph.
+
+- Preserve the null fast-path in `GetOrComputeValue` so already-materialized nodes avoid taking the semaphore or allocating a new async workflow.
+- Use `LegacyReferenceResolver` only through `ILegacyReferenceResolver.Resolve`, and preserve the `LegacyResolutionEnvironment` distinction between editing and execution.
+- Always wrap memoized jobs in `Async.TryCancelled` and `Async.Catch` and return the captured logger, or cancellations and failures bypass cache bookkeeping.
+- Route compiler failures through `DiagnosticsLogger` exception types like `WrappedError`, `ReportedError`, and `StopProcessingExn` instead of throwing ad hoc exceptions.
+- Keep `AttachRange` mapping unresolved-reference exceptions to range-bearing forms before they reach reporting code.

--- a/.github/instructions/fsharp-dependency-manager-nuget.instructions.md
+++ b/.github/instructions/fsharp-dependency-manager-nuget.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: 'src/FSharp.DependencyManager.Nuget/**'
+---
+
+NuGet dependency manager for FSI: FSharpDependencyManager parses #r/#i directives, builds restore inputs, and emits package-resolution metadata via ProjectFile helpers.
+
+- `parsePackageReferenceOption` must keep reserved-package checks (`mscorlib`, `FSharp.Core`, `System.ValueTuple`, `NETStandard.Library`, `Microsoft.NETFramework.ReferenceAssemblies`) before accepting `Include`.
+- `computeHashForResolutionInputs` must treat wildcard package versions as non-cacheable input.
+- `validateAndFormatRestoreSources` must reject missing local directories for file URIs and only append valid restore roots.

--- a/.github/instructions/fsharp-editor.instructions.md
+++ b/.github/instructions/fsharp-editor.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: 'vsintegration/src/FSharp.Editor/Common/**'
+---
+
+Shared VS editor helpers for FSharp.Editor: DocumentCache and RoslynHelpers.StartAsyncAsTask.
+
+- Use `StartAsyncAsTask` for background work so Roslyn never blocks the UI thread and cancellations flow through the provided token.
+- Treat `DocumentCache` entries as versioned by `Document.GetTextVersionAsync`; stale text versions must miss the cache and never key validity on `Document.Id` alone.

--- a/.github/instructions/fsharp-test-utilities.instructions.md
+++ b/.github/instructions/fsharp-test-utilities.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: 'tests/FSharp.Test.Utilities/**'
+---
+
+Compiler test infrastructure: the FSharp.Test.Utilities `Compiler` DSL drives compile/run assertions and baseline (.bsl/.err) comparison, refreshed via TEST_UPDATE_BSL.
+
+- Set `TEST_UPDATE_BSL` only when intentionally refreshing baselines, and re-run the same test to rewrite the expected file.
+- Compose `verifyBaselines` from both `verifyBaseline` and `verifyILBaseline`; never verify source baselines without also checking IL when a test expects both.
+- Use `Compiler.checkBaseline` and `Compiler.verifyBaselines` to keep .bsl/.err outputs normalized and comparable.
+- Use the binding-specific reflection entry points (`getMethod`, `getPrivateInstanceMethod`, `getPublicInstanceMethod`) instead of ad hoc lookup so access flags stay explicit.
+- Use `ExecuteAux` `beforeExecute` hook to copy dependencies before launch, especially when `newProcess` is set, or the spawned app may miss local assemblies.
+- Verify IL through `checkIL` and `verifyIL` rather than raw string comparison so normalization and fragment matching stay stable across ILDASM variants.

--- a/.github/instructions/graph-checking.instructions.md
+++ b/.github/instructions/graph-checking.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: 'src/Compiler/Driver/GraphChecking/**'
+---
+
+Parallel project dependency analysis and scheduling: Graph, DependencyResolution, TrieMapping, GraphProcessing.
+
+- `processGraph` and `processGraphAsync` must only queue a node after all `ProcessedDepsCount` dependencies are complete.
+- `mkGraph` must exclude implementation files that have backing signatures from the trie, because `TrieMapping.mkTrie` should only expose signature-backed symbols once.
+- `collectGhostDependencies` should add at most one earlier file for an unused namespace open; keep the ghost edge minimal and before the current file index.
+- Keep `Graph.transitive` and `Graph.reverse` consistent with the original DAG; `processGraph` assumes every node and dependency is present.

--- a/.github/instructions/language-service.instructions.md
+++ b/.github/instructions/language-service.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: 'vsintegration/src/FSharp.Editor/LanguageService/**'
+---
+
+F# VS language service wiring: FSharpWorkspaceServiceFactory, FSharpProjectOptionsManager, FSharpSolutionEvents, and workspace parse/check routing.
+
+- Update `FSharpProjectOptionsManager` cache invalidation on `WorkspaceChanged` and `DocumentClosed` so project and single-file options never drift.
+- Keep workspace-change handling in `FSharpWorkspaceServiceFactory` lightweight and notify checker state changes with `checker.NotifyFileChanged`.
+- Clear FSharpChecker caches and metadata-as-source state in `FSharpSolutionEvents.OnAfterCloseSolution` before releasing workspace state.
+- Route document parse/check requests through `ParseAndCheckDocument` and respect `UseTransparentCompiler` and stale-result settings.

--- a/.github/instructions/legacy-msbuild-resolver.instructions.md
+++ b/.github/instructions/legacy-msbuild-resolver.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: 'src/LegacyMSBuildResolver/**'
+---
+
+Legacy .NET Framework reference-assembly resolver: LegacyMSBuildReferenceResolver locates framework roots, chooses the highest installed target, and decodes MSBuild ResolvedFrom values.
+
+- `GetPathToDotNetFrameworkImplementationAssemblies` is only a last-resort path provider, so it must return at most one framework path per version.
+- `DeriveTargetFrameworkDirectories` must normalize the input to a `v`-prefixed version before calling MSBuild helpers.
+- `SupportedDesktopFrameworkVersions` and `HighestInstalledRefAssembliesOrDotNETFramework` must stay in sync, with the newest framework first.

--- a/.github/instructions/service.instructions.md
+++ b/.github/instructions/service.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: 'src/Compiler/Service/**'
+---
+
+Public FSharpChecker surface and background compilation plumbing: FSharpChecker, BackgroundCompiler, TransparentCompiler.
+
+- Keep `getNavigationFromImplFile` computing ranges with `unionRangesChecked` and `rangeOfDecls`; navigation items must span the whole declaration body, not just the identifier.
+- Honor `HasSignature` when mapping notified slots: implementation-file edits with a signature file must not invalidate the build, only propagate existing status.
+- Gate `FSharpChecker.TransparentCompiler` behind `UsesTransparentCompiler`; callers must not cast `backgroundCompiler` unless transparent mode is enabled.
+- Treat `TypeCheckInfo` as replace-only and key tooltip caching on the current line string, so stale scopes never leak across edits.
+- Make `GetUsesOfSymbol` and `GetUsesOfSymbolInFile` drop `ItemOccurrence.RelatedText` and `distinctBy` occurrence and range, so symbol-use results stay stable and duplicate-free.
+- When `getOrCreateBuilder` sees `IsReferencesInvalidated`, clear every matching `checkFileInProjectCache` entry before recreating the builder, or stale cached file results get reused.
+- In `GetSemanticClassification`, filter `CapturedNameResolutions` to the requested range and dedupe by range before classifying, or overlapping captures emit duplicate spans.
+- Keep `FSharpChecker.Create` enforcing the `keepAssemblyContents` and `enablePartialTypeChecking` exclusion.
+- Preserve directive post-processing in `processDirectiveLine`, `processHashIfLine`, and `processHashEndElse`; VS colorization depends on the split tokens and their exact offsets.
+- Preserve `inferParallelReferenceResolution` environment override behavior when changing `FSharpChecker.Create` options.

--- a/.github/instructions/utilities.instructions.md
+++ b/.github/instructions/utilities.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: 'src/Compiler/Utilities/**'
+---
+
+Low-level shared algorithms and collections used across the compiler: LruCache, EditDistance, DependencyGraph.
+
+- Preserve `LruCache` `requiredToKeep` exemption when demoting strong entries to weak ones.
+- When promoting a weak hit in `TryGet`, reinsert the node at the strong-list head before returning so recency and retention stay consistent.
+- Keep `CalculateEditDistance` using the restricted Damerau-Levenshtein path and the same `JaroWinklerDistance` fallback for suggestions.
+- Keep weak-list trimming ordered from oldest to newest so collected entries are purged before eviction can drop a still-live node.

--- a/.github/skills/codeoracle-kb/SKILL.md
+++ b/.github/skills/codeoracle-kb/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: codeoracle-kb
+description: >-
+  Drill into the CodeOracle knowledge base behind this repo's generated `.instructions.md` rules
+  — grounded findings, evidence, file history and graph neighbors. Use when a rule's rationale or
+  evidence is unclear, when asked "why is this the case / where is this enforced", when you need a
+  file or symbol's history, or when you want related code, concepts or findings for a path.
+---
+
+# codeoracle-kb
+
+The generated `.instructions.md` files carry self-contained rules. This skill is the optional
+drill-down layer: it lets you fetch the findings, evidence, history and related code behind those
+rules from the knowledge graph. The instruction files themselves stay clean — no headings that
+restate `applyTo`, no IDs, no evidence comments, no per-file footer — so all provenance is
+retrieved on demand here.
+
+## Drill-down protocol
+
+Every `.instructions.md` file is a graph node identified by its `applyTo` glob (the value in its
+frontmatter). To see what backs a rule, call `get_instruction_provenance` with
+`instruction:<applyTo>`. Pass the optional 1-based `ordinal` to scope the answer to a single rule
+(the Nth bullet in the file); omit it for the whole file. This mapping is uniform across every
+instruction, which is why the files carry no footer of their own.
+
+## Capabilities
+
+- `get_instruction_provenance` — the findings, evidence and rationale behind a rule (by
+  `instruction:<applyTo>`, optional `ordinal`).
+- `search_knowledge_base` — find grounded findings by keyword.
+- `get_history` — how a file or entity changed over time.
+- `graph_neighbors` — related code, concepts and findings for a ref.
+- `list_concepts` / `get_concept` — browse the concept map.
+
+## Boundaries
+
+- The knowledge base is **read-only**. This skill never writes, mutates or deletes anything.
+- There is **no arbitrary SQL**: only the curated, safe query tools above are available. Raw
+  database access is intentionally not exposed.
+- Every answer is grounded in stored findings and their citations; do not invent evidence.
+
+## Graceful degradation
+
+If the CodeOracle backend is **not connected** or the knowledge base is unavailable, this skill
+should **degrade** gracefully: say so plainly and fall back to the self-contained Tier-0 rules in
+the `.instructions.md` files, which remain valid on their own.


### PR DESCRIPTION
Editing a compiler source file now auto-loads a short set of high-level, grounded rules for that area — architectural invariants, ordering constraints between passes, and identity/cache contracts — through folder-scoped `.github/instructions`. An optional `codeoracle-kb` skill drills into the findings and evidence behind any rule on demand, so the instruction files themselves stay free of inline IDs or provenance comments.

The rules are generated from a knowledge graph over the compiler and deduplicated against the review instructions already on `main`, so each added file scopes a folder the curated set doesn't already own (checking, driver, service, facilities, utilities, abstract IL, graph checking, dependency manager, tests, and the VS editor layer).
