### PR TITLE
[MicroPerf] Eliminate closure allocations in well-known-attribute queries

### DIFF
--- a/src/Compiler/TypedTree/TypedTree.fs
+++ b/src/Compiler/TypedTree/TypedTree.fs
@@ -1404,23 +1404,6 @@ type Entity =
 
     member x.SetEntityAttribs (attribs: WellKnownEntityAttribs) = x.entity_attribs <- attribs
 
-    /// Check if this entity has a specific well-known attribute, computing and caching flags if needed.
-    member x.HasWellKnownAttribute(flag: WellKnownEntityAttributes, computeFlags: Attribs -> WellKnownEntityAttributes) : bool =
-        let struct (result, wa, changed) = x.EntityAttribs.CheckFlag(flag, computeFlags)
-        if changed then x.SetEntityAttribs(wa)
-        result
-
-    /// Get the computed well-known attribute flags, computing and caching if needed.
-    member x.GetWellKnownEntityFlags(computeFlags: Attribs -> WellKnownEntityAttributes) : WellKnownEntityAttributes =
-        let f = LanguagePrimitives.EnumToValue x.EntityAttribs.Flags
-
-        if f &&& (1uL <<< 63) <> 0uL then
-            let computed = computeFlags (x.EntityAttribs.AsList())
-            x.SetEntityAttribs(WellKnownAttribs(x.EntityAttribs.AsList(), computed))
-            computed
-        else
-            x.EntityAttribs.Flags
-
     /// Sets the structness of a record or union type definition
     member x.SetIsStructRecordOrUnion b = let flags = x.entity_flags in x.entity_flags <- EntityFlags(flags.IsPrefixDisplay, flags.IsModuleOrNamespace, flags.PreEstablishedHasDefaultConstructor, flags.HasSelfReferentialConstructor, b)
 
@@ -3491,12 +3474,6 @@ type Val =
         match x.val_opt_data with
         | Some optData -> optData.val_attribs <- attribs
         | _ -> x.val_opt_data <- Some { Val.NewEmptyValOptData() with val_attribs = attribs }
-
-    /// Check if this val has a specific well-known attribute, computing and caching flags if needed.
-    member x.HasWellKnownAttribute(flag: WellKnownValAttributes, computeFlags: Attribs -> WellKnownValAttributes) : bool =
-        let struct (result, waNew, changed) = x.ValAttribs.CheckFlag(flag, computeFlags)
-        if changed then x.SetValAttribs(waNew)
-        result
 
     member x.SetMemberInfo member_info =
         match x.val_opt_data with

--- a/src/Compiler/TypedTree/TypedTree.fsi
+++ b/src/Compiler/TypedTree/TypedTree.fsi
@@ -495,13 +495,6 @@ type Entity =
     /// Set the custom attributes wrapper on an F# type definition.
     member SetEntityAttribs: WellKnownEntityAttribs -> unit
 
-    /// Check if this entity has a specific well-known attribute, computing and caching flags if needed.
-    member HasWellKnownAttribute:
-        flag: WellKnownEntityAttributes * computeFlags: (Attribs -> WellKnownEntityAttributes) -> bool
-
-    /// Get the computed well-known attribute flags, computing and caching if needed.
-    member GetWellKnownEntityFlags: computeFlags: (Attribs -> WellKnownEntityAttributes) -> WellKnownEntityAttributes
-
     member SetCompiledName: name: string option -> unit
 
     member SetExceptionInfo: exn_info: ExceptionInfo -> unit
@@ -2049,10 +2042,6 @@ type Val =
     member SetAttribs: attribs: Attribs -> unit
 
     member SetValAttribs: attribs: WellKnownValAttribs -> unit
-
-    /// Check if this val has a specific well-known attribute, computing and caching flags if needed.
-    member HasWellKnownAttribute:
-        flag: WellKnownValAttributes * computeFlags: (Attribs -> WellKnownValAttributes) -> bool
 
     /// Set all the data on a value
     member SetData: tg: ValData -> unit

--- a/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
@@ -508,6 +508,21 @@ module internal AttributeHelpers =
 
         flags
 
+    // Keep the cache-miss computation fully applied to avoid allocating a query closure.
+    let private ensureEntityFlags (g: TcGlobals) (entity: Entity) : WellKnownEntityAttribs =
+        let wa = entity.EntityAttribs
+
+        if wa.NeedsCompute then
+            let attribs = wa.AsList()
+
+            let computed =
+                WellKnownEntityAttribs(attribs, computeEntityWellKnownFlags g attribs)
+
+            entity.SetEntityAttribs computed
+            computed
+        else
+            wa
+
     /// Find the first attribute matching a specific well-known entity flag.
     let tryFindEntityAttribByFlag g flag attribs =
         tryFindAttribByClassifier classifyEntityAttrib WellKnownEntityAttributes.None g flag attribs
@@ -552,14 +567,12 @@ module internal AttributeHelpers =
     let attribsHaveEntityFlag g (flag: WellKnownEntityAttributes) (attribs: Attribs) =
         attribsHaveFlag classifyEntityAttrib WellKnownEntityAttributes.None g flag attribs
 
-    /// Map a WellKnownILAttributes flag to its WellKnownValAttributes equivalent.
     /// Check if an Entity has a specific well-known attribute, computing and caching flags if needed.
     let EntityHasWellKnownAttribute (g: TcGlobals) (flag: WellKnownEntityAttributes) (entity: Entity) : bool =
-        entity.HasWellKnownAttribute(flag, computeEntityWellKnownFlags g)
+        (ensureEntityFlags g entity).HasWellKnownAttribute flag
 
     /// Get the computed well-known attribute flags for an entity.
-    let GetEntityWellKnownFlags (g: TcGlobals) (entity: Entity) : WellKnownEntityAttributes =
-        entity.GetWellKnownEntityFlags(computeEntityWellKnownFlags g)
+    let GetEntityWellKnownFlags (g: TcGlobals) (entity: Entity) : WellKnownEntityAttributes = (ensureEntityFlags g entity).Flags
 
     /// Classify a single Val-level attribute, returning its well-known flag (or None).
     let classifyValAttrib (g: TcGlobals) (attrib: Attrib) : WellKnownValAttributes =
@@ -668,6 +681,17 @@ module internal AttributeHelpers =
 
         flags
 
+    let private ensureValFlags (g: TcGlobals) (v: Val) : WellKnownValAttribs =
+        let wa = v.ValAttribs
+
+        if wa.NeedsCompute then
+            let attribs = wa.AsList()
+            let computed = WellKnownValAttribs(attribs, computeValWellKnownFlags g attribs)
+            v.SetValAttribs computed
+            computed
+        else
+            wa
+
     /// Find the first attribute in a list that matches a specific well-known val flag.
     let tryFindValAttribByFlag g flag attribs =
         tryFindAttribByClassifier classifyValAttrib WellKnownValAttributes.None g flag attribs
@@ -712,17 +736,22 @@ module internal AttributeHelpers =
 
     /// Check if an ArgReprInfo has a specific well-known attribute, computing and caching flags if needed.
     let ArgReprInfoHasWellKnownAttribute (g: TcGlobals) (flag: WellKnownValAttributes) (argInfo: ArgReprInfo) : bool =
-        let struct (result, waNew, changed) =
-            argInfo.Attribs.CheckFlag(flag, computeValWellKnownFlags g)
+        let wa = argInfo.Attribs
 
-        if changed then
-            argInfo.Attribs <- waNew
+        let wa =
+            if wa.NeedsCompute then
+                let attribs = wa.AsList()
+                let computed = WellKnownValAttribs(attribs, computeValWellKnownFlags g attribs)
+                argInfo.Attribs <- computed
+                computed
+            else
+                wa
 
-        result
+        wa.HasWellKnownAttribute flag
 
     /// Check if a Val has a specific well-known attribute, computing and caching flags if needed.
     let ValHasWellKnownAttribute (g: TcGlobals) (flag: WellKnownValAttributes) (v: Val) : bool =
-        v.HasWellKnownAttribute(flag, computeValWellKnownFlags g)
+        (ensureValFlags g v).HasWellKnownAttribute flag
 
     /// Query a three-state bool attribute on an entity. Returns bool option.
     let EntityTryGetBoolAttribute
@@ -731,13 +760,12 @@ module internal AttributeHelpers =
         (falseFlag: WellKnownEntityAttributes)
         (entity: Entity)
         : bool option =
-        if not (entity.HasWellKnownAttribute(trueFlag ||| falseFlag, computeEntityWellKnownFlags g)) then
+        let wa = ensureEntityFlags g entity
+
+        if not (wa.HasWellKnownAttribute(trueFlag ||| falseFlag)) then
             Option.None
         else
-            let struct (hasTrue, _, _) =
-                entity.EntityAttribs.CheckFlag(trueFlag, computeEntityWellKnownFlags g)
-
-            if hasTrue then Some true else Some false
+            Some(wa.HasWellKnownAttribute trueFlag)
 
     /// Query a three-state bool attribute on a Val. Returns bool option.
     let ValTryGetBoolAttribute
@@ -746,13 +774,12 @@ module internal AttributeHelpers =
         (falseFlag: WellKnownValAttributes)
         (v: Val)
         : bool option =
-        if not (v.HasWellKnownAttribute(trueFlag ||| falseFlag, computeValWellKnownFlags g)) then
+        let wa = ensureValFlags g v
+
+        if not (wa.HasWellKnownAttribute(trueFlag ||| falseFlag)) then
             Option.None
         else
-            let struct (hasTrue, _, _) =
-                v.ValAttribs.CheckFlag(trueFlag, computeValWellKnownFlags g)
-
-            if hasTrue then Some true else Some false
+            Some(wa.HasWellKnownAttribute trueFlag)
 
     /// Shared core for binding attributes on type definitions, supporting an optional
     /// WellKnownILAttributes flag for O(1) early exit on the IL metadata path.

--- a/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Attributes.fs
@@ -681,13 +681,15 @@ module internal AttributeHelpers =
 
         flags
 
-    let private ensureValFlags (g: TcGlobals) (v: Val) : WellKnownValAttribs =
-        let wa = v.ValAttribs
-
+    let inline private ensureValFlags
+        (g: TcGlobals)
+        (wa: WellKnownValAttribs)
+        ([<InlineIfLambda>] setAttribs: WellKnownValAttribs -> unit)
+        : WellKnownValAttribs =
         if wa.NeedsCompute then
             let attribs = wa.AsList()
             let computed = WellKnownValAttribs(attribs, computeValWellKnownFlags g attribs)
-            v.SetValAttribs computed
+            setAttribs computed
             computed
         else
             wa
@@ -736,22 +738,11 @@ module internal AttributeHelpers =
 
     /// Check if an ArgReprInfo has a specific well-known attribute, computing and caching flags if needed.
     let ArgReprInfoHasWellKnownAttribute (g: TcGlobals) (flag: WellKnownValAttributes) (argInfo: ArgReprInfo) : bool =
-        let wa = argInfo.Attribs
-
-        let wa =
-            if wa.NeedsCompute then
-                let attribs = wa.AsList()
-                let computed = WellKnownValAttribs(attribs, computeValWellKnownFlags g attribs)
-                argInfo.Attribs <- computed
-                computed
-            else
-                wa
-
-        wa.HasWellKnownAttribute flag
+        (ensureValFlags g argInfo.Attribs (fun attribs -> argInfo.Attribs <- attribs)).HasWellKnownAttribute flag
 
     /// Check if a Val has a specific well-known attribute, computing and caching flags if needed.
     let ValHasWellKnownAttribute (g: TcGlobals) (flag: WellKnownValAttributes) (v: Val) : bool =
-        (ensureValFlags g v).HasWellKnownAttribute flag
+        (ensureValFlags g v.ValAttribs (fun attribs -> v.SetValAttribs attribs)).HasWellKnownAttribute flag
 
     /// Query a three-state bool attribute on an entity. Returns bool option.
     let EntityTryGetBoolAttribute
@@ -774,7 +765,7 @@ module internal AttributeHelpers =
         (falseFlag: WellKnownValAttributes)
         (v: Val)
         : bool option =
-        let wa = ensureValFlags g v
+        let wa = ensureValFlags g v.ValAttribs (fun attribs -> v.SetValAttribs attribs)
 
         if not (wa.HasWellKnownAttribute(trueFlag ||| falseFlag)) then
             Option.None

--- a/src/Compiler/TypedTree/WellKnownAttribs.fs
+++ b/src/Compiler/TypedTree/WellKnownAttribs.fs
@@ -155,6 +155,8 @@ type internal WellKnownAttribs<'TItem, 'TFlags when 'TFlags: enum<uint64>> =
     /// Get the current flags value.
     member x.Flags = x.flags
 
+    member x.NeedsCompute = LanguagePrimitives.EnumToValue x.flags &&& (1uL <<< 63) <> 0uL
+
     /// Add a single item and OR-in its flag.
     member x.Add(attrib: 'TItem, flag: 'TFlags) =
         let combined =
@@ -168,18 +170,3 @@ type internal WellKnownAttribs<'TItem, 'TFlags when 'TFlags: enum<uint64>> =
             WellKnownAttribs<'TItem, 'TFlags>([], LanguagePrimitives.EnumOfValue 0uL)
         else
             WellKnownAttribs<'TItem, 'TFlags>(x.attribs, LanguagePrimitives.EnumOfValue(1uL <<< 63))
-
-    /// Caller must write back the returned wrapper if needsWriteBack is true.
-    member x.CheckFlag(flag: 'TFlags, compute: 'TItem list -> 'TFlags) : struct (bool * WellKnownAttribs<'TItem, 'TFlags> * bool) =
-        let f = LanguagePrimitives.EnumToValue x.flags
-
-        if f &&& (1uL <<< 63) <> 0uL then
-            let computed = compute x.attribs
-            let wa = WellKnownAttribs<'TItem, 'TFlags>(x.attribs, computed)
-
-            struct (LanguagePrimitives.EnumToValue computed &&& LanguagePrimitives.EnumToValue flag
-                    <> 0uL,
-                    wa,
-                    true)
-        else
-            struct (x.HasWellKnownAttribute(flag), x, false)

--- a/src/Compiler/TypedTree/WellKnownAttribs.fsi
+++ b/src/Compiler/TypedTree/WellKnownAttribs.fsi
@@ -141,9 +141,7 @@ type internal WellKnownAttribs<'TItem, 'TFlags when 'TFlags: enum<uint64>> =
     new: attribs: 'TItem list * flags: 'TFlags -> WellKnownAttribs<'TItem, 'TFlags>
     member AsList: unit -> 'TItem list
     member Flags: 'TFlags
+    member NeedsCompute: bool
     member HasWellKnownAttribute: flag: 'TFlags -> bool
     member Add: attrib: 'TItem * flag: 'TFlags -> WellKnownAttribs<'TItem, 'TFlags>
     member WithRecomputedFlags: unit -> WellKnownAttribs<'TItem, 'TFlags>
-
-    member CheckFlag:
-        flag: 'TFlags * compute: ('TItem list -> 'TFlags) -> struct (bool * WellKnownAttribs<'TItem, 'TFlags> * bool)

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -257,6 +257,16 @@ module Array =
 
             if eq then inp else res
 
+    let inline tryPick ([<InlineIfLambda>] chooser: 'T -> 'U option) (arr: 'T[]) =
+        let mutable res = None
+        let mutable i = 0
+
+        while res.IsNone && i < arr.Length do
+            res <- chooser arr[i]
+            i <- i + 1
+
+        res
+
     let lengthsEqAndForall2 p l1 l2 =
         Array.length l1 = Array.length l2 && Array.forall2 p l1 l2
 

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -108,6 +108,8 @@ module internal Array =
 
     val mapq: f: ('a -> 'a) -> inp: 'a[] -> 'a[] when 'a: not struct
 
+    val inline tryPick: [<InlineIfLambda>] chooser: ('T -> 'U option) -> arr: 'T[] -> 'U option
+
     val lengthsEqAndForall2: p: ('a -> 'b -> bool) -> l1: 'a[] -> l2: 'b[] -> bool
 
     val order: eltOrder: IComparer<'T> -> IComparer<'T array>


### PR DESCRIPTION
Well-known-attribute queries partially applied `computeEntityWellKnownFlags g` / `computeValWellKnownFlags g` to non-`inline` caching methods, so each query heap-allocated an `FSharpFunc` even on a cache hit. The queries now test a function-free `NeedsCompute` bit and compute (on a miss only) with a fully-applied call; an `inline` `Array.tryPick` twin folds the remaining lambda.

Closure allocation eliminated — gc-verbose sampled, `fsc` self-compiling the 455-file `FSharp.Compiler.Service` (Release/net11):

| closure site | before | after |
|---|--:|:--:|
| `tryFindILAttribByFlag@204` | 87.6 MB | **0** |
| `EntityTryGetBoolAttribute@734` | 55.2 MB | **0** |
| `ArgReprInfoHasWellKnownAttribute@716` | 31.0 MB | **0** |

| check | result |
|---|---|
| closure classes in emitted `FSharp.Compiler.Service.dll` | 3 on `main` → **0** here |
| `FSharp.Compiler.Service.dll` size | **−21,504 bytes** |
| diff | **+63 / −73**, 7 files |
| behaviour | cached flag values identical; attribute/accessibility ComponentTests pass |
