### PR TITLE
Name resolution: group C#-style extension members per 'open' and extended type

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -166,8 +166,7 @@
 * Support for the `<include>` XML documentation tag: at compile time, documentation is copied from an external XML file selected by an XPath query and emitted into the generated documentation file. `<inheritdoc>` remains unsupported. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19186](https://github.com/dotnet/fsharp/pull/19186))
 * Expand `<inheritdoc/>` at tooling time. In IDE tooltips, completion, and signature help, documentation is inherited from base classes, interfaces, overridden members, and constructors (matched by parameter signature). The FCS Symbols API (`FSharpSymbol.XmlDoc`) additionally resolves explicit `cref` targets, but does not expand constructor inheritance. The compiler emits the tag verbatim into generated XML documentation files, matching C#; `<include>` is not implemented. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19188](https://github.com/dotnet/fsharp/pull/19188))
 * Add symbol and type highlighting to F# diagnostics ([PR #20097](https://github.com/dotnet/fsharp/pull/20097))
-* IL: add `ILPreNamespace`, make `ILPreTypeDef` creation lazy ([PR #20092](https://github.com/dotnet/fsharp/pull/20092))
-* Name resolution: group C#-style extension members per `open` and extended type
+* Name resolution: group C#-style extension members per `open` and extended type ([PR #20298](https://github.com/dotnet/fsharp/pull/20298))
 
 ### Improved
 

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -166,6 +166,8 @@
 * Support for the `<include>` XML documentation tag: at compile time, documentation is copied from an external XML file selected by an XPath query and emitted into the generated documentation file. `<inheritdoc>` remains unsupported. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19186](https://github.com/dotnet/fsharp/pull/19186))
 * Expand `<inheritdoc/>` at tooling time. In IDE tooltips, completion, and signature help, documentation is inherited from base classes, interfaces, overridden members, and constructors (matched by parameter signature). The FCS Symbols API (`FSharpSymbol.XmlDoc`) additionally resolves explicit `cref` targets, but does not expand constructor inheritance. The compiler emits the tag verbatim into generated XML documentation files, matching C#; `<include>` is not implemented. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19188](https://github.com/dotnet/fsharp/pull/19188))
 * Add symbol and type highlighting to F# diagnostics ([PR #20097](https://github.com/dotnet/fsharp/pull/20097))
+* IL: add `ILPreNamespace`, make `ILPreTypeDef` creation lazy ([PR #20092](https://github.com/dotnet/fsharp/pull/20092))
+* Name resolution: group C#-style extension members per `open` and extended type
 
 ### Improved
 

--- a/src/Compiler/Checking/NameResolution.fs
+++ b/src/Compiler/Checking/NameResolution.fs
@@ -351,24 +351,31 @@ type ExtensionMember =
 
    /// ILExtMem(declaringTyconRef, ilMetadata, pri)
    ///
-   /// IL-style extension member, backed by some kind of method with an [<Extension>] attribute
-   | ILExtMem of TyconRef * MethInfo * ExtensionMethodPriority
+   /// IL-style extension members, backed by methods with an [<Extension>] attribute. Methods extending
+   /// the same type via one 'open' are grouped: an 'open' of a class like Enumerable adds dozens of them.
+   | ILExtMem of TyconRef * MethInfo list * ExtensionMethodPriority
+
+   static member MethInfoHash(m: MethInfo) =
+       match m with
+       | ILMeth(_, ilmeth, _) -> LanguagePrimitives.PhysicalHash ilmeth.RawMetadata
+       | FSMeth(_, _, vref, _) -> valRefHash vref
+       | _ -> 0
+
+   /// Groups compare by identity, so members duplicated by several 'open's are de-duplicated per method.
+   static member MethInfoComparer =
+       HashIdentity.FromFunctions ExtensionMember.MethInfoHash MethInfo.MethInfosUseIdenticalDefinitions
 
    /// Check if two extension members refer to the same definition
    static member Equality g e1 e2 =
        match e1, e2 with
        | FSExtMem (vref1, _), FSExtMem (vref2, _) -> valRefEq g vref1 vref2
-       | ILExtMem (_, md1, _), ILExtMem (_, md2, _) -> MethInfo.MethInfosUseIdenticalDefinitions md1 md2
+       | ILExtMem (_, ms1, _), ILExtMem (_, ms2, _) -> LanguagePrimitives.PhysicalEquality ms1 ms2
        | _ -> false
 
    static member Hash e1 =
        match e1 with
        | FSExtMem(vref, _) -> valRefHash vref
-       | ILExtMem(_, m, _) ->
-           match m with
-           | ILMeth(_, ilmeth, _) -> LanguagePrimitives.PhysicalHash ilmeth.RawMetadata
-           | FSMeth(_, _, vref, _) -> valRefHash vref
-           | _ -> 0
+       | ILExtMem(_, ms, _) -> LanguagePrimitives.PhysicalHash ms
 
    static member Comparer g = HashIdentity.FromFunctions ExtensionMember.Hash (ExtensionMember.Equality g)
 
@@ -611,6 +618,38 @@ let private ComputeCSharpStyleExtensionMembers (amap: Import.ImportMap) m  (tcre
             | None -> importFailed.Value <- true
             | Some thisTyconRefOpt -> yield (thisTyconRefOpt, minfo) ]
 
+/// The grouped form is cached per static class, so every 'open' of it shares the method lists.
+let private GroupCSharpStyleExtensionMembers (members: (TyconRef option * MethInfo) list) =
+    let indexed = Dictionary<Stamp, TyconRef * ResizeArray<MethInfo>>()
+    let order = ResizeArray<Stamp>()
+    let unindexed = ResizeArray<MethInfo>()
+
+    for thisTyconRefOpt, minfo in members do
+        match thisTyconRefOpt with
+        | Some tcref ->
+            match indexed.TryGetValue tcref.Stamp with
+            | true, (_, acc) -> acc.Add minfo
+            | _ ->
+                let acc = ResizeArray()
+                acc.Add minfo
+                indexed[tcref.Stamp] <- (tcref, acc)
+                order.Add tcref.Stamp
+        | None -> unindexed.Add minfo
+
+    // The caller prepends when folding this shape, so the ungrouped code left one 'open's members in
+    // reverse read order; preserve it to keep the candidate order overload resolution sees.
+    let inline reversed (acc: ResizeArray<MethInfo>) =
+        acc |> Seq.fold (fun l minfo -> minfo :: l) []
+
+    [
+        for stamp in order do
+            let tcref, acc = indexed[stamp]
+            yield Some tcref, reversed acc
+
+        if unindexed.Count > 0 then
+            yield None, reversed unindexed
+    ]
+
 let private GetCSharpStyleIndexedExtensionMembersForTyconRef (amap: Import.ImportMap) m (tcrefOfStaticClass: TyconRef) =
     let g = amap.g
 
@@ -628,14 +667,16 @@ let private GetCSharpStyleIndexedExtensionMembersForTyconRef (amap: Import.Impor
         // A local class is still gaining members while its own file is checked; only an imported one is
         // immutable enough to share. The cache lives on the CCU, so it goes when the project does.
         if tcrefOfStaticClass.IsLocalRef then
-            ComputeCSharpStyleExtensionMembers amap m tcrefOfStaticClass (ref false)
+            GroupCSharpStyleExtensionMembers(ComputeCSharpStyleExtensionMembers amap m tcrefOfStaticClass (ref false))
         else
             let cache = tcrefOfStaticClass.nlr.Ccu.Deref.CSharpStyleExtensionMembersCache
             match cache.TryGetValue tcrefOfStaticClass.Stamp with
-            | true, shape -> shape :?> (TyconRef option * MethInfo) list
+            | true, shape -> shape :?> (TyconRef option * MethInfo list) list
             | _ ->
                 let importFailed = ref false
-                let shape = ComputeCSharpStyleExtensionMembers amap m tcrefOfStaticClass importFailed
+
+                let shape =
+                    GroupCSharpStyleExtensionMembers(ComputeCSharpStyleExtensionMembers amap m tcrefOfStaticClass importFailed)
 
                 if not importFailed.Value then
                     cache.TryAdd(tcrefOfStaticClass.Stamp, (shape :> obj)) |> ignore
@@ -646,8 +687,8 @@ let private GetCSharpStyleIndexedExtensionMembersForTyconRef (amap: Import.Impor
 
     let pri = NextExtensionMethodPriority()
 
-    [ for thisTyconRefOpt, minfo in shape do
-        let ilExtMem = ILExtMem (tcrefOfStaticClass, minfo, pri)
+    [ for thisTyconRefOpt, minfos in shape do
+        let ilExtMem = ILExtMem (tcrefOfStaticClass, minfos, pri)
         match thisTyconRefOpt with
         | Some tcref -> yield Choice1Of2(tcref, ilExtMem)
         | None -> yield Choice2Of2 ilExtMem ]
@@ -740,25 +781,31 @@ let rec TrySelectExtensionMethInfoOfILExtMem m amap apparentTy (actualParent, mi
 /// Select from a list of extension methods
 let SelectMethInfosFromExtMembers (infoReader: InfoReader) optFilter apparentTy m extMemInfos =
     let g = infoReader.g
-    // NOTE: multiple "open"'s push multiple duplicate values into eIndexedExtensionMembers
+    // NOTE: multiple "open"'s push multiple duplicate values into eIndexedExtensionMembers.
+    // Duplicate IL-backed methods arrive in distinct groups, so they are de-duplicated per method.
     let seen = HashSet(ExtensionMember.Comparer g)
+    let seenMeths = HashSet(ExtensionMember.MethInfoComparer)
     [
         for emem in extMemInfos do
-            if seen.Add emem then
-                match emem with
-                | FSExtMem (vref, pri) ->
+            match emem with
+            | FSExtMem (vref, pri) ->
+                if seen.Add emem then
                     match vref.MemberInfo with
                     | None -> ()
                     | Some membInfo ->
                         match TrySelectMemberVal g optFilter apparentTy (Some pri) membInfo vref with
                         | Some m -> yield m
                         | _ -> ()
-                | ILExtMem (actualParent, minfo, pri) when (match optFilter with None -> true | Some nm -> nm = minfo.LogicalName) ->
-                    // Make a reference to the type containing the extension members
-                    match TrySelectExtensionMethInfoOfILExtMem m infoReader.amap apparentTy (actualParent, minfo, pri) with 
-                    | Some minfo -> yield minfo
-                    | None -> ()
-                | _ -> ()
+            | ILExtMem (actualParent, minfos, pri) ->
+                for minfo in minfos do
+                    if (match optFilter with
+                        | None -> true
+                        | Some nm -> nm = minfo.LogicalName)
+                       && seenMeths.Add minfo then
+                        // Make a reference to the type containing the extension members
+                        match TrySelectExtensionMethInfoOfILExtMem m infoReader.amap apparentTy (actualParent, minfo, pri) with
+                        | Some minfo -> yield minfo
+                        | None -> ()
     ]
 
 let IsExtensionMethCompatibleWithTy (infoReader: InfoReader) m (ty: TType) (minfo: MethInfo) =

--- a/src/Compiler/Checking/NameResolution.fsi
+++ b/src/Compiler/Checking/NameResolution.fsi
@@ -174,8 +174,9 @@ type ExtensionMember =
 
     /// ILExtMem(declaringTyconRef, ilMetadata, pri)
     ///
-    /// IL-style extension member, backed by some kind of method with an [<Extension>] attribute
-    | ILExtMem of TyconRef * MethInfo * ExtensionMethodPriority
+    /// IL-style extension members, backed by methods with an [<Extension>] attribute. Methods extending
+    /// the same type via one 'open' are grouped: an 'open' of a class like Enumerable adds dozens of them.
+    | ILExtMem of TyconRef * MethInfo list * ExtensionMethodPriority
 
     /// Describes the sequence order of the introduction of an extension method. Extension methods that are introduced
     /// later through 'open' get priority in overload resolution.


### PR DESCRIPTION
`ILExtMem` held one entry per (`open`, extension method). One `open` of a class like `Enumerable` therefore
added dozens of entries to the index for the same extended type, each costing an `ILExtMem` object and a
list cell, and every further `open` of that class repeated the lot with a new priority. On a
489-reference project that came to 95,408 `ILExtMem` wrapping only 9,741 distinct `MethInfo`s — 9.8
copies each — plus 96,094 list cells, 6.57 MB in total.

`ILExtMem` now carries a `MethInfo list`: all the methods from one static class, introduced by one
`open`, extending the same apparent type, sharing one priority. The grouped form is what the per-CCU
shape cache stores, so every `open` of an imported class shares the same method lists and only the group
object and one list cell are allocated per (`open`, extended type). Measured grouping ratio is 6.12
methods per group.

Candidate order is unchanged. `TyconRefMultiMap.Add` and the unindexed list both prepend while the caller
folds the shape left to right, so one `open`'s members were left in reverse read order; each group is
built by prepending for the same reason, reproducing that order exactly. De-duplication of IL-backed
members moves from whole entries to individual methods, because two `open`s now contribute equal methods
inside different groups — the existing comparer was already per-method for this case, ignoring both the
declaring class and the priority.

| Project | Before | After | Retained |
|---|--:|--:|--:|
| consoleapp | 31.06 MB | 30.97 MB | **-0.09 MB (-0.29%)** |
| Oxpecker | 65.43 MB | 64.90 MB | **-0.53 MB (-0.81%)** |
| IcedTasks | 44.84 MB | 44.51 MB | **-0.33 MB (-0.74%)** |
| FsToolkit | 67.72 MB | 67.22 MB | **-0.50 MB (-0.74%)** |
| Fantomas.Benchmarks | 61.24 MB | 61.18 MB | **-0.06 MB (-0.10%)** |
| Prime | 99.34 MB | 98.64 MB | **-0.70 MB (-0.70%)** |
| Fantomas.Core | 105.97 MB | 105.98 MB | +0.01 MB — below this subject's spread |
| Fantomas.Core.Tests | 137.45 MB | 137.28 MB | **-0.17 MB (-0.12%)** |
| FSharp.Common | 250.39 MB | 244.75 MB | **-5.64 MB (-2.25%)** |
| fcs | 1224.46 MB | 1221.09 MB | **-3.37 MB (-0.28%)** |

Retained memory after `ParseAndCheckProject`, mean of 3 runs in fresh processes per project. The saving
scales with `open` density times extension methods per extended type, so a project with many references
and many `open`s gains most. Analysis time is unchanged within measurement noise.