### PR TITLE
Enable ComponentTests to reference the shipped .NETCoreApp FSharp.Core

### DIFF
--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -517,6 +517,7 @@
     <Compile Include="Miscellaneous\TestUtilities.fs" />
     <Compile Include="Miscellaneous\MigratedMisc.fs" />
     <Compile Include="Libraries\NativeInterop.fs" />
+    <Compile Include="Libraries\FSharpCoreShippedNet.fs" />
     <Compile Include="Signatures\TestHelpers.fs" />
     <Compile Include="Signatures\ModuleOrNamespaceTests.fs" />
     <Compile Include="Signatures\RecordTests.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/Libraries/FSharpCoreShippedNet.fs
+++ b/tests/FSharp.Compiler.ComponentTests/Libraries/FSharpCoreShippedNet.fs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Libraries
+
+open Xunit
+open FSharp.Test
+open FSharp.Test.Compiler
+
+module FSharpCoreShippedNet =
+
+    // Dogfood guard: a ComponentTest can compile+run against the shipped .NETCoreApp FSharp.Core
+    // (e.g. net10.0) via withFSharpCoreShippedNet, instead of the default netstandard2.1 reference.
+    let private runsAgainstShippedNetCore expected source =
+        FSharp source
+        |> withFSharpCoreShippedNet
+        |> compileExeAndRun
+        |> shouldSucceed
+        |> withStdOutContains expected
+
+    // The expected framework name tracks FSharpCoreShippedNetTargetFramework in eng/TargetFrameworks.props - bump both together.
+    [<FactForNETCOREAPP>]
+    let ``compiles and runs against the shipped net FSharp.Core`` () =
+        runsAgainstShippedNetCore "FSharpCoreFrameworkName=.NETCoreApp,Version=v10.0" """
+module Test
+
+open System.Runtime.Versioning
+
+[<EntryPoint>]
+let main _ =
+    typeof<int list>.Assembly.GetCustomAttributes(typeof<TargetFrameworkAttribute>, false)
+    |> Array.map (fun a -> (a :?> TargetFrameworkAttribute).FrameworkName)
+    |> Array.tryHead
+    |> Option.defaultValue "<none>"
+    |> printfn "FSharpCoreFrameworkName=%s"
+    0
+"""
+
+    // Sanity: ordinary FSharp.Core code still compiles and runs under the shipped net asset.
+    [<FactForNETCOREAPP>]
+    let ``basic FSharp.Core code runs against the shipped net FSharp.Core`` () =
+        runsAgainstShippedNetCore "sum=385" """
+module Test
+
+[<EntryPoint>]
+let main _ =
+    [ 1..10 ] |> List.sumBy (fun x -> x * x) |> printfn "sum=%d"
+    0
+"""

--- a/tests/FSharp.Test.Utilities/Compiler.fs
+++ b/tests/FSharp.Test.Utilities/Compiler.fs
@@ -772,6 +772,15 @@ $ code --diff {outFile} {expectedFile}
         | CS cs -> CS { cs with TargetFramework = TargetFramework.NetStandard20 }
         | IL _ ->  failwith "References are not supported in IL"
 
+    /// Compile against the current BCL but reference the shipped .NETCoreApp FSharp.Core (e.g. net10.0)
+    /// instead of the netstandard2.1 build, so tests can exercise its .NETCoreApp-only surface.
+    /// Execution runs in a new process (dotnet app.dll) with that FSharp.Core copied beside the app;
+    /// external file references (withReferences) are not copied, so keep such snippets self-contained.
+    let withFSharpCoreShippedNet (cUnit: CompilationUnit) : CompilationUnit =
+        match cUnit with
+        | FS fs -> FS { fs with TargetFramework = TargetFramework.FSharpCoreShippedNet }
+        | CS _ | IL _ -> failwith "withFSharpCoreShippedNet is only supported for F# compilations"
+
     let withPlatform (platform:ExecutionPlatform) (cUnit: CompilationUnit) : CompilationUnit =
         match cUnit with
         | FS _ ->
@@ -1130,10 +1139,18 @@ $ code --diff {outFile} {expectedFile}
                         | SourceCodeFileKind.Fsx _ -> true
                         | _ -> false
                     | _ -> false
-                let output = CompilerAssert.ExecuteAndReturnResult (p, isFsx, s.Dependencies, false)
+                let useShippedNetFSharpCore =
+                    match s.Compilation with
+                    | FS fs -> fs.TargetFramework = TargetFramework.FSharpCoreShippedNet
+                    | _ -> false
+                if useShippedNetFSharpCore then
+                    File.Copy(TargetFrameworkUtil.shippedNetFSharpCorePath.Value, Path.Combine(Path.GetDirectoryName p, "FSharp.Core.dll"), overwrite = true)
+                let output = CompilerAssert.ExecuteAndReturnResult (p, isFsx, s.Dependencies, useShippedNetFSharpCore)
                 let executionResult = { s with Output = Some (ExecutionOutput output) }
                 match output.Outcome with
                 | Failure _ -> CompilationResult.Failure executionResult
+                // Shipped-net runs execute a new process, so surface a non-zero exit code as failure (in-process runs keep prior behaviour).
+                | ExitCode n when n <> 0 && useShippedNetFSharpCore -> CompilationResult.Failure executionResult
                 | _  -> CompilationResult.Success executionResult
 
     let compileAndRun = compile >> run

--- a/tests/FSharp.Test.Utilities/CompilerAssert.fs
+++ b/tests/FSharp.Test.Utilities/CompilerAssert.fs
@@ -631,7 +631,7 @@ module CompilerAssertHelpers =
         let fileName = outputFilePath
         let arguments = ""
 #else
-        let fileName = "dotnet"
+        let fileName = initialConfig.DotNetExe
         let arguments = outputFilePath
 
         // Use the actual runtime version so framework resolution works on preview SDKs

--- a/tests/FSharp.Test.Utilities/TestFramework.fs
+++ b/tests/FSharp.Test.Utilities/TestFramework.fs
@@ -286,13 +286,20 @@ let getMsbuildPropValue (xdoc: XDocument) (propName: string) =
         |> Seq.tryFind (fun el -> el.Name.LocalName = propName)
         |> function
             | Some el -> el.Value
-            | None -> failwithf "Property '%s' not found in Versions.props" propName
+            | None -> failwithf "Property '%s' not found" propName
 
 // Usage example:
 let versionsPropsDoc = loadVersionsProps ()
 let cscVersion = getMsbuildPropValue versionsPropsDoc "MicrosoftNetCompilersVersion"
 let ildasmVersion = getMsbuildPropValue versionsPropsDoc "MicrosoftNETCoreILDAsmVersion"
 let ilasmVersion = getMsbuildPropValue versionsPropsDoc "MicrosoftNETCoreILAsmVersion"
+
+/// The .NETCoreApp TFM shipped in the FSharp.Core NuGet package (deliberately lags the in-dev
+/// product TFM). Single source of truth: eng/TargetFrameworks.props.
+let fsharpCoreShippedNetTfm =
+    let path = repoRoot ++ "eng" ++ "TargetFrameworks.props"
+    if not (File.Exists path) then failwithf "TargetFrameworks.props file not found at %s" path
+    getMsbuildPropValue (XDocument.Load path) "FSharpCoreShippedNetTargetFramework"
 
 let config configurationName envVars =
 

--- a/tests/FSharp.Test.Utilities/Utilities.fs
+++ b/tests/FSharp.Test.Utilities/Utilities.fs
@@ -83,6 +83,7 @@ module Utilities =
     type TargetFramework =
         | NetStandard20
         | Current
+        | FSharpCoreShippedNet
 
     let private getResourceStream name =
         let assembly = typeof<TargetFramework>.GetTypeInfo().Assembly
@@ -262,23 +263,48 @@ An error occurred getting netcoreapp references (compare the output of `dotnet -
                 NetStandard20.References.systemDynamicRuntimeRef.Value,
                 NetStandard20.References.systemCollectionsImmutableRef.Value)
 
+        // The shipped .NETCoreApp FSharp.Core asset (e.g. net10.0) lives beside the netstandard ones in the artifacts tree.
+        let shippedNetFSharpCorePath =
+            lazy (
+                let coreArtifactRoot = Path.GetDirectoryName(Path.GetDirectoryName(config.FSCOREDLLPATH))
+                let path = Path.Combine(coreArtifactRoot, fsharpCoreShippedNetTfm, "FSharp.Core.dll")
+                if not (File.Exists path) then
+                    failwith $"Shipped .NETCoreApp FSharp.Core not found at {path}. Build FSharp.Core for {fsharpCoreShippedNetTfm} first."
+                path)
+
+        let private toPEs files =
+            files
+            |> Seq.map (fun x -> PortableExecutableReference.CreateFromFile(x))
+            |> ImmutableArray.CreateRange
+
         let currentReferences =
             getNetCoreAppReferences
 
         let currentReferencesAsPEs =
-            getNetCoreAppReferences
-            |> Seq.map (fun x -> PortableExecutableReference.CreateFromFile(x))
-            |> ImmutableArray.CreateRange
+            toPEs currentReferences
+
+        // Reuse the Current reference set (identical framework refs) and swap only FSharp.Core - avoids a second dotnet build.
+        let private shippedNetReferences =
+            lazy (
+                let isFSharpCore (r: string) = String.Equals(Path.GetFileName r, "FSharp.Core.dll", StringComparison.OrdinalIgnoreCase)
+                if not (Array.exists isFSharpCore currentReferences) then
+                    failwith "No FSharp.Core.dll found in the Current reference set to swap for the shipped .NETCoreApp asset."
+                currentReferences |> Array.map (fun r -> if isFSharpCore r then shippedNetFSharpCorePath.Value else r))
+
+        let private shippedNetReferencesAsPEs =
+            lazy toPEs shippedNetReferences.Value
 
         let getReferences tf =
             match tf with
                 | TargetFramework.NetStandard20 -> netStandard20References.Value
                 | TargetFramework.Current -> currentReferencesAsPEs
+                | TargetFramework.FSharpCoreShippedNet -> shippedNetReferencesAsPEs.Value
 
         let getFileReferences tf =
             match tf with
                 | TargetFramework.NetStandard20 -> netStandard20Files.Value |> Seq.toArray
                 | TargetFramework.Current -> currentReferences
+                | TargetFramework.FSharpCoreShippedNet -> shippedNetReferences.Value
 
 
 module internal FSharpProjectSnapshotSerialization =


### PR DESCRIPTION
ComponentTests reference the `netstandard2.1` FSharp.Core, so they can't reach the `.NETCoreApp`-only surface (e.g. `net10.0`) that ships in the FSharp.Core NuGet package. `withFSharpCoreShippedNet` opts a test into that shipped net asset: the FSharp.Core reference is swapped for the shipped build (no second build, the rest of the reference set is identical) and the compiled app runs in a new process with that FSharp.Core copied beside it. This lets `.NETCoreApp`-only additions be covered by ComponentTests instead of only by AOT dogfooding.

`Libraries/FSharpCoreShippedNet.fs` proves it end to end: the running FSharp.Core reports `.NETCoreApp,Version=v10.0`, and ordinary FSharp.Core code still works under that asset. Removing the opt-in flips the first test red, so it is non-vacuous.
