### PR TITLE
[MicroPerf] Drop the per-call closure in remarkExprs

### DIFF
--- a/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
@@ -2583,7 +2583,8 @@ module internal ExprAnalysis =
     and remarkInterfaceImpl m (ty, overrides) =
         (ty, List.map (remarkObjExprMethod m) overrides)
 
-    and remarkExprs m es = es |> List.map (remarkExpr m)
+    and remarkExprs m es =
+        es |> ListInline.map (fun e -> remarkExpr m e)
 
     and remarkDecisionTree m x =
         match x with


### PR DESCRIPTION
`List.map (remarkExpr m)` allocated a `remarkExpr m` closure per call; `ListInline.map (fun e -> remarkExpr m e)` inlines it away. Closure only — the result list still allocates its spine.

| closure | mechanism | before (MB) | after | note |
|---|---|--:|---|---|
| remarkExprs@2586 | ListInline.map | 28.4 | closure gone | result-list nodes unchanged |
