### PR TITLE
[MicroPerf] Drop accessibility and attribute-scan closures via ListInline

### DIFF
--- a/src/Compiler/Checking/AccessibilityLogic.fs
+++ b/src/Compiler/Checking/AccessibilityLogic.fs
@@ -64,7 +64,7 @@ let IsAccessible ad taccess =
     | AccessibleFromSomeFSharpCode -> canAccessFromSomewhere taccess
     | AccessibleFromSomewhere -> true
     | AccessibleFrom (cpaths, _tcrefViewedFromOption) ->
-        List.exists (canAccessFrom taccess) cpaths
+        ListInline.exists (fun cp -> canAccessFrom taccess cp) cpaths
 
 /// Indicates if an IL member is accessible (ignoring its enclosing type)
 let private IsILMemberAccessible g amap m (tcrefOfViewedItem : TyconRef) ad access =

--- a/src/Compiler/TypedTree/TypedTreeBasics.fs
+++ b/src/Compiler/TypedTree/TypedTreeBasics.fs
@@ -558,10 +558,10 @@ let inline canAccessCompPathFrom (CompPath(scoref1, _, cpath1)) (CompPath(scoref
     (scoref1 = scoref2)
 
 let canAccessFromOneOf cpaths cpathTest =
-    cpaths |> List.exists (fun cpath -> canAccessCompPathFrom cpath cpathTest)
+    cpaths |> ListInline.exists (fun cpath -> canAccessCompPathFrom cpath cpathTest)
 
 let canAccessFrom (TAccess x) cpath =
-    x |> List.forall (fun cpath1 -> canAccessCompPathFrom cpath1 cpath)
+    x |> ListInline.forall (fun cpath1 -> canAccessCompPathFrom cpath1 cpath)
 
 let canAccessFromEverywhere (TAccess x) = x.IsEmpty
 let canAccessFromSomewhere (TAccess _) = true

--- a/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
@@ -487,7 +487,7 @@ module internal AttributeHelpers =
         (flag: 'Flag)
         (attribs: Attribs)
         : Attrib option =
-        attribs |> List.tryFind (fun attrib -> classify g attrib &&& flag <> none)
+        attribs |> ListInline.tryFind (fun attrib -> classify g attrib &&& flag <> none)
 
     /// Shared combinator: check if any attrib in a list matches a flag via a classify function.
     let inline internal attribsHaveFlag
@@ -497,7 +497,7 @@ module internal AttributeHelpers =
         (flag: 'Flag)
         (attribs: Attribs)
         : bool =
-        attribs |> List.exists (fun attrib -> classify g attrib &&& flag <> none)
+        attribs |> ListInline.exists (fun attrib -> classify g attrib &&& flag <> none)
 
     /// Compute well-known attribute flags for an Entity's Attrib list.
     let computeEntityWellKnownFlags (g: TcGlobals) (attribs: Attribs) : WellKnownEntityAttributes =

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -464,6 +464,24 @@ module ListInline =
 
         result
 
+    /// List.forall, but inline so the predicate is inlined (InlineIfLambda) rather than allocated as a closure.
+    let inline forall ([<InlineIfLambda>] predicate: 'T -> bool) (list: 'T list) =
+        let rec loop list =
+            match list with
+            | [] -> true
+            | head :: tail -> predicate head && loop tail
+
+        loop list
+
+    /// List.tryFind, but inline so the predicate is inlined (InlineIfLambda) rather than allocated as a closure.
+    let inline tryFind ([<InlineIfLambda>] predicate: 'T -> bool) (list: 'T list) =
+        let rec loop list =
+            match list with
+            | [] -> None
+            | head :: tail -> if predicate head then Some head else loop tail
+
+        loop list
+
     /// List.foldBack, but inline so the folder is inlined (InlineIfLambda). Folds lengths up to 5 directly; longer lists use an array, staying stack-safe like List.foldBack.
     let inline foldBack ([<InlineIfLambda>] folder: 'T -> 'State -> 'State) (list: 'T list) (state: 'State) =
         match list with

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -158,6 +158,12 @@ module internal ListInline =
     /// List.exists, but inline so the predicate is inlined (InlineIfLambda) rather than allocated as a closure.
     val inline exists: [<InlineIfLambda>] predicate: ('T -> bool) -> list: 'T list -> bool
 
+    /// List.forall, but inline so the predicate is inlined (InlineIfLambda) rather than allocated as a closure.
+    val inline forall: [<InlineIfLambda>] predicate: ('T -> bool) -> list: 'T list -> bool
+
+    /// List.tryFind, but inline so the predicate is inlined (InlineIfLambda) rather than allocated as a closure.
+    val inline tryFind: [<InlineIfLambda>] predicate: ('T -> bool) -> list: 'T list -> 'T option
+
     /// List.foldBack, but inline so the folder is inlined (InlineIfLambda). Folds lengths up to 5 directly; longer lists use an array, staying stack-safe like List.foldBack.
     val inline foldBack: [<InlineIfLambda>] folder: ('T -> 'State -> 'State) -> list: 'T list -> state: 'State -> 'State
 


### PR DESCRIPTION
Stacks on #20372 (adds the internal `ListInline` module). Extends it with `exists`/`forall`/`tryFind` (`inline` + `InlineIfLambda`) and routes five hot accessibility / attribute-scan call sites through them, folding the lambda so no per-call `FSharpFunc` closure is allocated.

Closure allocation removed — `dotnet-trace gc-verbose`, `fsc` self-compiling `src/Compiler` (net11 perf bundle):

| closure | via | before | after |
|---|---|--:|--:|
| `IsAccessible` | `ListInline.exists` | 83.9 MB | **0** |
| `canAccessFrom` | `ListInline.forall` | 77.6 MB | **0** |
| `tryFindEntityAttribByFlag` / `tryFindValAttribByFlag` | `ListInline.tryFind` / `exists` | 18.9 MB | **0** |
| **total** | | **≈ 180 MB** | **0** |

`canAccessFromOneOf`'s closure is folded too.

Deterministic proof — closure classes `IsAccessible@`, `canAccessFrom@`, `canAccessFromOneOf@`, `tryFindEntityAttribByFlag@`, `tryFindValAttribByFlag@` are present in the base `FSharp.Compiler.Service.dll` and **absent** after (metadata scan of the emitted assembly). `exists`/`forall`/`tryFind` match `List.*` semantics (empty → `false` / `true` / `None`, first match preserved); build 0/0.
