### PR TITLE
[release/dev18.10] Change VS insertion target branch to 'rel/stable'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ variables:
   # VS Insertion branch name (NOT the same as F# branch)
   # ( for main we insert into VS main and for all *previous* releases we insert into corresponding VS release),
   - name: VSInsertionTargetBranchName
-    value: rel/insiders
+    value: rel/stable
   - name: _TeamName
     value: FSharp
   - name: TeamName


### PR DESCRIPTION
After the snap, this branch should flow into rel/stable and not rel/insiders