### PR TITLE
Avoid per-call FSharpFunc closure in remapVal member-info remap

### DIFF
--- a/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
@@ -1693,7 +1693,7 @@ module internal ExprRemapping =
 
         let memberInfoR =
             d.MemberInfo
-            |> Option.map (remapMemberInfo ctxt d.val_range valReprInfo ty tyR tmenv)
+            |> Option.map (fun mi -> remapMemberInfo ctxt d.val_range valReprInfo ty tyR tmenv mi)
 
         let attribsR = d.Attribs |> remapAttribs ctxt tmenv
 


### PR DESCRIPTION
`remapValData` runs once per copied `Val` (import, signature matching, inlining) and allocated an `FSharpFunc` for the `Option.map` mapping on every call — even for non-member vals, and even though `Option.map` is `inline`. The partial application `remapMemberInfo ctxt … tmenv` was the allocation; a syntactic lambda lets `[<InlineIfLambda>]` fire and lowers it to a direct call.

```fsharp
- |> Option.map (remapMemberInfo ctxt d.val_range valReprInfo ty tyR tmenv)
+ |> Option.map (fun mi -> remapMemberInfo ctxt d.val_range valReprInfo ty tyR tmenv mi)
```

`remapValData` IL, before → after:

| metric | before | after |
|---|---|---|
| `newobj` per call | 5 | 4 |
| `memberInfoR@1696` closure (72 B) | every call | none |
| member-info call | `callvirt FSharpFunc::Invoke` | direct `call remapMemberInfo` |

Closures removed per self-compile (one 72 B `FSharpFunc` per `remapValData` call):

| self-compile | calls | heap removed |
|---|---|---|
| FSharp.Compiler.Service | 795,281 | ~54.6 MiB |
| FSharp.Core | 126,100 | ~8.7 MiB |
