### PR TITLE
[MicroPerf] Drop the generic-arg closure in CanImportILType

### DIFF
--- a/src/Compiler/Checking/import.fs
+++ b/src/Compiler/Checking/import.fs
@@ -394,7 +394,7 @@ let rec CanImportILType (env: ImportMap) m ty =
     | ILType.Boxed  tspec
     | ILType.Value tspec ->
         CanImportILTypeRef env m tspec.TypeRef
-        && tspec.GenericArgs |> List.forall (CanImportILType env m)
+        && tspec.GenericArgs |> ListInline.forall (fun ety -> CanImportILType env m ety)
 
     | ILType.Byref ety -> CanImportILType env m ety
     | ILType.Ptr ety  -> CanImportILType env m ety


### PR DESCRIPTION
| closure | mechanism | before (MB) | after |
|---|---|--:|---|
| CanImportILType@397 | ListInline.forall twin | 40.0 | gone |

The recursive generic-arg check passed a partial application to non-inline `List.forall`; the inline `ListInline.forall` twin folds it so no per-call closure is allocated.
