### PR TITLE
Unpickling: share one EntityRef per non-local reference row

### DIFF
--- a/src/Compiler/TypedTree/TypedTreePickle.fs
+++ b/src/Compiler/TypedTree/TypedTreePickle.fs
@@ -202,6 +202,7 @@ type ReaderState =
         istrings: InputTable<string>
         ipubpaths: InputTable<string[]>
         inlerefs: InputTable<NonLocalEntityRef>
+        itcrefs: EntityRef array
         isimpletys: InputTable<TType>
         ifile: string
         iILModule: ILModuleDef option // the Abstract IL metadata for the DLL being read
@@ -889,7 +890,6 @@ let decode_nleref st ccuTab stringTab (a, b) =
 
 let lookup_nleref st nlerefTab x = lookup_uniq st nlerefTab x
 let u_encoded_nleref = u_tup2 u_int (u_array u_int)
-let u_nleref st = lookup_uniq st st.inlerefs (u_int st)
 
 let encode_nleref ccuTab stringTab nlerefTab thisCcu (nleref: NonLocalEntityRef) =
 #if !NO_TYPEPROVIDERS
@@ -1076,6 +1076,7 @@ let unpickleObjWithDanglingCcus
                     .Create(AnonRecdTypeInfo.NewUnlinked, (fun osgn tg -> osgn.Link tg), (fun osgn -> osgn.IsLinked), "ianoninfos", 0)
             istrings = new_itbl "istrings (fake)" [||]
             inlerefs = new_itbl "inlerefs (fake)" [||]
+            itcrefs = [||]
             ipubpaths = new_itbl "ipubpaths (fake)" [||]
             isimpletys = new_itbl "isimpletys (fake)" [||]
             ifile = file
@@ -1140,6 +1141,7 @@ let unpickleObjWithDanglingCcus
                 istrings = stringTab
                 ipubpaths = pubpathTab
                 inlerefs = nlerefTab
+                itcrefs = Array.zeroCreate nlerefTab.itbl_rows.Length
                 isimpletys = simpletypTab
                 ifile = file
                 iILModule = ilModule
@@ -1966,7 +1968,17 @@ let u_tcref st =
 
     match tag with
     | 0 -> u_local_item_ref st.ientities st |> ERefLocal
-    | 1 -> u_nleref st |> ERefNonLocal
+    | 1 ->
+        let idx = u_int st
+        let nleref = lookup_uniq st st.inlerefs idx
+        let cached = st.itcrefs[idx]
+
+        if obj.ReferenceEquals(cached, null) then
+            let tcref = ERefNonLocal nleref
+            st.itcrefs[idx] <- tcref
+            tcref
+        else
+            cached
     | _ -> ufailwith st "u_tcref"
 
 let u_ucref st =


### PR DESCRIPTION
`u_tcref` wrapped a fresh `EntityRef` around the shared `NonLocalEntityRef` on every mention. Reading a
489-reference project that is **88642 wrappers around 1919 rows — 46 per row**.

They are all equal. An `EntityRef` is the row plus a `binding` field that caches the resolution, and the
resolution is a function of the row, so sharing one wrapper per row also resolves once instead of once per
mention. The cache is an array beside the `inlerefs` table, keyed by the row index that is already being
read, so there is no lookup and no hashing.

| project | base | change | delta |
|---|--:|--:|--:|
| FSharp.Common | 141.2 | 138.5 | −2.68 (−1.9%) |
| Fantomas.Core.Tests | 75.7 | 73.9 | −1.77 (−2.3%) |
| Fantomas.Benchmarks | 52.4 | 50.7 | −1.73 (−3.3%) |
| Fantomas.Core | 57.1 | 55.7 | −1.37 (−2.4%) |
| FSharp.Compiler.Service | 359.4 | 358.4 | −1.03 (−0.3%) |
| Oxpecker | 50.4 | 49.9 | −0.54 (−1.1%) |
| consoleapp | 28.3 | 27.9 | −0.42 (−1.5%) |
| IcedTasks | 26.3 | 25.9 | −0.38 (−1.4%) |
| FsToolkit.ErrorHandling | 31.6 | 31.2 | −0.38 (−1.2%) |
| Prime | 39.9 | 39.6 | −0.31 (−0.8%) |

| solution | base | change | delta |
|---|--:|--:|--:|
| FSharp.Compiler.Service repo | 731.7 | 724.8 | −6.86 (−0.9%) |
| Fantomas | 291.3 | 287.2 | −4.10 (−1.4%) |
| ReSharper.FSharp | 293.0 | 290.4 | −2.59 (−0.9%) |
| IcedTasks | 90.1 | 88.3 | −1.83 (−2.0%) |
| Prime | 99.2 | 98.0 | −1.23 (−1.2%) |
| Oxpecker | 110.0 | 109.1 | −0.95 (−0.9%) |
| FsToolkit.ErrorHandling | 66.8 | 66.1 | −0.66 (−1.0%) |
| consoleapp | 28.3 | 28.0 | −0.33 (−1.2%) |

## Correctness

- Diagnostic counts identical in every cell of both sweeps (ReSharper.FSharp 1, this repo 413, Fantomas 20,
  the rest 0).
- Sharing the wrapper shares the `binding` cache. That is sound because the binding is derived from the
  row and nothing else: two mentions of the same row must resolve to the same entity or the existing
  per-mention resolution would already be inconsistent.
- The cache is per `ReaderState`, so it never spans two pickled blobs.
- Time: neutral. Measured 2026-08-23 as one rung of a 4-rung cumulative ladder, 5 rounds, 30 samples per
  cell: +0.2% on ReSharper.FSharp and +0.4% on Oxpecker against a +0.6% A/A control.
- Not run: the test suite.
