### PR TITLE
IL: share the pickled references

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -167,6 +167,7 @@
 ### Improved
 
 * Nullness warning FS3261 on dotted method or property access (e.g. `x.Member`) now underlines the receiver expression and includes the member name and (when known) the binding name in the message. ([Issue #19658](https://github.com/dotnet/fsharp/issues/19658), [PR #19814](https://github.com/dotnet/fsharp/pull/19814))
+* IL: share the pickled references ([PR #20301](https://github.com/dotnet/fsharp/pull/20301))
 * Direct delegate construction ([PR ##19993](https://github.com/dotnet/fsharp/pull/19993))
 
 ### Changed

--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -205,7 +205,21 @@ type ReaderState =
         isimpletys: InputTable<TType>
         ifile: string
         iILModule: ILModuleDef option // the Abstract IL metadata for the DLL being read
+
+        // The pickled format has no table for these, so each is written out at every mention while a
+        // blob names very few distinct ones.
+        iilscopes: Dictionary<ILScopeRef, ILScopeRef>
+        iiltyperefs: Dictionary<ILTypeRef, ILTypeRef>
+        iilmethodrefs: Dictionary<ILMethodRef, ILMethodRef>
     }
+
+// A `HashSet` would fit better, but the member returning the instance it holds is netstandard2.1.
+let shareIL (table: Dictionary<'T, 'T>) (v: 'T) : 'T =
+    match table.TryGetValue v with
+    | true, existing -> existing
+    | _ ->
+        table[v] <- v
+        v
 
 let ufailwith st str = ffailwith st.ifile str
 
@@ -1066,6 +1080,9 @@ let unpickleObjWithDanglingCcus
             isimpletys = new_itbl "isimpletys (fake)" [||]
             ifile = file
             iILModule = ilModule
+            iilscopes = Dictionary<_, _>()
+            iiltyperefs = Dictionary<_, _>()
+            iilmethodrefs = Dictionary<_, _>()
         }
 
     let ccuNameTab = u_array u_encoded_ccuref st2
@@ -1126,6 +1143,9 @@ let unpickleObjWithDanglingCcus
                 isimpletys = simpletypTab
                 ifile = file
                 iILModule = ilModule
+                iilscopes = Dictionary<_, _>()
+                iiltyperefs = Dictionary<_, _>()
+                iilmethodrefs = Dictionary<_, _>()
             }
 
         let res = u st1
@@ -1231,7 +1251,7 @@ let u_ILScopeRef st =
         | _ -> ufailwith st "u_ILScopeRef"
 
     let res = rescopeILScopeRef st.iilscope res
-    res
+    shareIL st.iilscopes res
 
 let p_ILHasThis x st =
     p_byte
@@ -1320,7 +1340,8 @@ let u_ILCallConv st =
 
 let u_ILTypeRef st =
     let a, b, c = u_tup3 u_ILScopeRef u_strings u_string st
-    ILTypeRef.Create(a, b, c)
+    let res = ILTypeRef.Create(a, b, c)
+    shareIL st.iiltyperefs res
 
 let u_ILArrayShape =
     u_wrap ILArrayShape (u_list (u_tup2 (u_option u_int32) (u_option u_int32)))
@@ -1413,7 +1434,8 @@ let u_ILMethodRef st =
     let x1, x2, x3, x4, x5, x6 =
         u_tup6 u_ILTypeRef u_ILCallConv u_int u_string u_ILTypes u_ILType st
 
-    ILMethodRef.Create(x1, x2, x4, x3, x5, x6)
+    let res = ILMethodRef.Create(x1, x2, x4, x3, x5, x6)
+    shareIL st.iilmethodrefs res
 
 let u_ILFieldRef st =
     let x1, x2, x3 = u_tup3 u_ILTypeRef u_string u_ILType st


### PR DESCRIPTION
The pickled form of a signature tables the things that repeat — strings, nonlocal entity references,
public paths, simple types — but not IL scope, type and method references, which are written out in full
at every mention. A blob names very few distinct ones, so unpickling built the same object graph over
and over:

| blob | `ILScopeRef` | `ILTypeRef` | `ILMethodRef` |
|---|---|---|---|
| FSharp.Compiler.Service.dll | 55721 → **2** | 17549 → **31** | 17424 → **25** |
| FSharp.Core.dll | 1399 → 2 | 391 → 28 | 305 → 23 |
| FSharp.Compiler.Interactive.Settings.dll | 66 → 2 | 31 → 14 | 15 → 12 |
| FSharp.DependencyManager.Nuget.dll | 145 → 2 | 23 → 13 | 11 → 11 |

Calls against structurally distinct results, reading the four references of a ReSharper F# plugin project
that carry pickled metadata. The distinct method references are the attribute constructors a public
signature is full of — `CompilationMapping`, `CompiledName`, `Obsolete` — and each occurrence rebuilt the
chain behind one: argument types, type reference, scope reference, assembly reference, public key.

`u_ILScopeRef`, `u_ILTypeRef` and `u_ILMethodRef` now return the instance this blob already read for an
equal value, from three dictionaries on `ReaderState`. The pickled format is unchanged.

- The tables live and die with the unpickling that fills them, so nothing outlives what it did before.
- `Dictionary<'T, 'T>` rather than `HashSet<'T>`: `HashSet.TryGetValue`, the only member that hands back
  the instance already held, is netstandard2.1 and this project targets netstandard2.0.
- Sharing an `ILTypeRef` shares its `asBoxedType` cache, which is sound: it only holds `ILType.Boxed` of
  the non-generic type spec, one value per type reference.

## Retained memory, one project checked and held

| project | base | change | delta |
|---|--:|--:|--:|
| Fantomas.Benchmarks | 60.8 | 56.6 | -4.2 (-6.9%) |
| Fantomas.Core | 104.7 | 100.9 | -3.8 (-3.6%) |
| Fantomas.Core.Tests | 135.8 | 131.6 | -4.3 (-3.1%) |
| FSharp.Common | 242.1 | 236.1 | -6.0 (-2.5%) |
| IcedTasks | 44.1 | 43.9 | -0.2 (-0.5%) |
| consoleapp | 30.6 | 30.5 | -0.2 (-0.5%) |
| Oxpecker | 64.4 | 64.2 | -0.2 (-0.3%) |
| FsToolkit.ErrorHandling | 66.0 | 65.9 | -0.1 (-0.2%) |
| Prime | 96.9 | 96.7 | -0.2 (-0.2%) |
| FSharp.Compiler.Service | 1205.0 | 1204.9 | -0.0 (-0.0%) |

## Retained memory, a whole solution checked and held

| solution | base | change | delta |
|---|--:|--:|--:|
| ReSharper.FSharp | 1544.5 | 1480.6 | -63.9 (-4.1%) |
| Fantomas | 664.8 | 643.7 | -21.0 (-3.2%) |
| FSharp.Compiler.Service | 2439.9 | 2423.5 | -16.4 (-0.7%) |
| consoleapp | 30.6 | 30.5 | -0.1 (-0.5%) |
| Prime | 215.0 | 214.0 | -0.9 (-0.4%) |
| Oxpecker | 226.7 | 225.8 | -1.0 (-0.4%) |
| IcedTasks | 194.3 | 193.6 | -0.8 (-0.4%) |
| FsToolkit.ErrorHandling | 218.3 | 218.1 | -0.2 (-0.1%) |