### PR TITLE
chore(Test): Revert #20308 precautionary serial testing

### DIFF
--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModuleFunctions.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncModuleFunctions.fs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
 // Tests for camelCase functions in module Async
-
-// Intentionally in same collection to help rule out potential flakiness due to concurrency re #20306
-[<Xunit.Collection(nameof FSharp.Test.NotThreadSafeResourceCollection)>]
 module FSharp.Core.UnitTests.Control.AsyncModuleFunctionsTests
 
 open System

--- a/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
+++ b/tests/FSharp.Core.UnitTests/FSharp.Core/Microsoft.FSharp.Control/AsyncType.fs
@@ -800,9 +800,7 @@ type AsyncType() =
         Assert.True(asyncWaitImm a)
 #endif
 
-// Intentionally in same collection to help rule out potential flakiness due to concurrency re #20306
-[<Collection(nameof FSharp.Test.NotThreadSafeResourceCollection)>]
-module AsyncTaskLikeAwaitTests =
+module AsyncAwaitTaskLikeTests =
 
     // Minimal custom task-like type wrapping Task<'T>
     type MyTask<'T>(inner: Task<'T>) =
@@ -904,8 +902,6 @@ module AsyncTaskLikeAwaitTests =
             |> asyncWaitImm
         Assert.Equal(42, result)
 
-// Intentionally in same collection to help rule out potential flakiness due to concurrency re #20306
-[<Collection(nameof FSharp.Test.NotThreadSafeResourceCollection)>]
 module AsyncStartTaskImmediateTaskLikeTests =
 
     [<Fact>]
@@ -946,8 +942,6 @@ module AsyncStartTaskImmediateTaskLikeTests =
 
         Assert.Equal(cts.Token, capturedCt)
 
-// Intentionally in same collection to help rule out potential flakiness due to concurrency re #20306
-[<Collection(nameof FSharp.Test.NotThreadSafeResourceCollection)>]
 module AsyncAwaitStackTraceTests =
 
     open System.Runtime.CompilerServices


### PR DESCRIPTION
Right now, `main` has precautionary serial running of some Async tests applied in #20308 in response to #20306

The original increase of parallelization that was suspected of causing the instability arose in #19785 and #20258

My contention is that:
- the key instability that was present was that a failsafe timeout on a wait in a new test was 5s, as opposed to the 30s as we learned makes sense for heavily loaded CI boxes running parallelized tests
- whether or not those Async/Task suites are run concurrently or not is not a factor (xunit conservative mode doesn't have `SynchronizationContext`-sensitive behavior, and we there's no reason to think we'd reintroduce that mode at a future point; [we're more likely to move to `ParallelizationMode.All`](https://github.com/dotnet/fsharp/issues/20306#issuecomment-5373535315))

resolves #20306