### PR TITLE
[MicroPerf] Eliminate closure allocations in List.mapq and List.lengthsEqAndForall2

### DIFF
--- a/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
@@ -2589,7 +2589,8 @@ module internal ExprAnalysis =
     and remarkInterfaceImpl m (ty, overrides) =
         (ty, List.map (remarkObjExprMethod m) overrides)
 
-    and remarkExprs m es = es |> List.map (remarkExpr m)
+    and remarkExprs m es =
+        es |> ListInline.map (fun e -> remarkExpr m e)
 
     and remarkDecisionTree m x =
         match x with

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -500,12 +500,9 @@ module List =
         loop 0 xs
 
     let inline lengthsEqAndForall2 ([<InlineIfLambda>] p) l1 l2 =
-        // Single pass that applies `p` directly (rather than forwarding it to the non-inline
-        // `List.forall2`), so that under [<InlineIfLambda>] no closure is allocated for `p`.
-        // Returns true iff the lists have equal length and every pair satisfies `p`.
+        // Apply `p` directly (not via the non-inline `List.forall2`) so [<InlineIfLambda>] allocates no closure for `p`.
         let mutable r1 = l1
         let mutable r2 = l2
-        let mutable ok = true
         let mutable go = true
 
         while go do
@@ -517,19 +514,11 @@ module List =
                         r1 <- t1
                         r2 <- t2
                     else
-                        ok <- false
                         go <- false
-                | [] ->
-                    ok <- false
-                    go <- false
-            | [] ->
-                match r2 with
                 | [] -> go <- false
-                | _ ->
-                    ok <- false
-                    go <- false
+            | [] -> go <- false
 
-        ok
+        List.isEmpty r1 && List.isEmpty r2
 
     let rec findi n f l =
         match l with
@@ -546,11 +535,6 @@ module List =
                 | Choice2Of2 sx -> ch acc1 (sx :: acc2) xs
 
         ch [] [] l
-
-    let rec checkq l1 l2 =
-        match l1, l2 with
-        | h1 :: t1, h2 :: t2 -> h1 === h2 && checkq t1 t2
-        | _ -> true
 
     let inline mapq ([<InlineIfLambda>] f: 'T -> 'T) inp =
         assert not typeof<'T>.IsValueType
@@ -575,9 +559,8 @@ module List =
             else
                 [ h2a; h2b; h2c ]
         | _ ->
-            // Apply `f` directly (rather than forwarding it to the non-inline `List.map`), so
-            // that under [<InlineIfLambda>] no closure is allocated for `f`. Identity preserving:
-            // the original `inp` instance is returned when every element is physically unchanged.
+            // Apply `f` directly (not via the non-inline `List.map`) so [<InlineIfLambda>] allocates no closure for `f`.
+            // Identity-preserving: returns the original `inp` when every element is physically unchanged.
             let mutable changed = false
             let mutable acc = []
             let mutable rest = inp

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -499,8 +499,37 @@ module List =
 
         loop 0 xs
 
-    let lengthsEqAndForall2 p l1 l2 =
-        List.length l1 = List.length l2 && List.forall2 p l1 l2
+    let inline lengthsEqAndForall2 ([<InlineIfLambda>] p) l1 l2 =
+        // Single pass that applies `p` directly (rather than forwarding it to the non-inline
+        // `List.forall2`), so that under [<InlineIfLambda>] no closure is allocated for `p`.
+        // Returns true iff the lists have equal length and every pair satisfies `p`.
+        let mutable r1 = l1
+        let mutable r2 = l2
+        let mutable ok = true
+        let mutable go = true
+
+        while go do
+            match r1 with
+            | h1 :: t1 ->
+                match r2 with
+                | h2 :: t2 ->
+                    if p h1 h2 then
+                        r1 <- t1
+                        r2 <- t2
+                    else
+                        ok <- false
+                        go <- false
+                | [] ->
+                    ok <- false
+                    go <- false
+            | [] ->
+                match r2 with
+                | [] -> go <- false
+                | _ ->
+                    ok <- false
+                    go <- false
+
+        ok
 
     let rec findi n f l =
         match l with
@@ -523,7 +552,7 @@ module List =
         | h1 :: t1, h2 :: t2 -> h1 === h2 && checkq t1 t2
         | _ -> true
 
-    let mapq (f: 'T -> 'T) inp =
+    let inline mapq ([<InlineIfLambda>] f: 'T -> 'T) inp =
         assert not typeof<'T>.IsValueType
 
         match inp with
@@ -546,8 +575,27 @@ module List =
             else
                 [ h2a; h2b; h2c ]
         | _ ->
-            let res = List.map f inp
-            if checkq inp res then inp else res
+            // Apply `f` directly (rather than forwarding it to the non-inline `List.map`), so
+            // that under [<InlineIfLambda>] no closure is allocated for `f`. Identity preserving:
+            // the original `inp` instance is returned when every element is physically unchanged.
+            let mutable changed = false
+            let mutable acc = []
+            let mutable rest = inp
+            let mutable go = true
+
+            while go do
+                match rest with
+                | h :: t ->
+                    let h2 = f h
+
+                    if not (h === h2) then
+                        changed <- true
+
+                    acc <- h2 :: acc
+                    rest <- t
+                | [] -> go <- false
+
+            if changed then List.rev acc else inp
 
     let frontAndBack l =
         let rec loop acc l =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -504,14 +504,14 @@ module ListInline =
         while go do
             // A struct tuple keeps the match flat without the per-iteration heap allocation a reference tuple would add.
             match struct (r1, r2) with
-            | struct (h1 :: t1, h2 :: t2) ->
+            | h1 :: t1, h2 :: t2 ->
                 if predicate h1 h2 then
                     r1 <- t1
                     r2 <- t2
                 else
                     result <- false
                     go <- false
-            | struct ([], []) -> go <- false
+            | [], [] -> go <- false
             | _ -> invalidArg (nameof list2) "The lists had different lengths."
 
         result

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -502,21 +502,17 @@ module ListInline =
         let mutable go = true
 
         while go do
-            match r1 with
-            | h1 :: t1 ->
-                match r2 with
-                | h2 :: t2 ->
-                    if predicate h1 h2 then
-                        r1 <- t1
-                        r2 <- t2
-                    else
-                        result <- false
-                        go <- false
-                | [] -> invalidArg "list2" "The lists had different lengths."
-            | [] ->
-                match r2 with
-                | [] -> go <- false
-                | _ -> invalidArg "list2" "The lists had different lengths."
+            // A struct tuple keeps the match flat without the per-iteration heap allocation a reference tuple would add.
+            match struct (r1, r2) with
+            | struct (h1 :: t1, h2 :: t2) ->
+                if predicate h1 h2 then
+                    r1 <- t1
+                    r2 <- t2
+                else
+                    result <- false
+                    go <- false
+            | struct ([], []) -> go <- false
+            | _ -> invalidArg (nameof list2) "The lists had different lengths."
 
         result
 

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -484,8 +484,7 @@ module ListInline =
         state
 
     /// As `List.map`.
-    let inline map ([<InlineIfLambda>] mapping: 'T -> 'U) (list: 'T list) =
-        [ for x in list -> mapping x ]
+    let inline map ([<InlineIfLambda>] mapping: 'T -> 'U) (list: 'T list) = [ for x in list -> mapping x ]
 
     /// As `List.forall2` (raising `ArgumentException` when the lists have different lengths).
     let inline forall2 ([<InlineIfLambda>] predicate: 'T1 -> 'T2 -> bool) (list1: 'T1 list) (list2: 'T2 list) =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -436,6 +436,12 @@ module Option =
 module internal ValueTuple =
     let inline map1Of2 ([<InlineIfLambda>] f) struct (a1, a2) = struct (f a1, a2)
 
+/// Inline counterparts to the `FSharp.Core` list combinators that take a function argument.
+/// The built-ins are not `inline`, so they force that argument into a heap `FSharpFunc`; marking
+/// these `inline` + `[<InlineIfLambda>]` and applying the function directly lets the optimizer
+/// beta-reduce it at the call site - even through an enclosing inline function - so no closure is
+/// allocated. Use in place of `List.map` / `List.forall2` on hot paths where the argument is a
+/// lambda or partial application.
 module ListInline =
     /// List.exists, but inline so the predicate is inlined (InlineIfLambda) rather than allocated as a closure.
     let inline exists ([<InlineIfLambda>] predicate: 'T -> bool) (list: 'T list) =
@@ -477,6 +483,43 @@ module ListInline =
 
         state
 
+    /// As `List.map`.
+    let inline map ([<InlineIfLambda>] mapping: 'T -> 'U) (list: 'T list) =
+        let mutable acc = []
+        let mutable rest = list
+
+        while not (List.isEmpty rest) do
+            acc <- mapping (List.head rest) :: acc
+            rest <- List.tail rest
+
+        List.rev acc
+
+    /// As `List.forall2` (raising `ArgumentException` when the lists have different lengths).
+    let inline forall2 ([<InlineIfLambda>] predicate: 'T1 -> 'T2 -> bool) (list1: 'T1 list) (list2: 'T2 list) =
+        let mutable r1 = list1
+        let mutable r2 = list2
+        let mutable result = true
+        let mutable go = true
+
+        while go do
+            match r1 with
+            | h1 :: t1 ->
+                match r2 with
+                | h2 :: t2 ->
+                    if predicate h1 h2 then
+                        r1 <- t1
+                        r2 <- t2
+                    else
+                        result <- false
+                        go <- false
+                | [] -> invalidArg "list2" "The lists had different lengths."
+            | [] ->
+                match r2 with
+                | [] -> go <- false
+                | _ -> invalidArg "list2" "The lists had different lengths."
+
+        result
+
 module List =
 
     let sortWithOrder (c: IComparer<'T>) elements =
@@ -500,17 +543,7 @@ module List =
         loop 0 xs
 
     let inline lengthsEqAndForall2 ([<InlineIfLambda>] p) l1 l2 =
-        // Apply `p` directly (not via the non-inline `List.forall2`) so [<InlineIfLambda>] allocates no closure for `p`.
-        let mutable r1 = l1
-        let mutable r2 = l2
-
-        while not (List.isEmpty r1)
-              && not (List.isEmpty r2)
-              && p (List.head r1) (List.head r2) do
-            r1 <- List.tail r1
-            r2 <- List.tail r2
-
-        List.isEmpty r1 && List.isEmpty r2
+        List.length l1 = List.length l2 && ListInline.forall2 p l1 l2
 
     let rec findi n f l =
         match l with
@@ -556,16 +589,7 @@ module List =
             else
                 [ h2a; h2b; h2c ]
         | _ ->
-            // Build the result applying `f` directly (not via the non-inline `List.map`) so [<InlineIfLambda>]
-            // allocates no closure for `f`; `checkq` then preserves identity when nothing changed.
-            let mutable acc = []
-            let mutable rest = inp
-
-            while not (List.isEmpty rest) do
-                acc <- f (List.head rest) :: acc
-                rest <- List.tail rest
-
-            let res = List.rev acc
+            let res = ListInline.map f inp
             if checkq inp res then inp else res
 
     let frontAndBack l =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -503,20 +503,12 @@ module List =
         // Apply `p` directly (not via the non-inline `List.forall2`) so [<InlineIfLambda>] allocates no closure for `p`.
         let mutable r1 = l1
         let mutable r2 = l2
-        let mutable go = true
 
-        while go do
-            match r1 with
-            | h1 :: t1 ->
-                match r2 with
-                | h2 :: t2 ->
-                    if p h1 h2 then
-                        r1 <- t1
-                        r2 <- t2
-                    else
-                        go <- false
-                | [] -> go <- false
-            | [] -> go <- false
+        while not (List.isEmpty r1)
+              && not (List.isEmpty r2)
+              && p (List.head r1) (List.head r2) do
+            r1 <- List.tail r1
+            r2 <- List.tail r2
 
         List.isEmpty r1 && List.isEmpty r2
 
@@ -535,6 +527,11 @@ module List =
                 | Choice2Of2 sx -> ch acc1 (sx :: acc2) xs
 
         ch [] [] l
+
+    let rec checkq l1 l2 =
+        match l1, l2 with
+        | h1 :: t1, h2 :: t2 -> h1 === h2 && checkq t1 t2
+        | _ -> true
 
     let inline mapq ([<InlineIfLambda>] f: 'T -> 'T) inp =
         assert not typeof<'T>.IsValueType
@@ -559,26 +556,17 @@ module List =
             else
                 [ h2a; h2b; h2c ]
         | _ ->
-            // Apply `f` directly (not via the non-inline `List.map`) so [<InlineIfLambda>] allocates no closure for `f`.
-            // Identity-preserving: returns the original `inp` when every element is physically unchanged.
-            let mutable changed = false
+            // Build the result applying `f` directly (not via the non-inline `List.map`) so [<InlineIfLambda>]
+            // allocates no closure for `f`; `checkq` then preserves identity when nothing changed.
             let mutable acc = []
             let mutable rest = inp
-            let mutable go = true
 
-            while go do
-                match rest with
-                | h :: t ->
-                    let h2 = f h
+            while not (List.isEmpty rest) do
+                acc <- f (List.head rest) :: acc
+                rest <- List.tail rest
 
-                    if not (h === h2) then
-                        changed <- true
-
-                    acc <- h2 :: acc
-                    rest <- t
-                | [] -> go <- false
-
-            if changed then List.rev acc else inp
+            let res = List.rev acc
+            if checkq inp res then inp else res
 
     let frontAndBack l =
         let rec loop acc l =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -485,14 +485,7 @@ module ListInline =
 
     /// As `List.map`.
     let inline map ([<InlineIfLambda>] mapping: 'T -> 'U) (list: 'T list) =
-        let mutable acc = []
-        let mutable rest = list
-
-        while not (List.isEmpty rest) do
-            acc <- mapping (List.head rest) :: acc
-            rest <- List.tail rest
-
-        List.rev acc
+        [ for x in list -> mapping x ]
 
     /// As `List.forall2` (raising `ArgumentException` when the lists have different lengths).
     let inline forall2 ([<InlineIfLambda>] predicate: 'T1 -> 'T2 -> bool) (list1: 'T1 list) (list2: 'T2 list) =

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -162,9 +162,9 @@ module internal ListInline =
     /// List.fold, but inline so the folder is inlined (InlineIfLambda) rather than allocated as a closure.
     val inline fold: [<InlineIfLambda>] folder: ('State -> 'T -> 'State) -> state: 'State -> list: 'T list -> 'State
 
-    val inline map: mapping: ('T -> 'U) -> list: 'T list -> 'U list
+    val inline map: [<InlineIfLambda>] mapping: ('T -> 'U) -> list: 'T list -> 'U list
 
-    val inline forall2: predicate: ('T1 -> 'T2 -> bool) -> list1: 'T1 list -> list2: 'T2 list -> bool
+    val inline forall2: [<InlineIfLambda>] predicate: ('T1 -> 'T2 -> bool) -> list1: 'T1 list -> list2: 'T2 list -> bool
 
 module internal List =
 
@@ -174,7 +174,7 @@ module internal List =
 
     val existsi: f: (int -> 'a -> bool) -> xs: 'a list -> bool
 
-    val inline lengthsEqAndForall2: p: ('a -> 'b -> bool) -> l1: 'a list -> l2: 'b list -> bool
+    val inline lengthsEqAndForall2: [<InlineIfLambda>] p: ('a -> 'b -> bool) -> l1: 'a list -> l2: 'b list -> bool
 
     val findi: n: int -> f: ('a -> bool) -> l: 'a list -> ('a * int) option
 
@@ -182,7 +182,7 @@ module internal List =
 
     val checkq: l1: 'a list -> l2: 'a list -> bool when 'a: not struct
 
-    val inline mapq: f: ('T -> 'T) -> inp: 'T list -> 'T list when 'T: not struct
+    val inline mapq: [<InlineIfLambda>] f: ('T -> 'T) -> inp: 'T list -> 'T list when 'T: not struct
 
     val frontAndBack: l: 'a list -> 'a list * 'a
 

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -170,7 +170,7 @@ module internal List =
 
     val existsi: f: (int -> 'a -> bool) -> xs: 'a list -> bool
 
-    val lengthsEqAndForall2: p: ('a -> 'b -> bool) -> l1: 'a list -> l2: 'b list -> bool
+    val inline lengthsEqAndForall2: p: ('a -> 'b -> bool) -> l1: 'a list -> l2: 'b list -> bool
 
     val findi: n: int -> f: ('a -> bool) -> l: 'a list -> ('a * int) option
 
@@ -178,7 +178,7 @@ module internal List =
 
     val checkq: l1: 'a list -> l2: 'a list -> bool when 'a: not struct
 
-    val mapq: f: ('T -> 'T) -> inp: 'T list -> 'T list when 'T: not struct
+    val inline mapq: f: ('T -> 'T) -> inp: 'T list -> 'T list when 'T: not struct
 
     val frontAndBack: l: 'a list -> 'a list * 'a
 

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -162,6 +162,10 @@ module internal ListInline =
     /// List.fold, but inline so the folder is inlined (InlineIfLambda) rather than allocated as a closure.
     val inline fold: [<InlineIfLambda>] folder: ('State -> 'T -> 'State) -> state: 'State -> list: 'T list -> 'State
 
+    val inline map: mapping: ('T -> 'U) -> list: 'T list -> 'U list
+
+    val inline forall2: predicate: ('T1 -> 'T2 -> bool) -> list1: 'T1 list -> list2: 'T2 list -> bool
+
 module internal List =
 
     val sortWithOrder: c: IComparer<'T> -> elements: 'T list -> 'T list

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -176,6 +176,8 @@ module internal List =
 
     val splitChoose: select: ('a -> Choice<'b, 'c>) -> l: 'a list -> 'b list * 'c list
 
+    val checkq: l1: 'a list -> l2: 'a list -> bool when 'a: not struct
+
     val inline mapq: f: ('T -> 'T) -> inp: 'T list -> 'T list when 'T: not struct
 
     val frontAndBack: l: 'a list -> 'a list * 'a

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -176,8 +176,6 @@ module internal List =
 
     val splitChoose: select: ('a -> Choice<'b, 'c>) -> l: 'a list -> 'b list * 'c list
 
-    val checkq: l1: 'a list -> l2: 'a list -> bool when 'a: not struct
-
     val inline mapq: f: ('T -> 'T) -> inp: 'T list -> 'T list when 'T: not struct
 
     val frontAndBack: l: 'a list -> 'a list * 'a

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -5,39 +5,13 @@ namespace EmittedIL
 open Xunit
 open FSharp.Test.Compiler
 
-/// Characterization of when a higher-order-function call site allocates a heap closure for
-/// its function argument, established by reading the emitted IL (`newobj` of a closure).
-///
-/// Each test compiles its own `module Test` with --optimize+ and asserts whether a closure
-/// `newobj` appears. The function argument captures a runtime value (`env`) so that any
-/// closure is a real per-call allocation, and the HOFs here return a bool (no list building)
-/// so that the ONLY possible `newobj` in the caller is the function closure itself.
-///
-/// The contract these tests lock in (verified against emitted IL, F# 11, --optimize+):
-///
-///  1. Vanilla `List.map` is NOT inline, so its mapping function must be materialised as a
-///     value => a closure is allocated in EVERY syntactic form (lambda literal or partial
-///     application, direct or piped). Eta-expanding a `List.map` call site buys nothing.
-///
-///  2. An `inline` + `[<InlineIfLambda>]` HOF whose body FORWARDS the function to another
-///     non-inline callee (e.g. `List.forall2 p` / `List.map f`) STILL allocates the closure,
-///     because the callee forces the function into value position. Eta-expanding the call
-///     site does NOT help here either.
-///
-///  3. An `inline` + `[<InlineIfLambda>]` HOF whose body APPLIES the function directly (a
-///     while-loop, no forwarding, no nested closure) allocates NOTHING - and this holds
-///     whether the call site passes a lambda literal OR a partial application. The optimizer
-///     beta-reduces the partial application into a direct call. Therefore the closure win
-///     comes from the HOF body applying the function directly, NOT from the call-site form.
-///
-/// Note on `<|`: a separately-observed "`prim <| (fun ..)` allocates" effect is context
-/// dependent (it needs a HOF the optimizer cannot fully reduce, e.g. one touching private
-/// state) and does NOT reproduce in minimal code - the optimizer recovers the saturated
-/// call - so it is deliberately not asserted here.
+/// Characterization (emitted IL, --optimize+) of when a higher-order-function call site
+/// allocates a heap closure for its function argument (`newobj` of a closure). Each test
+/// compiles its own `module Test`; the argument captures `env` so any allocated closure is a
+/// real per-call allocation, and the HOFs return bool so the only possible caller `newobj` is
+/// the closure itself. The test names state the contract being locked in.
 module InlineIfLambdaClosureForms =
 
-    // Shared definitions. `eqf env` is the partial application used by the "partial
-    // application" call sites; capturing `env` makes any allocated closure per-call.
     let private prelude = """
 module Test
 
@@ -74,11 +48,7 @@ let inline forall2Direct ([<InlineIfLambda>] p: string -> string -> bool) (l1: s
     let private assertNoClosure src =
         FSharp (prelude + src) |> withOptimize |> compile |> shouldSucceed |> verifyILNotPresent [ "newobj" ]
 
-    // ---- (1) Vanilla List.map: allocates the mapping closure in every form ----
-
-    [<Fact>]
-    let ``Vanilla List.map + lambda literal allocates a closure`` () =
-        assertClosure "let test (env: int) (xs: string list) = List.map (fun (s: string) -> string (s.Length + env)) xs"
+    // ---- (1) Vanilla (non-inline) List.map: always allocates the mapping closure ----
 
     [<Fact>]
     let ``Vanilla List.map + partial application allocates a closure`` () =

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace EmittedIL
+
+open Xunit
+open FSharp.Test.Compiler
+
+/// Characterization of when a higher-order-function call site allocates a heap closure for
+/// its function argument, established by reading the emitted IL (`newobj` of a closure).
+///
+/// Each test compiles its own `module Test` with --optimize+ and asserts whether a closure
+/// `newobj` appears. The function argument captures a runtime value (`env`) so that any
+/// closure is a real per-call allocation, and the HOFs here return a bool (no list building)
+/// so that the ONLY possible `newobj` in the caller is the function closure itself.
+///
+/// The contract these tests lock in (verified against emitted IL, F# 11, --optimize+):
+///
+///  1. Vanilla `List.map` is NOT inline, so its mapping function must be materialised as a
+///     value => a closure is allocated in EVERY syntactic form (lambda literal or partial
+///     application, direct or piped). Eta-expanding a `List.map` call site buys nothing.
+///
+///  2. An `inline` + `[<InlineIfLambda>]` HOF whose body FORWARDS the function to another
+///     non-inline callee (e.g. `List.forall2 p` / `List.map f`) STILL allocates the closure,
+///     because the callee forces the function into value position. Eta-expanding the call
+///     site does NOT help here either.
+///
+///  3. An `inline` + `[<InlineIfLambda>]` HOF whose body APPLIES the function directly (a
+///     while-loop, no forwarding, no nested closure) allocates NOTHING - and this holds
+///     whether the call site passes a lambda literal OR a partial application. The optimizer
+///     beta-reduces the partial application into a direct call. Therefore the closure win
+///     comes from the HOF body applying the function directly, NOT from the call-site form.
+///
+/// Note on `<|`: a separately-observed "`prim <| (fun ..)` allocates" effect is context
+/// dependent (it needs a HOF the optimizer cannot fully reduce, e.g. one touching private
+/// state) and does NOT reproduce in minimal code - the optimizer recovers the saturated
+/// call - so it is deliberately not asserted here.
+module InlineIfLambdaClosureForms =
+
+    // Shared definitions. `eqf env` is the partial application used by the "partial
+    // application" call sites; capturing `env` makes any allocated closure per-call.
+    let private prelude = """
+module Test
+
+let eqf (env: int) (a: string) (b: string) = a.Length = b.Length + env
+
+// (2) inline HOF that FORWARDS the function to a non-inline callee (mirrors the current
+//     List.lengthsEqAndForall2 body `List.length l1 = List.length l2 && List.forall2 p l1 l2`).
+let inline forall2Forward ([<InlineIfLambda>] p: string -> string -> bool) (l1: string list) (l2: string list) =
+    List.length l1 = List.length l2 && List.forall2 p l1 l2
+
+// (3) inline HOF that APPLIES the function directly in a while-loop (mirrors the proposed fix).
+//     Nested matches (not `match r1, r2 with`) avoid a per-iteration tuple allocation.
+let inline forall2Direct ([<InlineIfLambda>] p: string -> string -> bool) (l1: string list) (l2: string list) =
+    let mutable r1 = l1
+    let mutable r2 = l2
+    let mutable ok = true
+    let mutable go = true
+    while go do
+        match r1 with
+        | h1 :: t1 ->
+            match r2 with
+            | h2 :: t2 -> if p h1 h2 then r1 <- t1; r2 <- t2 else (ok <- false; go <- false)
+            | [] -> ok <- false; go <- false
+        | [] ->
+            match r2 with
+            | [] -> go <- false
+            | _ -> ok <- false; go <- false
+    ok
+"""
+
+    let private assertClosure src =
+        FSharp (prelude + src) |> withOptimize |> compile |> shouldSucceed |> verifyILPresent [ "newobj" ]
+
+    let private assertNoClosure src =
+        FSharp (prelude + src) |> withOptimize |> compile |> shouldSucceed |> verifyILNotPresent [ "newobj" ]
+
+    // ---- (1) Vanilla List.map: allocates the mapping closure in every form ----
+
+    [<Fact>]
+    let ``Vanilla List.map + lambda literal allocates a closure`` () =
+        assertClosure "let test (env: int) (xs: string list) = List.map (fun (s: string) -> string (s.Length + env)) xs"
+
+    [<Fact>]
+    let ``Vanilla List.map + partial application allocates a closure`` () =
+        assertClosure "let f (env: int) (s: string) = string (s.Length + env)\nlet test (env: int) (xs: string list) = List.map (f env) xs"
+
+    // ---- (2) Forwarding inline HOF: still allocates; eta-expansion does not help ----
+
+    [<Fact>]
+    let ``Forwarding inline HOF + partial application allocates a closure`` () =
+        assertClosure "let test (env: int) (a: string list) (b: string list) = forall2Forward (eqf env) a b"
+
+    [<Fact>]
+    let ``Forwarding inline HOF + eta-expanded lambda still allocates a closure`` () =
+        // Eta-expanding the call site does not help: `List.forall2` forces `p` into value position.
+        assertClosure "let test (env: int) (a: string list) (b: string list) = forall2Forward (fun x y -> eqf env x y) a b"
+
+    // ---- (3) Direct-apply inline HOF: allocates nothing, regardless of call-site form ----
+
+    [<Fact>]
+    let ``Direct-apply inline HOF + partial application allocates no closure`` () =
+        // The partial application `(eqf env)` is beta-reduced into a direct call; no closure.
+        assertNoClosure "let test (env: int) (a: string list) (b: string list) = forall2Direct (eqf env) a b"
+
+    [<Fact>]
+    let ``Direct-apply inline HOF + eta-expanded lambda allocates no closure`` () =
+        assertNoClosure "let test (env: int) (a: string list) (b: string list) = forall2Direct (fun x y -> eqf env x y) a b"

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -140,10 +140,12 @@ let test (env: int) (a: string list) (b: string list) =
     forall2Chained (eqf env) a b
 """
 
-    // For this direct-apply shape, an instance `member inline` preserves InlineIfLambda through `<|`;
-    // the instance receiver does not cause closure allocation. (Forwarding to a non-inline callee is
-    // covered above - and that is the real cause of the closure a member/`<|` call site is sometimes
-    // blamed for: the lambda escaping into the callee, not the member or the pipe.)
+    // A direct-apply instance `member inline` whose lambda does NOT escape keeps InlineIfLambda through
+    // `<|` - no closure. This does not generalise: once the lambda escapes (e.g. captured by a slow-path
+    // closure, as in StackGuard.Guard), `<|` defeats InlineIfLambda and materialises it UNCONDITIONALLY
+    // every call, whereas a method-call `Guard(fun ..)` keeps InlineIfLambda firing so the closure stays
+    // in the cold escape branch. That is a per-call placement/byte difference a newobj-presence check
+    // cannot see, so it is characterised by allocation measurement, not asserted here.
 
     [<Fact>]
     let ``direct-apply inline instance member, back-piped with <| -> no closure`` () =

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -126,3 +126,16 @@ let test (env: int) =
 let test (env: int) =
     applyDirect <| (fun () -> eqf env "a" "b" |> System.Convert.ToInt32)
 """
+
+    // InlineIfLambda chains: an inline HOF that delegates to another inline + InlineIfLambda
+    // combinator is still closure-free. This is what lets List.mapq / lengthsEqAndForall2 keep
+    // their elegant bodies and call the ListInline combinators without allocating.
+
+    [<Fact>]
+    let ``inline HOF delegating to another inline combinator -> no closure`` () =
+        allocatesNoClosure
+            """
+let inline forall2Chained ([<InlineIfLambda>] p: string -> string -> bool) l1 l2 = forall2Direct p l1 l2
+let test (env: int) (a: string list) (b: string list) =
+    forall2Chained (eqf env) a b
+"""

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -5,73 +5,124 @@ namespace EmittedIL
 open Xunit
 open FSharp.Test.Compiler
 
-/// Characterization (emitted IL, --optimize+) of when a higher-order-function call site
-/// allocates a heap closure for its function argument (`newobj` of a closure). Each test
-/// compiles its own `module Test`; the argument captures `env` so any allocated closure is a
-/// real per-call allocation, and the HOFs return bool so the only possible caller `newobj` is
-/// the closure itself. The test names state the contract being locked in.
+/// Characterization (emitted IL, --optimize+) of when a higher-order-function call site allocates a
+/// heap closure for its function argument (a `newobj` of a closure). Each test compiles the shared
+/// `prelude` plus one `test` function; the argument captures `env`, so any closure it needs is a real
+/// per-call allocation, and the probe HOFs return `bool` (no list building) so the only `newobj` a
+/// caller could show is the function closure itself.
 module InlineIfLambdaClosureForms =
 
-    let private prelude = """
+    let private prelude =
+        """
 module Test
 
 let eqf (env: int) (a: string) (b: string) = a.Length = b.Length + env
 
-// (2) inline HOF that FORWARDS the function to a non-inline callee (mirrors the current
-//     List.lengthsEqAndForall2 body `List.length l1 = List.length l2 && List.forall2 p l1 l2`).
-let inline forall2Forward ([<InlineIfLambda>] p: string -> string -> bool) (l1: string list) (l2: string list) =
+// Forwards the function to a non-inline callee (the OLD List.lengthsEqAndForall2 shape).
+let inline forall2Forward ([<InlineIfLambda>] p: string -> string -> bool) l1 l2 =
     List.length l1 = List.length l2 && List.forall2 p l1 l2
 
-// (3) inline HOF that APPLIES the function directly in a while-loop (mirrors the proposed fix).
-//     Nested matches (not `match r1, r2 with`) avoid a per-iteration tuple allocation.
-let inline forall2Direct ([<InlineIfLambda>] p: string -> string -> bool) (l1: string list) (l2: string list) =
+// Applies the function directly in a loop (the NEW shape).
+let inline forall2Direct ([<InlineIfLambda>] p: string -> string -> bool) l1 l2 =
     let mutable r1 = l1
     let mutable r2 = l2
-    let mutable ok = true
-    let mutable go = true
-    while go do
-        match r1 with
-        | h1 :: t1 ->
-            match r2 with
-            | h2 :: t2 -> if p h1 h2 then r1 <- t1; r2 <- t2 else (ok <- false; go <- false)
-            | [] -> ok <- false; go <- false
-        | [] ->
-            match r2 with
-            | [] -> go <- false
-            | _ -> ok <- false; go <- false
-    ok
+    while not (List.isEmpty r1) && not (List.isEmpty r2) && p (List.head r1) (List.head r2) do
+        r1 <- List.tail r1
+        r2 <- List.tail r2
+    List.isEmpty r1 && List.isEmpty r2
+
+// Single-argument inline HOF, used to probe `<|`.
+let inline applyDirect ([<InlineIfLambda>] f: unit -> int) = f ()
 """
 
-    let private assertClosure src =
-        FSharp (prelude + src) |> withOptimize |> compile |> shouldSucceed |> verifyILPresent [ "newobj" ]
+    let private allocatesClosure body =
+        FSharp(prelude + body) |> withOptimize |> compile |> shouldSucceed |> verifyILPresent [ "newobj" ]
 
-    let private assertNoClosure src =
-        FSharp (prelude + src) |> withOptimize |> compile |> shouldSucceed |> verifyILNotPresent [ "newobj" ]
+    let private allocatesNoClosure body =
+        FSharp(prelude + body) |> withOptimize |> compile |> shouldSucceed |> verifyILNotPresent [ "newobj" ]
 
-    // ---- (1) Vanilla (non-inline) List.map: always allocates the mapping closure ----
-
-    [<Fact>]
-    let ``Vanilla List.map + partial application allocates a closure`` () =
-        assertClosure "let f (env: int) (s: string) = string (s.Length + env)\nlet test (env: int) (xs: string list) = List.map (f env) xs"
-
-    // ---- (2) Forwarding inline HOF: still allocates; eta-expansion does not help ----
+    // Vanilla List.map is not inline, so the mapping function is always materialised as a value:
+    // a closure is allocated whatever the syntactic form.
 
     [<Fact>]
-    let ``Forwarding inline HOF + partial application allocates a closure`` () =
-        assertClosure "let test (env: int) (a: string list) (b: string list) = forall2Forward (eqf env) a b"
+    let ``vanilla List.map, lambda literal -> closure`` () =
+        allocatesClosure
+            """
+let test (env: int) (xs: string list) =
+    List.map (fun (s: string) -> string (s.Length + env)) xs
+"""
 
     [<Fact>]
-    let ``Forwarding inline HOF + eta-expanded lambda still allocates a closure`` () =
-        // Eta-expanding the call site does not help: `List.forall2` forces `p` into value position.
-        assertClosure "let test (env: int) (a: string list) (b: string list) = forall2Forward (fun x y -> eqf env x y) a b"
+    let ``vanilla List.map, partial application -> closure`` () =
+        allocatesClosure
+            """
+let g (env: int) (s: string) = string (s.Length + env)
+let test (env: int) (xs: string list) =
+    List.map (g env) xs
+"""
 
-    // ---- (3) Direct-apply inline HOF: allocates nothing, regardless of call-site form ----
+    // An inline + InlineIfLambda HOF that forwards the function to a non-inline callee still allocates,
+    // and eta-expanding the call site does not change that.
 
     [<Fact>]
-    let ``Direct-apply inline HOF + partial application allocates no closure`` () =
-        // The partial application `(eqf env)` is beta-reduced into a direct call; no closure.
-        assertNoClosure "let test (env: int) (a: string list) (b: string list) = forall2Direct (eqf env) a b"
+    let ``forwarding inline HOF, partial application -> closure`` () =
+        allocatesClosure
+            """
+let test (env: int) (a: string list) (b: string list) =
+    forall2Forward (eqf env) a b
+"""
 
     [<Fact>]
-    let ``Direct-apply inline HOF + eta-expanded lambda allocates no closure`` () =
-        assertNoClosure "let test (env: int) (a: string list) (b: string list) = forall2Direct (fun x y -> eqf env x y) a b"
+    let ``forwarding inline HOF, eta-expanded lambda -> closure`` () =
+        allocatesClosure
+            """
+let test (env: int) (a: string list) (b: string list) =
+    forall2Forward (fun x y -> eqf env x y) a b
+"""
+
+    // An inline + InlineIfLambda HOF that applies the function directly allocates nothing - for a lambda
+    // literal, a partial application, or a piped call alike. The optimizer beta-reduces the partial
+    // application into a direct call, so no call-site eta-expansion is needed.
+
+    [<Fact>]
+    let ``direct-apply inline HOF, lambda literal -> no closure`` () =
+        allocatesNoClosure
+            """
+let test (env: int) (a: string list) (b: string list) =
+    forall2Direct (fun x y -> eqf env x y) a b
+"""
+
+    [<Fact>]
+    let ``direct-apply inline HOF, partial application -> no closure`` () =
+        allocatesNoClosure
+            """
+let test (env: int) (a: string list) (b: string list) =
+    forall2Direct (eqf env) a b
+"""
+
+    [<Fact>]
+    let ``direct-apply inline HOF, piped -> no closure`` () =
+        allocatesNoClosure
+            """
+let test (env: int) (a: string list) (b: string list) =
+    (a, b) ||> forall2Direct (eqf env)
+"""
+
+    // `<|` does not defeat InlineIfLambda for a module-level `let inline`: the optimizer recovers the
+    // saturated call, so both the direct and back-piped forms are closure-free.
+
+    [<Fact>]
+    let ``direct-apply inline HOF, direct call -> no closure`` () =
+        allocatesNoClosure
+            """
+let test (env: int) =
+    applyDirect (fun () -> eqf env "a" "b" |> System.Convert.ToInt32)
+"""
+
+    [<Fact>]
+    let ``direct-apply inline HOF, back-piped with <| -> no closure`` () =
+        allocatesNoClosure
+            """
+let test (env: int) =
+    applyDirect <| (fun () -> eqf env "a" "b" |> System.Convert.ToInt32)
+"""

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -9,7 +9,7 @@ open FSharp.Test.Compiler
 /// heap closure for its function argument (a `newobj` of a closure). Each test compiles the shared
 /// `prelude` plus one `test` function; the argument captures `env`, so any closure it needs is a real
 /// per-call allocation, and the probe HOFs return `bool` (no list building) so the only `newobj` a
-/// caller could show is the function closure itself.
+/// caller could show is the function closure itself. The two sub-modules split the cases by outcome.
 module InlineIfLambdaClosureForms =
 
     let private prelude =
@@ -41,117 +41,132 @@ let inline applyDirect ([<InlineIfLambda>] f: unit -> int) = f ()
     let private allocatesNoClosure body =
         FSharp(prelude + body) |> withOptimize |> compile |> shouldSucceed |> verifyILNotPresent [ "newobj" ]
 
-    // Vanilla List.map is not inline, so the mapping function is always materialised as a value:
-    // a closure is allocated whatever the syntactic form.
+    module DoesNotAllocate =
 
-    [<Fact>]
-    let ``vanilla List.map, lambda literal -> closure`` () =
-        allocatesClosure
-            """
-let test (env: int) (xs: string list) =
-    List.map (fun (s: string) -> string (s.Length + env)) xs
-"""
+        // An inline + InlineIfLambda HOF that applies the function directly allocates nothing - for a
+        // lambda literal, a forward pipe, or a partial application of a top-level function alike; the
+        // optimizer beta-reduces it into a direct call, so no call-site eta-expansion is needed.
 
-    [<Fact>]
-    let ``vanilla List.map, partial application -> closure`` () =
-        allocatesClosure
-            """
-let g (env: int) (s: string) = string (s.Length + env)
-let test (env: int) (xs: string list) =
-    List.map (g env) xs
-"""
-
-    // An inline + InlineIfLambda HOF that forwards the function to a non-inline callee still allocates,
-    // and eta-expanding the call site does not change that.
-
-    [<Fact>]
-    let ``forwarding inline HOF, partial application -> closure`` () =
-        allocatesClosure
-            """
-let test (env: int) (a: string list) (b: string list) =
-    forall2Forward (eqf env) a b
-"""
-
-    [<Fact>]
-    let ``forwarding inline HOF, eta-expanded lambda -> closure`` () =
-        allocatesClosure
-            """
-let test (env: int) (a: string list) (b: string list) =
-    forall2Forward (fun x y -> eqf env x y) a b
-"""
-
-    // An inline + InlineIfLambda HOF that applies the function directly allocates nothing - for a lambda
-    // literal, a partial application, or a piped call alike. The optimizer beta-reduces the partial
-    // application into a direct call, so no call-site eta-expansion is needed.
-
-    [<Fact>]
-    let ``direct-apply inline HOF, lambda literal -> no closure`` () =
-        allocatesNoClosure
-            """
+        [<Fact>]
+        let ``direct-apply inline HOF, lambda literal`` () =
+            allocatesNoClosure
+                """
 let test (env: int) (a: string list) (b: string list) =
     forall2Direct (fun x y -> eqf env x y) a b
 """
 
-    [<Fact>]
-    let ``direct-apply inline HOF, partial application -> no closure`` () =
-        allocatesNoClosure
-            """
+        // Partial application of a TOP-LEVEL function: the optimizer knows its arity and forms the
+        // saturated call, so no closure. (Contrast with the local-function case in AllocatesClosure.)
+        [<Fact>]
+        let ``direct-apply inline HOF, partial application of a top-level function`` () =
+            allocatesNoClosure
+                """
 let test (env: int) (a: string list) (b: string list) =
     forall2Direct (eqf env) a b
 """
 
-    [<Fact>]
-    let ``direct-apply inline HOF, piped -> no closure`` () =
-        allocatesNoClosure
-            """
+        [<Fact>]
+        let ``direct-apply inline HOF, forward-piped`` () =
+            allocatesNoClosure
+                """
 let test (env: int) (a: string list) (b: string list) =
     (a, b) ||> forall2Direct (eqf env)
 """
 
-    // `<|` does not defeat InlineIfLambda for a module-level `let inline`: the optimizer recovers the
-    // saturated call, so both the direct and back-piped forms are closure-free.
+        // `<|` does not defeat InlineIfLambda for a module-level `let inline` whose param does not escape:
+        // the optimizer recovers the saturated call, so both the direct and back-piped forms are clean.
 
-    [<Fact>]
-    let ``direct-apply inline HOF, direct call -> no closure`` () =
-        allocatesNoClosure
-            """
+        [<Fact>]
+        let ``direct-apply inline HOF, direct call`` () =
+            allocatesNoClosure
+                """
 let test (env: int) =
     applyDirect (fun () -> eqf env "a" "b" |> System.Convert.ToInt32)
 """
 
-    [<Fact>]
-    let ``direct-apply inline HOF, back-piped with <| -> no closure`` () =
-        allocatesNoClosure
-            """
+        [<Fact>]
+        let ``direct-apply inline HOF, back-piped with <|`` () =
+            allocatesNoClosure
+                """
 let test (env: int) =
     applyDirect <| (fun () -> eqf env "a" "b" |> System.Convert.ToInt32)
 """
 
-    // InlineIfLambda chains: an inline HOF that delegates to another inline + InlineIfLambda
-    // combinator is still closure-free. This is what lets List.mapq / lengthsEqAndForall2 keep
-    // their elegant bodies and call the ListInline combinators without allocating.
-
-    [<Fact>]
-    let ``inline HOF delegating to another inline combinator -> no closure`` () =
-        allocatesNoClosure
-            """
+        // InlineIfLambda chains: an inline HOF that delegates to another inline + InlineIfLambda
+        // combinator is still closure-free. This is what lets List.mapq / lengthsEqAndForall2 keep their
+        // elegant bodies and call the ListInline combinators without allocating.
+        [<Fact>]
+        let ``inline HOF delegating to another inline combinator`` () =
+            allocatesNoClosure
+                """
 let inline forall2Chained ([<InlineIfLambda>] p: string -> string -> bool) l1 l2 = forall2Direct p l1 l2
 let test (env: int) (a: string list) (b: string list) =
     forall2Chained (eqf env) a b
 """
 
-    // A direct-apply instance `member inline` whose lambda does NOT escape keeps InlineIfLambda through
-    // `<|` - no closure. This does not generalise: once the lambda escapes (e.g. captured by a slow-path
-    // closure, as in StackGuard.Guard), `<|` defeats InlineIfLambda and materialises it UNCONDITIONALLY
-    // every call, whereas a method-call `Guard(fun ..)` keeps InlineIfLambda firing so the closure stays
-    // in the cold escape branch. That is a per-call placement/byte difference a newobj-presence check
-    // cannot see, so it is characterised by allocation measurement, not asserted here.
-
-    [<Fact>]
-    let ``direct-apply inline instance member, back-piped with <| -> no closure`` () =
-        allocatesNoClosure
-            """
+        // A direct-apply instance `member inline` whose lambda does NOT escape keeps InlineIfLambda through
+        // `<|`. This does not generalise: once the lambda escapes (e.g. captured by a slow-path closure, as
+        // in StackGuard.Guard), `<|` defeats InlineIfLambda and materialises it UNCONDITIONALLY every call,
+        // whereas a method-call `Guard(fun ..)` keeps InlineIfLambda firing so the closure stays in the cold
+        // escape branch. That is a per-call placement/byte difference a newobj-presence check cannot see.
+        [<Fact>]
+        let ``direct-apply inline instance member, back-piped with <|`` () =
+            allocatesNoClosure
+                """
 type H() =
     member inline _.M ([<InlineIfLambda>] f: unit -> int) = f ()
 let test (h: H) (env: int) = h.M <| (fun () -> env)
+"""
+
+    module AllocatesClosure =
+
+        // Vanilla List.map is not inline, so the mapping function is always materialised as a value -
+        // a closure is allocated whatever the syntactic form.
+
+        [<Fact>]
+        let ``vanilla List.map, lambda literal`` () =
+            allocatesClosure
+                """
+let test (env: int) (xs: string list) =
+    List.map (fun (s: string) -> string (s.Length + env)) xs
+"""
+
+        [<Fact>]
+        let ``vanilla List.map, partial application`` () =
+            allocatesClosure
+                """
+let g (env: int) (s: string) = string (s.Length + env)
+let test (env: int) (xs: string list) =
+    List.map (g env) xs
+"""
+
+        // An inline + InlineIfLambda HOF that FORWARDS the function to a non-inline callee still allocates,
+        // and eta-expanding the call site does not change that.
+
+        [<Fact>]
+        let ``forwarding inline HOF, partial application`` () =
+            allocatesClosure
+                """
+let test (env: int) (a: string list) (b: string list) =
+    forall2Forward (eqf env) a b
+"""
+
+        [<Fact>]
+        let ``forwarding inline HOF, eta-expanded lambda`` () =
+            allocatesClosure
+                """
+let test (env: int) (a: string list) (b: string list) =
+    forall2Forward (fun x y -> eqf env x y) a b
+"""
+
+        // Partial application of a LOCAL function that closes over a local: unlike a top-level function
+        // (see DoesNotAllocate), the local is itself a closure value the optimizer cannot reduce, so it is
+        // materialised even though the HOF applies it directly.
+        [<Fact>]
+        let ``direct-apply inline HOF, partial application of a local closure`` () =
+            allocatesClosure
+                """
+let test (env: int) (a: string list) (b: string list) =
+    let local (cap: int) (x: string) (y: string) = x.Length = y.Length + cap + env
+    forall2Direct (local 5) a b
 """

--- a/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
+++ b/tests/FSharp.Compiler.ComponentTests/EmittedIL/Inlining/InlineIfLambdaClosureForms.fs
@@ -139,3 +139,17 @@ let inline forall2Chained ([<InlineIfLambda>] p: string -> string -> bool) l1 l2
 let test (env: int) (a: string list) (b: string list) =
     forall2Chained (eqf env) a b
 """
+
+    // For this direct-apply shape, an instance `member inline` preserves InlineIfLambda through `<|`;
+    // the instance receiver does not cause closure allocation. (Forwarding to a non-inline callee is
+    // covered above - and that is the real cause of the closure a member/`<|` call site is sometimes
+    // blamed for: the lambda escaping into the callee, not the member or the pipe.)
+
+    [<Fact>]
+    let ``direct-apply inline instance member, back-piped with <| -> no closure`` () =
+        allocatesNoClosure
+            """
+type H() =
+    member inline _.M ([<InlineIfLambda>] f: unit -> int) = f ()
+let test (h: H) (env: int) = h.M <| (fun () -> env)
+"""

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -288,6 +288,7 @@
     <Compile Include="EmittedIL\Inlining\Regression_RealsigAugmentationClosure.fs" />
     <Compile Include="EmittedIL\Inlining\Regression_Specialize_ConstraintVerification.fs" />
     <Compile Include="EmittedIL\Inlining\Inlining.fs" />
+    <Compile Include="EmittedIL\Inlining\InlineIfLambdaClosureForms.fs" />
     <Compile Include="EmittedIL\ListExpressionStepping\ListExpressionStepping.fs" />
     <Compile Include="EmittedIL\MethodImplAttribute\MethodImplAttribute.fs" />
     <Compile Include="EmittedIL\ByRefTests.fs" />


### PR DESCRIPTION
Add a `ListInline` module of `inline` + `[<InlineIfLambda>]` counterparts to the `FSharp.Core` list combinators (`map`, `forall2`), and route `List.mapq` / `List.lengthsEqAndForall2` through them. The built-ins aren't inline, so they force the function argument into a heap `FSharpFunc`; the `ListInline` versions apply it directly and `[<InlineIfLambda>]` chains through, so the partial-application closures at the hot remap / type-equivalence call sites (e.g. `List.mapq (remapTypeAux tyenv) types`) are beta-reduced away. No call-site changes.

Total allocation compiling a 120-file / 65,880-LOC input (`GC.GetTotalAllocatedBytes`): **10,615 → 10,321 MB, −294 MB per compile.**

Eliminated closures (per-closure allocation from a gc-verbose trace, cumulative over the traced run):

| closure (call site) | before | after |
|---|--:|--:|
| `typesAEquivAux@1646` | 599.6 MB | 0 |
| `remapTypes@419` | 591.5 MB | 0 |
| `remapExprs@2045` | 493.8 MB | 0 |
| `remapTypesAux@276` | 386.5 MB | 0 |
| `remapDecisionTree@2076-1` | 68.3 MB | 0 |

Output-identical: 3,000,000-trial in-process differential (values + the same-instance-when-unchanged identity contract) and `--deterministic+` self-compile SHA-256 byte-identity on a real input file. New `EmittedIL` test `InlineIfLambdaClosureForms` codifies when a HOF call site allocates a closure for its function argument.
