### PR TITLE
Cut allocations in the VS project options caches and drop a boxing check

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -192,7 +192,6 @@
 * IL: use empty tables for members when possible ([PR #20249](https://github.com/dotnet/fsharp/pull/20249))
 * Make Entity's adhoc members list lazy ([PR #20286](https://github.com/dotnet/fsharp/pull/20286/changes))
 * Constraint solver: `TryD` is now `inline` with `[<InlineIfLambda>]` on its always-run continuation, so the argument closures are no longer allocated at the (very hot) constraint-solver call sites; `IgnoreFailedMemberConstraintResolution` is `inline` so its forwarded continuation stays a literal. ([PR #20367](https://github.com/dotnet/fsharp/pull/20367))
-* Codegen: build the merged property, method, nested-type and field tables in `IlxGen` without the intermediate lists that `@` and the `List.sortBy`/`List.map` chain in `HashRangeSorted` materialised. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
 * `DelayedILModuleReader` no longer boxes its cached `ILModuleReader` on every read: the field is typed `ILModuleReader | null` and matched directly. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
 
 ### Changed

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -192,6 +192,8 @@
 * IL: use empty tables for members when possible ([PR #20249](https://github.com/dotnet/fsharp/pull/20249))
 * Make Entity's adhoc members list lazy ([PR #20286](https://github.com/dotnet/fsharp/pull/20286/changes))
 * Constraint solver: `TryD` is now `inline` with `[<InlineIfLambda>]` on its always-run continuation, so the argument closures are no longer allocated at the (very hot) constraint-solver call sites; `IgnoreFailedMemberConstraintResolution` is `inline` so its forwarded continuation stays a literal. ([PR #20367](https://github.com/dotnet/fsharp/pull/20367))
+* Codegen: build the merged property, method, nested-type and field tables in `IlxGen` without the intermediate lists that `@` and the `List.sortBy`/`List.map` chain in `HashRangeSorted` materialised. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
+* `DelayedILModuleReader` no longer boxes its cached `ILModuleReader` on every read: the field is typed `ILModuleReader | null` and matched directly. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
 
 ### Changed
 * The `--warnaserror` option now ignores unrecognized diagnostic identifiers in warning lists while still applying recognized F# warning codes. ([PR #20246](https://github.com/dotnet/fsharp/pull/20246))

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -14,6 +14,7 @@
 * Make Alt+F1 (momentary toggle) work for inlay hints. ([PR #19421](https://github.com/dotnet/fsharp/pull/19421))
 * Fix doubled F# diagnostics in tooltips. ([Issue #16360](https://github.com/dotnet/fsharp/issues/16360))
 * Fix `NotSupportedException` in the memory-mapped-file optimization when copying `ReadOnlyMemory` into `MemoryMappedFileViewStream`. ([Issue #20263](https://github.com/dotnet/fsharp/issues/20263))
+* Reduce allocations in the VS project options reactor: the command-line options and project options caches and the mailbox reply payloads now hold struct tuples, and `IProjectSite.CompilationBinOutputPath` returns `string voption` picked with a new `Array.tryPickV`. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
 
 ### Changed
 

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -1972,7 +1972,7 @@ let GenPossibleILDebugRange (cenv: cenv) m =
 //--------------------------------------------------------------------------
 
 let HashRangeSorted (ht: IDictionary<_, int * _>) =
-    seq { for KeyValue(_k, v) in ht -> v } |> Seq.sortBy fst |> Seq.map snd
+    [ for KeyValue(_k, v) in ht -> v ] |> List.sortBy fst |> List.map snd
 
 let MergeOptions m o1 o2 =
     match o1, o2 with
@@ -2075,9 +2075,9 @@ type TypeDefBuilder(tdef: ILTypeDef, tdefDiscards) =
         tdef.With(
             methods = mkILMethods (sortByKey gmethods),
             fields = mkILFields (sortByKey gfields),
-            properties = mkILProperties [ yield! tdef.Properties.AsList(); yield! HashRangeSorted gproperties ],
+            properties = mkILProperties (tdef.Properties.AsList() @ HashRangeSorted gproperties),
             events = mkILEvents (sortByKey gevents),
-            nestedTypes = mkILTypeDefs [ yield! tdef.NestedTypes.AsList(); yield! gnested.Close(g) ],
+            nestedTypes = mkILTypeDefs (tdef.NestedTypes.AsList() @ gnested.Close(g)),
             customAttrs = storeILCustomAttrs attrs
         )
 
@@ -12291,16 +12291,8 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) : ILTypeRef option 
                     | _ -> ()
                 ]
 
-            let ilMethods =
-                [
-                    yield! methodDefs
-                    yield! augmentOverrideMethodDefs
-                    yield! abstractMethodDefs
-                ]
-
-            let ilProperties =
-                mkILProperties [ yield! ilPropertyDefsForFields; yield! abstractPropDefs ]
-
+            let ilMethods = methodDefs @ augmentOverrideMethodDefs @ abstractMethodDefs
+            let ilProperties = mkILProperties (ilPropertyDefsForFields @ abstractPropDefs)
             let ilEvents = mkILEvents abstractEventDefs
             let ilFields = mkILFields ilFieldDefs
 

--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -1972,7 +1972,7 @@ let GenPossibleILDebugRange (cenv: cenv) m =
 //--------------------------------------------------------------------------
 
 let HashRangeSorted (ht: IDictionary<_, int * _>) =
-    [ for KeyValue(_k, v) in ht -> v ] |> List.sortBy fst |> List.map snd
+    seq { for KeyValue(_k, v) in ht -> v } |> Seq.sortBy fst |> Seq.map snd
 
 let MergeOptions m o1 o2 =
     match o1, o2 with
@@ -2075,9 +2075,9 @@ type TypeDefBuilder(tdef: ILTypeDef, tdefDiscards) =
         tdef.With(
             methods = mkILMethods (sortByKey gmethods),
             fields = mkILFields (sortByKey gfields),
-            properties = mkILProperties (tdef.Properties.AsList() @ HashRangeSorted gproperties),
+            properties = mkILProperties [ yield! tdef.Properties.AsList(); yield! HashRangeSorted gproperties ],
             events = mkILEvents (sortByKey gevents),
-            nestedTypes = mkILTypeDefs (tdef.NestedTypes.AsList() @ gnested.Close(g)),
+            nestedTypes = mkILTypeDefs [ yield! tdef.NestedTypes.AsList(); yield! gnested.Close(g) ],
             customAttrs = storeILCustomAttrs attrs
         )
 
@@ -12291,8 +12291,16 @@ and GenTypeDef cenv mgbuf lazyInitInfo eenv m (tycon: Tycon) : ILTypeRef option 
                     | _ -> ()
                 ]
 
-            let ilMethods = methodDefs @ augmentOverrideMethodDefs @ abstractMethodDefs
-            let ilProperties = mkILProperties (ilPropertyDefsForFields @ abstractPropDefs)
+            let ilMethods =
+                [
+                    yield! methodDefs
+                    yield! augmentOverrideMethodDefs
+                    yield! abstractMethodDefs
+                ]
+
+            let ilProperties =
+                mkILProperties [ yield! ilPropertyDefsForFields; yield! abstractPropDefs ]
+
             let ilEvents = mkILEvents abstractEventDefs
             let ilFields = mkILFields ilFieldDefs
 

--- a/src/Compiler/Service/FSharpCheckerResults.fs
+++ b/src/Compiler/Service/FSharpCheckerResults.fs
@@ -69,21 +69,21 @@ type DelayedILModuleReader =
     val private name: string
     val private gate: obj
     val mutable private getStream: (CancellationToken -> Stream option)
-    val mutable private result: ILModuleReader
+    val mutable private result: ILModuleReader | null
 
     new(name, getStream) =
         {
             name = name
             gate = obj ()
             getStream = getStream
-            result = Unchecked.defaultof<_>
+            result = null
         }
 
     member this.OutputFile = this.name
 
     member this.TryGetILModuleReader() =
         // fast path
-        match box this.result with
+        match this.result with
         | null ->
             cancellable {
                 let! ct = Cancellable.token ()
@@ -91,7 +91,7 @@ type DelayedILModuleReader =
                 return
                     lock this.gate (fun () ->
                         // see if we have a result or not after the lock so we do not evaluate the stream more than once
-                        match box this.result with
+                        match this.result with
                         | null ->
                             try
                                 let streamOpt = this.getStream ct
@@ -114,9 +114,9 @@ type DelayedILModuleReader =
                             with ex ->
                                 Trace.TraceInformation("FCS: Unable to get an ILModuleReader: {0}", ex)
                                 None
-                        | _ -> Some this.result)
+                        | result -> Some result)
             }
-        | _ -> cancellable.Return(Some this.result)
+        | result -> cancellable.Return(Some result)
 
 [<RequireQualifiedAccess; NoComparison; CustomEquality>]
 type FSharpReferencedProject =

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -527,6 +527,18 @@ module Array =
 
         loop 0
 
+    let inline tryPickV ([<InlineIfLambda>] chooser: 'T -> 'U voption) (array: 'T[]) =
+
+        let rec loop i =
+            if i >= array.Length then
+                ValueNone
+            else
+                match chooser array[i] with
+                | ValueNone -> loop (i + 1)
+                | res -> res
+
+        loop 0
+
     let inline chooseV ([<InlineIfLambda>] chooser: 'T -> 'U voption) (array: 'T[]) =
 
         let mutable i = 0

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -27,7 +27,7 @@ open Microsoft.VisualStudio.TextManager.Interop
 [<AutoOpen>]
 module private FSharpProjectOptionsHelpers =
 
-    let mapCpsProjectToSite (project: Project, cpsCommandLineOptions: IDictionary<ProjectId, string[] * string[]>) =
+    let mapCpsProjectToSite (project: Project, cpsCommandLineOptions: IDictionary<ProjectId, struct (string[] * string[])>) =
         let sourcePaths, referencePaths, options =
             match cpsCommandLineOptions.TryGetValue(project.Id) with
             | true, (sourcePaths, options) -> sourcePaths, [||], options
@@ -105,10 +105,13 @@ module private FSharpProjectOptionsHelpers =
 type private FSharpProjectOptionsMessage =
     | TryGetOptionsByDocument of
         Document *
-        AsyncReplyChannel<(FSharpParsingOptions * FSharpProjectOptions) voption> *
+        AsyncReplyChannel<struct (FSharpParsingOptions * FSharpProjectOptions) voption> *
         CancellationToken *
         userOpName: string
-    | TryGetOptionsByProject of Project * AsyncReplyChannel<(FSharpParsingOptions * FSharpProjectOptions) voption> * CancellationToken
+    | TryGetOptionsByProject of
+        Project *
+        AsyncReplyChannel<struct (FSharpParsingOptions * FSharpProjectOptions) voption> *
+        CancellationToken
     | ClearOptions of ProjectId
     | ClearSingleFileOptionsCache of DocumentId
 
@@ -117,12 +120,13 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
     let cancellationTokenSource = new CancellationTokenSource()
 
     // Store command line options
-    let commandLineOptions = ConcurrentDictionary<ProjectId, string[] * string[]>()
+    let commandLineOptions =
+        ConcurrentDictionary<ProjectId, struct (string[] * string[])>()
 
     let legacyProjectSites = ConcurrentDictionary<ProjectId, IProjectSite>()
 
     let cache =
-        ConcurrentDictionary<ProjectId, Project * FSharpParsingOptions * FSharpProjectOptions>()
+        ConcurrentDictionary<ProjectId, struct (Project * FSharpParsingOptions * FSharpProjectOptions)>()
 
     let singleFileCache =
         ConcurrentDictionary<DocumentId, Project * VersionStamp * FSharpParsingOptions * FSharpProjectOptions * ConnectionPointSubscription>()
@@ -298,7 +302,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                 )
                 |> ignore
 
-                return ValueSome(parsingOptions, projectOptions)
+                return ValueSome struct (parsingOptions, projectOptions)
 
             | true, (oldProject, oldFileStamp, parsingOptions, projectOptions, _) ->
                 if fileStamp <> oldFileStamp || isProjectInvalidated document.Project oldProject ct then
@@ -308,7 +312,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
 
                     return! tryComputeOptionsBySingleScriptOrFile document userOpName
                 else
-                    return ValueSome(parsingOptions, projectOptions)
+                    return ValueSome struct (parsingOptions, projectOptions)
         }
 
     let tryGetProjectSite (project: Project) =
@@ -342,7 +346,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         if referencedProject.Language = FSharpConstants.FSharpLanguageName then
                             match! tryComputeOptions referencedProject with
                             | ValueNone -> canBail <- true
-                            | ValueSome(_, projectOptions) ->
+                            | ValueSome struct (_, projectOptions) ->
                                 referencedProjects.Add(
                                     FSharpReferencedProject.FSharpReference(referencedProject.OutputFilePath, projectOptions)
                                 )
@@ -413,7 +417,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                                 let options =
                                     projectsToClearCache
                                     |> Seq.map (fun pair ->
-                                        let _, _, projectOptions = pair.Value
+                                        let struct (_, _, projectOptions) = pair.Value
                                         projectOptions)
 
                                 checker.ClearCache(options, userOpName = "tryComputeOptions")
@@ -427,16 +431,16 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
 
                             let parsingOptions, _ = checker.GetParsingOptionsFromProjectOptions(projectOptions)
 
-                            cache.[projectId] <- (project, parsingOptions, projectOptions)
+                            cache.[projectId] <- struct (project, parsingOptions, projectOptions)
 
-                            return ValueSome(parsingOptions, projectOptions)
+                            return ValueSome struct (parsingOptions, projectOptions)
 
-            | true, (oldProject, parsingOptions, projectOptions) ->
+            | true, struct (oldProject, parsingOptions, projectOptions) ->
                 if isProjectInvalidated oldProject project ct then
                     cache.TryRemove(projectId) |> ignore
                     return! tryComputeOptions project ct
                 else
-                    return ValueSome(parsingOptions, projectOptions)
+                    return ValueSome struct (parsingOptions, projectOptions)
         }
 
     let loop (agent: MailboxProcessor<FSharpProjectOptionsMessage>) =
@@ -508,7 +512,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
 
                 | FSharpProjectOptionsMessage.ClearOptions(projectId) ->
                     match cache.TryRemove(projectId) with
-                    | true, (_, _, projectOptions) ->
+                    | true, struct (_, _, projectOptions) ->
                         lastSuccessfulCompilations.TryRemove(projectId) |> ignore
                         checker.ClearCache([ projectOptions ])
                     | _ -> ()
@@ -539,7 +543,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
         agent.Post(FSharpProjectOptionsMessage.ClearSingleFileOptionsCache(documentId))
 
     member _.SetCommandLineOptions(projectId, sourcePaths, options) =
-        commandLineOptions.[projectId] <- (sourcePaths, options)
+        commandLineOptions.[projectId] <- struct (sourcePaths, options)
 
     member _.SetLegacyProjectSite(projectId, projectSite) =
         legacyProjectSites.[projectId] <- projectSite

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -46,7 +46,7 @@ module private FSharpProjectOptionsHelpers =
 
             member site.CompilationBinOutputPath =
                 site.CompilationOptions
-                |> Array.tryPick (fun s -> if s.StartsWith("-o:") then Some s.[3..] else None)
+                |> Array.tryPickV (fun s -> if s.StartsWith("-o:") then ValueSome s.[3..] else ValueNone)
 
             member _.ProjectFileName = project.FilePath
             member _.AdviseProjectSiteChanges(_, _) = ()

--- a/vsintegration/src/FSharp.Editor/LanguageService/IProjectSite.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/IProjectSite.fs
@@ -25,7 +25,7 @@ and internal IProjectSite =
     abstract CompilationReferences: string[]
 
     /// The '-o:' output bin path, without the '-o:'
-    abstract CompilationBinOutputPath: string option
+    abstract CompilationBinOutputPath: string voption
 
     /// The name of the project file.
     abstract ProjectFileName: string

--- a/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LegacyProjectWorkspaceMap.fs
@@ -117,7 +117,7 @@ type internal LegacyProjectWorkspaceMap
 
             optionsAssociation.Add(projectContext, updatedOptions)
 
-            projectContext.BinOutputPath <- Option.toObj site.CompilationBinOutputPath
+            projectContext.BinOutputPath <- ValueOption.toObj site.CompilationBinOutputPath
 
         let info = (updatedFiles, updatedRefs)
         legacyProjectLookup.AddOrUpdate(projectId, info, (fun _ _ -> info)) |> ignore
@@ -142,7 +142,7 @@ type internal LegacyProjectWorkspaceMap
                     projectFileName,
                     projectGuid,
                     hierarchy,
-                    Option.toObj site.CompilationBinOutputPath
+                    ValueOption.toObj site.CompilationBinOutputPath
                 )
 
             legacyProjectIdLookup.[projectGuid] <- projectContext.Id

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/Project.fs
@@ -1388,7 +1388,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member _.CompilationReferences = x.CompilationReferences
                     member _.CompilationBinOutputPath = 
                         let outputPath = x.GetCurrentOutputAssembly()
-                        if String.IsNullOrWhiteSpace(outputPath) then None else Some(outputPath)
+                        if String.IsNullOrWhiteSpace(outputPath) then ValueNone else ValueSome(outputPath)
 
                     member _.Description = 
                         match sourcesAndFlags with
@@ -1431,7 +1431,7 @@ namespace rec Microsoft.VisualStudio.FSharp.ProjectSystem
                     member _.CompilationSourceFiles = sourceFiles
                     member _.CompilationOptions = options
                     member _.CompilationReferences = refs
-                    member _.CompilationBinOutputPath = if String.IsNullOrWhiteSpace(outputPath) then None else Some(outputPath)
+                    member _.CompilationBinOutputPath = if String.IsNullOrWhiteSpace(outputPath) then ValueNone else ValueSome(outputPath)
                     member _.ProjectFileName = projFileName
                     member _.BuildErrorReporter 
                         with get() = staticBuildErrorReporter


### PR DESCRIPTION
Three independent allocation cleanups, one per commit, no behaviour change.

### `DelayedILModuleReader.result` — declare it nullable instead of boxing

The field was declared non-nullable and initialised with `Unchecked.defaultof<_>`, so both the fast path and the inside-the-lock recheck had to `box` it just to test for null. Typing it `ILModuleReader | null` lets `match` narrow the type directly and drops the boxes.

This is confined to the private field; the public `DelayedILModuleReader` surface is unchanged.

### `Array.tryPickV` + `IProjectSite.CompilationBinOutputPath`

`CompilationBinOutputPath` is probed for the `-o:` flag on every project-site mapping and its result is immediately turned into a string or `null`. Added an `Array.tryPickV` next to the existing `Array.chooseV` and changed the (internal) `IProjectSite` member to `string voption`, so neither the pick nor the result allocates. Call sites move from `Option.toObj` to `ValueOption.toObj`.

`IProjectSite` here is `Microsoft.VisualStudio.FSharp.Editor.IProjectSite`, which is `internal`; the identically-shaped `Microsoft.VisualStudio.FSharp.LanguageService.IProjectSite` used by the legacy project system and Salsa is untouched.

### Struct tuples for the project options caches

`FSharpProjectOptionsReactor`'s `commandLineOptions` and project options `cache` dictionaries, and the `AsyncReplyChannel` payloads of `TryGetOptionsByDocument`/`TryGetOptionsByProject`, all carried reference tuples allocated on every cache write and every reply. None of them escape the reactor, so they are now `struct` tuples.

### Validation

`FSharp.Compiler.Service` and `FSharp.Editor` both build clean in `Debug`.

---

**Update:** this PR originally also included a small `IlxGen.fs` change (`HashRangeSorted` and two `@` concatenations rewritten to avoid intermediate lists). It's been reverted (see the "Revert the IlxGen.fs list-creation micro-optimization" commit): CI's `ILVerify` job flagged `FSharp.Compiler.IlxGen::HashRangeSorted` with a `StackUnexpected` error in Release builds that didn't match the checked-in baseline, even though the identical error text is already present in that baseline as a known, pre-existing issue. I could not pin down the exact mechanism locally (a byte-identical `origin/main` `IlxGen.fs` reproduces the same baselined error through the same build path, but a partial revert didn't clear the CI mismatch either), and the allocation savings there were marginal — not worth the risk of shipping IL that `ILVerify` disagrees with in a shipped compiler DLL. Happy to revisit that piece separately with more thorough (bootstrap-build-equivalent) local verification.
