### PR TITLE
Resolve F# frames for Debug ▸ Show Call Stack on Code Map

### DIFF
--- a/.claude/rules/CcrOptout.md
+++ b/.claude/rules/CcrOptout.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "**"
+---
+
+@../../.github/instructions/CcrOptout.instructions.md

--- a/.claude/rules/CodeGen.md
+++ b/.claude/rules/CodeGen.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/Compiler/CodeGen/**/*.{fs,fsi}"
+---
+
+@../../.github/instructions/CodeGen.instructions.md

--- a/.claude/rules/ComponentTests.md
+++ b/.claude/rules/ComponentTests.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "tests/FSharp.Compiler.ComponentTests/**/*.fs"
+---
+
+@../../.github/instructions/ComponentTests.instructions.md

--- a/.claude/rules/DebugEmit.md
+++ b/.claude/rules/DebugEmit.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/Compiler/AbstractIL/ilwritepdb.{fs,fsi}"
+---
+
+@../../.github/instructions/DebugEmit.instructions.md

--- a/.claude/rules/EngVersioning.md
+++ b/.claude/rules/EngVersioning.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "eng/Packages.props"
+  - "eng/Versions.props"
+  - "eng/Version.Details.xml"
+  - "eng/Version.Details.props"
+---
+
+@../../.github/instructions/EngVersioning.instructions.md

--- a/.claude/rules/ExpertReview.md
+++ b/.claude/rules/ExpertReview.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/Compiler/**/*.{fs,fsi}"
+---
+
+@../../.github/instructions/ExpertReview.instructions.md

--- a/.claude/rules/FSComp.md
+++ b/.claude/rules/FSComp.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/Compiler/FSComp.txt"
+---
+
+@../../.github/instructions/FSComp.instructions.md

--- a/.claude/rules/FSharp.md
+++ b/.claude/rules/FSharp.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "src/**/*.{fs,fsi,fsx}"
+  - "vsintegration/src/**/*.{fs,fsi}"
+  - "tests/**/*.{fs,fsi,fsx}"
+---
+
+@../../.github/instructions/FSharp.instructions.md

--- a/.claude/rules/FSharpCore.md
+++ b/.claude/rules/FSharpCore.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/FSharp.Core/**/*.{fs,fsi}"
+---
+
+@../../.github/instructions/FSharpCore.instructions.md

--- a/.claude/rules/LSP.md
+++ b/.claude/rules/LSP.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/FSharp.Compiler.LanguageServer/**/*.{fs,fsi}"
+---
+
+@../../.github/instructions/LSP.instructions.md

--- a/.claude/rules/NoBloat.md
+++ b/.claude/rules/NoBloat.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "src/Compiler/**/*.{fs,fsi}"
+  - "vsintegration/src/**/*.{fs,fsi}"
+  - "tests/FSharp.Compiler.ComponentTests/**/*.fs"
+  - "tests/FSharp.Compiler.Service.Tests/**/*.fs"
+  - "vsintegration/tests/**/*.fs"
+---
+
+@../../.github/instructions/NoBloat.instructions.md

--- a/.claude/rules/Optimizer.md
+++ b/.claude/rules/Optimizer.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "src/Compiler/Optimize/**/*.{fs,fsi}"
+---
+
+@../../.github/instructions/Optimizer.instructions.md

--- a/.claude/rules/SyntaxTree.md
+++ b/.claude/rules/SyntaxTree.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "src/Compiler/SyntaxTree/SyntaxTree.{fs,fsi}"
+  - "src/Compiler/SyntaxTree/SyntaxTreeOps.{fs,fsi}"
+  - "src/Compiler/SyntaxTree/ParseHelpers.{fs,fsi}"
+  - "src/Compiler/pars.fsy"
+---
+
+@../../.github/instructions/SyntaxTree.instructions.md

--- a/.claude/rules/TypedTreePickle.md
+++ b/.claude/rules/TypedTreePickle.md
@@ -1,0 +1,8 @@
+---
+paths:
+  - "src/Compiler/TypedTree/TypedTreePickle.{fs,fsi}"
+  - "src/Compiler/TypedTree/TypedTree.{fs,fsi}"
+  - "src/Compiler/Driver/CompilerImports.{fs,fsi}"
+---
+
+@../../.github/instructions/TypedTreePickle.instructions.md

--- a/.github/instructions/FSharp.instructions.md
+++ b/.github/instructions/FSharp.instructions.md
@@ -1,0 +1,89 @@
+---
+applyTo:
+  - "src/**/*.{fs,fsi,fsx}"
+  - "vsintegration/src/**/*.{fs,fsi}"
+  - "tests/**/*.{fs,fsi,fsx}"
+---
+
+# Writing F#
+
+Which constructs to reach for. Code shape and comments are NoBloat's; naming and the abbreviation glossary belong to `docs/coding-standards.md` and `DEVGUIDE.md`.
+
+These rules govern code you write or touch. Do not sweep the codebase to apply them – `CONTRIBUTING.md`: *"DO NOT submit large code formatting changes without discussing with the team first."*
+
+## Tools
+
+When the IDE's F# semantic tools are unavailable, use the `F#` MCP server (`.mcp.json`, FsLangMCP) for navigation, symbol discovery, diagnostics and cross-project usage search. Prefer its semantic tools over plain text search for F#-specific work.
+
+## Strings
+
+- Prefer interpolated strings over `sprintf` and `String.Format`. Use `$"""…"""` when the text itself contains quotes.
+- Format specifiers are valid in interpolated strings and help type inference: `$"count %d{n}"`.
+- `nameof` over a string literal that names a value, member or type.
+- An explicit `StringComparison` on every `Equals`, `StartsWith`, `EndsWith`, `Contains`, `IndexOf` and `Compare`, and an explicit comparer on every `HashSet<string>` and `Dictionary<string, _>`. `Ordinal` by default, `OrdinalIgnoreCase` for identifiers and paths. Culture-sensitive comparison is a decision, never a default.
+
+## Values and types
+
+- `voption` – `ValueSome`/`ValueNone` – over `option` when the value does not escape; it is this compiler's option type. Exception: when an API hands you `'T option` (`Seq.tryHead`, `List.tryFind`), unwrap with `Option.defaultValue`/`Option.defaultWith` directly – do not insert `ValueOption.ofOption` just to switch modules.
+- `struct ('T1 * 'T2)` tuples and `[<Struct>]` types on allocation-sensitive paths.
+- Anonymous struct records (`struct {| … |}`) over bare tuples for multi-value returns of internal helpers. Public FCS surface is governed by `.fsi` files and compatibility – do not change it for style.
+- The compiler generates `IsCaseName` properties (`IsDefault`, `IsCustom`) for DU cases – use them for a specific-case check instead of a full `match`.
+- Deconstruct `KeyValuePair` with the `KeyValue` active pattern: `for KeyValue(k, v) in map do …`.
+- `[<InlineIfLambda>]` on `inline` higher-order helpers whose lambda argument must not become a closure.
+
+## Lambdas and collections
+
+- Prefer the `_.Property` shorthand in pipeline position: `tys |> List.map _.Type`. Complex expressions (`fun x -> x.Name = name`, `fun x -> x.A, x.B`) cannot use it. Never add a space – `_.MethodCall ()` breaks parsing. Unrelated to the `member _.Foo` self-identifier.
+- Eta-reduce: `Seq.map (fun x -> someFunction x)` must become `Seq.map someFunction`.
+- Several pipeline stages in a row over a `List`/`Array` allocate an intermediate collection each – route the chain through `Seq` and materialize once at the end.
+- Concatenate with `[ yield! xs; yield! ys ]` / `seq { yield! xs; yield! ys }` rather than `@` or `Seq.append` – `@` forces both sides to lists and is O(n).
+- Cast sequence items with `Seq.cast<Target>`, not `Seq.map (fun item -> item :> Target)`.
+
+## Async and exceptions
+
+- `src/Compiler` targets `netstandard2.0`: use `async { }` and the repo's `cancellable { }` (`src/Compiler/Utilities/Cancellable.fs`). `task { }` has no foothold there.
+- `vsintegration` runs on the VS threading model where `task { }` is at home. When an override must return non-generic `Task`, annotate explicitly – `override _.M(…) : Task = task { … }` – never cast through pipelines.
+- Thread cancellation through; see `ExpertReview.instructions.md`.
+- `reraise ()` does not compile inside a `task`/`async` CE (FS0413). There, rethrow with `ExceptionDispatchInfo.Capture(ex).Throw()`; outside CEs plain `reraise ()` is correct.
+
+## Nullness
+
+Enabled in `src/Compiler`, `src/FSharp.Build`, `src/FSharp.Compiler.LanguageServer`. There:
+
+- Declare non-nullable; check for `null` at entry points. Trust C#/F# annotations – no null checks where the type system says a value cannot be null.
+- Prefer `match x with | null -> … | x -> …` over `isNull` – the match narrows the type, `isNull` does not.
+- Use `withNull` to hint nullability instead of boxing (`isNull (box f)`).
+- Before suppressing a nullness warning (3261, 3262, …), escalate in order: `nonNull value` (runtime assert, fail fast) → `Unchecked.nonNull value` (null provably impossible upstream) → inline `#nowarn`/`#warnon` pair, centralised in one interop helper rather than scattered across call sites.
+
+## Warning suppression
+
+Inline `#nowarn "NN"` / `#warnon "NN"` pairs around the smallest possible scope – they are valid anywhere in an `.fs` file, not only at the top. File-level suppression is a last resort.
+
+## Classes (mostly `vsintegration`)
+
+- Initializer syntax over post-construction property assignment: `MyType(ctorArg, MutableProp1 = v1, MutableProp2 = (5 |> string))` – settable properties by name after positional arguments, computed values in parentheses.
+- Extension members consumable from C#: `[<AutoOpen; Extension>]` module, `[<Extension; CompiledName "…">]` on each member.
+- Prefer a root module (`module Ns.FeatureExtensions`) over `namespace` + a static holder type for extension files; name it after the single target type plus `Extensions`, or after the feature when there are several targets.
+- XML doc comments that use markup (`<see/>`, `<c/>`) need their text wrapped in `<summary>`.
+
+## Opens
+
+Sort into blank-line-separated groups, alphabetically within each: `System.*` → `Microsoft.*` → `Internal.Utilities.*` → `FSharp.Compiler.*` (see the top of `src/Compiler/Service/TransparentCompiler.fs`). `open type` last within its group; type and module aliases at the very end.
+
+## Do not mistake for conventions
+
+This codebase implements every F# feature, so finding one here is no evidence that it is used here. These have no foothold – introducing them is a new pattern, not a continuation:
+
+- `while!` and `and!` – no uses at all; the matches are the parser and the checker implementing them.
+- `[<TailCall>]` – a handful of deliberate assertions on specific recursive functions, not a habit.
+
+## The language version is not uniform
+
+`FSharp.Profiles.props` sets `LangVersion=preview`, but not under `Configuration=Proto` and not when `BUILDING_USING_DOTNET=true`. The compiler bootstraps, so a feature this repository is *adding* cannot be used in its own source until it ships in the SDK compiler named by `global.json` – otherwise the Proto stage fails.
+
+- `src/FSharp.Build` is pinned to `LangVersion 9`; it can load in Visual Studio against an older FSharp.Core.
+- `src/FSharp.Core` leaves nullness off and is bound by `docs/fsharp-core-notes.md`.
+
+## Tests
+
+The ComponentTests DSL and its pipeline are covered by `ComponentTests.instructions.md`. Name tests with backticked spaces: ``let ``Issue 12345 - brief description`` () = …``.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+See [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for build, test, and coding rules for this repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,18 @@
 @.github/copilot-instructions.md
+
+## Visual Studio first
+
+The `vs` MCP server reaches the Visual Studio instance holding this repo's solution. Where it and the shell both work, use it — it reports what the IDE's compiler and symbol graph know, not what the text files say.
+
+- Build with `build_solution` / `build_project` / `build_clean` rather than `dotnet build` or `msbuild`; the Build section above is the fallback for when no solution is loaded (`ide_get_workspace_folders` is empty).
+- Read errors from `ide_get_diagnostics`, not by parsing build output.
+- Navigate and rename with `nav_go_to_definition`, `nav_find_references`, `nav_search_workspace_symbols`, `nav_rename_symbol` — the symbol graph, not `grep` plus hand edits.
+- Format what you touched with `document_format` / `document_organize_imports` before reaching for `dotnet fantomas`.
+
+Before editing a file on disk, `document_check_dirty` it. An unsaved VS buffer is the real content: read it with `document_read_buffer` and `document_save` first, or the edit lands on stale text and the user's next save reverts it.
+
+`build_*` compiles whichever configuration the IDE has active, and `solution_set_configuration` changes it for the user's next manual build too — read `solution_get_configuration` before assuming `Debug`.
+
+`project_add_file` appends without a position, so it cannot place a new `<Compile Include>` correctly in an order-sensitive F# project: add those to the `.fsproj` by hand.
+
+Tests have no IDE path — the `vs` server exposes no Test Explorer tools (https://github.com/Corsinvest/cv4vs-agents/issues/192), so they run through `dotnet test` as described above.

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -2,6 +2,7 @@
 
 * Code-fixes for FS3888 (compiler-semantic attribute on the `.fs` but not the `.fsi`): copy the attribute into the `.fsi`, or remove it from the `.fs`. ([Issue #19560](https://github.com/dotnet/fsharp/issues/19560), [PR #19880](https://github.com/dotnet/fsharp/pull/19880))
 * Expand `<inheritdoc/>` in IDE tooltips, completion, and signature help, inheriting XML documentation from base classes, interfaces, overridden members, and constructors. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19188](https://github.com/dotnet/fsharp/pull/19188))
+* Resolve F# frames in **Debug ▸ Show Call Stack on Code Map**: a frame now carries its source location and navigates to the declaration instead of showing as an unresolved node. Lambdas, local functions and computation-expression bodies report the binding that contains them.
 
 ### Fixed
 

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -2,7 +2,7 @@
 
 * Code-fixes for FS3888 (compiler-semantic attribute on the `.fs` but not the `.fsi`): copy the attribute into the `.fsi`, or remove it from the `.fs`. ([Issue #19560](https://github.com/dotnet/fsharp/issues/19560), [PR #19880](https://github.com/dotnet/fsharp/pull/19880))
 * Expand `<inheritdoc/>` in IDE tooltips, completion, and signature help, inheriting XML documentation from base classes, interfaces, overridden members, and constructors. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19188](https://github.com/dotnet/fsharp/pull/19188))
-* Resolve F# frames in **Debug ▸ Show Call Stack on Code Map**: a frame now carries its source location and navigates to the declaration instead of showing as an unresolved node. Lambdas, local functions and computation-expression bodies report the binding that contains them.
+* Resolve F# frames in **Debug ▸ Show Call Stack on Code Map**: a frame now carries its source location and navigates to the declaration instead of showing as an unresolved node. Lambdas, local functions and computation-expression bodies report the binding that contains them. ([Issue #11787](https://github.com/dotnet/fsharp/issues/11787), [PR #20433](https://github.com/dotnet/fsharp/pull/20433))
 
 ### Fixed
 

--- a/tests/projects/CodeMapCallStack/ClassLibrary/ClassLibrary.fsproj
+++ b/tests/projects/CodeMapCallStack/ClassLibrary/ClassLibrary.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Demo.fs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/projects/CodeMapCallStack/ClassLibrary/Demo.fs
+++ b/tests/projects/CodeMapCallStack/ClassLibrary/Demo.fs
@@ -1,0 +1,281 @@
+namespace ClassLibrary
+
+open System
+open System.Threading.Tasks
+
+/// A delegate reaches the lambda through `Invoke` on a generated type, so the frame for the body is
+/// a closure rather than anything named in source.
+type Callback = delegate of int -> int
+
+/// Call shapes for exercising "Show Call Stack on Code Map".
+/// Every scenario funnels into `Demo.sink`, so a single breakpoint there is hit once per scenario
+/// with a differently shaped stack each time.
+module Demo =
+
+    /// PUT THE BREAKPOINT HERE.
+    let sink (scenario: string) =
+        printfn "scenario: %s" scenario
+        scenario.Length
+
+    // ------------------------------------------------------------ plain module functions
+    let private moduleLevelThree (a: int, b: string) = sink "module functions"
+    let private moduleLevelTwo (a: int) (b: string) (c: float) = moduleLevelThree (a, b)
+    let moduleFunctions () = moduleLevelTwo 1 "x" 2.0
+
+    // ------------------------------------------------------------ lambdas in a pipeline
+    let pipelineLambdas () =
+        [ 1 ]
+        |> List.map (fun x -> x + 1)
+        |> List.collect (fun x -> [ x ])
+        |> List.map (fun x -> sink "pipeline lambdas")
+        |> List.sum
+
+    // ------------------------------------------------------------ nested closures
+    let nestedClosures () =
+        let outer factor =
+            let middle scale =
+                let inner () = sink "nested closures"
+                inner () * scale
+
+            middle 2 * factor
+
+        outer 3
+
+    // ------------------------------------------------------------ local functions
+    let localFunctions (n: int) =
+        let helperTwo k = sink "local functions"
+        let helperOne k = helperTwo (k + 1)
+        helperOne n
+
+    // ------------------------------------------------------------ generics, operators, renames
+    let genericFunction<'T> (value: 'T) = sink "generic function"
+
+    let (>=>) a b =
+        sink "custom operator" |> ignore
+        a + b
+
+    let customOperator () = 1 >=> 2
+
+    [<CompiledName("RenamedInMetadata")>]
+    let originalSourceName () = sink "CompiledName rename"
+
+    // ------------------------------------------------------------ active patterns
+    let (|Even|Odd|) n =
+        sink "active pattern" |> ignore
+        if n % 2 = 0 then Even else Odd
+
+    let activePattern () =
+        match 4 with
+        | Even -> 0
+        | Odd -> 1
+
+    let (|Positive|_|) n =
+        sink "partial active pattern" |> ignore
+        if n > 0 then Some n else None
+
+    let partialActivePattern () =
+        match 3 with
+        | Positive _ -> 0
+        | _ -> 1
+
+    // ------------------------------------------------------------ recursion
+    let rec private countdown n =
+        if n <= 0 then sink "recursion" else countdown (n - 1)
+
+    let recursion () = countdown 5
+
+    let rec private isEven n =
+        if n = 0 then sink "mutual recursion" else isOdd (n - 1)
+
+    and private isOdd n =
+        if n = 0 then sink "mutual recursion" else isEven (n - 1)
+
+    let mutualRecursion () = isEven 4
+
+    // ------------------------------------------------------------ higher-order functions
+    let private applyTwice (f: int -> int) x = f (f x)
+    let higherOrder () = applyTwice (fun x -> sink "higher order") 1
+
+    // ------------------------------------------------------------ computation expressions
+    let asyncBody () =
+        async {
+            do! Async.Sleep 1
+            return sink "async body"
+        }
+        |> Async.RunSynchronously
+
+    /// Two levels on purpose. The debugger builds its logical async stack by walking continuations,
+    /// so the inner body is reached from the outer one through `let!` - a continuation it can follow,
+    /// and the pipeline draws that hop as an indirect link. The last hop out, `GetResult`, is a
+    /// blocking wait rather than an await: whoever is parked on it sits on another thread, and no
+    /// continuation leads back there, which is why the body never joins `Main`.
+    let taskBody () =
+        let inner () =
+            task {
+                do! Task.Delay 1
+                return sink "task body"
+            }
+
+        let outer =
+            task {
+                let! value = inner ()
+                return value + sink "task continuation"
+            }
+
+        outer.GetAwaiter().GetResult()
+
+    let seqBody () =
+        seq {
+            yield sink "seq body"
+            yield 0
+        }
+        |> Seq.head
+
+    // ------------------------------------------------------------ nested modules
+    module Outer =
+        module Middle =
+            module Inner =
+                let deeplyNested () = sink "nested modules"
+
+    let nestedModules () = Outer.Middle.Inner.deeplyNested ()
+
+    // ------------------------------------------------------------ a C# callback reached from F#
+    /// Gives a stack that alternates languages: C# -> F# -> closure -> C# -> F#.
+    let throughCallback (callback: Func<int, int>) =
+        [ 1 ]
+        |> List.map (fun x -> callback.Invoke x)
+        |> List.sum
+
+    // ------------------------------------------------------------ delegates
+    /// The lambda is reached through `Invoke` on the delegate type, so its frame is a closure.
+    let throughDelegate (callback: Callback) = callback.Invoke 1
+
+/// Members, properties, constructors and an interface implementation.
+type Worker(seed: int) =
+    let mutable state = seed
+    do state <- state + 1
+
+    member this.Start() = this.CurriedStep 1 2
+    member _.CurriedStep (a: int) (b: int) = Demo.sink "class members"
+
+    member _.Computed =
+        state <- state + 1
+        Demo.sink "property getter"
+
+    member _.Tuned
+        with get () = state
+        and set value =
+            Demo.sink "property setter" |> ignore
+            state <- value
+
+    static member StaticEntry() = Demo.sink "static member"
+
+/// An event adds a second indirection - the handler runs through `MulticastDelegate.Invoke` - and the
+/// `[<CLIEvent>]` accessors are the only `add_`/`remove_` frames F# produces.
+type Publisher() =
+    let fired = Event<int>()
+
+    /// An event is never a frame a debugger stops in. F# reads `p.Fired` by building an `IEvent`
+    /// over `add_Fired`/`remove_Fired` rather than by calling the getter, C# subscribes through the
+    /// same accessors, and those hold no user code. What reaches the stack is the handler.
+    [<CLIEvent>]
+    member _.Fired = fired.Publish
+
+    member _.Fire() = fired.Trigger 1
+
+type IRunner =
+    abstract Run: string -> int
+
+type Runner() =
+    interface IRunner with
+        member _.Run name = Demo.sink "interface implementation"
+
+/// Generic type member.
+type Box<'T>(value: 'T) =
+    member _.Unwrap() = Demo.sink "generic type member"
+
+/// Constructor and static-constructor frames (`..ctor` / `..cctor` in metadata).
+/// The first `new Initialized(...)` hits the breakpoint twice: static init, then instance init.
+type Initialized(seed: int) =
+    static let staticState = Demo.sink "static constructor"
+    let state = Demo.sink "constructor" + seed
+
+    member _.State = state
+    static member StaticState = staticState
+
+/// Members on a discriminated union and on a record.
+type Shape =
+    | Circle of radius: float
+    | Rect of width: float * height: float
+
+    member this.Area() =
+        Demo.sink "union member" |> ignore
+
+        match this with
+        | Circle r -> Math.PI * r * r
+        | Rect(w, h) -> w * h
+
+type Point =
+    { X: float
+      Y: float }
+
+    member this.Norm() =
+        Demo.sink "record member" |> ignore
+        sqrt (this.X * this.X + this.Y * this.Y)
+
+/// Module-level initialization: the stack frame comes from the compiler-synthesized
+/// `<StartupCode$...>` class, not from any user-visible method.
+module Startup =
+    let initialized = Demo.sink "module initialization"
+
+/// The longest mixed stack: member, local function and lambda in one chain.
+module MixedChain =
+
+    let run () =
+        let stage (values: int list) =
+            values
+            |> List.map (fun v ->
+                let finish () = Demo.sink "long mixed chain"
+                finish () + v)
+            |> List.sum
+
+        Worker(1).Start() |> ignore
+        stage [ 1; 2 ]
+
+/// Zero-argument entry points, so the C# driver can pass a method group instead of a lambda.
+/// A C# lambda reaches the map as an `AnonymousMethod__N` node from the built-in provider and
+/// buries the F# frames the map is meant to show.
+module Scenarios =
+
+    let localFunctions () = Demo.localFunctions 1
+    let genericFunction () = Demo.genericFunction 42
+    let unionMember () = int ((Shape.Circle 1.0).Area())
+    let recordMember () = int ({ X = 3.0; Y = 4.0 }.Norm())
+    let genericTypeMember () = Box<string>("s").Unwrap()
+    let interfaceImplementation () = (Runner() :> IRunner).Run "x"
+    let constructors () = Initialized(1).State
+    let moduleInitialization () = Startup.initialized
+
+    /// Owned here rather than by the C# driver: passing an instance in would force a lambda at the
+    /// call site, and that lambda becomes an `AnonymousMethod__N` node on the map.
+    let private worker = Worker 10
+
+    let propertyGetter () = worker.Computed
+
+    let propertySetter () =
+        worker.Tuned <- 5
+        worker.Tuned
+
+    let instanceMember () = worker.Start()
+
+    let delegateCall () =
+        Demo.throughDelegate (Callback(fun _ -> Demo.sink "delegate call"))
+
+    let eventHandler () =
+        let publisher = Publisher()
+        let mutable result = 0
+        publisher.Fired.Add(fun _ -> result <- Demo.sink "event handler")
+        publisher.Fire()
+        result
+
+    let callbackIntoCSharp (callback: Func<int, int>) = Demo.throughCallback callback

--- a/tests/projects/CodeMapCallStack/CodeMapCallStack.sln
+++ b/tests/projects/CodeMapCallStack/CodeMapCallStack.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35806.99 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp", "ConsoleApp\ConsoleApp.csproj", "{824A4BBD-F182-41A0-8F55-DB7D7CDEADF4}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ClassLibrary", "ClassLibrary\ClassLibrary.fsproj", "{7BD986F3-B4CD-4428-AEEC-2F00D2207CD5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{824A4BBD-F182-41A0-8F55-DB7D7CDEADF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{824A4BBD-F182-41A0-8F55-DB7D7CDEADF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{824A4BBD-F182-41A0-8F55-DB7D7CDEADF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{824A4BBD-F182-41A0-8F55-DB7D7CDEADF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BD986F3-B4CD-4428-AEEC-2F00D2207CD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BD986F3-B4CD-4428-AEEC-2F00D2207CD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BD986F3-B4CD-4428-AEEC-2F00D2207CD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BD986F3-B4CD-4428-AEEC-2F00D2207CD5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AE831289-3D4F-413E-B4C4-68AC3C7F02F9}
+	EndGlobalSection
+EndGlobal

--- a/tests/projects/CodeMapCallStack/ConsoleApp/ConsoleApp.csproj
+++ b/tests/projects/CodeMapCallStack/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/projects/CodeMapCallStack/ConsoleApp/Program.cs
+++ b/tests/projects/CodeMapCallStack/ConsoleApp/Program.cs
@@ -1,0 +1,66 @@
+using ClassLibrary;
+
+namespace ConsoleApp
+{
+    /// <summary>
+    /// Sits between Main and the F# library so every stack has C# frames above the F# ones -
+    /// that mix is what "Show Call Stack on Code Map" has to render.
+    /// </summary>
+    internal static class Driver
+    {
+        internal static void Run(string name, Func<int> scenario) => Dispatch(name, scenario);
+
+        private static void Dispatch(string name, Func<int> scenario) => scenario();
+
+        internal static int CallbackIntoCSharp(int value) => Demo.sink("C# callback from F#");
+
+        internal static int CallbackScenario() => Scenarios.callbackIntoCSharp(CallbackIntoCSharp);
+    }
+
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            // Every scenario is passed as a method group: a C# lambda would show up on the Code Map
+            // as an `AnonymousMethod__N` node and hide the F# frames this repro is about.
+            Driver.Run("module functions", Demo.moduleFunctions);
+            Driver.Run("pipeline lambdas", Demo.pipelineLambdas);
+            Driver.Run("nested closures", Demo.nestedClosures);
+            Driver.Run("local functions", Scenarios.localFunctions);
+
+            Driver.Run("generic function", Scenarios.genericFunction);
+            Driver.Run("custom operator", Demo.customOperator);
+            Driver.Run("CompiledName rename", Demo.RenamedInMetadata);
+            Driver.Run("active pattern", Demo.activePattern);
+            Driver.Run("partial active pattern", Demo.partialActivePattern);
+            Driver.Run("recursion", Demo.recursion);
+            Driver.Run("mutual recursion", Demo.mutualRecursion);
+            Driver.Run("higher order", Demo.higherOrder);
+
+            Driver.Run("async body", Demo.asyncBody);
+            Driver.Run("task body", Demo.taskBody);
+            Driver.Run("seq body", Demo.seqBody);
+            Driver.Run("nested modules", Demo.nestedModules);
+
+            Driver.Run("class members", Scenarios.instanceMember);
+            Driver.Run("static member", Worker.StaticEntry);
+            Driver.Run("property getter", Scenarios.propertyGetter);
+            Driver.Run("property setter", Scenarios.propertySetter);
+            Driver.Run("interface implementation", Scenarios.interfaceImplementation);
+            Driver.Run("generic type member", Scenarios.genericTypeMember);
+            Driver.Run("union member", Scenarios.unionMember);
+            Driver.Run("record member", Scenarios.recordMember);
+
+            Driver.Run("ctor + static ctor", Scenarios.constructors);
+            Driver.Run("module initialization", Scenarios.moduleInitialization);
+
+            Driver.Run("delegate call", Scenarios.delegateCall);
+            Driver.Run("event handler", Scenarios.eventHandler);
+
+            Driver.Run("C# callback from F#", Driver.CallbackScenario);
+            Driver.Run("long mixed chain", MixedChain.run);
+
+            Console.WriteLine("done");
+        }
+    }
+}

--- a/tests/projects/CodeMapCallStack/Directory.Build.props
+++ b/tests/projects/CodeMapCallStack/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <!-- Several bindings here are unused on purpose: an unused parameter is what gives a frame the
+         shape the Code Map has to render, and the repro is meant to read like ordinary user code. -->
+    <TolerateUnusedBindings>true</TolerateUnusedBindings>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Opened in Visual Studio by hand; no solution the build produces contains it, so it takes
+         FSharp.Core from the SDK rather than from this repo's central package versions. -->
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+  </PropertyGroup>
+</Project>

--- a/tests/projects/CodeMapCallStack/README.md
+++ b/tests/projects/CodeMapCallStack/README.md
@@ -1,0 +1,32 @@
+# Show Call Stack on Code Map — manual repro
+
+Every call shape an F# stack can take, in one solution, for exercising
+**Debug ▸ Show Call Stack on Code Map** by hand. Not part of any solution the build
+produces, and no CI job restores it.
+
+The unit tests for the same shapes live in `vsintegration/tests/FSharp.Editor.Tests/CodeMap`.
+They run against `CallStackSample.fs`, which is compiled into the test assembly and captures
+its own frames at runtime, so the frame corpus there is observed rather than written down.
+This solution is what those shapes look like to a debugger.
+
+## Layout
+
+| Project | Why |
+|---|---|
+| `ClassLibrary` (F#) | `Demo.fs` — the scenarios. Every one funnels into `Demo.sink`. |
+| `ConsoleApp` (C#) | Calls them through `Driver.Run` → `Driver.Dispatch`, so every stack has C# frames above the F# ones. |
+
+## Running it
+
+1. Build the `VisualFSharp` solution and start the experimental VS instance (`devenv /rootSuffix RoslynDev`).
+2. Open this solution in it, put a breakpoint on `printfn` inside `Demo.sink`, and start debugging.
+3. At each stop: **Debug ▸ Show Call Stack on Code Map**, then continue.
+
+Two things about the map are worth knowing before reading it:
+
+- A map document **accumulates** across stops and across debug sessions — the pipeline removes
+  neither nodes nor links. Close it and open a new one when you want to read one stack.
+- Resolution is cached per debug session (`CallStackCache`, cleared only when debugging starts
+  or stops), so the first answer for a given frame name is the one you keep. This matters for
+  `<StartupCode$…>` frames: a file's module-level bindings and the `static let` of a type
+  declared in it all run in **one** compiler-generated method, so they share a node.

--- a/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
+++ b/vsintegration/Vsix/VisualFSharpFull/Source.extension.vsixmanifest
@@ -51,6 +51,7 @@
 
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="FSharp.Editor" Path="|FSharp.Editor|" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="FSharp.Editor" Path="|FSharp.Editor|" />
+    <Asset Type="Microsoft.VisualStudio.DirectedGraph.Provider" d:Source="Project" d:ProjectName="FSharp.Editor" Path="|FSharp.Editor|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="ProjectSystem.Base" Path="|ProjectSystem.Base|" />
 
     <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|AppConfig;TemplateProjectOutputGroup|" d:ProjectName="AppConfig" d:VsixSubPath="ItemTemplates" />

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackPlan.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackPlan.fs
@@ -43,15 +43,24 @@ module internal FSharpCallStackPlan =
         | _ -> ValueNone
 
     /// FSharp.Core ships with SourceLink, so the debugger has source for its frames and does not fold
-    /// them into External Code the way it folds the BCL. They are recognised by the module the frame
-    /// names, or - when it names none - by the file the debugger placed it in.
-    let private isFSharpCore (facts: FrameFacts) =
-        match facts.ModuleAssembly with
+    /// them into External Code the way it folds the BCL.
+    ///
+    /// The module alone settles it, which is what lets a frame be folded whose name the parser could
+    /// not take apart: an unreadable name is no reason to leave `MoveNext` standing on the map.
+    let isFSharpCoreModule (moduleAssembly: string voption) =
+        match moduleAssembly with
         | ValueSome assembly -> String.Equals(assembly, FSharpCore, StringComparison.OrdinalIgnoreCase)
-        | ValueNone ->
-            match facts.Frame.SourcePosition with
-            | ValueSome position -> position.File.IndexOf(FSharpCore, StringComparison.OrdinalIgnoreCase) >= 0
-            | ValueNone -> false
+        | ValueNone -> false
+
+    /// The debugger leaves some frames without a module, and SourceLink puts FSharp.Core's own source
+    /// path on those instead.
+    let private isFSharpCore (facts: FrameFacts) =
+        if isFSharpCoreModule facts.ModuleAssembly then
+            true
+        else
+            match facts.ModuleAssembly, facts.Frame.SourcePosition with
+            | ValueNone, ValueSome position -> position.File.IndexOf(FSharpCore, StringComparison.OrdinalIgnoreCase) >= 0
+            | _ -> false
 
     /// `assemblyForFile` answers which project's assembly a source file belongs to, which is the only
     /// thing this decision needs from the workspace - and the only way to address a frame whose module

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackPlan.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackPlan.fs
@@ -32,6 +32,16 @@ module internal FSharpCallStackPlan =
     [<Literal>]
     let private FSharpCore = "FSharp.Core"
 
+    /// The pipeline removes neither nodes nor links, so a map accumulates both across runs and one
+    /// method node ends up claimed by frames from several of them, each reporting the line *its* run
+    /// stopped on. A position is only worth trusting when every frame that claims the node agrees:
+    /// picking one of them gave a static initializer the name of whichever type happened to sit above
+    /// a stale line. An unresolved frame is honest; a confidently wrong one is not.
+    let positionOf (claimed: SourcePosition seq) =
+        match claimed |> Seq.distinct |> Seq.truncate 2 |> List.ofSeq with
+        | [ agreed ] -> ValueSome agreed
+        | _ -> ValueNone
+
     /// FSharp.Core ships with SourceLink, so the debugger has source for its frames and does not fold
     /// them into External Code the way it folds the BCL. They are recognised by the module the frame
     /// names, or - when it names none - by the file the debugger placed it in.

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackPlan.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackPlan.fs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+
+/// What a frame node says about itself once the graph has been read: the name taken apart, the
+/// assembly the debugger named as its module, and the position it reported for it. Nothing here
+/// refers to the graph, so deciding what to do with a frame needs no Visual Studio at all.
+[<Struct; NoEquality; NoComparison>]
+type internal FrameFacts =
+    {
+        Frame: ParsedFrame
+        /// The assembly named by the frame's module. Empty on the frames the debugger leaves without
+        /// one - accessors and module initialization among them.
+        ModuleAssembly: string voption
+    }
+
+/// What the provider does with a frame.
+type internal FrameAction =
+    /// Nothing names the assembly the frame belongs to, so it is left as the platform made it.
+    | LeaveUnresolved
+    /// FSharp.Core's own async, task and seq plumbing. It cannot be resolved - the assembly is no
+    /// project of the workspace - and the pipeline folds it into External Code once told it is
+    /// external, which is what keeps `MoveNext` and `Invoke` off the map.
+    | FoldAsExternalCode
+    | ResolveIn of assembly: string
+
+[<RequireQualifiedAccess>]
+module internal FSharpCallStackPlan =
+
+    [<Literal>]
+    let private FSharpCore = "FSharp.Core"
+
+    /// FSharp.Core ships with SourceLink, so the debugger has source for its frames and does not fold
+    /// them into External Code the way it folds the BCL. They are recognised by the module the frame
+    /// names, or - when it names none - by the file the debugger placed it in.
+    let private isFSharpCore (facts: FrameFacts) =
+        match facts.ModuleAssembly with
+        | ValueSome assembly -> String.Equals(assembly, FSharpCore, StringComparison.OrdinalIgnoreCase)
+        | ValueNone ->
+            match facts.Frame.SourcePosition with
+            | ValueSome position -> position.File.IndexOf(FSharpCore, StringComparison.OrdinalIgnoreCase) >= 0
+            | ValueNone -> false
+
+    /// `assemblyForFile` answers which project's assembly a source file belongs to, which is the only
+    /// thing this decision needs from the workspace - and the only way to address a frame whose module
+    /// the debugger left empty.
+    let decide (assemblyForFile: string -> string voption) (facts: FrameFacts) =
+        if isFSharpCore facts then
+            FoldAsExternalCode
+        else
+            let assembly =
+                match facts.ModuleAssembly with
+                | ValueSome assembly -> ValueSome assembly
+                | ValueNone ->
+                    facts.Frame.SourcePosition
+                    |> ValueOption.bind (fun position -> assemblyForFile position.File)
+
+            match assembly with
+            | ValueSome assembly -> ResolveIn assembly
+            | ValueNone -> LeaveUnresolved

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -7,9 +7,73 @@ open System
 open Microsoft.CodeAnalysis
 
 open FSharp.Compiler.Symbols
+open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
 
 open CancellableTasks
+
+/// What kind of node the resolved frame should become on the map.
+type internal ResolvedFrameKind =
+    | ResolvedMethod
+    | ResolvedProperty
+    | ResolvedEvent
+
+/// The modifiers the Properties pane and the map's styles read off a node. Anything the frame does
+/// not genuinely have stays `false` rather than being guessed.
+type internal ResolvedFrameModifiers =
+    {
+        IsPublic: bool
+        IsInternal: bool
+        IsPrivate: bool
+        IsStatic: bool
+        IsGeneric: bool
+        IsConstructor: bool
+        IsOperator: bool
+        IsExtension: bool
+        IsAbstract: bool
+        IsCompilerGenerated: bool
+        IsPropertyGet: bool
+        IsPropertySet: bool
+        // Facts the code schema has no place for, because it was shaped for C# and VB.
+        IsModule: bool
+        IsUnion: bool
+        IsRecord: bool
+        IsException: bool
+        IsMeasure: bool
+        IsActivePattern: bool
+        IsUnionCaseTester: bool
+        IsFunction: bool
+        IsInline: bool
+        IsMutable: bool
+        IsLifted: bool
+    }
+
+    static member None =
+        {
+            IsPublic = false
+            IsInternal = false
+            IsPrivate = false
+            IsStatic = false
+            IsGeneric = false
+            IsConstructor = false
+            IsOperator = false
+            IsExtension = false
+            IsAbstract = false
+            IsCompilerGenerated = false
+            IsPropertyGet = false
+            IsPropertySet = false
+            IsModule = false
+            IsUnion = false
+            IsRecord = false
+            IsException = false
+            IsMeasure = false
+            IsActivePattern = false
+            IsUnionCaseTester = false
+            IsFunction = false
+            IsInline = false
+            IsMutable = false
+            IsLifted = false
+        }
 
 /// Where a stack frame was written, together with the identity the Code Map needs to fuse the
 /// node with the ones its metadata provider produces.
@@ -25,6 +89,11 @@ type internal ResolvedFrame =
         /// the member.
         TypeChain: struct (string * int) array
         MemberName: string voption
+        Kind: ResolvedFrameKind
+        Modifiers: ResolvedFrameModifiers
+        /// The source name, which for an operator or an active pattern reads very differently from
+        /// the compiled one the node is identified by.
+        DisplayName: string voption
     }
 
 [<RequireQualifiedAccess>]
@@ -90,6 +159,11 @@ module internal FSharpCallStackResolver =
         || String.Equals(m.DisplayName, name, StringComparison.Ordinal)
         || String.Equals(m.LogicalName, name, StringComparison.Ordinal)
 
+    /// The signature exposes a property through its accessor methods, so `get_Computed` is what a
+    /// `Computed.get` frame has to match - `IsProperty` alone finds nothing.
+    let private matchesAccessor prefix (name: string) (m: FSharpMemberOrFunctionOrValue) =
+        matchesName name m || matchesName (prefix + name) m
+
     let private tryFindMember (frame: ParsedFrame) (name: string) (entity: FSharpEntity) =
         let members = entity.TryGetMembersFunctionsAndValues()
 
@@ -97,8 +171,12 @@ module internal FSharpCallStackResolver =
             match frame.Member with
             | FrameConstructor
             | FrameStaticConstructor -> members |> Seq.filter _.IsConstructor
-            | FramePropertyGetter _
-            | FramePropertySetter _ -> members |> Seq.filter (fun m -> m.IsProperty && matchesName name m)
+            | FramePropertyGetter _ ->
+                members
+                |> Seq.filter (fun m -> (m.IsProperty || m.IsPropertyGetterMethod) && matchesAccessor "get_" name m)
+            | FramePropertySetter _ ->
+                members
+                |> Seq.filter (fun m -> (m.IsProperty || m.IsPropertySetterMethod) && matchesAccessor "set_" name m)
             | _ -> members |> Seq.filter (matchesName name)
 
         byKind
@@ -107,19 +185,46 @@ module internal FSharpCallStackResolver =
             || frame.MethodGenericArity = 0)
         |> Seq.tryHeadV
 
+    /// The name the compiler gave the closure class, which is unique within its declaring entity and
+    /// so keeps sibling and nested closures apart on the map.
+    let private closureIdentity (origin: ClosureOrigin) =
+        match origin.Ordinal with
+        | ValueSome ordinal -> $"{origin.EnclosingName}@{origin.Line}-{ordinal}"
+        | ValueNone -> $"{origin.EnclosingName}@{origin.Line}"
+
     /// A closure is compiled to its own class, so nothing in the assembly signature carries its name.
-    /// Report the enclosing declaration instead - the nearest one starting at or above the line the
-    /// closure was written on, which is what C# and VB do for lambdas.
-    let private tryFindEnclosingDeclaration (origin: ClosureOrigin) (entity: FSharpEntity) =
+    /// The enclosing declaration is what locates it: the nearest one starting at or above the line.
+    let private tryFindDeclarationAbove line (entity: FSharpEntity) =
         entity.TryGetMembersFunctionsAndValues()
-        |> Seq.filter (fun m -> m.DeclarationLocation.StartLine <= origin.Line)
+        |> Seq.filter (fun m -> m.DeclarationLocation.StartLine <= line)
         |> Seq.sortByDescending _.DeclarationLocation.StartLine
         |> Seq.tryHeadV
+
+    /// The line a closure class is named after, except for the ones a state machine lifts out of a
+    /// `task` body: the compiler numbers those from line 1, where no declaration can be found. There
+    /// the line the debugger reports for the frame is the honest one.
+    let private closureLine (frame: ParsedFrame) (origin: ClosureOrigin) (entity: FSharpEntity) =
+        match tryFindDeclarationAbove origin.Line entity with
+        | ValueSome _ -> origin.Line
+        | ValueNone ->
+            match frame.SourcePosition with
+            | ValueSome(struct (_, line)) -> line
+            | ValueNone -> origin.Line
 
     let private stripArity (compiledName: string) =
         match compiledName.IndexOf '`' with
         | -1 -> compiledName
         | i -> compiledName.Substring(0, i)
+
+    /// FCS records the namespace on the outermost type or module only - a nested one reports `None` -
+    /// so finding it means walking the declaring chain the same way the type chain does.
+    let rec private namespaceOf (entity: FSharpEntity) =
+        match entity.DeclaringEntity with
+        | Some parent when not parent.IsNamespace -> namespaceOf parent
+        | _ ->
+            match entity.Namespace with
+            | Some ns when not (String.IsNullOrEmpty ns) -> ValueSome ns
+            | _ -> ValueNone
 
     /// Compiled type names from the outermost type or module down to `entity`, with generic arities.
     let private typeChainOf (entity: FSharpEntity) =
@@ -133,33 +238,196 @@ module internal FSharpCallStackResolver =
 
         walk entity [] |> Array.ofList
 
+    let private kindOf (m: FSharpMemberOrFunctionOrValue) =
+        if m.IsProperty || m.IsPropertyGetterMethod || m.IsPropertySetterMethod then
+            ResolvedProperty
+        elif m.IsEventAddMethod || m.IsEventRemoveMethod then
+            ResolvedEvent
+        else
+            ResolvedMethod
+
+    let private declaringKind (m: FSharpMemberOrFunctionOrValue) =
+        match m.DeclaringEntity with
+        | Some entity -> entity.IsFSharpUnion, entity.IsFSharpRecord, entity.IsFSharpExceptionDeclaration
+        | None -> false, false, false
+
+    /// `lifted` marks a frame that came from a closure class rather than from a name the user wrote.
+    let private modifiersOf lifted (m: FSharpMemberOrFunctionOrValue) =
+        let isUnion, isRecord, isException = declaringKind m
+
+        {
+            IsPublic = m.Accessibility.IsPublic
+            IsInternal = m.Accessibility.IsInternal
+            IsPrivate = m.Accessibility.IsPrivate
+            // A module-level function compiles to a static method even though F# has no `static`
+            // keyword for it, so instance membership is the honest test.
+            IsStatic = not m.IsInstanceMember
+            IsGeneric = m.GenericParameters.Count > 0
+            IsConstructor = m.IsConstructor
+            IsOperator = PrettyNaming.IsLogicalOpName m.CompiledName
+            IsExtension = m.IsExtensionMember
+            IsAbstract = m.IsDispatchSlot
+            IsCompilerGenerated = m.IsCompilerGenerated
+            IsPropertyGet = m.IsPropertyGetterMethod
+            IsPropertySet = m.IsPropertySetterMethod
+            IsModule = false
+            IsUnion = isUnion
+            IsRecord = isRecord
+            IsException = isException
+            IsMeasure = false
+            IsActivePattern = m.IsActivePattern
+            IsUnionCaseTester = m.IsUnionCaseTester
+            IsFunction = m.IsFunction
+            IsInline =
+                match m.InlineAnnotation with
+                | FSharpInlineAnnotation.AlwaysInline
+                | FSharpInlineAnnotation.AggressiveInline -> true
+                | _ -> false
+            IsMutable = m.IsMutable
+            IsLifted = lifted
+        }
+
+    let private entityModifiers (entity: FSharpEntity) =
+        { ResolvedFrameModifiers.None with
+            IsPublic = entity.Accessibility.IsPublic
+            IsInternal = entity.Accessibility.IsInternal
+            IsPrivate = entity.Accessibility.IsPrivate
+            IsStatic = entity.IsFSharpModule
+            IsGeneric = entity.GenericParameters.Count > 0
+            IsModule = entity.IsFSharpModule
+            IsUnion = entity.IsFSharpUnion
+            IsRecord = entity.IsFSharpRecord
+            IsException = entity.IsFSharpExceptionDeclaration
+            IsMeasure = entity.IsMeasure
+        }
+
+    /// A `<StartupCode$…>.$Demo.$Demo` frame names the file, not the construct: its path is useless,
+    /// but the debugger reports the source line the initializer is running. Resolve by that position -
+    /// the public binding written on the line (`initialized`), else the type or module whose static
+    /// initializer owns it (`Initialized`); private `static let` bindings are absent from the public
+    /// signature, so the enclosing entity is the closest honest name.
+    let private tryResolveByPosition (fileName: string) (line: int) (signature: FSharpAssemblySignature) =
+        let sameFile (r: range) =
+            String.Equals(r.FileName, fileName, StringComparison.OrdinalIgnoreCase)
+
+        let rec flatten (entity: FSharpEntity) =
+            seq {
+                entity
+
+                for nested in entity.NestedEntities do
+                    yield! flatten nested
+            }
+
+        let entities = signature.Entities |> Seq.collect flatten |> Seq.toArray
+
+        let bindingOnLine =
+            entities
+            |> Seq.collect (fun entity ->
+                entity.TryGetMembersFunctionsAndValues()
+                |> Seq.map (fun m -> struct (entity, m)))
+            |> Seq.filter (fun struct (_, m) -> sameFile m.DeclarationLocation && m.DeclarationLocation.StartLine = line)
+            |> Seq.tryHeadV
+
+        match bindingOnLine with
+        | ValueSome(struct (entity, m)) ->
+            ValueSome(m.DeclarationLocation, [||], entity, ValueSome m.CompiledName, kindOf m, modifiersOf false m, ValueSome m.DisplayName)
+        | ValueNone ->
+            entities
+            |> Seq.filter (fun entity ->
+                sameFile entity.DeclarationLocation
+                && entity.DeclarationLocation.StartLine <= line)
+            |> Seq.sortByDescending (fun entity -> entity.DeclarationLocation.StartLine)
+            |> Seq.tryHeadV
+            |> ValueOption.map (fun entity ->
+                // A private `static let` runs in the type's static constructor; naming that as the
+                // enclosing type is honest, and marking it a static ctor gives it the ctor glyph
+                // instead of a class one and keeps it distinct from the instance ctor's `.ctor` node.
+                let modifiers =
+                    { entityModifiers entity with
+                        IsStatic = true
+                        IsConstructor = true
+                    }
+
+                entity.DeclarationLocation, [||], entity, ValueSome ".cctor", ResolvedMethod, modifiers, ValueSome entity.DisplayName)
+
     let private tryResolveInProject (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
-        let requested = memberName frame.Member
+        match frame.Member, frame.SourcePosition with
+        | FrameStartupCode, ValueSome(struct (file, line)) -> tryResolveByPosition file line signature
+        | FrameStartupCode, ValueNone -> ValueNone
+        | _ ->
 
-        entityPathCandidates frame.Path requested
-        |> Seq.tryPickV (fun struct (entityPath, qualifiedMember) ->
-            match signature.FindEntityByPath(List.ofArray entityPath) with
-            | None -> ValueNone
-            | Some entity ->
-                let resolved (location: range) memberName =
-                    ValueSome(location, entityPath, entity, memberName)
+            let requested = memberName frame.Member
 
-                match frame.Member, qualifiedMember with
-                | FrameStartupCode, _ -> resolved entity.DeclarationLocation ValueNone
-                | FrameClosureBody origin, _ ->
-                    let enclosing =
-                        match qualifiedMember with
-                        | ValueSome name ->
-                            tryFindMember frame name entity
-                            |> ValueOption.orElseWith (fun () -> tryFindEnclosingDeclaration origin entity)
-                        | ValueNone -> tryFindEnclosingDeclaration origin entity
+            entityPathCandidates frame.Path requested
+            |> Seq.tryPickV (fun struct (entityPath, qualifiedMember) ->
+                match signature.FindEntityByPath(List.ofArray entityPath) with
+                | None -> ValueNone
+                | Some entity ->
+                    let resolvedMember lifted (m: FSharpMemberOrFunctionOrValue) =
+                        ValueSome(
+                            m.DeclarationLocation,
+                            entityPath,
+                            entity,
+                            ValueSome m.CompiledName,
+                            kindOf m,
+                            modifiersOf lifted m,
+                            ValueSome m.DisplayName
+                        )
 
-                    enclosing
-                    |> ValueOption.bind (fun m -> resolved m.DeclarationLocation (ValueSome m.CompiledName))
-                | _, ValueSome name ->
-                    tryFindMember frame name entity
-                    |> ValueOption.bind (fun m -> resolved m.DeclarationLocation (ValueSome m.CompiledName))
-                | _, ValueNone -> ValueNone)
+                    match frame.Member, qualifiedMember with
+                    | FrameClosureBody origin, _ ->
+                        let line = closureLine frame origin entity
+
+                        let enclosing =
+                            match qualifiedMember with
+                            | ValueSome name ->
+                                tryFindMember frame name entity
+                                |> ValueOption.orElseWith (fun () -> tryFindDeclarationAbove line entity)
+                            | ValueNone -> tryFindDeclarationAbove line entity
+
+                        // A `task` builder's resumption thunk is numbered from line 1 and carries no
+                        // sequence points, so neither its name nor the debugger places it. It is still
+                        // the user's binding by name, and leaving it unresolved would put a bare
+                        // `Invoke` on the map, so it falls back to the declaration that contains it.
+                        let struct (host, hostName, modifiers, anchor) =
+                            match enclosing with
+                            | ValueSome m -> struct (m.DeclarationLocation, m.DisplayName, modifiersOf true m, line)
+                            | ValueNone ->
+                                let host = entity.DeclarationLocation
+
+                                struct (host,
+                                        entity.DisplayName,
+                                        { entityModifiers entity with
+                                            IsLifted = true
+                                        },
+                                        host.StartLine)
+
+                        // `outer`, `inner` and `work` name a real binding and read well on their own.
+                        // A synthesized name - `Pipe #1 input at line 97` for a computation expression
+                        // body or a pipeline stage - names nothing, and the function the body belongs to
+                        // may be absent from the stack entirely: an `async` block runs from FSharp.Core,
+                        // so nothing else on the map says `asyncBody`. Taking the enclosing declaration
+                        // alone would collide with that function's own node where it *is* on the stack,
+                        // as a pipeline's is, so the line comes with it.
+                        let displayName =
+                            if origin.EnclosingName.IndexOf ' ' >= 0 then
+                                $"%s{hostName}@%d{anchor}"
+                            else
+                                origin.EnclosingName
+
+                        // A closure has no entity of its own, but it is still a distinct frame: the
+                        // compiler's own `name@line` keeps nested and sibling closures apart.
+                        ValueSome(
+                            Range.mkRange host.FileName (Position.mkPos anchor 0) (Position.mkPos anchor 0),
+                            entityPath,
+                            entity,
+                            ValueSome(closureIdentity origin),
+                            ResolvedMethod,
+                            modifiers,
+                            ValueSome displayName
+                        )
+                    | _, ValueSome name -> tryFindMember frame name entity |> ValueOption.bind (resolvedMember false)
+                    | _, ValueNone -> ValueNone)
 
     let private projectsProducing (workspace: Workspace) (assemblyName: string) =
         workspace.CurrentSolution.Projects
@@ -184,18 +452,19 @@ module internal FSharpCallStackResolver =
                         if resolved.[i].IsNone then
                             resolved.[i] <-
                                 tryResolveInProject frame results.AssemblySignature
-                                |> ValueOption.map (fun (declarationRange, entityPath, entity, resolvedMember) ->
-                                    {
-                                        DeclarationRange = declarationRange
-                                        Project = project
-                                        EntityPath = entityPath
-                                        Namespace =
-                                            match entity.Namespace with
-                                            | Some ns when not (String.IsNullOrEmpty ns) -> ValueSome ns
-                                            | _ -> ValueNone
-                                        TypeChain = typeChainOf entity
-                                        MemberName = resolvedMember
-                                    }))
+                                |> ValueOption.map
+                                    (fun (declarationRange, entityPath, entity, resolvedMember, kind, modifiers, displayName) ->
+                                        {
+                                            DeclarationRange = declarationRange
+                                            Project = project
+                                            EntityPath = entityPath
+                                            Namespace = namespaceOf entity
+                                            TypeChain = typeChainOf entity
+                                            MemberName = resolvedMember
+                                            Kind = kind
+                                            Modifiers = modifiers
+                                            DisplayName = displayName
+                                        }))
 
             return resolved
         }

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -81,7 +81,6 @@ type internal ResolvedFrame =
     {
         DeclarationRange: range
         Project: Project
-        EntityPath: string array
         /// The enclosing namespace only – containing modules and types go into `TypeChain` instead,
         /// matching how the metadata provider identifies nested types.
         Namespace: string voption
@@ -93,7 +92,20 @@ type internal ResolvedFrame =
         Modifiers: ResolvedFrameModifiers
         /// The source name, which for an operator or an active pattern reads very differently from
         /// the compiled one the node is identified by.
-        DisplayName: string voption
+        DisplayName: string
+    }
+
+/// What one resolution strategy found. `tryResolveMany` is what turns it into a `ResolvedFrame`,
+/// because only it knows which project the signature came from.
+[<NoEquality; NoComparison>]
+type private Resolution =
+    {
+        Range: range
+        Entity: FSharpEntity
+        MemberName: string voption
+        Kind: ResolvedFrameKind
+        Modifiers: ResolvedFrameModifiers
+        DisplayName: string
     }
 
 [<RequireQualifiedAccess>]
@@ -208,7 +220,7 @@ module internal FSharpCallStackResolver =
         | ValueSome _ -> origin.Line
         | ValueNone ->
             match frame.SourcePosition with
-            | ValueSome(struct (_, line)) -> line
+            | ValueSome position -> position.Line
             | ValueNone -> origin.Line
 
     let private stripArity (compiledName: string) =
@@ -306,9 +318,9 @@ module internal FSharpCallStackResolver =
     /// the public binding written on the line (`initialized`), else the type or module whose static
     /// initializer owns it (`Initialized`); private `static let` bindings are absent from the public
     /// signature, so the enclosing entity is the closest honest name.
-    let private tryResolveByPosition (fileName: string) (line: int) (signature: FSharpAssemblySignature) =
+    let private tryResolveByPosition (position: SourcePosition) (signature: FSharpAssemblySignature) =
         let sameFile (r: range) =
-            String.Equals(r.FileName, fileName, StringComparison.OrdinalIgnoreCase)
+            String.Equals(r.FileName, position.File, StringComparison.OrdinalIgnoreCase)
 
         let rec flatten (entity: FSharpEntity) =
             seq {
@@ -325,109 +337,130 @@ module internal FSharpCallStackResolver =
             |> Seq.collect (fun entity ->
                 entity.TryGetMembersFunctionsAndValues()
                 |> Seq.map (fun m -> struct (entity, m)))
-            |> Seq.filter (fun struct (_, m) -> sameFile m.DeclarationLocation && m.DeclarationLocation.StartLine = line)
+            |> Seq.filter (fun struct (_, m) ->
+                sameFile m.DeclarationLocation
+                && m.DeclarationLocation.StartLine = position.Line)
             |> Seq.tryHeadV
 
         match bindingOnLine with
         | ValueSome(struct (entity, m)) ->
-            ValueSome(m.DeclarationLocation, [||], entity, ValueSome m.CompiledName, kindOf m, modifiersOf false m, ValueSome m.DisplayName)
+            ValueSome
+                {
+                    Range = m.DeclarationLocation
+                    Entity = entity
+                    MemberName = ValueSome m.CompiledName
+                    Kind = kindOf m
+                    Modifiers = modifiersOf false m
+                    DisplayName = m.DisplayName
+                }
         | ValueNone ->
             entities
             |> Seq.filter (fun entity ->
                 sameFile entity.DeclarationLocation
-                && entity.DeclarationLocation.StartLine <= line)
+                && entity.DeclarationLocation.StartLine <= position.Line)
             |> Seq.sortByDescending (fun entity -> entity.DeclarationLocation.StartLine)
             |> Seq.tryHeadV
             |> ValueOption.map (fun entity ->
                 // A private `static let` runs in the type's static constructor; naming that as the
                 // enclosing type is honest, and marking it a static ctor gives it the ctor glyph
                 // instead of a class one and keeps it distinct from the instance ctor's `.ctor` node.
-                let modifiers =
-                    { entityModifiers entity with
-                        IsStatic = true
-                        IsConstructor = true
-                    }
+                {
+                    Range = entity.DeclarationLocation
+                    Entity = entity
+                    MemberName = ValueSome ".cctor"
+                    Kind = ResolvedMethod
+                    Modifiers =
+                        { entityModifiers entity with
+                            IsStatic = true
+                            IsConstructor = true
+                        }
+                    DisplayName = entity.DisplayName
+                })
 
-                entity.DeclarationLocation, [||], entity, ValueSome ".cctor", ResolvedMethod, modifiers, ValueSome entity.DisplayName)
+    /// A closure has no entity of its own, so it is placed by the declaration that contains it, and
+    /// identified by the compiler's own `name@line` - which keeps nested and sibling closures apart.
+    let private resolveClosure (frame: ParsedFrame) origin (entity: FSharpEntity) qualifiedMember =
+        let line = closureLine frame origin entity
 
+        let enclosing =
+            match qualifiedMember with
+            | ValueSome name ->
+                tryFindMember frame name entity
+                |> ValueOption.orElseWith (fun () -> tryFindDeclarationAbove line entity)
+            | ValueNone -> tryFindDeclarationAbove line entity
+
+        // A `task` builder's resumption thunk is numbered from line 1 and carries no sequence points,
+        // so neither its name nor the debugger places it. It is still the user's binding by name, and
+        // leaving it unresolved would put a bare `Invoke` on the map, so it falls back to the
+        // declaration that contains it.
+        let struct (host, hostName, modifiers, anchor) =
+            match enclosing with
+            | ValueSome m -> struct (m.DeclarationLocation, m.DisplayName, modifiersOf true m, line)
+            | ValueNone ->
+                let host = entity.DeclarationLocation
+
+                struct (host,
+                        entity.DisplayName,
+                        { entityModifiers entity with
+                            IsLifted = true
+                        },
+                        host.StartLine)
+
+        // `outer`, `inner` and `work` name a real binding and read well on their own. A synthesized
+        // name - `Pipe #1 input at line 97` for a computation expression body or a pipeline stage -
+        // names nothing, and the function the body belongs to may be absent from the stack entirely:
+        // an `async` block runs from FSharp.Core, so nothing else on the map says `asyncBody`. Taking
+        // the enclosing declaration alone would collide with that function's own node where it *is*
+        // on the stack, as a pipeline's is, so the line comes with it.
+        let displayName =
+            if origin.EnclosingName.IndexOf ' ' >= 0 then
+                $"%s{hostName}@%d{anchor}"
+            else
+                origin.EnclosingName
+
+        ValueSome
+            {
+                Range = Range.mkRange host.FileName (Position.mkPos anchor 0) (Position.mkPos anchor 0)
+                Entity = entity
+                MemberName = ValueSome(closureIdentity origin)
+                Kind = ResolvedMethod
+                Modifiers = modifiers
+                DisplayName = displayName
+            }
+
+    let private resolveMember (frame: ParsedFrame) (entity: FSharpEntity) name =
+        tryFindMember frame name entity
+        |> ValueOption.map (fun m ->
+            {
+                Range = m.DeclarationLocation
+                Entity = entity
+                MemberName = ValueSome m.CompiledName
+                Kind = kindOf m
+                Modifiers = modifiersOf false m
+                DisplayName = m.DisplayName
+            })
+
+    /// A frame name flattens the declaring path, so the entity it names is found by trying every
+    /// split of that path; within the entity it is the frame's own shape that says what to look for.
+    let private tryResolveByName (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
+        entityPathCandidates frame.Path (memberName frame.Member)
+        |> Seq.tryPickV (fun struct (entityPath, qualifiedMember) ->
+            match signature.FindEntityByPath(List.ofArray entityPath) with
+            | None -> ValueNone
+            | Some entity ->
+                match frame.Member, qualifiedMember with
+                | FrameClosureBody origin, _ -> resolveClosure frame origin entity qualifiedMember
+                | _, ValueSome name -> resolveMember frame entity name
+                | _, ValueNone -> ValueNone)
+
+    /// Module initialization names the file rather than a construct, so only the debugger's position
+    /// places it; everything else is found by name.
     let private tryResolveInProject (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
-        match frame.Member, frame.SourcePosition with
-        | FrameStartupCode, ValueSome(struct (file, line)) -> tryResolveByPosition file line signature
-        | FrameStartupCode, ValueNone -> ValueNone
-        | _ ->
-
-            let requested = memberName frame.Member
-
-            entityPathCandidates frame.Path requested
-            |> Seq.tryPickV (fun struct (entityPath, qualifiedMember) ->
-                match signature.FindEntityByPath(List.ofArray entityPath) with
-                | None -> ValueNone
-                | Some entity ->
-                    let resolvedMember lifted (m: FSharpMemberOrFunctionOrValue) =
-                        ValueSome(
-                            m.DeclarationLocation,
-                            entityPath,
-                            entity,
-                            ValueSome m.CompiledName,
-                            kindOf m,
-                            modifiersOf lifted m,
-                            ValueSome m.DisplayName
-                        )
-
-                    match frame.Member, qualifiedMember with
-                    | FrameClosureBody origin, _ ->
-                        let line = closureLine frame origin entity
-
-                        let enclosing =
-                            match qualifiedMember with
-                            | ValueSome name ->
-                                tryFindMember frame name entity
-                                |> ValueOption.orElseWith (fun () -> tryFindDeclarationAbove line entity)
-                            | ValueNone -> tryFindDeclarationAbove line entity
-
-                        // A `task` builder's resumption thunk is numbered from line 1 and carries no
-                        // sequence points, so neither its name nor the debugger places it. It is still
-                        // the user's binding by name, and leaving it unresolved would put a bare
-                        // `Invoke` on the map, so it falls back to the declaration that contains it.
-                        let struct (host, hostName, modifiers, anchor) =
-                            match enclosing with
-                            | ValueSome m -> struct (m.DeclarationLocation, m.DisplayName, modifiersOf true m, line)
-                            | ValueNone ->
-                                let host = entity.DeclarationLocation
-
-                                struct (host,
-                                        entity.DisplayName,
-                                        { entityModifiers entity with
-                                            IsLifted = true
-                                        },
-                                        host.StartLine)
-
-                        // `outer`, `inner` and `work` name a real binding and read well on their own.
-                        // A synthesized name - `Pipe #1 input at line 97` for a computation expression
-                        // body or a pipeline stage - names nothing, and the function the body belongs to
-                        // may be absent from the stack entirely: an `async` block runs from FSharp.Core,
-                        // so nothing else on the map says `asyncBody`. Taking the enclosing declaration
-                        // alone would collide with that function's own node where it *is* on the stack,
-                        // as a pipeline's is, so the line comes with it.
-                        let displayName =
-                            if origin.EnclosingName.IndexOf ' ' >= 0 then
-                                $"%s{hostName}@%d{anchor}"
-                            else
-                                origin.EnclosingName
-
-                        // A closure has no entity of its own, but it is still a distinct frame: the
-                        // compiler's own `name@line` keeps nested and sibling closures apart.
-                        ValueSome(
-                            Range.mkRange host.FileName (Position.mkPos anchor 0) (Position.mkPos anchor 0),
-                            entityPath,
-                            entity,
-                            ValueSome(closureIdentity origin),
-                            ResolvedMethod,
-                            modifiers,
-                            ValueSome displayName
-                        )
-                    | _, ValueSome name -> tryFindMember frame name entity |> ValueOption.bind (resolvedMember false)
-                    | _, ValueNone -> ValueNone)
+        match frame.Member with
+        | FrameStartupCode ->
+            frame.SourcePosition
+            |> ValueOption.bind (fun position -> tryResolveByPosition position signature)
+        | _ -> tryResolveByName frame signature
 
     let private projectsProducing (workspace: Workspace) (assemblyName: string) =
         workspace.CurrentSolution.Projects
@@ -452,19 +485,17 @@ module internal FSharpCallStackResolver =
                         if resolved.[i].IsNone then
                             resolved.[i] <-
                                 tryResolveInProject frame results.AssemblySignature
-                                |> ValueOption.map
-                                    (fun (declarationRange, entityPath, entity, resolvedMember, kind, modifiers, displayName) ->
-                                        {
-                                            DeclarationRange = declarationRange
-                                            Project = project
-                                            EntityPath = entityPath
-                                            Namespace = namespaceOf entity
-                                            TypeChain = typeChainOf entity
-                                            MemberName = resolvedMember
-                                            Kind = kind
-                                            Modifiers = modifiers
-                                            DisplayName = displayName
-                                        }))
+                                |> ValueOption.map (fun resolution ->
+                                    {
+                                        DeclarationRange = resolution.Range
+                                        Project = project
+                                        Namespace = namespaceOf resolution.Entity
+                                        TypeChain = typeChainOf resolution.Entity
+                                        MemberName = resolution.MemberName
+                                        Kind = resolution.Kind
+                                        Modifiers = resolution.Modifiers
+                                        DisplayName = resolution.DisplayName
+                                    }))
 
             return resolved
         }

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -170,6 +170,9 @@ module internal FSharpCallStackResolver =
         |> Seq.filter (fun m ->
             m.GenericParameters.Count = frame.MethodGenericArity
             || frame.MethodGenericArity = 0)
+        // The signature carries an `[<CLIEvent>]` twice, as the event and as the getter behind it,
+        // and both answer to the same compiled name. The event is the one that says what it is.
+        |> Seq.sortByDescending _.IsEvent
         |> Seq.tryHeadV
 
     /// The name the compiler gave the closure class, which is unique within its declaring entity and
@@ -225,11 +228,13 @@ module internal FSharpCallStackResolver =
 
         walk entity [] |> Array.ofList
 
+    /// An `[<CLIEvent>]` is a property as well - the getter behind it is how the event is read - so
+    /// the event has to be asked about first or every event answers as a property.
     let private kindOf (m: FSharpMemberOrFunctionOrValue) =
-        if m.IsProperty || m.IsPropertyGetterMethod || m.IsPropertySetterMethod then
-            ResolvedProperty
-        elif m.IsEventAddMethod || m.IsEventRemoveMethod then
+        if m.IsEvent || m.IsEventAddMethod || m.IsEventRemoveMethod then
             ResolvedEvent
+        elif m.IsProperty || m.IsPropertyGetterMethod || m.IsPropertySetterMethod then
+            ResolvedProperty
         else
             ResolvedMethod
 

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -18,62 +18,35 @@ type internal ResolvedFrameKind =
     | ResolvedProperty
     | ResolvedEvent
 
-/// The modifiers the Properties pane and the map's styles read off a node. Anything the frame does
-/// not genuinely have stays `false` rather than being guessed.
-type internal ResolvedFrameModifiers =
-    {
-        IsPublic: bool
-        IsInternal: bool
-        IsPrivate: bool
-        IsStatic: bool
-        IsGeneric: bool
-        IsConstructor: bool
-        IsOperator: bool
-        IsExtension: bool
-        IsAbstract: bool
-        IsCompilerGenerated: bool
-        IsPropertyGet: bool
-        IsPropertySet: bool
-        // Facts the code schema has no place for, because it was shaped for C# and VB.
-        IsModule: bool
-        IsUnion: bool
-        IsRecord: bool
-        IsException: bool
-        IsMeasure: bool
-        IsActivePattern: bool
-        IsUnionCaseTester: bool
-        IsFunction: bool
-        IsInline: bool
-        IsMutable: bool
-        IsLifted: bool
-    }
-
-    static member None =
-        {
-            IsPublic = false
-            IsInternal = false
-            IsPrivate = false
-            IsStatic = false
-            IsGeneric = false
-            IsConstructor = false
-            IsOperator = false
-            IsExtension = false
-            IsAbstract = false
-            IsCompilerGenerated = false
-            IsPropertyGet = false
-            IsPropertySet = false
-            IsModule = false
-            IsUnion = false
-            IsRecord = false
-            IsException = false
-            IsMeasure = false
-            IsActivePattern = false
-            IsUnionCaseTester = false
-            IsFunction = false
-            IsInline = false
-            IsMutable = false
-            IsLifted = false
-        }
+/// Something true of a frame that the Properties pane shows and the map's styles can filter on. A
+/// frame carries the traits it genuinely has and nothing else, so there is no way to spell "it is
+/// not a constructor" - and no way to leave a field of a wide record accidentally set.
+type internal FrameTrait =
+    | Public
+    | Internal
+    | Private
+    | Static
+    | Generic
+    | Constructor
+    | Operator
+    | Extension
+    | Abstract
+    | CompilerGenerated
+    | PropertyGet
+    | PropertySet
+    // Traits the code schema has no place for, because it was shaped for C# and VB.
+    | Module
+    | Union
+    | Record
+    | Exception
+    | Measure
+    | ActivePattern
+    | UnionCaseTester
+    | Function
+    | Inline
+    | Mutable
+    /// The frame came from a compiler-generated closure class rather than from a name the user wrote.
+    | Lifted
 
 /// Where a stack frame was written, together with the identity the Code Map needs to fuse the
 /// node with the ones its metadata provider produces.
@@ -89,7 +62,7 @@ type internal ResolvedFrame =
         TypeChain: struct (string * int) array
         MemberName: string voption
         Kind: ResolvedFrameKind
-        Modifiers: ResolvedFrameModifiers
+        Traits: Set<FrameTrait>
         /// The source name, which for an operator or an active pattern reads very differently from
         /// the compiled one the node is identified by.
         DisplayName: string
@@ -104,7 +77,7 @@ type private Resolution =
         Entity: FSharpEntity
         MemberName: string voption
         Kind: ResolvedFrameKind
-        Modifiers: ResolvedFrameModifiers
+        Traits: Set<FrameTrait>
         DisplayName: string
     }
 
@@ -263,55 +236,85 @@ module internal FSharpCallStackResolver =
         | Some entity -> entity.IsFSharpUnion, entity.IsFSharpRecord, entity.IsFSharpExceptionDeclaration
         | None -> false, false, false
 
-    /// `lifted` marks a frame that came from a closure class rather than from a name the user wrote.
-    let private modifiersOf lifted (m: FSharpMemberOrFunctionOrValue) =
+    let private isInline (m: FSharpMemberOrFunctionOrValue) =
+        match m.InlineAnnotation with
+        | FSharpInlineAnnotation.AlwaysInline
+        | FSharpInlineAnnotation.AggressiveInline -> true
+        | _ -> false
+
+    let private traitsOf (m: FSharpMemberOrFunctionOrValue) =
         let isUnion, isRecord, isException = declaringKind m
 
-        {
-            IsPublic = m.Accessibility.IsPublic
-            IsInternal = m.Accessibility.IsInternal
-            IsPrivate = m.Accessibility.IsPrivate
-            // A module-level function compiles to a static method even though F# has no `static`
-            // keyword for it, so instance membership is the honest test.
-            IsStatic = not m.IsInstanceMember
-            IsGeneric = m.GenericParameters.Count > 0
-            IsConstructor = m.IsConstructor
-            IsOperator = PrettyNaming.IsLogicalOpName m.CompiledName
-            IsExtension = m.IsExtensionMember
-            IsAbstract = m.IsDispatchSlot
-            IsCompilerGenerated = m.IsCompilerGenerated
-            IsPropertyGet = m.IsPropertyGetterMethod
-            IsPropertySet = m.IsPropertySetterMethod
-            IsModule = false
-            IsUnion = isUnion
-            IsRecord = isRecord
-            IsException = isException
-            IsMeasure = false
-            IsActivePattern = m.IsActivePattern
-            IsUnionCaseTester = m.IsUnionCaseTester
-            IsFunction = m.IsFunction
-            IsInline =
-                match m.InlineAnnotation with
-                | FSharpInlineAnnotation.AlwaysInline
-                | FSharpInlineAnnotation.AggressiveInline -> true
-                | _ -> false
-            IsMutable = m.IsMutable
-            IsLifted = lifted
-        }
+        set
+            [
+                if m.Accessibility.IsPublic then
+                    Public
+                if m.Accessibility.IsInternal then
+                    Internal
+                if m.Accessibility.IsPrivate then
+                    Private
+                // A module-level function compiles to a static method even though F# has no `static`
+                // keyword for it, so instance membership is the honest test.
+                if not m.IsInstanceMember then
+                    Static
+                if m.GenericParameters.Count > 0 then
+                    Generic
+                if m.IsConstructor then
+                    Constructor
+                if PrettyNaming.IsLogicalOpName m.CompiledName then
+                    Operator
+                if m.IsExtensionMember then
+                    Extension
+                if m.IsDispatchSlot then
+                    Abstract
+                if m.IsCompilerGenerated then
+                    CompilerGenerated
+                if m.IsPropertyGetterMethod then
+                    PropertyGet
+                if m.IsPropertySetterMethod then
+                    PropertySet
+                if isUnion then
+                    Union
+                if isRecord then
+                    Record
+                if isException then
+                    Exception
+                if m.IsActivePattern then
+                    ActivePattern
+                if m.IsUnionCaseTester then
+                    UnionCaseTester
+                if m.IsFunction then
+                    Function
+                if isInline m then
+                    Inline
+                if m.IsMutable then
+                    Mutable
+            ]
 
-    let private entityModifiers (entity: FSharpEntity) =
-        { ResolvedFrameModifiers.None with
-            IsPublic = entity.Accessibility.IsPublic
-            IsInternal = entity.Accessibility.IsInternal
-            IsPrivate = entity.Accessibility.IsPrivate
-            IsStatic = entity.IsFSharpModule
-            IsGeneric = entity.GenericParameters.Count > 0
-            IsModule = entity.IsFSharpModule
-            IsUnion = entity.IsFSharpUnion
-            IsRecord = entity.IsFSharpRecord
-            IsException = entity.IsFSharpExceptionDeclaration
-            IsMeasure = entity.IsMeasure
-        }
+    let private entityTraits (entity: FSharpEntity) =
+        set
+            [
+                if entity.Accessibility.IsPublic then
+                    Public
+                if entity.Accessibility.IsInternal then
+                    Internal
+                if entity.Accessibility.IsPrivate then
+                    Private
+                if entity.IsFSharpModule then
+                    Static
+                if entity.GenericParameters.Count > 0 then
+                    Generic
+                if entity.IsFSharpModule then
+                    Module
+                if entity.IsFSharpUnion then
+                    Union
+                if entity.IsFSharpRecord then
+                    Record
+                if entity.IsFSharpExceptionDeclaration then
+                    Exception
+                if entity.IsMeasure then
+                    Measure
+            ]
 
     /// A `<StartupCode$…>.$Demo.$Demo` frame names the file, not the construct: its path is useless,
     /// but the debugger reports the source line the initializer is running. Resolve by that position -
@@ -350,7 +353,7 @@ module internal FSharpCallStackResolver =
                     Entity = entity
                     MemberName = ValueSome m.CompiledName
                     Kind = kindOf m
-                    Modifiers = modifiersOf false m
+                    Traits = traitsOf m
                     DisplayName = m.DisplayName
                 }
         | ValueNone ->
@@ -369,11 +372,7 @@ module internal FSharpCallStackResolver =
                     Entity = entity
                     MemberName = ValueSome ".cctor"
                     Kind = ResolvedMethod
-                    Modifiers =
-                        { entityModifiers entity with
-                            IsStatic = true
-                            IsConstructor = true
-                        }
+                    Traits = entityTraits entity |> Set.add Static |> Set.add Constructor
                     DisplayName = entity.DisplayName
                 })
 
@@ -393,18 +392,13 @@ module internal FSharpCallStackResolver =
         // so neither its name nor the debugger places it. It is still the user's binding by name, and
         // leaving it unresolved would put a bare `Invoke` on the map, so it falls back to the
         // declaration that contains it.
-        let struct (host, hostName, modifiers, anchor) =
+        let struct (host, hostName, traits, anchor) =
             match enclosing with
-            | ValueSome m -> struct (m.DeclarationLocation, m.DisplayName, modifiersOf true m, line)
+            | ValueSome m -> struct (m.DeclarationLocation, m.DisplayName, traitsOf m |> Set.add Lifted, line)
             | ValueNone ->
                 let host = entity.DeclarationLocation
 
-                struct (host,
-                        entity.DisplayName,
-                        { entityModifiers entity with
-                            IsLifted = true
-                        },
-                        host.StartLine)
+                struct (host, entity.DisplayName, entityTraits entity |> Set.add Lifted, host.StartLine)
 
         // `outer`, `inner` and `work` name a real binding and read well on their own. A synthesized
         // name - `Pipe #1 input at line 97` for a computation expression body or a pipeline stage -
@@ -424,7 +418,7 @@ module internal FSharpCallStackResolver =
                 Entity = entity
                 MemberName = ValueSome(closureIdentity origin)
                 Kind = ResolvedMethod
-                Modifiers = modifiers
+                Traits = traits
                 DisplayName = displayName
             }
 
@@ -436,7 +430,7 @@ module internal FSharpCallStackResolver =
                 Entity = entity
                 MemberName = ValueSome m.CompiledName
                 Kind = kindOf m
-                Modifiers = modifiersOf false m
+                Traits = traitsOf m
                 DisplayName = m.DisplayName
             })
 
@@ -493,7 +487,7 @@ module internal FSharpCallStackResolver =
                                         TypeChain = typeChainOf resolution.Entity
                                         MemberName = resolution.MemberName
                                         Kind = resolution.Kind
-                                        Modifiers = resolution.Modifiers
+                                        Traits = resolution.Traits
                                         DisplayName = resolution.DisplayName
                                     }))
 

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -3,9 +3,11 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
+open System.Collections.Generic
 
 open Microsoft.CodeAnalysis
 
+open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
@@ -316,12 +318,41 @@ module internal FSharpCallStackResolver =
                     Measure
             ]
 
+    /// The line of the type or module that owns a source line. An entity's own range covers nothing
+    /// but its name, so a line inside a member body belongs to no entity and a line in the blank
+    /// space, doc comment or attributes between two declarations belongs to both by proximity -
+    /// which is how a static initializer came to be answered with the generic type above it. The
+    /// parse tree has the range of each declaration in full, so the line is answered by the
+    /// innermost declaration that actually contains it, and trivia, contained by none, is answered
+    /// by the declaration below it, which is what the trivia was written for.
+    let private declarationOwning (shape: NavigationItems) line =
+        let declarations =
+            shape.Declarations
+            |> Array.map _.Declaration
+            // A namespace is no entity of its own and its range spans the whole file.
+            |> Array.filter (fun d -> d.Kind <> NavigationItemKind.Namespace)
+
+        let containing =
+            declarations
+            |> Array.filter (fun d -> d.Range.StartLine <= line && line <= d.Range.EndLine)
+            // The innermost one: a module's range spans every type written inside it.
+            |> Array.sortByDescending _.Range.StartLine
+            |> Array.tryHeadV
+
+        let below () =
+            declarations
+            |> Array.filter (fun d -> d.Range.StartLine > line)
+            |> Array.sortBy _.Range.StartLine
+            |> Array.tryHeadV
+
+        containing |> ValueOption.orElseWith below |> ValueOption.map _.Range
+
     /// A `<StartupCode$…>.$Demo.$Demo` frame names the file, not the construct: its path is useless,
     /// but the debugger reports the source line the initializer is running. Resolve by that position -
     /// the public binding written on the line (`initialized`), else the type or module whose static
     /// initializer owns it (`Initialized`); private `static let` bindings are absent from the public
     /// signature, so the enclosing entity is the closest honest name.
-    let private tryResolveByPosition (position: SourcePosition) (signature: FSharpAssemblySignature) =
+    let private tryResolveByPosition (position: SourcePosition) (declaration: range) (signature: FSharpAssemblySignature) =
         let sameFile (r: range) =
             String.Equals(r.FileName, position.File, StringComparison.OrdinalIgnoreCase)
 
@@ -357,11 +388,14 @@ module internal FSharpCallStackResolver =
                     DisplayName = m.DisplayName
                 }
         | ValueNone ->
+            // The declaration's own entity: the outermost one written inside its range, since
+            // anything nested starts further down.
             entities
             |> Seq.filter (fun entity ->
                 sameFile entity.DeclarationLocation
-                && entity.DeclarationLocation.StartLine <= position.Line)
-            |> Seq.sortByDescending (fun entity -> entity.DeclarationLocation.StartLine)
+                && declaration.StartLine <= entity.DeclarationLocation.StartLine
+                && entity.DeclarationLocation.StartLine <= declaration.EndLine)
+            |> Seq.sortBy (fun entity -> entity.DeclarationLocation.StartLine)
             |> Seq.tryHeadV
             |> ValueOption.map (fun entity ->
                 // A private `static let` runs in the type's static constructor; naming that as the
@@ -449,11 +483,14 @@ module internal FSharpCallStackResolver =
 
     /// Module initialization names the file rather than a construct, so only the debugger's position
     /// places it; everything else is found by name.
-    let private tryResolveInProject (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
+    let private tryResolveInProject (frame: ParsedFrame) shapeOf (signature: FSharpAssemblySignature) =
         match frame.Member with
         | FrameStartupCode ->
             frame.SourcePosition
-            |> ValueOption.bind (fun position -> tryResolveByPosition position signature)
+            |> ValueOption.bind (fun position ->
+                shapeOf position.File
+                |> ValueOption.bind (fun shape -> declarationOwning shape position.Line)
+                |> ValueOption.bind (fun declaration -> tryResolveByPosition position declaration signature))
         | _ -> tryResolveByName frame signature
 
     let private projectsProducing (workspace: Workspace) (assemblyName: string) =
@@ -474,11 +511,36 @@ module internal FSharpCallStackResolver =
                     let! checker, _, _, options = project.GetFSharpCompilationOptionsAsync()
                     let! results = checker.ParseAndCheckProject(options)
 
+                    // Only a startup frame is placed by its line rather than its name, and only that
+                    // needs the shape of the file it landed in.
+                    let shapes = Dictionary<string, NavigationItems>(StringComparer.OrdinalIgnoreCase)
+
+                    for file in
+                        frames
+                        |> Seq.choose (fun frame ->
+                            match frame.Member, frame.SourcePosition with
+                            | FrameStartupCode, ValueSome position -> Some position.File
+                            | _ -> None)
+                        |> Seq.distinct do
+                        match
+                            project.Documents
+                            |> Seq.tryFind (fun d -> String.Equals(d.FilePath, file, StringComparison.OrdinalIgnoreCase))
+                        with
+                        | None -> ()
+                        | Some document ->
+                            let! parseResults = document.GetFSharpParseResultsAsync "FSharpCallStackResolver"
+                            shapes.[file] <- Navigation.getNavigation parseResults.ParseTree
+
+                    let shapeOf file =
+                        match shapes.TryGetValue file with
+                        | true, shape -> ValueSome shape
+                        | _ -> ValueNone
+
                     frames
                     |> Array.iteri (fun i frame ->
                         if resolved.[i].IsNone then
                             resolved.[i] <-
-                                tryResolveInProject frame results.AssemblySignature
+                                tryResolveInProject frame shapeOf results.AssemblySignature
                                 |> ValueOption.map (fun resolution ->
                                     {
                                         DeclarationRange = resolution.Range

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -17,7 +17,13 @@ type internal ResolvedFrame =
     {
         DeclarationRange: range
         Project: Project
-        EntityPath: string list
+        EntityPath: string array
+        /// The enclosing namespace only – containing modules and types go into `TypeChain` instead,
+        /// matching how the metadata provider identifies nested types.
+        Namespace: string voption
+        /// Compiled type names outermost-first, each with its generic arity; the last one declares
+        /// the member.
+        TypeChain: struct (string * int) array
         MemberName: string voption
     }
 
@@ -37,25 +43,34 @@ module internal FSharpCallStackResolver =
     /// A frame name flattens namespaces, modules and nested types into one dotted path, and an
     /// explicit interface implementation puts the interface name inside the member name. Both are
     /// undone by trying every split of the path, longest entity path first.
-    let private entityPathCandidates (path: FramePathSegment list) (memberName: string voption) =
+    /// `FindEntityByPath` looks entities up by their mangled names, so a generic segment must keep
+    /// its arity suffix (`Box`1`), which the frame parser split off.
+    let private mangledName (segment: FramePathSegment) =
+        if segment.GenericArity = 0 then
+            segment.Name
+        else
+            $"{segment.Name}`{segment.GenericArity}"
+
+    let private entityPathCandidates (path: FramePathSegment array) (memberName: string voption) =
         seq {
-            for split in List.length path .. -1 .. 1 do
-                let entityNames = path |> List.truncate split |> List.map _.Name
-                let trailing = path |> List.skip split |> List.map _.Name
+            for split in path.Length .. -1 .. 1 do
+                let entityNames = path |> Seq.truncate split |> Seq.map mangledName |> Seq.toArray
+                let trailing = path |> Seq.skip split |> Seq.map _.Name |> Seq.toArray
 
                 let qualifiedMember =
-                    match memberName, trailing with
-                    | ValueSome name, trailing -> ValueSome(String.Join(".", [ yield! trailing; yield name ]))
-                    | ValueNone, [] -> ValueNone
-                    | ValueNone, trailing -> ValueSome(String.Join(".", trailing))
+                    match memberName with
+                    | ValueSome name -> ValueSome(String.Join(".", [| yield! trailing; yield name |]))
+                    | ValueNone when trailing.Length = 0 -> ValueNone
+                    | ValueNone -> ValueSome(String.Join(".", trailing))
 
                 yield struct (entityNames, qualifiedMember)
 
-                let unsuffixed =
-                    entityNames
-                    |> List.map (fun name -> stripModuleSuffix name |> ValueOption.defaultValue name)
+                // Only worth a second candidate when a segment actually carries the suffix.
+                if entityNames |> Array.exists (stripModuleSuffix >> ValueOption.isSome) then
+                    let unsuffixed =
+                        entityNames
+                        |> Array.map (fun name -> stripModuleSuffix name |> ValueOption.defaultValue name)
 
-                if unsuffixed <> entityNames then
                     yield struct (unsuffixed, qualifiedMember)
         }
 
@@ -101,16 +116,36 @@ module internal FSharpCallStackResolver =
         |> Seq.sortByDescending _.DeclarationLocation.StartLine
         |> Seq.tryHeadV
 
+    let private stripArity (compiledName: string) =
+        match compiledName.IndexOf '`' with
+        | -1 -> compiledName
+        | i -> compiledName.Substring(0, i)
+
+    /// Compiled type names from the outermost type or module down to `entity`, with generic arities.
+    let private typeChainOf (entity: FSharpEntity) =
+        let rec walk (entity: FSharpEntity) chain =
+            let chain =
+                struct (stripArity entity.CompiledName, entity.GenericParameters.Count) :: chain
+
+            match entity.DeclaringEntity with
+            | Some parent when not parent.IsNamespace -> walk parent chain
+            | _ -> chain
+
+        walk entity [] |> Array.ofList
+
     let private tryResolveInProject (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
         let requested = memberName frame.Member
 
         entityPathCandidates frame.Path requested
         |> Seq.tryPickV (fun struct (entityPath, qualifiedMember) ->
-            match signature.FindEntityByPath entityPath with
+            match signature.FindEntityByPath(List.ofArray entityPath) with
             | None -> ValueNone
             | Some entity ->
+                let resolved (location: range) memberName =
+                    ValueSome(location, entityPath, entity, memberName)
+
                 match frame.Member, qualifiedMember with
-                | FrameStartupCode, _ -> ValueSome(entity.DeclarationLocation, entityPath, ValueNone)
+                | FrameStartupCode, _ -> resolved entity.DeclarationLocation ValueNone
                 | FrameClosureBody origin, _ ->
                     let enclosing =
                         match qualifiedMember with
@@ -120,10 +155,10 @@ module internal FSharpCallStackResolver =
                         | ValueNone -> tryFindEnclosingDeclaration origin entity
 
                     enclosing
-                    |> ValueOption.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
+                    |> ValueOption.bind (fun m -> resolved m.DeclarationLocation (ValueSome m.CompiledName))
                 | _, ValueSome name ->
                     tryFindMember frame name entity
-                    |> ValueOption.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
+                    |> ValueOption.bind (fun m -> resolved m.DeclarationLocation (ValueSome m.CompiledName))
                 | _, ValueNone -> ValueNone)
 
     let private projectsProducing (workspace: Workspace) (assemblyName: string) =
@@ -135,9 +170,9 @@ module internal FSharpCallStackResolver =
     /// Maps parsed frames back to the source they were written in, searching only the projects that
     /// produced the module the debugger reported. Frames are resolved as a batch so a project is
     /// checked once for the whole stack rather than once per frame.
-    let tryResolveMany (workspace: Workspace) (assemblyName: string) (frames: ParsedFrame list) =
+    let tryResolveMany (workspace: Workspace) (assemblyName: string) (frames: ParsedFrame array) =
         cancellableTask {
-            let resolved = Array.create (List.length frames) ValueNone
+            let resolved = Array.create frames.Length ValueNone
 
             for project in projectsProducing workspace assemblyName do
                 if resolved |> Array.exists _.IsNone then
@@ -145,23 +180,28 @@ module internal FSharpCallStackResolver =
                     let! results = checker.ParseAndCheckProject(options)
 
                     frames
-                    |> List.iteri (fun i frame ->
+                    |> Array.iteri (fun i frame ->
                         if resolved.[i].IsNone then
                             resolved.[i] <-
                                 tryResolveInProject frame results.AssemblySignature
-                                |> ValueOption.map (fun (declarationRange, entityPath, resolvedMember) ->
+                                |> ValueOption.map (fun (declarationRange, entityPath, entity, resolvedMember) ->
                                     {
                                         DeclarationRange = declarationRange
                                         Project = project
                                         EntityPath = entityPath
+                                        Namespace =
+                                            match entity.Namespace with
+                                            | Some ns when not (String.IsNullOrEmpty ns) -> ValueSome ns
+                                            | _ -> ValueNone
+                                        TypeChain = typeChainOf entity
                                         MemberName = resolvedMember
                                     }))
 
-            return List.ofArray resolved
+            return resolved
         }
 
     let tryResolve (workspace: Workspace) (assemblyName: string) (frame: ParsedFrame) =
         cancellableTask {
-            let! resolved = tryResolveMany workspace assemblyName [ frame ]
-            return List.head resolved
+            let! resolved = tryResolveMany workspace assemblyName [| frame |]
+            return Array.head resolved
         }

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Threading
+
+open Microsoft.CodeAnalysis
+
+open FSharp.Compiler.Symbols
+open FSharp.Compiler.Text
+
+open CancellableTasks
+
+/// Where a stack frame was written, together with the identity the Code Map needs to fuse the
+/// node with the ones its metadata provider produces.
+type internal ResolvedFrame =
+    {
+        DeclarationRange: range
+        Project: Project
+        EntityPath: string list
+        MemberName: string voption
+    }
+
+[<RequireQualifiedAccess>]
+module internal FSharpCallStackResolver =
+
+    /// The `Module` suffix is added when a module would otherwise collide with a type of the same name.
+    [<Literal>]
+    let private ModuleSuffix = "Module"
+
+    let private stripModuleSuffix (name: string) =
+        if name.EndsWith(ModuleSuffix, StringComparison.Ordinal) then
+            ValueSome(name.Substring(0, name.Length - ModuleSuffix.Length))
+        else
+            ValueNone
+
+    /// A frame name flattens namespaces, modules and nested types into one dotted path, and an
+    /// explicit interface implementation puts the interface name inside the member name. Both are
+    /// undone by trying every split of the path, longest entity path first.
+    let private entityPathCandidates (path: FramePathSegment list) (memberName: string voption) =
+        [
+            for split in List.length path .. -1 .. 1 do
+                let entityNames = path |> List.truncate split |> List.map _.Name
+                let trailing = path |> List.skip split |> List.map _.Name
+
+                let qualifiedMember =
+                    match memberName, trailing with
+                    | ValueSome name, trailing -> ValueSome(String.Join(".", [ yield! trailing; yield name ]))
+                    | ValueNone, [] -> ValueNone
+                    | ValueNone, trailing -> ValueSome(String.Join(".", trailing))
+
+                yield entityNames, qualifiedMember
+
+                let unsuffixed =
+                    entityNames
+                    |> List.map (fun name -> stripModuleSuffix name |> ValueOption.defaultValue name)
+
+                if unsuffixed <> entityNames then
+                    yield unsuffixed, qualifiedMember
+        ]
+
+    let private memberName frameMember =
+        match frameMember with
+        | FrameMethod name -> ValueSome name
+        | FrameConstructor -> ValueSome ".ctor"
+        | FrameStaticConstructor -> ValueSome ".cctor"
+        | FramePropertyGetter name
+        | FramePropertySetter name -> ValueSome name
+        | FrameActivePattern cases -> ValueSome($"""|{String.Join("|", cases)}|""")
+        | FrameClosureBody origin -> ValueSome origin.EnclosingName
+        | FrameStartupCode -> ValueNone
+
+    let private matchesName (name: string) (m: FSharpMemberOrFunctionOrValue) =
+        String.Equals(m.CompiledName, name, StringComparison.Ordinal)
+        || String.Equals(m.DisplayName, name, StringComparison.Ordinal)
+        || String.Equals(m.LogicalName, name, StringComparison.Ordinal)
+
+    let private tryFindMember (frame: ParsedFrame) (name: string) (entity: FSharpEntity) =
+        let members = entity.TryGetMembersFunctionsAndValues()
+
+        let byKind =
+            match frame.Member with
+            | FrameConstructor
+            | FrameStaticConstructor -> members |> Seq.filter _.IsConstructor
+            | FramePropertyGetter _
+            | FramePropertySetter _ -> members |> Seq.filter (fun m -> m.IsProperty && matchesName name m)
+            | _ -> members |> Seq.filter (matchesName name)
+
+        byKind
+        |> Seq.filter (fun m ->
+            m.GenericParameters.Count = frame.MethodGenericArity
+            || frame.MethodGenericArity = 0)
+        |> Seq.tryHead
+
+    /// A closure is compiled to its own class, so nothing in the assembly signature carries its name.
+    /// Report the enclosing declaration instead - the nearest one starting at or above the line the
+    /// closure was written on, which is what C# and VB do for lambdas.
+    let private tryFindEnclosingDeclaration (origin: ClosureOrigin) (entity: FSharpEntity) =
+        entity.TryGetMembersFunctionsAndValues()
+        |> Seq.filter (fun m -> m.DeclarationLocation.StartLine <= origin.Line)
+        |> Seq.sortByDescending _.DeclarationLocation.StartLine
+        |> Seq.tryHead
+
+    let private tryResolveInProject (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
+        let requested = memberName frame.Member
+
+        entityPathCandidates frame.Path requested
+        |> Seq.tryPick (fun (entityPath, qualifiedMember) ->
+            match signature.FindEntityByPath entityPath with
+            | None -> None
+            | Some entity ->
+                match frame.Member, qualifiedMember with
+                | FrameStartupCode, _ -> Some(entity.DeclarationLocation, entityPath, ValueNone)
+                | FrameClosureBody origin, _ ->
+                    let enclosing =
+                        match qualifiedMember with
+                        | ValueSome name ->
+                            tryFindMember frame name entity
+                            |> Option.orElseWith (fun () -> tryFindEnclosingDeclaration origin entity)
+                        | ValueNone -> tryFindEnclosingDeclaration origin entity
+
+                    enclosing
+                    |> Option.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
+                | _, ValueSome name ->
+                    tryFindMember frame name entity
+                    |> Option.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
+                | _, ValueNone -> None)
+
+    /// Maps a parsed frame back to the source it was written in, searching only the projects that
+    /// produced the module the debugger reported.
+    let tryResolve (workspace: Workspace) (assemblyName: string) (frame: ParsedFrame) =
+        cancellableTask {
+            let projects =
+                workspace.CurrentSolution.Projects
+                |> Seq.filter (fun p ->
+                    p.IsFSharp
+                    && String.Equals(p.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase))
+
+            let mutable resolved = ValueNone
+
+            for project in projects do
+                if resolved.IsNone then
+                    let! checker, _, _, options = project.GetFSharpCompilationOptionsAsync()
+                    let! results = checker.ParseAndCheckProject(options)
+
+                    match tryResolveInProject frame results.AssemblySignature with
+                    | Some(declarationRange, entityPath, resolvedMember) ->
+                        resolved <-
+                            ValueSome
+                                {
+                                    DeclarationRange = declarationRange
+                                    Project = project
+                                    EntityPath = entityPath
+                                    MemberName = resolvedMember
+                                }
+                    | None -> ()
+
+            return resolved
+        }
+
+    let tryResolveFrameName (workspace: Workspace) (assemblyName: string) (frameName: string) (cancellationToken: CancellationToken) =
+        match FSharpStackFrameNameParser.parse frameName with
+        | ValueNone -> System.Threading.Tasks.Task.FromResult ValueNone
+        | ValueSome frame ->
+            tryResolve workspace assemblyName frame
+            |> CancellableTask.start cancellationToken

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpCallStackResolver.fs
@@ -3,7 +3,6 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
-open System.Threading
 
 open Microsoft.CodeAnalysis
 
@@ -39,7 +38,7 @@ module internal FSharpCallStackResolver =
     /// explicit interface implementation puts the interface name inside the member name. Both are
     /// undone by trying every split of the path, longest entity path first.
     let private entityPathCandidates (path: FramePathSegment list) (memberName: string voption) =
-        [
+        seq {
             for split in List.length path .. -1 .. 1 do
                 let entityNames = path |> List.truncate split |> List.map _.Name
                 let trailing = path |> List.skip split |> List.map _.Name
@@ -50,15 +49,15 @@ module internal FSharpCallStackResolver =
                     | ValueNone, [] -> ValueNone
                     | ValueNone, trailing -> ValueSome(String.Join(".", trailing))
 
-                yield entityNames, qualifiedMember
+                yield struct (entityNames, qualifiedMember)
 
                 let unsuffixed =
                     entityNames
                     |> List.map (fun name -> stripModuleSuffix name |> ValueOption.defaultValue name)
 
                 if unsuffixed <> entityNames then
-                    yield unsuffixed, qualifiedMember
-        ]
+                    yield struct (unsuffixed, qualifiedMember)
+        }
 
     let private memberName frameMember =
         match frameMember with
@@ -91,7 +90,7 @@ module internal FSharpCallStackResolver =
         |> Seq.filter (fun m ->
             m.GenericParameters.Count = frame.MethodGenericArity
             || frame.MethodGenericArity = 0)
-        |> Seq.tryHead
+        |> Seq.tryHeadV
 
     /// A closure is compiled to its own class, so nothing in the assembly signature carries its name.
     /// Report the enclosing declaration instead - the nearest one starting at or above the line the
@@ -100,68 +99,69 @@ module internal FSharpCallStackResolver =
         entity.TryGetMembersFunctionsAndValues()
         |> Seq.filter (fun m -> m.DeclarationLocation.StartLine <= origin.Line)
         |> Seq.sortByDescending _.DeclarationLocation.StartLine
-        |> Seq.tryHead
+        |> Seq.tryHeadV
 
     let private tryResolveInProject (frame: ParsedFrame) (signature: FSharpAssemblySignature) =
         let requested = memberName frame.Member
 
         entityPathCandidates frame.Path requested
-        |> Seq.tryPick (fun (entityPath, qualifiedMember) ->
+        |> Seq.tryPickV (fun struct (entityPath, qualifiedMember) ->
             match signature.FindEntityByPath entityPath with
-            | None -> None
+            | None -> ValueNone
             | Some entity ->
                 match frame.Member, qualifiedMember with
-                | FrameStartupCode, _ -> Some(entity.DeclarationLocation, entityPath, ValueNone)
+                | FrameStartupCode, _ -> ValueSome(entity.DeclarationLocation, entityPath, ValueNone)
                 | FrameClosureBody origin, _ ->
                     let enclosing =
                         match qualifiedMember with
                         | ValueSome name ->
                             tryFindMember frame name entity
-                            |> Option.orElseWith (fun () -> tryFindEnclosingDeclaration origin entity)
+                            |> ValueOption.orElseWith (fun () -> tryFindEnclosingDeclaration origin entity)
                         | ValueNone -> tryFindEnclosingDeclaration origin entity
 
                     enclosing
-                    |> Option.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
+                    |> ValueOption.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
                 | _, ValueSome name ->
                     tryFindMember frame name entity
-                    |> Option.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
-                | _, ValueNone -> None)
+                    |> ValueOption.map (fun m -> m.DeclarationLocation, entityPath, ValueSome m.CompiledName)
+                | _, ValueNone -> ValueNone)
 
-    /// Maps a parsed frame back to the source it was written in, searching only the projects that
-    /// produced the module the debugger reported.
-    let tryResolve (workspace: Workspace) (assemblyName: string) (frame: ParsedFrame) =
+    let private projectsProducing (workspace: Workspace) (assemblyName: string) =
+        workspace.CurrentSolution.Projects
+        |> Seq.filter (fun p ->
+            p.IsFSharp
+            && String.Equals(p.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase))
+
+    /// Maps parsed frames back to the source they were written in, searching only the projects that
+    /// produced the module the debugger reported. Frames are resolved as a batch so a project is
+    /// checked once for the whole stack rather than once per frame.
+    let tryResolveMany (workspace: Workspace) (assemblyName: string) (frames: ParsedFrame list) =
         cancellableTask {
-            let projects =
-                workspace.CurrentSolution.Projects
-                |> Seq.filter (fun p ->
-                    p.IsFSharp
-                    && String.Equals(p.AssemblyName, assemblyName, StringComparison.OrdinalIgnoreCase))
+            let resolved = Array.create (List.length frames) ValueNone
 
-            let mutable resolved = ValueNone
-
-            for project in projects do
-                if resolved.IsNone then
+            for project in projectsProducing workspace assemblyName do
+                if resolved |> Array.exists _.IsNone then
                     let! checker, _, _, options = project.GetFSharpCompilationOptionsAsync()
                     let! results = checker.ParseAndCheckProject(options)
 
-                    match tryResolveInProject frame results.AssemblySignature with
-                    | Some(declarationRange, entityPath, resolvedMember) ->
-                        resolved <-
-                            ValueSome
-                                {
-                                    DeclarationRange = declarationRange
-                                    Project = project
-                                    EntityPath = entityPath
-                                    MemberName = resolvedMember
-                                }
-                    | None -> ()
+                    frames
+                    |> List.iteri (fun i frame ->
+                        if resolved.[i].IsNone then
+                            resolved.[i] <-
+                                tryResolveInProject frame results.AssemblySignature
+                                |> ValueOption.map (fun (declarationRange, entityPath, resolvedMember) ->
+                                    {
+                                        DeclarationRange = declarationRange
+                                        Project = project
+                                        EntityPath = entityPath
+                                        MemberName = resolvedMember
+                                    }))
 
-            return resolved
+            return List.ofArray resolved
         }
 
-    let tryResolveFrameName (workspace: Workspace) (assemblyName: string) (frameName: string) (cancellationToken: CancellationToken) =
-        match FSharpStackFrameNameParser.parse frameName with
-        | ValueNone -> System.Threading.Tasks.Task.FromResult ValueNone
-        | ValueSome frame ->
-            tryResolve workspace assemblyName frame
-            |> CancellableTask.start cancellationToken
+    let tryResolve (workspace: Workspace) (assemblyName: string) (frame: ParsedFrame) =
+        cancellableTask {
+            let! resolved = tryResolveMany workspace assemblyName [ frame ]
+            return List.head resolved
+        }

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -76,23 +76,20 @@ type internal FSharpGraphProvider() =
 
             componentModel.GetService<VisualStudioWorkspace>()
 
-    /// The debugger encodes the frame's module and mangled name into the node id; `CallStackMethodNode`
-    /// is the schema's own reader for it. The module Uri is relative (`ClassLibrary.dll`) for
-    /// workspace assemblies and absolute for external ones.
-    let frameOf (node: GraphNode) =
-        let frame = CallStackMethodNode node
-
-        match frame.Module, frame.FunctionName with
-        | null, _ -> ValueNone
-        | _, (null | "") -> ValueNone
-        | moduleUri, functionName ->
+    /// The assembly the debugger named as the frame's module, which it leaves empty on accessors and
+    /// on module initialization. The Uri is relative (`ClassLibrary.dll`) for workspace assemblies
+    /// and absolute for external ones.
+    let moduleAssemblyOf (frame: CallStackMethodNode) =
+        match frame.Module with
+        | null -> ValueNone
+        | moduleUri ->
             let modulePath =
                 if moduleUri.IsAbsoluteUri then
                     moduleUri.LocalPath
                 else
                     moduleUri.OriginalString
 
-            ValueSome(Path.GetFileNameWithoutExtension modulePath, functionName)
+            ValueSome(Path.GetFileNameWithoutExtension modulePath)
 
     /// The source position the debugger already resolved for a frame - the only usable anchor for a
     /// startup frame, whose name (`$Demo.$Demo`) points at the file rather than the construct.
@@ -315,70 +312,51 @@ type internal FSharpGraphProvider() =
             let parsedFrames =
                 [|
                     for frameNode in context.UnhandledInputNodes() do
-                        match FSharpStackFrameNameParser.parse (CallStackMethodNode frameNode).FunctionName with
+                        let frame = CallStackMethodNode frameNode
+
+                        match FSharpStackFrameNameParser.parse frame.FunctionName with
                         | ValueNone -> ()
                         | ValueSome parsed ->
-                            let position = frameSourcePosition frameNode
+                            let facts =
+                                {
+                                    Frame =
+                                        { parsed with
+                                            SourcePosition = frameSourcePosition frameNode
+                                        }
+                                    ModuleAssembly = moduleAssemblyOf frame
+                                }
 
-                            yield
-                                frameNode,
-                                { parsed with
-                                    SourcePosition = position
-                                },
-                                position
+                            yield frameNode, facts, FSharpCallStackPlan.decide assemblyNameForFile facts
                 |]
 
-            // FSharp.Core's own async/task/seq plumbing - `MoveNext`, `Invoke`, `ResumableStateMachine` -
-            // rides the real stack, and the SourceLink it ships with stops the debugger folding it into
-            // External Code the way it folds the BCL.
-            let isFSharpCoreFrame (frameNode: GraphNode) (position: struct (string * int) voption) =
-                match frameOf frameNode with
-                | ValueSome(name, _) -> String.Equals(name, "FSharp.Core", StringComparison.OrdinalIgnoreCase)
-                | ValueNone ->
-                    match position with
-                    | ValueSome position -> position.File.IndexOf("FSharp.Core", StringComparison.OrdinalIgnoreCase) >= 0
-                    | ValueNone -> false
-
-            // Frames we can resolve: F# code in the workspace, addressed by the assembly the module Uri
-            // names or, when it is empty, the project the debugger's source position points into.
-            let candidates =
+            // The pipeline's `ResolveUnresolvedNodesStep` calls `MarkAsExternal` on every unresolved
+            // frame whose `IsExternal` is set, collapsing it into the map's External Code group rather
+            // than giving it a node of its own.
+            let external =
                 [|
-                    for frameNode, parsed, position in parsedFrames do
-                        if not (isFSharpCoreFrame frameNode position) then
-                            let assemblyName =
-                                match frameOf frameNode with
-                                | ValueSome(name, _) -> ValueSome name
-                                | ValueNone -> position |> ValueOption.bind (fun position -> assemblyNameForFile position.File)
-
-                            match assemblyName with
-                            | ValueNone -> ()
-                            | ValueSome assemblyName -> yield assemblyName, frameNode, parsed
-                |]
-
-            // Marking those frames external is how the pipeline is told to fold them away: its
-            // `ResolveUnresolvedNodesStep` calls `MarkAsExternal` on every unresolved frame whose
-            // `IsExternal` is set, collapsing it into the map's External Code group instead of giving
-            // it a node of its own. Relabelling them would be pointless - that same step replaces the
-            // node, and the label with it, for anything left unresolved.
-            let core =
-                [|
-                    for frameNode, _, position in parsedFrames do
-                        if isFSharpCoreFrame frameNode position then
+                    for frameNode, _, action in parsedFrames do
+                        if action = FoldAsExternalCode then
                             frameNode
                 |]
 
-            if core.Length > 0 then
+            if external.Length > 0 then
                 use marking = new GraphTransactionScope()
 
-                for frameNode in core do
+                for frameNode in external do
                     CallStackMethodNode(frameNode).IsExternal <- true
 
                 marking.Complete()
 
             let byAssembly =
-                candidates
-                |> Seq.groupBy (fun (assemblyName, _, _) -> assemblyName)
-                |> Seq.map (fun (assemblyName, group) -> assemblyName, group |> Seq.map (fun (_, frameNode, parsed) -> frameNode, parsed))
+                [|
+                    for frameNode, facts, action in parsedFrames do
+                        match action with
+                        | ResolveIn assembly -> yield assembly, frameNode, facts.Frame
+                        | FoldAsExternalCode
+                        | LeaveUnresolved -> ()
+                |]
+                |> Seq.groupBy (fun (assembly, _, _) -> assembly)
+                |> Seq.map (fun (assembly, group) -> assembly, group |> Seq.map (fun (_, frameNode, frame) -> frameNode, frame))
                 |> Seq.toArray
 
             let! resolutions =

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -252,7 +252,7 @@ type internal FSharpGraphProvider() =
 
     /// Mirrors what the built-in C#/VB resolver does for a frame it recognises: create the method
     /// node, give it a source location, and link the frame to it - all inside a graph transaction.
-    let attachResolvedMethod (graph: Graph) (frameNode: GraphNode) (resolved: ResolvedFrame) =
+    let attachResolvedMethod (graph: Graph) (frameNode: GraphNode) keepsDeclaration (resolved: ResolvedFrame) =
         // The compiled name identifies the node, but the source name is what reads well: an operator
         // is `(>=>)`, not `op_GreaterEqualsGreater`, and a constructor is its type, not `.ctor`.
         let typeName () =
@@ -283,13 +283,20 @@ type internal FSharpGraphProvider() =
         | ResolvedProperty -> methodNode.AddCategory CodeNodeCategories.Property |> ignore
         | ResolvedEvent -> methodNode.AddCategory CodeNodeCategories.Event |> ignore
 
-        // The declaration, which is what a frame with no file of its own is left with. Where the
-        // frame does name a file, `AddSourceLocations` overwrites this with the line that was
-        // executing - a call stack navigates to the call, not to the declaration - and it writes
-        // once per node for the life of the map, guarded by the category it adds. The C# resolver
-        // sets the declaration here and is overwritten the same way.
+        // The declaration. Where the frame names a file, `AddSourceLocations` overwrites this with
+        // the line that was executing - a call stack navigates to the call, not to the declaration -
+        // and it writes once per node for the life of the map, guarded by the category it adds. The
+        // C# resolver sets the declaration here and is overwritten the same way.
+        //
+        // A startup frame is the exception: the line the debugger reports for it is the source
+        // range of a method the compiler wrote for the whole file, which lands on the blank line
+        // above the type whose initializer is running. The declaration is the only place it can
+        // navigate to, so the category is added here and the platform leaves it alone.
         let location = sourceLocationOf resolved
         methodNode.SetValue(CodeNodeProperties.SourceLocation, location) |> ignore
+
+        if keepsDeclaration then
+            methodNode.AddCategory CodeNodeCategories.SourceLocation |> ignore
 
         // `SourceLocation` alone lands navigation on the start of the line; the identifier location
         // is the one carrying the column, so the caret reaches the declaration itself.
@@ -371,12 +378,30 @@ type internal FSharpGraphProvider() =
             // and the hop over FSharp.Core is drawn by the code that draws every other hop. What is
             // left behind - the method node and the grey one the pipeline will pair with it - is in
             // no `CallStack*Call` link and so is not in the result graph.
+            //
+            // The whole graph is walked for this, not only the nodes handed to this action: the
+            // pipeline remembers every method node it has seen for the rest of the debug session and
+            // hands a provider only the new ones, while the frame links are rebuilt on every stop.
+            // Folding only what was handed over folds each FSharp.Core frame once per session and
+            // leaves it standing every time after.
             let foldedAway =
-                [|
-                    for methodNode, _, action in parsedFrames do
+                let byModule =
+                    graph.Nodes.GetByCategory ProgressionNodeCategories.CallStackMethod
+                    |> Seq.filter (fun methodNode ->
+                        FSharpCallStackPlan.isFSharpCoreModule (moduleAssemblyOf (CallStackMethodNode methodNode)))
+
+                let byDecision =
+                    parsedFrames
+                    |> Seq.choose (fun (methodNode, _, action) ->
                         if action = FoldAsExternalCode then
-                            yield! frameLinksOf methodNode
-                |]
+                            Some methodNode
+                        else
+                            None)
+
+                Seq.append byModule byDecision
+                |> Seq.distinct
+                |> Seq.collect frameLinksOf
+                |> Seq.toArray
 
             if foldedAway.Length > 0 then
                 use folding = new GraphTransactionScope()
@@ -407,12 +432,17 @@ type internal FSharpGraphProvider() =
             let mutable resolvedCount = 0
 
             for (_, group), results in Seq.zip byAssembly resolutions do
-                for (frameNode, _), resolved in Seq.zip group results do
+                for (frameNode, frame), resolved in Seq.zip group results do
                     match resolved with
                     | ValueNone -> ()
                     | ValueSome resolved ->
+                        let keepsDeclaration =
+                            match frame.Member with
+                            | FrameStartupCode -> true
+                            | _ -> false
+
                         try
-                            attachResolvedMethod graph frameNode resolved
+                            attachResolvedMethod graph frameNode keepsDeclaration resolved
                             context.AddHandled frameNode
                             resolvedCount <- resolvedCount + 1
                         with e ->

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -27,7 +27,6 @@ type private CodeSchemaProperties = Microsoft.VisualStudio.Progression.CodeSchem
 type private CodeQualifiedName = Microsoft.VisualStudio.Progression.CodeSchema.CodeQualifiedName
 type private ProgressionNodeCategories = Microsoft.VisualStudio.Progression.CodeSchema.NodeCategories
 type private ProgressionLinkCategories = Microsoft.VisualStudio.Progression.LinkCategories
-type private CodeSchemaLinkCategories = Microsoft.VisualStudio.Progression.CodeSchema.LinkCategories
 
 /// The code schema was shaped for C# and VB, so it has nowhere to record that a frame came from a
 /// module, a union, an active pattern or an inline function. A property carries its own schema, so
@@ -118,31 +117,6 @@ type internal FSharpGraphProvider() =
             | "" -> None
             | file -> Some { File = file; Line = frame.StartLine })
         |> FSharpCallStackPlan.positionOf
-
-    /// The map's edges are drawn by the pipeline's `BuildResultLinks`, which walks the `Calls` links
-    /// between frame nodes. A frame is taken off the map by re-pointing its caller at its callee -
-    /// marking the method external only greys it, because what the pipeline folds into External Code
-    /// it decides in its first step, before this handler ever runs.
-    let liftFrameOutOfChain (graph: Graph) (frameNode: GraphNode) =
-        let callsLinks (links: GraphLink seq) sideOf =
-            links
-            |> Seq.filter (fun link -> link.HasCategory CodeSchemaLinkCategories.Calls && isFrameNode (sideOf link))
-            |> Seq.toArray
-
-        let toCallee = callsLinks frameNode.OutgoingLinks (fun link -> link.Target)
-        let fromCallers = callsLinks frameNode.IncomingLinks (fun link -> link.Source)
-
-        for callerLink in fromCallers do
-            for calleeLink in toCallee do
-                graph.Links.GetOrCreate(callerLink.Source, calleeLink.Target, String.Empty, CodeSchemaLinkCategories.Calls)
-                |> ignore
-
-            graph.Links.Remove callerLink |> ignore
-
-        for calleeLink in toCallee do
-            graph.Links.Remove calleeLink |> ignore
-
-        graph.Nodes.Remove frameNode |> ignore
 
     /// A startup frame carries no module, so its owning assembly is read from the project the source
     /// file belongs to instead.
@@ -361,10 +335,12 @@ type internal FSharpGraphProvider() =
                 |]
 
             // FSharp.Core's plumbing sits in the middle of the stack, where the pipeline folds nothing:
-            // what goes into External Code it decides in its first step, from the debugger's own
-            // Just My Code state, and these frames carry SourceLink so the debugger counts them as
-            // ours. Taking them out of the frame chain is what removes them - the caller is re-pointed
-            // at the callee, so `pipelineLambdas` links straight to the lambda it ran.
+            // what goes into External Code it decides in its first step, from the debugger's own Just
+            // My Code state, and these frames carry SourceLink so the debugger counts them as ours.
+            // Marking them external is all that can be done from here - it greys them rather than
+            // removing them. Taking them out of the frame chain instead, by re-pointing the caller at
+            // the callee, breaks opening the map, so the graph is left with the shape the pipeline
+            // gave it.
             let external =
                 [|
                     for methodNode, _, action in parsedFrames do
@@ -373,20 +349,12 @@ type internal FSharpGraphProvider() =
                 |]
 
             if external.Length > 0 then
-                use folding = new GraphTransactionScope()
+                use marking = new GraphTransactionScope()
 
                 for methodNode in external do
-                    try
-                        for frame in framesOf methodNode |> Seq.toArray do
-                            liftFrameOutOfChain graph frame
+                    CallStackMethodNode(methodNode).IsExternal <- true
 
-                        graph.Nodes.Remove methodNode |> ignore
-                    with e ->
-                        // Nothing here is worth a broken map: a frame left in place is only noise.
-                        CallStackMethodNode(methodNode).IsExternal <- true
-                        Trace.WriteLine $"[FSharpCodeMap] could not fold a FSharp.Core frame: {e.Message}"
-
-                folding.Complete()
+                marking.Complete()
 
             let byAssembly =
                 [|

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -113,7 +113,7 @@ type internal FSharpGraphProvider() =
                 match frame.FileName with
                 | null
                 | "" -> ValueNone
-                | file -> ValueSome(struct (file, frame.StartLine))
+                | file -> ValueSome { File = file; Line = frame.StartLine }
             else
                 ValueNone)
 
@@ -261,10 +261,7 @@ type internal FSharpGraphProvider() =
             if resolved.Modifiers.IsConstructor then
                 typeName () |> ValueOption.defaultValue ".ctor"
             else
-                match resolved.DisplayName, resolved.MemberName with
-                | ValueSome display, _ when not (String.IsNullOrEmpty display) -> display
-                | _, ValueSome name -> name
-                | _ -> String.Join(".", resolved.EntityPath)
+                resolved.DisplayName
 
         use transaction = new GraphTransactionScope()
 
@@ -339,7 +336,7 @@ type internal FSharpGraphProvider() =
                 | ValueSome(name, _) -> String.Equals(name, "FSharp.Core", StringComparison.OrdinalIgnoreCase)
                 | ValueNone ->
                     match position with
-                    | ValueSome(struct (file, _)) -> file.IndexOf("FSharp.Core", StringComparison.OrdinalIgnoreCase) >= 0
+                    | ValueSome position -> position.File.IndexOf("FSharp.Core", StringComparison.OrdinalIgnoreCase) >= 0
                     | ValueNone -> false
 
             // Frames we can resolve: F# code in the workspace, addressed by the assembly the module Uri
@@ -351,9 +348,7 @@ type internal FSharpGraphProvider() =
                             let assemblyName =
                                 match frameOf frameNode with
                                 | ValueSome(name, _) -> ValueSome name
-                                | ValueNone ->
-                                    position
-                                    |> ValueOption.bind (fun (struct (file, _)) -> assemblyNameForFile file)
+                                | ValueNone -> position |> ValueOption.bind (fun position -> assemblyNameForFile position.File)
 
                             match assemblyName with
                             | ValueNone -> ()

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -7,6 +7,9 @@ open System.ComponentModel.Composition
 open System.Diagnostics
 open System.IO
 open System.Threading
+open System.Threading.Tasks
+
+open FSharp.Compiler.Syntax
 
 open Microsoft.VisualStudio.ComponentModelHost
 open Microsoft.VisualStudio.LanguageServices
@@ -18,6 +21,8 @@ open Microsoft.VisualStudio.GraphModel.Schemas
 open Microsoft.VisualStudio.Progression
 open Microsoft.VisualStudio.Progression.CodeSchema.Api
 
+open CancellableTasks
+
 /// Resolves the F# frames of a debugger call stack shown on a Code Map. The debugger contributes
 /// `CodeSchema_CallStackMethod` nodes carrying nothing but the module and the mangled frame name;
 /// without a provider claiming them they stay unresolved and carry no source location.
@@ -27,8 +32,6 @@ open Microsoft.VisualStudio.Progression.CodeSchema.Api
                  IntellisenseType = "{BC6DD5A5-D4D6-4dab-A00D-A51242DBAF1B}",
                  ProjectCapability = "FSharp")>]
 type internal FSharpGraphProvider() =
-
-    let callStackMethodCategory = "CodeSchema_CallStackMethod"
 
     /// The frame resolution runs on a Progression worker, so a project that is slow to check must
     /// leave the node unresolved rather than stall the whole map.
@@ -61,29 +64,47 @@ type internal FSharpGraphProvider() =
 
             ValueSome(Path.GetFileNameWithoutExtension modulePath, functionName)
 
+    /// Builds the same node identity Roslyn's `GraphNodeIdCreation.GetIdForMemberAsync` produced,
+    /// so a frame resolved here fuses with the node the metadata provider creates for the same
+    /// method: a nested type becomes `Type=(Name=… ParentType=…)`, a generic one carries
+    /// `GenericParameterCount`, and only a top-level non-generic type collapses to a plain string.
+    let rec private typePartial (chain: struct (string * int) array) upTo (nodeName: GraphNodeIdName) =
+        let struct (name, arity) = chain.[upTo]
+
+        if upTo = 0 && arity = 0 then
+            GraphNodeId.GetPartial(nodeName, name)
+        else
+            let partials =
+                [|
+                    GraphNodeId.GetPartial(Microsoft.VisualStudio.Progression.CodeSchema.CodeQualifiedName.Name, name)
+                    if arity > 0 then
+                        GraphNodeId.GetPartial(CodeGraphNodeIdName.GenericParameterCountIdentifier, string arity)
+                    if upTo > 0 then
+                        typePartial chain (upTo - 1) CodeGraphNodeIdName.ParentType
+                |]
+
+            let value: obj =
+                if partials.Length > 1 then
+                    GraphNodeIdCollection(false, partials)
+                else
+                    GraphNodeId.GetNested partials
+
+            GraphNodeId.GetPartial(nodeName, value)
+
     let resolvedNodeId (resolved: ResolvedFrame) =
-        let assembly =
+        [|
             match resolved.Project.OutputFilePath with
-            | null -> GraphNodeId.Empty
+            | null -> ()
             | path -> GraphNodeId.GetPartial(CodeGraphNodeIdName.Assembly, Uri(path))
-
-        let ``namespace``, typeName =
-            match resolved.EntityPath with
-            | [] -> "", ""
-            | path -> String.Join(".", path |> List.truncate (path.Length - 1)), List.last path
-
-        [
-            if assembly <> GraphNodeId.Empty then
-                assembly
-            if not (String.IsNullOrEmpty ``namespace``) then
-                GraphNodeId.GetPartial(CodeGraphNodeIdName.Namespace, ``namespace``)
-            if not (String.IsNullOrEmpty typeName) then
-                GraphNodeId.GetPartial(CodeGraphNodeIdName.Type, typeName)
+            match resolved.Namespace with
+            | ValueSome ns -> GraphNodeId.GetPartial(CodeGraphNodeIdName.Namespace, ns)
+            | ValueNone -> ()
+            if resolved.TypeChain.Length > 0 then
+                typePartial resolved.TypeChain (resolved.TypeChain.Length - 1) CodeGraphNodeIdName.Type
             match resolved.MemberName with
             | ValueSome name -> GraphNodeId.GetPartial(CodeGraphNodeIdName.Member, name)
             | ValueNone -> ()
-        ]
-        |> Array.ofList
+        |]
         |> GraphNodeId.GetNested
 
     let sourceLocationOf (resolved: ResolvedFrame) =
@@ -92,50 +113,59 @@ type internal FSharpGraphProvider() =
         SourceLocation(Uri(range.FileName), Position(range.StartLine - 1, range.StartColumn), Position(range.EndLine - 1, range.EndColumn))
 
     /// Checks every reported assembly concurrently, each one exactly once for the whole stack.
-    /// The Progression action handler returns void, so the platform moves on to the next pipeline
-    /// step as soon as it returns - the graph must be complete by then, hence the single wait here.
-    let resolveAll (context: ActionContext) (framesByAssembly: (string * ParsedFrame list) list) =
-        use cancellation = new CancellationTokenSource(resolutionTimeout)
-        use _ = context.Cancelled.Subscribe(fun _ -> cancellation.Cancel())
+    /// `ActionManager` runs the action on a `JobQueue` worker, so blocking here never reaches the
+    /// UI - but the handler returns void and the platform continues into the next pipeline step the
+    /// moment it does, so the graph has to be complete before we return.
+    let resolveAll (context: ActionContext) (framesByAssembly: struct (string * ParsedFrame array) array) =
+        cancellableTask {
+            let! ambient = CancellableTask.getCancellationToken ()
+            use cancellation = CancellationTokenSource.CreateLinkedTokenSource ambient
+            cancellation.CancelAfter resolutionTimeout
+            use _ = context.Cancelled.Subscribe(fun _ -> cancellation.Cancel())
 
-        try
-            framesByAssembly
-            |> List.map (fun (assemblyName, frames) ->
-                FSharpCallStackResolver.tryResolveMany workspace.Value assemblyName frames
-                |> CancellableTask.start cancellation.Token
-                |> Async.AwaitTask)
-            |> Async.Parallel
-            |> Async.RunSynchronously
-            |> Array.toList
-        with
-        | :? OperationCanceledException -> reraise ()
-        | e ->
-            Trace.WriteLine $"[FSharpCodeMap] resolution failed: {e.Message}"
+            try
+                let resolveEverything =
+                    framesByAssembly
+                    |> Seq.map (fun struct (assemblyName, frames) ->
+                        FSharpCallStackResolver.tryResolveMany workspace.Value assemblyName frames)
+                    |> CancellableTask.whenAllThrottled (max 1 Environment.ProcessorCount)
 
-            framesByAssembly
-            |> List.map (fun (_, frames) -> frames |> List.map (fun _ -> ValueNone))
+                return! resolveEverything cancellation.Token
+            with e when not (e :? OperationCanceledException) ->
+                Trace.WriteLine $"[FSharpCodeMap] resolution failed: {e.Message}"
 
-    /// The synthesized parts of a frame name (`helperTwo@42.Invoke`) make ugly node labels even
-    /// when full resolution fails; the parsed shape always yields a better one.
+                return
+                    framesByAssembly
+                    |> Array.map (fun struct (_, frames) -> frames |> Array.map (fun _ -> ValueNone))
+        }
+
+    /// The synthesized parts of a frame name (`helperTwo@42.Invoke`, `op_PlusBangPlus`) make ugly
+    /// node labels even when full resolution fails; the parsed shape always yields a better one.
     let friendlyLabel (frame: ParsedFrame) =
         match frame.Member with
         | FrameClosureBody origin -> ValueSome origin.EnclosingName
         | FramePropertyGetter name
         | FramePropertySetter name -> ValueSome name
+        | FrameMethod name when PrettyNaming.IsLogicalOpName name ->
+            ValueSome $"({PrettyNaming.ConvertValLogicalNameToDisplayNameCore name})"
         | FrameStartupCode ->
             match frame.Path with
-            | [] -> ValueNone
-            | path -> ValueSome (List.last path).Name
+            | [||] -> ValueNone
+            | path -> ValueSome (Array.last path).Name
         | FrameMethod _
         | FrameConstructor
         | FrameStaticConstructor
         | FrameActivePattern _ -> ValueNone
 
+    /// Mirrors what the built-in C#/VB resolver does for a frame it recognises: create the method
+    /// node, give it a source location, and link the frame to it - all inside a graph transaction.
     let attachResolvedMethod (graph: Graph) (frameNode: GraphNode) (resolved: ResolvedFrame) =
         let label =
             match resolved.MemberName with
             | ValueSome name -> name
             | ValueNone -> String.Join(".", resolved.EntityPath)
+
+        use transaction = new GraphTransactionScope()
 
         let methodNode =
             graph.Nodes.GetOrCreate(resolvedNodeId resolved, label, CodeNodeCategories.Method)
@@ -143,58 +173,77 @@ type internal FSharpGraphProvider() =
         methodNode.SetValue(CodeNodeProperties.SourceLocation, sourceLocationOf resolved)
         |> ignore
 
-        CallStackMethodNode(frameNode).ReferencesMethodNode <- MethodNode methodNode
+        CodeSchemaHelper.GetOrCreateLink<CallStackMethodReferencesMethodLink>(graph, frameNode.Id, methodNode.Id, String.Empty)
+        |> ignore
+
+        transaction.Complete()
 
     let resolveCallStack (context: ActionContext) =
-        let graph = context.Graph
+        cancellableTask {
+            let graph = context.Graph
 
-        // Read the graph before touching it: resolving a frame adds nodes to the very collection
-        // `GetByCategory` enumerates.
-        let candidates =
-            [
-                for frameNode in graph.Nodes.GetByCategory [| callStackMethodCategory |] do
-                    match frameOf frameNode with
-                    | ValueNone -> ()
-                    | ValueSome(assemblyName, functionName) ->
-                        match FSharpStackFrameNameParser.parse functionName with
+            // The platform hands the frame nodes in as the action's input; a node another provider
+            // already claimed is excluded. Snapshot before resolution starts mutating the graph.
+            let candidates =
+                [|
+                    for frameNode in context.UnhandledInputNodes() do
+                        match frameOf frameNode with
                         | ValueNone -> ()
-                        | ValueSome parsed -> yield assemblyName, frameNode, parsed
-            ]
+                        | ValueSome(assemblyName, functionName) ->
+                            match FSharpStackFrameNameParser.parse functionName with
+                            | ValueNone -> ()
+                            | ValueSome parsed -> yield assemblyName, frameNode, parsed
+                |]
 
-        for _, frameNode, parsed in candidates do
-            friendlyLabel parsed |> ValueOption.iter (fun label -> frameNode.Label <- label)
+            if candidates.Length > 0 then
+                use labelling = new GraphTransactionScope()
 
-        let byAssembly =
-            candidates
-            |> List.groupBy (fun (assemblyName, _, _) -> assemblyName)
-            |> List.map (fun (assemblyName, group) -> assemblyName, group |> List.map (fun (_, frameNode, parsed) -> frameNode, parsed))
+                for _, frameNode, parsed in candidates do
+                    friendlyLabel parsed |> ValueOption.iter (fun label -> frameNode.Label <- label)
 
-        let resolutions =
-            byAssembly
-            |> List.map (fun (assemblyName, group) -> assemblyName, group |> List.map snd)
-            |> resolveAll context
+                labelling.Complete()
 
-        let mutable resolvedCount = 0
+            let byAssembly =
+                candidates
+                |> Array.groupBy (fun (assemblyName, _, _) -> assemblyName)
+                |> Array.map (fun (assemblyName, group) ->
+                    assemblyName, group |> Array.map (fun (_, frameNode, parsed) -> frameNode, parsed))
 
-        for (_, group), results in List.zip byAssembly resolutions do
-            for (frameNode, _), resolved in List.zip group results do
-                match resolved with
-                | ValueNone -> ()
-                | ValueSome resolved ->
-                    try
-                        attachResolvedMethod graph frameNode resolved
-                        context.AddHandled frameNode
-                        resolvedCount <- resolvedCount + 1
-                    with e ->
-                        // An unresolvable frame is expected - it stays a grey unresolved node, and
-                        // one bad frame must not abandon the rest of the stack.
-                        Trace.WriteLine $"[FSharpCodeMap] frame failed: {e.Message}"
+            let! resolutions =
+                byAssembly
+                |> Array.map (fun (assemblyName, group) -> struct (assemblyName, group |> Array.map snd))
+                |> resolveAll context
 
-        Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{candidates.Length} F# frames resolved"
+            let mutable resolvedCount = 0
+
+            for (_, group), results in Array.zip byAssembly resolutions do
+                for (frameNode, _), resolved in Array.zip group results do
+                    match resolved with
+                    | ValueNone -> ()
+                    | ValueSome resolved ->
+                        try
+                            attachResolvedMethod graph frameNode resolved
+                            context.AddHandled frameNode
+                            resolvedCount <- resolvedCount + 1
+                        with e ->
+                            // An unresolvable frame is expected - it stays a grey unresolved node, and
+                            // one bad frame must not abandon the rest of the stack.
+                            Trace.WriteLine $"[FSharpCodeMap] frame failed: {e.Message}"
+
+            Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{candidates.Length} F# frames resolved"
+        }
 
     interface IProvider with
         member _.Schema = schema
 
         member _.Initialize(_serviceProvider: IServiceProvider) =
             Trace.WriteLine "[FSharpCodeMap] FSharpGraphProvider.Initialize"
-            Actions.ResolveCallStack.ActionHandlers.Add(ActionHandler(resolveCallStack))
+
+            // The handler contract is synchronous: `ActionManager` runs it on a `JobQueue` worker
+            // and continues into the next pipeline step the moment it returns, so the graph must be
+            // complete by then. `JoinableTaskFactory.Run` is the same blocking bridge the built-in
+            // C#/VB provider uses for this action.
+            Actions.ResolveCallStack.ActionHandlers.Add(
+                ActionHandler(fun context ->
+                    ThreadHelper.JoinableTaskFactory.Run(fun () -> resolveCallStack context CancellationToken.None :> Task))
+            )

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -91,15 +91,29 @@ type internal FSharpGraphProvider() =
 
         SourceLocation(Uri(range.FileName), Position(range.StartLine - 1, range.StartColumn), Position(range.EndLine - 1, range.EndColumn))
 
-    let tryResolve (frameName: string) (assemblyName: string) =
+    /// Checks every reported assembly concurrently, each one exactly once for the whole stack.
+    /// The Progression action handler returns void, so the platform moves on to the next pipeline
+    /// step as soon as it returns - the graph must be complete by then, hence the single wait here.
+    let resolveAll (context: ActionContext) (framesByAssembly: (string * ParsedFrame list) list) =
         use cancellation = new CancellationTokenSource(resolutionTimeout)
+        use _ = context.Cancelled.Subscribe(fun _ -> cancellation.Cancel())
 
         try
-            FSharpCallStackResolver.tryResolveFrameName workspace.Value assemblyName frameName cancellation.Token
-            |> Async.AwaitTask
+            framesByAssembly
+            |> List.map (fun (assemblyName, frames) ->
+                FSharpCallStackResolver.tryResolveMany workspace.Value assemblyName frames
+                |> CancellableTask.start cancellation.Token
+                |> Async.AwaitTask)
+            |> Async.Parallel
             |> Async.RunSynchronously
-        with _ ->
-            ValueNone
+            |> Array.toList
+        with
+        | :? OperationCanceledException -> reraise ()
+        | e ->
+            Trace.WriteLine $"[FSharpCodeMap] resolution failed: {e.Message}"
+
+            framesByAssembly
+            |> List.map (fun (_, frames) -> frames |> List.map (fun _ -> ValueNone))
 
     /// The synthesized parts of a frame name (`helperTwo@42.Invoke`) make ugly node labels even
     /// when full resolution fails; the parsed shape always yields a better one.
@@ -117,51 +131,66 @@ type internal FSharpGraphProvider() =
         | FrameStaticConstructor
         | FrameActivePattern _ -> ValueNone
 
-    let resolveNode (graph: Graph) (frameNode: GraphNode) =
-        match frameOf frameNode with
-        | ValueNone -> false
-        | ValueSome(assemblyName, functionName) ->
-            match FSharpStackFrameNameParser.parse functionName with
-            | ValueNone -> false
-            | ValueSome parsed ->
-                friendlyLabel parsed
-                |> ValueOption.iter (fun label -> frameNode.Label <- label)
+    let attachResolvedMethod (graph: Graph) (frameNode: GraphNode) (resolved: ResolvedFrame) =
+        let label =
+            match resolved.MemberName with
+            | ValueSome name -> name
+            | ValueNone -> String.Join(".", resolved.EntityPath)
 
-                match tryResolve functionName assemblyName with
-                | ValueNone -> false
-                | ValueSome resolved ->
-                    let label =
-                        match resolved.MemberName with
-                        | ValueSome name -> name
-                        | ValueNone -> String.Join(".", resolved.EntityPath)
+        let methodNode =
+            graph.Nodes.GetOrCreate(resolvedNodeId resolved, label, CodeNodeCategories.Method)
 
-                    let methodNode =
-                        graph.Nodes.GetOrCreate(resolvedNodeId resolved, label, CodeNodeCategories.Method)
+        methodNode.SetValue(CodeNodeProperties.SourceLocation, sourceLocationOf resolved)
+        |> ignore
 
-                    methodNode.SetValue(CodeNodeProperties.SourceLocation, sourceLocationOf resolved)
-                    |> ignore
-
-                    CallStackMethodNode(frameNode).ReferencesMethodNode <- MethodNode methodNode
-                    true
+        CallStackMethodNode(frameNode).ReferencesMethodNode <- MethodNode methodNode
 
     let resolveCallStack (context: ActionContext) =
         let graph = context.Graph
-        let mutable seen = 0
+
+        // Read the graph before touching it: resolving a frame adds nodes to the very collection
+        // `GetByCategory` enumerates.
+        let candidates =
+            [
+                for frameNode in graph.Nodes.GetByCategory [| callStackMethodCategory |] do
+                    match frameOf frameNode with
+                    | ValueNone -> ()
+                    | ValueSome(assemblyName, functionName) ->
+                        match FSharpStackFrameNameParser.parse functionName with
+                        | ValueNone -> ()
+                        | ValueSome parsed -> yield assemblyName, frameNode, parsed
+            ]
+
+        for _, frameNode, parsed in candidates do
+            friendlyLabel parsed |> ValueOption.iter (fun label -> frameNode.Label <- label)
+
+        let byAssembly =
+            candidates
+            |> List.groupBy (fun (assemblyName, _, _) -> assemblyName)
+            |> List.map (fun (assemblyName, group) -> assemblyName, group |> List.map (fun (_, frameNode, parsed) -> frameNode, parsed))
+
+        let resolutions =
+            byAssembly
+            |> List.map (fun (assemblyName, group) -> assemblyName, group |> List.map snd)
+            |> resolveAll context
+
         let mutable resolvedCount = 0
 
-        for frameNode in graph.Nodes.GetByCategory [| callStackMethodCategory |] |> Seq.toArray do
-            try
-                seen <- seen + 1
+        for (_, group), results in List.zip byAssembly resolutions do
+            for (frameNode, _), resolved in List.zip group results do
+                match resolved with
+                | ValueNone -> ()
+                | ValueSome resolved ->
+                    try
+                        attachResolvedMethod graph frameNode resolved
+                        context.AddHandled frameNode
+                        resolvedCount <- resolvedCount + 1
+                    with e ->
+                        // An unresolvable frame is expected - it stays a grey unresolved node, and
+                        // one bad frame must not abandon the rest of the stack.
+                        Trace.WriteLine $"[FSharpCodeMap] frame failed: {e.Message}"
 
-                if resolveNode graph frameNode then
-                    resolvedCount <- resolvedCount + 1
-                    context.AddHandled frameNode
-            with e ->
-                // An unresolvable frame is expected - it stays a grey unresolved node, and one bad
-                // frame must not abandon the rest of the stack.
-                Trace.WriteLine $"[FSharpCodeMap] frame failed: {e.Message}"
-
-        Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{seen} F# frames resolved"
+        Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{candidates.Length} F# frames resolved"
 
     interface IProvider with
         member _.Schema = schema

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -94,11 +94,14 @@ type internal FSharpGraphProvider() =
     let isFrameNode (node: GraphNode) =
         node.HasCategory ProgressionNodeCategories.CallStackFrame
 
-    /// Every frame that claims this method node, which in an accumulated map is more than one.
-    let framesOf (methodNode: GraphNode) =
+    /// The links by which frames claim this method node - one per frame, and in an accumulated map
+    /// that is more than one.
+    let frameLinksOf (methodNode: GraphNode) =
         methodNode.IncomingLinks
         |> Seq.filter (fun link -> link.HasCategory ProgressionLinkCategories.References && isFrameNode link.Source)
-        |> Seq.map _.Source
+
+    let framesOf (methodNode: GraphNode) =
+        frameLinksOf methodNode |> Seq.map _.Source
 
     /// The source position the debugger resolved for a frame - the only usable anchor for a startup
     /// frame, whose name (`$Demo.$Demo`) points at the file rather than the construct.
@@ -280,6 +283,11 @@ type internal FSharpGraphProvider() =
         | ResolvedProperty -> methodNode.AddCategory CodeNodeCategories.Property |> ignore
         | ResolvedEvent -> methodNode.AddCategory CodeNodeCategories.Event |> ignore
 
+        // The declaration, which is what a frame with no file of its own is left with. Where the
+        // frame does name a file, `AddSourceLocations` overwrites this with the line that was
+        // executing - a call stack navigates to the call, not to the declaration - and it writes
+        // once per node for the life of the map, guarded by the category it adds. The C# resolver
+        // sets the declaration here and is overwritten the same way.
         let location = sourceLocationOf resolved
         methodNode.SetValue(CodeNodeProperties.SourceLocation, location) |> ignore
 
@@ -334,27 +342,45 @@ type internal FSharpGraphProvider() =
                             yield frameNode, facts, FSharpCallStackPlan.decide assemblyNameForFile facts
                 |]
 
-            // FSharp.Core's plumbing sits in the middle of the stack, where the pipeline folds nothing:
-            // what goes into External Code it decides in its first step, from the debugger's own Just
-            // My Code state, and these frames carry SourceLink so the debugger counts them as ours.
-            // Marking them external is all that can be done from here - it greys them rather than
-            // removing them. Taking them out of the frame chain instead, by re-pointing the caller at
-            // the callee, breaks opening the map, so the graph is left with the shape the pipeline
-            // gave it.
-            let external =
+            // What the debug engine handed us, before anything is resolved. A position here belongs to
+            // the PDB of the running build, while the resolver reads the file the workspace has open:
+            // when the two disagree the answer is a construct on the same line of a different version
+            // of the source, and this line is the only place that shows it.
+            for methodNode, facts, action in parsedFrames do
+                let position =
+                    match facts.Frame.SourcePosition with
+                    | ValueNone -> "no position"
+                    | ValueSome position -> $"{Path.GetFileName position.File}:{position.Line}"
+
+                Trace.WriteLine $"[FSharpCodeMap] {CallStackMethodNode(methodNode).FunctionName} at {position} -> {action}"
+
+            // FSharp.Core's plumbing is external code that Just My Code did not filter out: it ships
+            // with SourceLink, so the debugger counts it as ours and the pipeline's first step keeps
+            // its frames.
+            //
+            // What folds a frame away is reaching no method node from it. `BuildResultLinks` walks
+            // the chain of `Calls` links and draws one link per frame that reaches one, joining the
+            // ends of a run of frames that do not by a single indirect link it labels "External
+            // Code" - the same link it draws over everything else the debugger folded. So the whole
+            // operation is cutting the frame loose from its method node: the chain of `Calls` links
+            // keeps the exact shape the pipeline gave it, nothing here creates or re-points a link,
+            // and the hop over FSharp.Core is drawn by the code that draws every other hop. What is
+            // left behind - the method node and the grey one the pipeline will pair with it - is in
+            // no `CallStack*Call` link and so is not in the result graph.
+            let foldedAway =
                 [|
                     for methodNode, _, action in parsedFrames do
                         if action = FoldAsExternalCode then
-                            methodNode
+                            yield! frameLinksOf methodNode
                 |]
 
-            if external.Length > 0 then
-                use marking = new GraphTransactionScope()
+            if foldedAway.Length > 0 then
+                use folding = new GraphTransactionScope()
 
-                for methodNode in external do
-                    CallStackMethodNode(methodNode).IsExternal <- true
+                for link in foldedAway do
+                    graph.Links.Remove link |> ignore
 
-                marking.Complete()
+                folding.Complete()
 
             let byAssembly =
                 [|

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -27,6 +27,7 @@ type private CodeSchemaProperties = Microsoft.VisualStudio.Progression.CodeSchem
 type private CodeQualifiedName = Microsoft.VisualStudio.Progression.CodeSchema.CodeQualifiedName
 type private ProgressionNodeCategories = Microsoft.VisualStudio.Progression.CodeSchema.NodeCategories
 type private ProgressionLinkCategories = Microsoft.VisualStudio.Progression.LinkCategories
+type private CodeSchemaLinkCategories = Microsoft.VisualStudio.Progression.CodeSchema.LinkCategories
 
 /// The code schema was shaped for C# and VB, so it has nowhere to record that a frame came from a
 /// module, a union, an active pattern or an inline function. A property carries its own schema, so
@@ -91,28 +92,57 @@ type internal FSharpGraphProvider() =
 
             ValueSome(Path.GetFileNameWithoutExtension modulePath)
 
-    /// The source position the debugger already resolved for a frame - the only usable anchor for a
-    /// startup frame, whose name (`$Demo.$Demo`) points at the file rather than the construct.
+    let isFrameNode (node: GraphNode) =
+        node.HasCategory ProgressionNodeCategories.CallStackFrame
+
+    /// Every frame that claims this method node, which in an accumulated map is more than one.
+    let framesOf (methodNode: GraphNode) =
+        methodNode.IncomingLinks
+        |> Seq.filter (fun link -> link.HasCategory ProgressionLinkCategories.References && isFrameNode link.Source)
+        |> Seq.map _.Source
+
+    /// The source position the debugger resolved for a frame - the only usable anchor for a startup
+    /// frame, whose name (`$Demo.$Demo`) points at the file rather than the construct.
     ///
     /// It cannot be read off the method node this action hands us: the pipeline stamps
     /// `CodeNodeProperties.SourceLocation` on those in its `AddSourceLocations` step, which runs
-    /// after this handler. The frame node referencing the method already carries it, and its
-    /// `StartLine` is 1-based, the same base an FCS range uses.
+    /// after this handler. The frame nodes carry it already, and their `StartLine` is 1-based, the
+    /// same base an FCS range uses.
     let frameSourcePosition (methodNode: GraphNode) =
-        methodNode.IncomingLinks
-        |> Seq.tryPickV (fun link ->
-            if
-                link.HasCategory ProgressionLinkCategories.References
-                && link.Source.HasCategory ProgressionNodeCategories.CallStackFrame
-            then
-                let frame = CallStackFrameNode link.Source
+        framesOf methodNode
+        |> Seq.choose (fun node ->
+            let frame = CallStackFrameNode node
 
-                match frame.FileName with
-                | null
-                | "" -> ValueNone
-                | file -> ValueSome { File = file; Line = frame.StartLine }
-            else
-                ValueNone)
+            match frame.FileName with
+            | null
+            | "" -> None
+            | file -> Some { File = file; Line = frame.StartLine })
+        |> FSharpCallStackPlan.positionOf
+
+    /// The map's edges are drawn by the pipeline's `BuildResultLinks`, which walks the `Calls` links
+    /// between frame nodes. A frame is taken off the map by re-pointing its caller at its callee -
+    /// marking the method external only greys it, because what the pipeline folds into External Code
+    /// it decides in its first step, before this handler ever runs.
+    let liftFrameOutOfChain (graph: Graph) (frameNode: GraphNode) =
+        let callsLinks (links: GraphLink seq) sideOf =
+            links
+            |> Seq.filter (fun link -> link.HasCategory CodeSchemaLinkCategories.Calls && isFrameNode (sideOf link))
+            |> Seq.toArray
+
+        let toCallee = callsLinks frameNode.OutgoingLinks (fun link -> link.Target)
+        let fromCallers = callsLinks frameNode.IncomingLinks (fun link -> link.Source)
+
+        for callerLink in fromCallers do
+            for calleeLink in toCallee do
+                graph.Links.GetOrCreate(callerLink.Source, calleeLink.Target, String.Empty, CodeSchemaLinkCategories.Calls)
+                |> ignore
+
+            graph.Links.Remove callerLink |> ignore
+
+        for calleeLink in toCallee do
+            graph.Links.Remove calleeLink |> ignore
+
+        graph.Nodes.Remove frameNode |> ignore
 
     /// A startup frame carries no module, so its owning assembly is read from the project the source
     /// file belongs to instead.
@@ -330,23 +360,33 @@ type internal FSharpGraphProvider() =
                             yield frameNode, facts, FSharpCallStackPlan.decide assemblyNameForFile facts
                 |]
 
-            // The pipeline's `ResolveUnresolvedNodesStep` calls `MarkAsExternal` on every unresolved
-            // frame whose `IsExternal` is set, collapsing it into the map's External Code group rather
-            // than giving it a node of its own.
+            // FSharp.Core's plumbing sits in the middle of the stack, where the pipeline folds nothing:
+            // what goes into External Code it decides in its first step, from the debugger's own
+            // Just My Code state, and these frames carry SourceLink so the debugger counts them as
+            // ours. Taking them out of the frame chain is what removes them - the caller is re-pointed
+            // at the callee, so `pipelineLambdas` links straight to the lambda it ran.
             let external =
                 [|
-                    for frameNode, _, action in parsedFrames do
+                    for methodNode, _, action in parsedFrames do
                         if action = FoldAsExternalCode then
-                            frameNode
+                            methodNode
                 |]
 
             if external.Length > 0 then
-                use marking = new GraphTransactionScope()
+                use folding = new GraphTransactionScope()
 
-                for frameNode in external do
-                    CallStackMethodNode(frameNode).IsExternal <- true
+                for methodNode in external do
+                    try
+                        for frame in framesOf methodNode |> Seq.toArray do
+                            liftFrameOutOfChain graph frame
 
-                marking.Complete()
+                        graph.Nodes.Remove methodNode |> ignore
+                    with e ->
+                        // Nothing here is worth a broken map: a frame left in place is only noise.
+                        CallStackMethodNode(methodNode).IsExternal <- true
+                        Trace.WriteLine $"[FSharpCodeMap] could not fold a FSharp.Core frame: {e.Message}"
+
+                folding.Complete()
 
             let byAssembly =
                 [|
@@ -381,7 +421,7 @@ type internal FSharpGraphProvider() =
                             // one bad frame must not abandon the rest of the stack.
                             Trace.WriteLine $"[FSharpCodeMap] frame failed: {e.Message}"
 
-            Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{candidates.Length} F# frames resolved"
+            Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{parsedFrames.Length} F# frames resolved"
         }
 
     interface IProvider with

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -9,8 +9,6 @@ open System.IO
 open System.Threading
 open System.Threading.Tasks
 
-open FSharp.Compiler.Syntax
-
 open Microsoft.VisualStudio.ComponentModelHost
 open Microsoft.VisualStudio.LanguageServices
 open Microsoft.VisualStudio.Shell
@@ -22,6 +20,40 @@ open Microsoft.VisualStudio.Progression
 open Microsoft.VisualStudio.Progression.CodeSchema.Api
 
 open CancellableTasks
+
+/// `Microsoft.VisualStudio.GraphModel.CodeSchema` is already open and the two namespaces share type
+/// names, so the Progression half is reached through aliases rather than a second `open`.
+type private CodeSchemaProperties = Microsoft.VisualStudio.Progression.CodeSchema.Properties
+type private CodeQualifiedName = Microsoft.VisualStudio.Progression.CodeSchema.CodeQualifiedName
+type private ProgressionNodeCategories = Microsoft.VisualStudio.Progression.CodeSchema.NodeCategories
+type private ProgressionLinkCategories = Microsoft.VisualStudio.Progression.LinkCategories
+
+/// The code schema was shaped for C# and VB, so it has nowhere to record that a frame came from a
+/// module, a union, an active pattern or an inline function. A property carries its own schema, so
+/// declaring them here is enough for them to reach the Properties pane and DGML styles - the schema
+/// itself is never handed to a graph, the way Roslyn's `RoslynGraphProperties` did it.
+[<RequireQualifiedAccess>]
+module internal FSharpGraphSchema =
+
+    let private schema = GraphSchema "FSharp"
+
+    let private declare name =
+        schema.Properties.AddNewProperty(name, typeof<bool>)
+
+    let IsModule = declare "FSharpProperty_IsModule"
+    let IsUnion = declare "FSharpProperty_IsUnion"
+    let IsRecord = declare "FSharpProperty_IsRecord"
+    let IsException = declare "FSharpProperty_IsException"
+    let IsMeasure = declare "FSharpProperty_IsMeasure"
+    let IsActivePattern = declare "FSharpProperty_IsActivePattern"
+    let IsUnionCaseTester = declare "FSharpProperty_IsUnionCaseTester"
+    let IsFunction = declare "FSharpProperty_IsFunction"
+    let IsInline = declare "FSharpProperty_IsInline"
+    let IsMutable = declare "FSharpProperty_IsMutable"
+
+    /// The frame came from a compiler-generated closure class, so the node names the binding the
+    /// lambda or local function was lifted out of rather than anything the user can point at.
+    let IsLifted = declare "FSharpProperty_IsLifted"
 
 /// Resolves the F# frames of a debugger call stack shown on a Code Map. The debugger contributes
 /// `CodeSchema_CallStackMethod` nodes carrying nothing but the module and the mangled frame name;
@@ -36,8 +68,6 @@ type internal FSharpGraphProvider() =
     /// The frame resolution runs on a Progression worker, so a project that is slow to check must
     /// leave the node unresolved rather than stall the whole map.
     let resolutionTimeout = TimeSpan.FromSeconds 30.0
-
-    let schema = Graph()
 
     let workspace =
         lazy
@@ -64,11 +94,44 @@ type internal FSharpGraphProvider() =
 
             ValueSome(Path.GetFileNameWithoutExtension modulePath, functionName)
 
+    /// The source position the debugger already resolved for a frame - the only usable anchor for a
+    /// startup frame, whose name (`$Demo.$Demo`) points at the file rather than the construct.
+    ///
+    /// It cannot be read off the method node this action hands us: the pipeline stamps
+    /// `CodeNodeProperties.SourceLocation` on those in its `AddSourceLocations` step, which runs
+    /// after this handler. The frame node referencing the method already carries it, and its
+    /// `StartLine` is 1-based, the same base an FCS range uses.
+    let frameSourcePosition (methodNode: GraphNode) =
+        methodNode.IncomingLinks
+        |> Seq.tryPickV (fun link ->
+            if
+                link.HasCategory ProgressionLinkCategories.References
+                && link.Source.HasCategory ProgressionNodeCategories.CallStackFrame
+            then
+                let frame = CallStackFrameNode link.Source
+
+                match frame.FileName with
+                | null
+                | "" -> ValueNone
+                | file -> ValueSome(struct (file, frame.StartLine))
+            else
+                ValueNone)
+
+    /// A startup frame carries no module, so its owning assembly is read from the project the source
+    /// file belongs to instead.
+    let assemblyNameForFile (file: string) =
+        workspace.Value.CurrentSolution.GetDocumentIdsWithFilePath file
+        |> Seq.tryHeadV
+        |> ValueOption.bind (fun documentId ->
+            match workspace.Value.CurrentSolution.GetProject documentId.ProjectId with
+            | null -> ValueNone
+            | project -> ValueSome project.AssemblyName)
+
     /// Builds the same node identity Roslyn's `GraphNodeIdCreation.GetIdForMemberAsync` produced,
     /// so a frame resolved here fuses with the node the metadata provider creates for the same
     /// method: a nested type becomes `Type=(Name=… ParentType=…)`, a generic one carries
     /// `GenericParameterCount`, and only a top-level non-generic type collapses to a plain string.
-    let rec private typePartial (chain: struct (string * int) array) upTo (nodeName: GraphNodeIdName) =
+    let rec typePartial (chain: struct (string * int) array) upTo (nodeName: GraphNodeIdName) =
         let struct (name, arity) = chain.[upTo]
 
         if upTo = 0 && arity = 0 then
@@ -76,7 +139,7 @@ type internal FSharpGraphProvider() =
         else
             let partials =
                 [|
-                    GraphNodeId.GetPartial(Microsoft.VisualStudio.Progression.CodeSchema.CodeQualifiedName.Name, name)
+                    GraphNodeId.GetPartial(CodeQualifiedName.Name, name)
                     if arity > 0 then
                         GraphNodeId.GetPartial(CodeGraphNodeIdName.GenericParameterCountIdentifier, string arity)
                     if upTo > 0 then
@@ -139,39 +202,106 @@ type internal FSharpGraphProvider() =
                     |> Array.map (fun struct (_, frames) -> frames |> Array.map (fun _ -> ValueNone))
         }
 
-    /// The synthesized parts of a frame name (`helperTwo@42.Invoke`, `op_PlusBangPlus`) make ugly
-    /// node labels even when full resolution fails; the parsed shape always yields a better one.
-    let friendlyLabel (frame: ParsedFrame) =
-        match frame.Member with
-        | FrameClosureBody origin -> ValueSome origin.EnclosingName
-        | FramePropertyGetter name
-        | FramePropertySetter name -> ValueSome name
-        | FrameMethod name when PrettyNaming.IsLogicalOpName name ->
-            ValueSome $"({PrettyNaming.ConvertValLogicalNameToDisplayNameCore name})"
-        | FrameStartupCode ->
-            match frame.Path with
-            | [||] -> ValueNone
-            | path -> ValueSome (Array.last path).Name
-        | FrameMethod _
-        | FrameConstructor
-        | FrameStaticConstructor
-        | FrameActivePattern _ -> ValueNone
+    /// The modifiers the Properties pane shows and the map's styles can filter on. Only the flags
+    /// that hold are written, so a node carries no misleading `false`s.
+    let describeModifiers (node: GraphNode) (modifiers: ResolvedFrameModifiers) =
+        let set (property: GraphProperty) value =
+            if value then
+                node.SetValue(property, true) |> ignore
+
+        set CodeSchemaProperties.IsPublic modifiers.IsPublic
+        set CodeSchemaProperties.IsInternal modifiers.IsInternal
+        set CodeSchemaProperties.IsPrivate modifiers.IsPrivate
+        set CodeSchemaProperties.IsStatic modifiers.IsStatic
+        set CodeSchemaProperties.IsGeneric modifiers.IsGeneric
+        set CodeSchemaProperties.IsConstructor modifiers.IsConstructor
+        set CodeSchemaProperties.IsOperator modifiers.IsOperator
+        set CodeSchemaProperties.IsExtension modifiers.IsExtension
+        set CodeSchemaProperties.IsAbstract modifiers.IsAbstract
+        set CodeSchemaProperties.IsCompilerGenerated modifiers.IsCompilerGenerated
+        set CodeSchemaProperties.IsPropertyGet modifiers.IsPropertyGet
+        set CodeSchemaProperties.IsPropertySet modifiers.IsPropertySet
+        // The built-in provider marks C# lambdas this way, and the map styles key off it.
+        set CodeSchemaProperties.IsAnonymous modifiers.IsLifted
+
+        set FSharpGraphSchema.IsModule modifiers.IsModule
+        set FSharpGraphSchema.IsUnion modifiers.IsUnion
+        set FSharpGraphSchema.IsRecord modifiers.IsRecord
+        set FSharpGraphSchema.IsException modifiers.IsException
+        set FSharpGraphSchema.IsMeasure modifiers.IsMeasure
+        set FSharpGraphSchema.IsActivePattern modifiers.IsActivePattern
+        set FSharpGraphSchema.IsUnionCaseTester modifiers.IsUnionCaseTester
+        set FSharpGraphSchema.IsFunction modifiers.IsFunction
+        set FSharpGraphSchema.IsInline modifiers.IsInline
+        set FSharpGraphSchema.IsMutable modifiers.IsMutable
+        set FSharpGraphSchema.IsLifted modifiers.IsLifted
+
+    /// `CallStackEntry` belongs to the Architecture Explorer, not to a schema this provider can
+    /// reference, so it is looked up by id in whichever schema the map document already carries.
+    let callStackEntryCategory (graph: Graph) =
+        graph.AllSchemas
+        |> Seq.tryPickV (fun schema ->
+            match schema.FindCategory "CallStackEntry" with
+            | null -> ValueNone
+            | category -> ValueSome category)
 
     /// Mirrors what the built-in C#/VB resolver does for a frame it recognises: create the method
     /// node, give it a source location, and link the frame to it - all inside a graph transaction.
     let attachResolvedMethod (graph: Graph) (frameNode: GraphNode) (resolved: ResolvedFrame) =
+        // The compiled name identifies the node, but the source name is what reads well: an operator
+        // is `(>=>)`, not `op_GreaterEqualsGreater`, and a constructor is its type, not `.ctor`.
+        let typeName () =
+            match resolved.TypeChain with
+            | [||] -> ValueNone
+            | chain ->
+                let struct (name, _) = Array.last chain
+                ValueSome name
+
         let label =
-            match resolved.MemberName with
-            | ValueSome name -> name
-            | ValueNone -> String.Join(".", resolved.EntityPath)
+            if resolved.Modifiers.IsConstructor then
+                typeName () |> ValueOption.defaultValue ".ctor"
+            else
+                match resolved.DisplayName, resolved.MemberName with
+                | ValueSome display, _ when not (String.IsNullOrEmpty display) -> display
+                | _, ValueSome name -> name
+                | _ -> String.Join(".", resolved.EntityPath)
 
         use transaction = new GraphTransactionScope()
 
+        // A frame is always a method invocation, and the pipeline enforces that: `ReferencesMethodNode`
+        // only follows a link whose target carries `Method`, and the next step declares every frame
+        // without one unresolved - replacing the node and the label with `get`, `set` or `$Demo`.
+        // What the member really is rides along as a category beside `Method`, plus the accessor
+        // flags `describeModifiers` sets, which is how C# frames render a property getter too.
         let methodNode =
             graph.Nodes.GetOrCreate(resolvedNodeId resolved, label, CodeNodeCategories.Method)
 
-        methodNode.SetValue(CodeNodeProperties.SourceLocation, sourceLocationOf resolved)
+        match resolved.Kind with
+        | ResolvedMethod -> ()
+        | ResolvedProperty -> methodNode.AddCategory CodeNodeCategories.Property |> ignore
+        | ResolvedEvent -> methodNode.AddCategory CodeNodeCategories.Event |> ignore
+
+        let location = sourceLocationOf resolved
+        methodNode.SetValue(CodeNodeProperties.SourceLocation, location) |> ignore
+
+        // `SourceLocation` alone lands navigation on the start of the line; the identifier location
+        // is the one carrying the column, so the caret reaches the declaration itself.
+        methodNode.SetValue(CodeNodeProperties.IdentifierSourceLocation, location)
         |> ignore
+
+        describeModifiers methodNode resolved.Modifiers
+
+        // The built-in resolver dispatches on this, so a node that does not carry it reads as
+        // language-less to anything walking the map later.
+        methodNode.SetValue(CodeSchemaProperties.Language, FSharpConstants.FSharpLanguageName)
+        |> ignore
+
+        // Double-clicking a plain `CodeSchema_Method` runs that category's default action - follow
+        // outgoing `Calls` links - and a call-stack map has none, so the node looks dead. Navigation
+        // comes from `CallStackEntry`, which is what the resolved C# and VB nodes carry. It cannot be
+        // copied off the frame: the platform adds it further down the pipeline, after this handler.
+        callStackEntryCategory graph
+        |> ValueOption.iter (fun category -> methodNode.AddCategory category |> ignore)
 
         CodeSchemaHelper.GetOrCreateLink<CallStackMethodReferencesMethodLink>(graph, frameNode.Id, methodNode.Id, String.Empty)
         |> ignore
@@ -182,42 +312,89 @@ type internal FSharpGraphProvider() =
         cancellableTask {
             let graph = context.Graph
 
-            // The platform hands the frame nodes in as the action's input; a node another provider
-            // already claimed is excluded. Snapshot before resolution starts mutating the graph.
-            let candidates =
+            // Every input frame we can parse, with the source position the debugger resolved for it -
+            // the only anchor a module-less startup frame has. `UnhandledInputNodes` already excludes
+            // nodes another provider claimed.
+            let parsedFrames =
                 [|
                     for frameNode in context.UnhandledInputNodes() do
-                        match frameOf frameNode with
+                        match FSharpStackFrameNameParser.parse (CallStackMethodNode frameNode).FunctionName with
                         | ValueNone -> ()
-                        | ValueSome(assemblyName, functionName) ->
-                            match FSharpStackFrameNameParser.parse functionName with
-                            | ValueNone -> ()
-                            | ValueSome parsed -> yield assemblyName, frameNode, parsed
+                        | ValueSome parsed ->
+                            let position = frameSourcePosition frameNode
+
+                            yield
+                                frameNode,
+                                { parsed with
+                                    SourcePosition = position
+                                },
+                                position
                 |]
 
-            if candidates.Length > 0 then
-                use labelling = new GraphTransactionScope()
+            // FSharp.Core's own async/task/seq plumbing - `MoveNext`, `Invoke`, `ResumableStateMachine` -
+            // rides the real stack, and the SourceLink it ships with stops the debugger folding it into
+            // External Code the way it folds the BCL.
+            let isFSharpCoreFrame (frameNode: GraphNode) (position: struct (string * int) voption) =
+                match frameOf frameNode with
+                | ValueSome(name, _) -> String.Equals(name, "FSharp.Core", StringComparison.OrdinalIgnoreCase)
+                | ValueNone ->
+                    match position with
+                    | ValueSome(struct (file, _)) -> file.IndexOf("FSharp.Core", StringComparison.OrdinalIgnoreCase) >= 0
+                    | ValueNone -> false
 
-                for _, frameNode, parsed in candidates do
-                    friendlyLabel parsed |> ValueOption.iter (fun label -> frameNode.Label <- label)
+            // Frames we can resolve: F# code in the workspace, addressed by the assembly the module Uri
+            // names or, when it is empty, the project the debugger's source position points into.
+            let candidates =
+                [|
+                    for frameNode, parsed, position in parsedFrames do
+                        if not (isFSharpCoreFrame frameNode position) then
+                            let assemblyName =
+                                match frameOf frameNode with
+                                | ValueSome(name, _) -> ValueSome name
+                                | ValueNone ->
+                                    position
+                                    |> ValueOption.bind (fun (struct (file, _)) -> assemblyNameForFile file)
 
-                labelling.Complete()
+                            match assemblyName with
+                            | ValueNone -> ()
+                            | ValueSome assemblyName -> yield assemblyName, frameNode, parsed
+                |]
+
+            // Marking those frames external is how the pipeline is told to fold them away: its
+            // `ResolveUnresolvedNodesStep` calls `MarkAsExternal` on every unresolved frame whose
+            // `IsExternal` is set, collapsing it into the map's External Code group instead of giving
+            // it a node of its own. Relabelling them would be pointless - that same step replaces the
+            // node, and the label with it, for anything left unresolved.
+            let core =
+                [|
+                    for frameNode, _, position in parsedFrames do
+                        if isFSharpCoreFrame frameNode position then
+                            frameNode
+                |]
+
+            if core.Length > 0 then
+                use marking = new GraphTransactionScope()
+
+                for frameNode in core do
+                    CallStackMethodNode(frameNode).IsExternal <- true
+
+                marking.Complete()
 
             let byAssembly =
                 candidates
-                |> Array.groupBy (fun (assemblyName, _, _) -> assemblyName)
-                |> Array.map (fun (assemblyName, group) ->
-                    assemblyName, group |> Array.map (fun (_, frameNode, parsed) -> frameNode, parsed))
+                |> Seq.groupBy (fun (assemblyName, _, _) -> assemblyName)
+                |> Seq.map (fun (assemblyName, group) -> assemblyName, group |> Seq.map (fun (_, frameNode, parsed) -> frameNode, parsed))
+                |> Seq.toArray
 
             let! resolutions =
                 byAssembly
-                |> Array.map (fun (assemblyName, group) -> struct (assemblyName, group |> Array.map snd))
+                |> Array.map (fun (assemblyName, group) -> struct (assemblyName, group |> Seq.map snd |> Seq.toArray))
                 |> resolveAll context
 
             let mutable resolvedCount = 0
 
-            for (_, group), results in Array.zip byAssembly resolutions do
-                for (frameNode, _), resolved in Array.zip group results do
+            for (_, group), results in Seq.zip byAssembly resolutions do
+                for (frameNode, _), resolved in Seq.zip group results do
                     match resolved with
                     | ValueNone -> ()
                     | ValueSome resolved ->
@@ -234,7 +411,9 @@ type internal FSharpGraphProvider() =
         }
 
     interface IProvider with
-        member _.Schema = schema
+        /// A provider contributes graph content, not a document schema; the built-in Roslyn one
+        /// returns nothing here too, and handing back a graph that owns a schema corrupts the map.
+        member _.Schema = null
 
         member _.Initialize(_serviceProvider: IServiceProvider) =
             Trace.WriteLine "[FSharpCodeMap] FSharpGraphProvider.Initialize"
@@ -243,7 +422,13 @@ type internal FSharpGraphProvider() =
             // and continues into the next pipeline step the moment it returns, so the graph must be
             // complete by then. `JoinableTaskFactory.Run` is the same blocking bridge the built-in
             // C#/VB provider uses for this action.
+            //
+            // Nothing this provider does may take the map down with it: a stack it cannot resolve
+            // has to degrade to unresolved nodes, which is exactly the state it started in.
             Actions.ResolveCallStack.ActionHandlers.Add(
                 ActionHandler(fun context ->
-                    ThreadHelper.JoinableTaskFactory.Run(fun () -> resolveCallStack context CancellationToken.None :> Task))
+                    try
+                        ThreadHelper.JoinableTaskFactory.Run(fun () -> resolveCallStack context CancellationToken.None :> Task)
+                    with e ->
+                        Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack failed: {e}")
             )

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -328,7 +328,11 @@ type internal FSharpGraphProvider() =
                         let frame = CallStackMethodNode frameNode
 
                         match FSharpStackFrameNameParser.parse frame.FunctionName with
-                        | ValueNone -> ()
+                        | ValueNone ->
+                            // A name we cannot take apart is still a name we can place, and
+                            // FSharp.Core's belongs off the map whether or not it reads.
+                            if FSharpCallStackPlan.isFSharpCoreModule (moduleAssemblyOf frame) then
+                                yield frameNode, ValueNone, FoldAsExternalCode
                         | ValueSome parsed ->
                             let facts =
                                 {
@@ -339,7 +343,7 @@ type internal FSharpGraphProvider() =
                                     ModuleAssembly = moduleAssemblyOf frame
                                 }
 
-                            yield frameNode, facts, FSharpCallStackPlan.decide assemblyNameForFile facts
+                            yield frameNode, ValueSome facts, FSharpCallStackPlan.decide assemblyNameForFile facts
                 |]
 
             // What the debug engine handed us, before anything is resolved. A position here belongs to
@@ -348,7 +352,7 @@ type internal FSharpGraphProvider() =
             // of the source, and this line is the only place that shows it.
             for methodNode, facts, action in parsedFrames do
                 let position =
-                    match facts.Frame.SourcePosition with
+                    match facts |> ValueOption.bind _.Frame.SourcePosition with
                     | ValueNone -> "no position"
                     | ValueSome position -> $"{Path.GetFileName position.File}:{position.Line}"
 
@@ -385,10 +389,11 @@ type internal FSharpGraphProvider() =
             let byAssembly =
                 [|
                     for frameNode, facts, action in parsedFrames do
-                        match action with
-                        | ResolveIn assembly -> yield assembly, frameNode, facts.Frame
-                        | FoldAsExternalCode
-                        | LeaveUnresolved -> ()
+                        match action, facts with
+                        | ResolveIn assembly, ValueSome facts -> yield assembly, frameNode, facts.Frame
+                        | ResolveIn _, ValueNone
+                        | FoldAsExternalCode, _
+                        | LeaveUnresolved, _ -> ()
                 |]
                 |> Seq.groupBy (fun (assembly, _, _) -> assembly)
                 |> Seq.map (fun (assembly, group) -> assembly, group |> Seq.map (fun (_, frameNode, frame) -> frameNode, frame))

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -201,37 +201,38 @@ type internal FSharpGraphProvider() =
 
     /// The modifiers the Properties pane shows and the map's styles can filter on. Only the flags
     /// that hold are written, so a node carries no misleading `false`s.
-    let describeModifiers (node: GraphNode) (modifiers: ResolvedFrameModifiers) =
-        let set (property: GraphProperty) value =
-            if value then
+    /// The graph properties a trait sets. A lifted frame sets two: `IsAnonymous` is how the built-in
+    /// provider marks a C# lambda, and the map's styles key off it.
+    let propertiesOf =
+        function
+        | Public -> [ CodeSchemaProperties.IsPublic ]
+        | Internal -> [ CodeSchemaProperties.IsInternal ]
+        | Private -> [ CodeSchemaProperties.IsPrivate ]
+        | Static -> [ CodeSchemaProperties.IsStatic ]
+        | Generic -> [ CodeSchemaProperties.IsGeneric ]
+        | Constructor -> [ CodeSchemaProperties.IsConstructor ]
+        | Operator -> [ CodeSchemaProperties.IsOperator ]
+        | Extension -> [ CodeSchemaProperties.IsExtension ]
+        | Abstract -> [ CodeSchemaProperties.IsAbstract ]
+        | CompilerGenerated -> [ CodeSchemaProperties.IsCompilerGenerated ]
+        | PropertyGet -> [ CodeSchemaProperties.IsPropertyGet ]
+        | PropertySet -> [ CodeSchemaProperties.IsPropertySet ]
+        | Lifted -> [ CodeSchemaProperties.IsAnonymous; FSharpGraphSchema.IsLifted ]
+        | Module -> [ FSharpGraphSchema.IsModule ]
+        | Union -> [ FSharpGraphSchema.IsUnion ]
+        | Record -> [ FSharpGraphSchema.IsRecord ]
+        | Exception -> [ FSharpGraphSchema.IsException ]
+        | Measure -> [ FSharpGraphSchema.IsMeasure ]
+        | ActivePattern -> [ FSharpGraphSchema.IsActivePattern ]
+        | UnionCaseTester -> [ FSharpGraphSchema.IsUnionCaseTester ]
+        | Function -> [ FSharpGraphSchema.IsFunction ]
+        | Inline -> [ FSharpGraphSchema.IsInline ]
+        | Mutable -> [ FSharpGraphSchema.IsMutable ]
+
+    let describeTraits (node: GraphNode) traits =
+        for frameTrait in traits do
+            for property in propertiesOf frameTrait do
                 node.SetValue(property, true) |> ignore
-
-        set CodeSchemaProperties.IsPublic modifiers.IsPublic
-        set CodeSchemaProperties.IsInternal modifiers.IsInternal
-        set CodeSchemaProperties.IsPrivate modifiers.IsPrivate
-        set CodeSchemaProperties.IsStatic modifiers.IsStatic
-        set CodeSchemaProperties.IsGeneric modifiers.IsGeneric
-        set CodeSchemaProperties.IsConstructor modifiers.IsConstructor
-        set CodeSchemaProperties.IsOperator modifiers.IsOperator
-        set CodeSchemaProperties.IsExtension modifiers.IsExtension
-        set CodeSchemaProperties.IsAbstract modifiers.IsAbstract
-        set CodeSchemaProperties.IsCompilerGenerated modifiers.IsCompilerGenerated
-        set CodeSchemaProperties.IsPropertyGet modifiers.IsPropertyGet
-        set CodeSchemaProperties.IsPropertySet modifiers.IsPropertySet
-        // The built-in provider marks C# lambdas this way, and the map styles key off it.
-        set CodeSchemaProperties.IsAnonymous modifiers.IsLifted
-
-        set FSharpGraphSchema.IsModule modifiers.IsModule
-        set FSharpGraphSchema.IsUnion modifiers.IsUnion
-        set FSharpGraphSchema.IsRecord modifiers.IsRecord
-        set FSharpGraphSchema.IsException modifiers.IsException
-        set FSharpGraphSchema.IsMeasure modifiers.IsMeasure
-        set FSharpGraphSchema.IsActivePattern modifiers.IsActivePattern
-        set FSharpGraphSchema.IsUnionCaseTester modifiers.IsUnionCaseTester
-        set FSharpGraphSchema.IsFunction modifiers.IsFunction
-        set FSharpGraphSchema.IsInline modifiers.IsInline
-        set FSharpGraphSchema.IsMutable modifiers.IsMutable
-        set FSharpGraphSchema.IsLifted modifiers.IsLifted
 
     /// `CallStackEntry` belongs to the Architecture Explorer, not to a schema this provider can
     /// reference, so it is looked up by id in whichever schema the map document already carries.
@@ -255,7 +256,7 @@ type internal FSharpGraphProvider() =
                 ValueSome name
 
         let label =
-            if resolved.Modifiers.IsConstructor then
+            if resolved.Traits.Contains Constructor then
                 typeName () |> ValueOption.defaultValue ".ctor"
             else
                 resolved.DisplayName
@@ -266,7 +267,7 @@ type internal FSharpGraphProvider() =
         // only follows a link whose target carries `Method`, and the next step declares every frame
         // without one unresolved - replacing the node and the label with `get`, `set` or `$Demo`.
         // What the member really is rides along as a category beside `Method`, plus the accessor
-        // flags `describeModifiers` sets, which is how C# frames render a property getter too.
+        // traits `describeTraits` writes, which is how C# frames render a property getter too.
         let methodNode =
             graph.Nodes.GetOrCreate(resolvedNodeId resolved, label, CodeNodeCategories.Method)
 
@@ -283,7 +284,7 @@ type internal FSharpGraphProvider() =
         methodNode.SetValue(CodeNodeProperties.IdentifierSourceLocation, location)
         |> ignore
 
-        describeModifiers methodNode resolved.Modifiers
+        describeTraits methodNode resolved.Traits
 
         // The built-in resolver dispatches on this, so a node that does not carry it reads as
         // language-less to anything walking the map later.

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpGraphProvider.fs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.ComponentModel.Composition
+open System.Diagnostics
+open System.IO
+open System.Threading
+
+open Microsoft.VisualStudio.ComponentModelHost
+open Microsoft.VisualStudio.LanguageServices
+open Microsoft.VisualStudio.Shell
+
+open Microsoft.VisualStudio.GraphModel
+open Microsoft.VisualStudio.GraphModel.CodeSchema
+open Microsoft.VisualStudio.GraphModel.Schemas
+open Microsoft.VisualStudio.Progression
+open Microsoft.VisualStudio.Progression.CodeSchema.Api
+
+/// Resolves the F# frames of a debugger call stack shown on a Code Map. The debugger contributes
+/// `CodeSchema_CallStackMethod` nodes carrying nothing but the module and the mangled frame name;
+/// without a provider claiming them they stay unresolved and carry no source location.
+[<LegacyProvider(typeof<IProvider>,
+                 Name = "FSharpProvider",
+                 Priority = 2.0,
+                 IntellisenseType = "{BC6DD5A5-D4D6-4dab-A00D-A51242DBAF1B}",
+                 ProjectCapability = "FSharp")>]
+type internal FSharpGraphProvider() =
+
+    let callStackMethodCategory = "CodeSchema_CallStackMethod"
+
+    /// The frame resolution runs on a Progression worker, so a project that is slow to check must
+    /// leave the node unresolved rather than stall the whole map.
+    let resolutionTimeout = TimeSpan.FromSeconds 30.0
+
+    let schema = Graph()
+
+    let workspace =
+        lazy
+            let componentModel =
+                Package.GetGlobalService(typeof<SComponentModel>) :?> IComponentModel
+
+            componentModel.GetService<VisualStudioWorkspace>()
+
+    /// The debugger encodes the frame's module and mangled name into the node id; `CallStackMethodNode`
+    /// is the schema's own reader for it. The module Uri is relative (`ClassLibrary.dll`) for
+    /// workspace assemblies and absolute for external ones.
+    let frameOf (node: GraphNode) =
+        let frame = CallStackMethodNode node
+
+        match frame.Module, frame.FunctionName with
+        | null, _ -> ValueNone
+        | _, (null | "") -> ValueNone
+        | moduleUri, functionName ->
+            let modulePath =
+                if moduleUri.IsAbsoluteUri then
+                    moduleUri.LocalPath
+                else
+                    moduleUri.OriginalString
+
+            ValueSome(Path.GetFileNameWithoutExtension modulePath, functionName)
+
+    let resolvedNodeId (resolved: ResolvedFrame) =
+        let assembly =
+            match resolved.Project.OutputFilePath with
+            | null -> GraphNodeId.Empty
+            | path -> GraphNodeId.GetPartial(CodeGraphNodeIdName.Assembly, Uri(path))
+
+        let ``namespace``, typeName =
+            match resolved.EntityPath with
+            | [] -> "", ""
+            | path -> String.Join(".", path |> List.truncate (path.Length - 1)), List.last path
+
+        [
+            if assembly <> GraphNodeId.Empty then
+                assembly
+            if not (String.IsNullOrEmpty ``namespace``) then
+                GraphNodeId.GetPartial(CodeGraphNodeIdName.Namespace, ``namespace``)
+            if not (String.IsNullOrEmpty typeName) then
+                GraphNodeId.GetPartial(CodeGraphNodeIdName.Type, typeName)
+            match resolved.MemberName with
+            | ValueSome name -> GraphNodeId.GetPartial(CodeGraphNodeIdName.Member, name)
+            | ValueNone -> ()
+        ]
+        |> Array.ofList
+        |> GraphNodeId.GetNested
+
+    let sourceLocationOf (resolved: ResolvedFrame) =
+        let range = resolved.DeclarationRange
+
+        SourceLocation(Uri(range.FileName), Position(range.StartLine - 1, range.StartColumn), Position(range.EndLine - 1, range.EndColumn))
+
+    let tryResolve (frameName: string) (assemblyName: string) =
+        use cancellation = new CancellationTokenSource(resolutionTimeout)
+
+        try
+            FSharpCallStackResolver.tryResolveFrameName workspace.Value assemblyName frameName cancellation.Token
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+        with _ ->
+            ValueNone
+
+    /// The synthesized parts of a frame name (`helperTwo@42.Invoke`) make ugly node labels even
+    /// when full resolution fails; the parsed shape always yields a better one.
+    let friendlyLabel (frame: ParsedFrame) =
+        match frame.Member with
+        | FrameClosureBody origin -> ValueSome origin.EnclosingName
+        | FramePropertyGetter name
+        | FramePropertySetter name -> ValueSome name
+        | FrameStartupCode ->
+            match frame.Path with
+            | [] -> ValueNone
+            | path -> ValueSome (List.last path).Name
+        | FrameMethod _
+        | FrameConstructor
+        | FrameStaticConstructor
+        | FrameActivePattern _ -> ValueNone
+
+    let resolveNode (graph: Graph) (frameNode: GraphNode) =
+        match frameOf frameNode with
+        | ValueNone -> false
+        | ValueSome(assemblyName, functionName) ->
+            match FSharpStackFrameNameParser.parse functionName with
+            | ValueNone -> false
+            | ValueSome parsed ->
+                friendlyLabel parsed
+                |> ValueOption.iter (fun label -> frameNode.Label <- label)
+
+                match tryResolve functionName assemblyName with
+                | ValueNone -> false
+                | ValueSome resolved ->
+                    let label =
+                        match resolved.MemberName with
+                        | ValueSome name -> name
+                        | ValueNone -> String.Join(".", resolved.EntityPath)
+
+                    let methodNode =
+                        graph.Nodes.GetOrCreate(resolvedNodeId resolved, label, CodeNodeCategories.Method)
+
+                    methodNode.SetValue(CodeNodeProperties.SourceLocation, sourceLocationOf resolved)
+                    |> ignore
+
+                    CallStackMethodNode(frameNode).ReferencesMethodNode <- MethodNode methodNode
+                    true
+
+    let resolveCallStack (context: ActionContext) =
+        let graph = context.Graph
+        let mutable seen = 0
+        let mutable resolvedCount = 0
+
+        for frameNode in graph.Nodes.GetByCategory [| callStackMethodCategory |] |> Seq.toArray do
+            try
+                seen <- seen + 1
+
+                if resolveNode graph frameNode then
+                    resolvedCount <- resolvedCount + 1
+                    context.AddHandled frameNode
+            with e ->
+                // An unresolvable frame is expected - it stays a grey unresolved node, and one bad
+                // frame must not abandon the rest of the stack.
+                Trace.WriteLine $"[FSharpCodeMap] frame failed: {e.Message}"
+
+        Trace.WriteLine $"[FSharpCodeMap] ResolveCallStack: {resolvedCount}/{seen} F# frames resolved"
+
+    interface IProvider with
+        member _.Schema = schema
+
+        member _.Initialize(_serviceProvider: IServiceProvider) =
+            Trace.WriteLine "[FSharpCodeMap] FSharpGraphProvider.Initialize"
+            Actions.ResolveCallStack.ActionHandlers.Add(ActionHandler(resolveCallStack))

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
@@ -36,6 +36,10 @@ type internal ParsedFrame =
         Path: FramePathSegment array
         Member: FrameMember
         MethodGenericArity: int
+        /// The file and line the debugger resolved for this frame, which the provider fills in - the
+        /// name alone locates nothing for module initialization (`$Demo.$Demo` names the file) and
+        /// lies for a state machine's closure, which the compiler numbers from line 1.
+        SourcePosition: struct (string * int) voption
     }
 
 /// Turns the name a debug engine reports for a stack frame back into the F# construct it came from.
@@ -69,14 +73,75 @@ module internal FSharpStackFrameNameParser =
 
             name.Substring(0, i), arity
 
+    /// Splits on `.` and `+`, but not inside `<...>` - the debug engine prints instantiations like
+    /// `Box<System.String>.Unwrap`, where the inner dot is part of an argument, not the path.
+    let private splitPath (name: string) =
+        let segments = ResizeArray()
+        let mutable start = 0
+        let mutable depth = 0
+
+        for i in 0 .. name.Length - 1 do
+            match name.[i] with
+            | '<' -> depth <- depth + 1
+            | '>' -> depth <- depth - 1
+            | '.'
+            | '+' when depth = 0 ->
+                if i > start then
+                    segments.Add(name.Substring(start, i - start))
+
+                start <- i + 1
+            | _ -> ()
+
+        if start < name.Length then
+            segments.Add(name.Substring start)
+
+        segments.ToArray()
+
+    /// Takes `Box<int>` or `Box<Ns.Item, int>` apart; the argument count doubles as the arity
+    /// because the engine prints instantiations, never open definitions.
+    let private dropAngleArguments (segment: string) =
+        let close = segment.Length - 1
+
+        if close < 1 || segment.[close] <> '>' then
+            segment, 0
+        else
+            let mutable depth = 0
+            let mutable openIndex = -1
+            let mutable arguments = 1
+            let mutable i = close
+
+            while openIndex < 0 && i >= 0 do
+                match segment.[i] with
+                | '>' -> depth <- depth + 1
+                | '<' ->
+                    depth <- depth - 1
+
+                    if depth = 0 then
+                        openIndex <- i
+                | ',' when depth = 1 -> arguments <- arguments + 1
+                | _ -> ()
+
+                i <- i - 1
+
+            if openIndex <= 0 then
+                segment, 0
+            else
+                segment.Substring(0, openIndex), arguments
+
     let private parseSegment (segment: string) =
+        let segment, angleArity = dropAngleArguments segment
+
         match segment.IndexOf('`') with
-        | -1 -> { Name = segment; GenericArity = 0 }
+        | -1 ->
+            {
+                Name = segment
+                GenericArity = angleArity
+            }
         | i ->
             let arity =
                 match Int32.TryParse(segment.Substring(i + 1)) with
                 | true, n -> n
-                | _ -> 0
+                | _ -> angleArity
 
             {
                 Name = segment.Substring(0, i)
@@ -100,7 +165,17 @@ module internal FSharpStackFrameNameParser =
 
     /// Matches `enclosingName@line` and `enclosingName@line-ordinal`, the shapes the compiler gives
     /// the classes it lifts closures, local functions and computation-expression bodies into.
+    /// A generic closure class carries a trailing `T` (`helperTwo@42T`), and the engine may print
+    /// its instantiation (`helperTwo@42T<int>`).
     let private parseClosureOrigin (segment: string) =
+        let segment, _ = dropAngleArguments segment
+
+        let segment =
+            if segment.EndsWith("T", StringComparison.Ordinal) then
+                segment.Substring(0, segment.Length - 1)
+            else
+                segment
+
         let at = segment.LastIndexOf '@'
 
         if at <= 0 || at = segment.Length - 1 then
@@ -157,22 +232,23 @@ module internal FSharpStackFrameNameParser =
                 else
                     name, ValueNone
 
-            let segments =
-                name.Split([| '.'; '+' |])
-                |> Seq.filter (fun segment -> not (String.IsNullOrEmpty segment))
-                |> Seq.toArray
+            let segments = splitPath name
 
             match segments with
             | [||] -> ValueNone
             | segments ->
                 // Flexible so the branches below can pass either the segment array or a filtered seq.
-                let frame (path: #seq<string>) frameMember =
+                let frameWithArity (path: #seq<string>) frameMember memberArity =
                     ValueSome
                         {
                             Path = path |> Seq.map parseSegment |> Seq.toArray
                             Member = frameMember
-                            MethodGenericArity = methodGenericArity
+                            MethodGenericArity = memberArity
+                            SourcePosition = ValueNone
                         }
+
+                let frame path frameMember =
+                    frameWithArity path frameMember methodGenericArity
 
                 let isStartupCode =
                     segments
@@ -197,4 +273,24 @@ module internal FSharpStackFrameNameParser =
                 | ValueNone, false, ValueSome i ->
                     let origin = (parseClosureOrigin segments.[i]).Value
                     frame (Seq.truncate i segments) (FrameClosureBody origin)
-                | ValueNone, false, ValueNone -> frame (Seq.truncate (segments.Length - 1) segments) (classifyMember (Array.last segments))
+                | ValueNone, false, ValueNone ->
+                    let lastName, lastArity = dropAngleArguments (Array.last segments)
+                    let memberArity = max methodGenericArity lastArity
+                    let path = Seq.truncate (segments.Length - 1) segments
+
+                    let previousName =
+                        if segments.Length >= 2 then
+                            (dropAngleArguments segments.[segments.Length - 2] |> fst)
+                        else
+                            ""
+
+                    // The debug engine prints a constructor as `Type.Type` and an accessor as a
+                    // trailing `.get`/`.set` segment, unlike the `..ctor`/`get_` metadata shapes.
+                    if String.Equals(lastName, previousName, StringComparison.Ordinal) then
+                        frameWithArity path FrameConstructor memberArity
+                    elif lastName = "get" && segments.Length >= 2 then
+                        frameWithArity (Seq.truncate (segments.Length - 2) segments) (FramePropertyGetter previousName) memberArity
+                    elif lastName = "set" && segments.Length >= 2 then
+                        frameWithArity (Seq.truncate (segments.Length - 2) segments) (FramePropertySetter previousName) memberArity
+                    else
+                        frameWithArity path (classifyMember lastName) memberArity

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.FSharp.Editor
+
+open System
+open System.Text.RegularExpressions
+
+/// A compiler-synthesized closure class such as `outer@47-1` names the binding it was lifted out of
+/// and the line that binding was written on.
+[<Struct>]
+type internal ClosureOrigin =
+    {
+        EnclosingName: string
+        Line: int
+        Ordinal: int voption
+    }
+
+[<Struct>]
+type internal FramePathSegment = { Name: string; GenericArity: int }
+
+type internal FrameMember =
+    | FrameMethod of name: string
+    | FrameConstructor
+    | FrameStaticConstructor
+    | FramePropertyGetter of getter: string
+    | FramePropertySetter of setter: string
+    | FrameActivePattern of cases: string list
+    | FrameClosureBody of origin: ClosureOrigin
+    | FrameStartupCode
+
+type internal ParsedFrame =
+    {
+        /// Declaring path, outermost first. Namespace, module and nested type segments are
+        /// indistinguishable in a frame name, so consumers must try several splits.
+        Path: FramePathSegment list
+        Member: FrameMember
+        MethodGenericArity: int
+    }
+
+/// Turns the name a debug engine reports for a stack frame back into the F# construct it came from.
+[<RequireQualifiedAccess>]
+module internal FSharpStackFrameNameParser =
+
+    let private closureSuffix =
+        Regex(@"^(?<name>.+)@(?<line>\d+)(?:-(?<ordinal>\d+))?$", RegexOptions.Compiled ||| RegexOptions.CultureInvariant)
+
+    let private startupCodePrefix = "<StartupCode$"
+
+    [<Literal>]
+    let private ConstructorSuffix = "..ctor"
+
+    [<Literal>]
+    let private StaticConstructorSuffix = "..cctor"
+
+    let private dropParameters (name: string) =
+        match name.IndexOf('(') with
+        | -1 -> name
+        | i -> name.Substring(0, i)
+
+    let private dropGenericArguments (name: string) =
+        match name.IndexOf('[') with
+        | -1 -> name, 0
+        | i ->
+            let arguments = name.Substring(i + 1).TrimEnd(']')
+
+            let arity =
+                if String.IsNullOrEmpty arguments then
+                    0
+                else
+                    arguments.Split(',').Length
+
+            name.Substring(0, i), arity
+
+    let private parseSegment (segment: string) =
+        match segment.IndexOf('`') with
+        | -1 -> { Name = segment; GenericArity = 0 }
+        | i ->
+            let arity =
+                match Int32.TryParse(segment.Substring(i + 1)) with
+                | true, n -> n
+                | _ -> 0
+
+            {
+                Name = segment.Substring(0, i)
+                GenericArity = arity
+            }
+
+    let private parseClosureOrigin (segment: string) =
+        let m = closureSuffix.Match segment
+
+        if m.Success then
+            ValueSome
+                {
+                    EnclosingName = m.Groups.["name"].Value
+                    Line = Int32.Parse(m.Groups.["line"].Value)
+                    Ordinal =
+                        if m.Groups.["ordinal"].Success then
+                            ValueSome(Int32.Parse(m.Groups.["ordinal"].Value))
+                        else
+                            ValueNone
+                }
+        else
+            ValueNone
+
+    let private isActivePattern (name: string) =
+        name.Length > 2
+        && name.StartsWith("|", StringComparison.Ordinal)
+        && name.EndsWith("|", StringComparison.Ordinal)
+
+    let private activePatternCases (name: string) =
+        name.Trim('|').Split('|')
+        |> Array.filter (fun case -> not (String.IsNullOrEmpty case))
+        |> List.ofArray
+
+    let private classifyMember (segment: string) =
+        if isActivePattern segment then
+            FrameActivePattern(activePatternCases segment)
+        elif segment.StartsWith("get_", StringComparison.Ordinal) then
+            FramePropertyGetter(segment.Substring 4)
+        elif segment.StartsWith("set_", StringComparison.Ordinal) then
+            FramePropertySetter(segment.Substring 4)
+        else
+            FrameMethod segment
+
+    /// `name` is the raw frame name, e.g. `GateC.Library.outer@47-1.Invoke` or `Ns.Type..ctor`.
+    let parse (frameName: string) : ParsedFrame voption =
+        if String.IsNullOrWhiteSpace frameName then
+            ValueNone
+        else
+
+            let name = (dropParameters frameName).Trim()
+            let name, methodGenericArity = dropGenericArguments name
+
+            let name, constructorMember =
+                if name.EndsWith(StaticConstructorSuffix, StringComparison.Ordinal) then
+                    name.Substring(0, name.Length - StaticConstructorSuffix.Length), ValueSome FrameStaticConstructor
+                elif name.EndsWith(ConstructorSuffix, StringComparison.Ordinal) then
+                    name.Substring(0, name.Length - ConstructorSuffix.Length), ValueSome FrameConstructor
+                else
+                    name, ValueNone
+
+            let segments =
+                name.Split([| '.'; '+' |])
+                |> Array.filter (fun segment -> not (String.IsNullOrEmpty segment))
+                |> List.ofArray
+
+            match segments with
+            | [] -> ValueNone
+            | segments ->
+                let frame path frameMember =
+                    ValueSome
+                        {
+                            Path = path |> List.map parseSegment
+                            Member = frameMember
+                            MethodGenericArity = methodGenericArity
+                        }
+
+                let isStartupCode =
+                    segments
+                    |> List.exists (fun segment -> segment.StartsWith(startupCodePrefix, StringComparison.Ordinal))
+
+                let closureIndex =
+                    segments
+                    |> List.tryFindIndexBack (fun segment -> (parseClosureOrigin segment).IsSome)
+
+                match constructorMember, isStartupCode, closureIndex with
+                | ValueSome constructorMember, _, _ -> frame segments constructorMember
+                | ValueNone, true, _ ->
+                    let declaringModule =
+                        segments
+                        |> List.filter (fun segment -> not (segment.StartsWith(startupCodePrefix, StringComparison.Ordinal)))
+                        |> List.map _.TrimStart('$')
+                        |> List.filter (fun segment ->
+                            not (String.IsNullOrEmpty segment)
+                            && not (segment.EndsWith("@", StringComparison.Ordinal)))
+
+                    frame declaringModule FrameStartupCode
+                | ValueNone, false, Some i ->
+                    let origin = (parseClosureOrigin segments.[i]).Value
+                    frame (List.truncate i segments) (FrameClosureBody origin)
+                | ValueNone, false, None -> frame (List.truncate (segments.Length - 1) segments) (classifyMember (List.last segments))

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
@@ -3,7 +3,6 @@
 namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
-open System.Text.RegularExpressions
 
 /// A compiler-synthesized closure class such as `outer@47-1` names the binding it was lifted out of
 /// and the line that binding was written on.
@@ -40,9 +39,6 @@ type internal ParsedFrame =
 /// Turns the name a debug engine reports for a stack frame back into the F# construct it came from.
 [<RequireQualifiedAccess>]
 module internal FSharpStackFrameNameParser =
-
-    let private closureSuffix =
-        Regex(@"^(?<name>.+)@(?<line>\d+)(?:-(?<ordinal>\d+))?$", RegexOptions.Compiled ||| RegexOptions.CultureInvariant)
 
     let private startupCodePrefix = "<StartupCode$"
 
@@ -85,22 +81,47 @@ module internal FSharpStackFrameNameParser =
                 GenericArity = arity
             }
 
-    let private parseClosureOrigin (segment: string) =
-        let m = closureSuffix.Match segment
-
-        if m.Success then
-            ValueSome
-                {
-                    EnclosingName = m.Groups.["name"].Value
-                    Line = Int32.Parse(m.Groups.["line"].Value)
-                    Ordinal =
-                        if m.Groups.["ordinal"].Success then
-                            ValueSome(Int32.Parse(m.Groups.["ordinal"].Value))
-                        else
-                            ValueNone
-                }
-        else
+    /// Reads `digits` spanning [start, stop), rejecting an empty or non-numeric run.
+    let private digitsIn (segment: string) start stop =
+        if start >= stop then
             ValueNone
+        else
+
+            let mutable value = 0
+            let mutable i = start
+
+            while i < stop && Char.IsDigit segment.[i] do
+                value <- value * 10 + int segment.[i] - int '0'
+                i <- i + 1
+
+            if i = stop then ValueSome value else ValueNone
+
+    /// Matches `enclosingName@line` and `enclosingName@line-ordinal`, the shapes the compiler gives
+    /// the classes it lifts closures, local functions and computation-expression bodies into.
+    let private parseClosureOrigin (segment: string) =
+        let at = segment.LastIndexOf '@'
+
+        if at <= 0 || at = segment.Length - 1 then
+            ValueNone
+        else
+
+            let origin line ordinal =
+                ValueSome
+                    {
+                        EnclosingName = segment.Substring(0, at)
+                        Line = line
+                        Ordinal = ordinal
+                    }
+
+            match segment.IndexOf('-', at + 1) with
+            | -1 ->
+                match digitsIn segment (at + 1) segment.Length with
+                | ValueSome line -> origin line ValueNone
+                | ValueNone -> ValueNone
+            | dash ->
+                match digitsIn segment (at + 1) dash, digitsIn segment (dash + 1) segment.Length with
+                | ValueSome line, ValueSome ordinal -> origin line (ValueSome ordinal)
+                | _ -> ValueNone
 
     let private isActivePattern (name: string) =
         name.Length > 2
@@ -109,8 +130,8 @@ module internal FSharpStackFrameNameParser =
 
     let private activePatternCases (name: string) =
         name.Trim('|').Split('|')
-        |> Array.filter (fun case -> not (String.IsNullOrEmpty case))
-        |> List.ofArray
+        |> Seq.filter (fun case -> not (String.IsNullOrEmpty case))
+        |> Seq.toList
 
     let private classifyMember (segment: string) =
         if isActivePattern segment then
@@ -141,8 +162,8 @@ module internal FSharpStackFrameNameParser =
 
             let segments =
                 name.Split([| '.'; '+' |])
-                |> Array.filter (fun segment -> not (String.IsNullOrEmpty segment))
-                |> List.ofArray
+                |> Seq.filter (fun segment -> not (String.IsNullOrEmpty segment))
+                |> Seq.toList
 
             match segments with
             | [] -> ValueNone
@@ -161,21 +182,22 @@ module internal FSharpStackFrameNameParser =
 
                 let closureIndex =
                     segments
-                    |> List.tryFindIndexBack (fun segment -> (parseClosureOrigin segment).IsSome)
+                    |> List.tryFindIndexBackV (fun segment -> (parseClosureOrigin segment).IsSome)
 
                 match constructorMember, isStartupCode, closureIndex with
                 | ValueSome constructorMember, _, _ -> frame segments constructorMember
                 | ValueNone, true, _ ->
                     let declaringModule =
                         segments
-                        |> List.filter (fun segment -> not (segment.StartsWith(startupCodePrefix, StringComparison.Ordinal)))
-                        |> List.map _.TrimStart('$')
-                        |> List.filter (fun segment ->
+                        |> Seq.filter (fun segment -> not (segment.StartsWith(startupCodePrefix, StringComparison.Ordinal)))
+                        |> Seq.map _.TrimStart('$')
+                        |> Seq.filter (fun segment ->
                             not (String.IsNullOrEmpty segment)
                             && not (segment.EndsWith("@", StringComparison.Ordinal)))
+                        |> Seq.toList
 
                     frame declaringModule FrameStartupCode
-                | ValueNone, false, Some i ->
+                | ValueNone, false, ValueSome i ->
                     let origin = (parseClosureOrigin segments.[i]).Value
                     frame (List.truncate i segments) (FrameClosureBody origin)
-                | ValueNone, false, None -> frame (List.truncate (segments.Length - 1) segments) (classifyMember (List.last segments))
+                | ValueNone, false, ValueNone -> frame (List.truncate (segments.Length - 1) segments) (classifyMember (List.last segments))

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
@@ -19,6 +19,10 @@ type internal ClosureOrigin =
 [<Struct>]
 type internal FramePathSegment = { Name: string; GenericArity: int }
 
+/// Where a debug engine says a frame is executing. Lines are 1-based, as FCS ranges are.
+[<Struct>]
+type internal SourcePosition = { File: string; Line: int }
+
 type internal FrameMember =
     | FrameMethod of name: string
     | FrameConstructor
@@ -36,10 +40,10 @@ type internal ParsedFrame =
         Path: FramePathSegment array
         Member: FrameMember
         MethodGenericArity: int
-        /// The file and line the debugger resolved for this frame, which the provider fills in - the
-        /// name alone locates nothing for module initialization (`$Demo.$Demo` names the file) and
-        /// lies for a state machine's closure, which the compiler numbers from line 1.
-        SourcePosition: struct (string * int) voption
+        /// The position the debugger resolved for this frame, which the provider fills in - the name
+        /// alone locates nothing for module initialization (`$Demo.$Demo` names the file) and lies
+        /// for a state machine's closure, which the compiler numbers from line 1.
+        SourcePosition: SourcePosition voption
     }
 
 /// Turns the name a debug engine reports for a stack frame back into the F# construct it came from.

--- a/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
+++ b/vsintegration/src/FSharp.Editor/CodeMap/FSharpStackFrameNameParser.fs
@@ -4,6 +4,8 @@ namespace Microsoft.VisualStudio.FSharp.Editor
 
 open System
 
+open FSharp.Compiler.Syntax
+
 /// A compiler-synthesized closure class such as `outer@47-1` names the binding it was lifted out of
 /// and the line that binding was written on.
 [<Struct>]
@@ -31,7 +33,7 @@ type internal ParsedFrame =
     {
         /// Declaring path, outermost first. Namespace, module and nested type segments are
         /// indistinguishable in a frame name, so consumers must try several splits.
-        Path: FramePathSegment list
+        Path: FramePathSegment array
         Member: FrameMember
         MethodGenericArity: int
     }
@@ -123,18 +125,13 @@ module internal FSharpStackFrameNameParser =
                 | ValueSome line, ValueSome ordinal -> origin line (ValueSome ordinal)
                 | _ -> ValueNone
 
-    let private isActivePattern (name: string) =
-        name.Length > 2
-        && name.StartsWith("|", StringComparison.Ordinal)
-        && name.EndsWith("|", StringComparison.Ordinal)
-
     let private activePatternCases (name: string) =
         name.Trim('|').Split('|')
         |> Seq.filter (fun case -> not (String.IsNullOrEmpty case))
         |> Seq.toList
 
     let private classifyMember (segment: string) =
-        if isActivePattern segment then
+        if PrettyNaming.IsActivePatternName segment then
             FrameActivePattern(activePatternCases segment)
         elif segment.StartsWith("get_", StringComparison.Ordinal) then
             FramePropertyGetter(segment.Substring 4)
@@ -163,26 +160,27 @@ module internal FSharpStackFrameNameParser =
             let segments =
                 name.Split([| '.'; '+' |])
                 |> Seq.filter (fun segment -> not (String.IsNullOrEmpty segment))
-                |> Seq.toList
+                |> Seq.toArray
 
             match segments with
-            | [] -> ValueNone
+            | [||] -> ValueNone
             | segments ->
-                let frame path frameMember =
+                // Flexible so the branches below can pass either the segment array or a filtered seq.
+                let frame (path: #seq<string>) frameMember =
                     ValueSome
                         {
-                            Path = path |> List.map parseSegment
+                            Path = path |> Seq.map parseSegment |> Seq.toArray
                             Member = frameMember
                             MethodGenericArity = methodGenericArity
                         }
 
                 let isStartupCode =
                     segments
-                    |> List.exists (fun segment -> segment.StartsWith(startupCodePrefix, StringComparison.Ordinal))
+                    |> Array.exists (fun segment -> segment.StartsWith(startupCodePrefix, StringComparison.Ordinal))
 
                 let closureIndex =
                     segments
-                    |> List.tryFindIndexBackV (fun segment -> (parseClosureOrigin segment).IsSome)
+                    |> Array.tryFindIndexBackV (fun segment -> (parseClosureOrigin segment).IsSome)
 
                 match constructorMember, isStartupCode, closureIndex with
                 | ValueSome constructorMember, _, _ -> frame segments constructorMember
@@ -194,10 +192,9 @@ module internal FSharpStackFrameNameParser =
                         |> Seq.filter (fun segment ->
                             not (String.IsNullOrEmpty segment)
                             && not (segment.EndsWith("@", StringComparison.Ordinal)))
-                        |> Seq.toList
 
                     frame declaringModule FrameStartupCode
                 | ValueNone, false, ValueSome i ->
                     let origin = (parseClosureOrigin segments.[i]).Value
-                    frame (List.truncate i segments) (FrameClosureBody origin)
-                | ValueNone, false, ValueNone -> frame (List.truncate (segments.Length - 1) segments) (classifyMember (List.last segments))
+                    frame (Seq.truncate i segments) (FrameClosureBody origin)
+                | ValueNone, false, ValueNone -> frame (Seq.truncate (segments.Length - 1) segments) (classifyMember (Array.last segments))

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -603,6 +603,23 @@ module List =
         | [] -> ValueNone
         | h :: t -> if predicate h then ValueSome h else tryFindV predicate t
 
+    let inline tryFindIndexV ([<InlineIfLambda>] predicate) list =
+        let rec loop i rest =
+            match rest with
+            | [] -> ValueNone
+            | h :: t -> if predicate h then ValueSome i else loop (i + 1) t
+
+        loop 0 list
+
+    /// Walks forward keeping the last match, so it stays tail-recursive on long lists.
+    let inline tryFindIndexBackV ([<InlineIfLambda>] predicate) list =
+        let rec loop i last rest =
+            match rest with
+            | [] -> last
+            | h :: t -> loop (i + 1) (if predicate h then ValueSome i else last) t
+
+        loop 0 ValueNone list
+
 [<RequireQualifiedAccess>]
 module Exception =
 

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -527,6 +527,24 @@ module Array =
 
         loop 0
 
+    let inline tryFindIndexV ([<InlineIfLambda>] predicate) (array: _[]) =
+
+        let rec loop i =
+            if i >= array.Length then ValueNone
+            else if predicate array.[i] then ValueSome i
+            else loop (i + 1)
+
+        loop 0
+
+    let inline tryFindIndexBackV ([<InlineIfLambda>] predicate) (array: _[]) =
+
+        let rec loop i =
+            if i < 0 then ValueNone
+            else if predicate array.[i] then ValueSome i
+            else loop (i - 1)
+
+        loop (array.Length - 1)
+
     let inline chooseV ([<InlineIfLambda>] chooser: 'T -> 'U voption) (array: 'T[]) =
 
         let mutable i = 0

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -96,7 +96,6 @@
     <Compile Include="Navigation\FindDefinitionService.fs" />
     <Compile Include="CodeMap\FSharpStackFrameNameParser.fs" />
     <Compile Include="CodeMap\FSharpCallStackResolver.fs" />
-    <Compile Include="CodeMap\FSharpGraphProvider.fs" />
     <Compile Include="QuickInfo\WpfFactories.fs" />
     <Compile Include="QuickInfo\Views.fs" />
     <Compile Include="QuickInfo\QuickInfoProvider.fs" />
@@ -191,20 +190,33 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
-  <!-- The Progression assemblies backing Code Map ship only inside Visual Studio; they have no NuGet package. -->
-  <ItemGroup>
+  <!-- The Progression assemblies backing Code Map ship only inside Visual Studio and have no NuGet
+       package. $(MSBuildExtensionsPath) reaches the IDE only when the IDE is doing the building -
+       under `dotnet build` it resolves into the SDK - so the Code Map provider is compiled where
+       they are present and left out where they are not. The frame parser and the call stack
+       resolver, which carry the language knowledge and the tests, never reference them. -->
+  <PropertyGroup>
+    <VisualStudioIdeDirectory>$(MSBuildExtensionsPath)\..\Common7\IDE\</VisualStudioIdeDirectory>
+    <VisualStudioIdeDirectory Condition="!Exists('$(VisualStudioIdeDirectory)') AND '$(DevEnvDir)' != ''">$(DevEnvDir)</VisualStudioIdeDirectory>
+    <ProgressionAssemblyDirectory>$(VisualStudioIdeDirectory)CommonExtensions\Microsoft\Architecture Tools\GraphProviderPackage\</ProgressionAssemblyDirectory>
+    <HasProgressionAssemblies Condition="Exists('$(ProgressionAssemblyDirectory)Microsoft.VisualStudio.Progression.Interfaces.dll')">true</HasProgressionAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(HasProgressionAssemblies)' == 'true'">
     <Reference Include="Microsoft.VisualStudio.Progression.Interfaces">
-      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\GraphProviderPackage\Microsoft.VisualStudio.Progression.Interfaces.dll</HintPath>
+      <HintPath>$(ProgressionAssemblyDirectory)Microsoft.VisualStudio.Progression.Interfaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Progression.CodeSchema">
-      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\GraphProviderPackage\Microsoft.VisualStudio.Progression.CodeSchema.dll</HintPath>
+      <HintPath>$(ProgressionAssemblyDirectory)Microsoft.VisualStudio.Progression.CodeSchema.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.GraphModel">
-      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.GraphModel.dll</HintPath>
+      <HintPath>$(VisualStudioIdeDirectory)PublicAssemblies\Microsoft.VisualStudio.GraphModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <!-- Nothing compiles against the provider, so it goes last rather than beside the two files it uses. -->
+    <Compile Include="CodeMap\FSharpGraphProvider.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -172,11 +172,14 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Runtime.Caching" />
+    <!-- GraphTransactionScope has a System.Transactions.Transaction overload, so the whole ctor
+         group needs this reference even though the Code Map provider uses the parameterless one. -->
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
-    <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -96,6 +96,7 @@
     <Compile Include="Navigation\FindDefinitionService.fs" />
     <Compile Include="CodeMap\FSharpStackFrameNameParser.fs" />
     <Compile Include="CodeMap\FSharpCallStackResolver.fs" />
+    <Compile Include="CodeMap\FSharpCallStackPlan.fs" />
     <Compile Include="QuickInfo\WpfFactories.fs" />
     <Compile Include="QuickInfo\Views.fs" />
     <Compile Include="QuickInfo\QuickInfoProvider.fs" />

--- a/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
+++ b/vsintegration/src/FSharp.Editor/FSharp.Editor.fsproj
@@ -94,6 +94,9 @@
     <Compile Include="Navigation\NavigateToSearchService.fs" />
     <Compile Include="Navigation\FindUsagesService.fs" />
     <Compile Include="Navigation\FindDefinitionService.fs" />
+    <Compile Include="CodeMap\FSharpStackFrameNameParser.fs" />
+    <Compile Include="CodeMap\FSharpCallStackResolver.fs" />
+    <Compile Include="CodeMap\FSharpGraphProvider.fs" />
     <Compile Include="QuickInfo\WpfFactories.fs" />
     <Compile Include="QuickInfo\Views.fs" />
     <Compile Include="QuickInfo\QuickInfoProvider.fs" />
@@ -183,6 +186,22 @@
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Condition="'$(Configuration)' == 'Debug'" />
+  </ItemGroup>
+
+  <!-- The Progression assemblies backing Code Map ship only inside Visual Studio; they have no NuGet package. -->
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Progression.Interfaces">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\GraphProviderPackage\Microsoft.VisualStudio.Progression.Interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Progression.CodeSchema">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\Architecture Tools\GraphProviderPackage\Microsoft.VisualStudio.Progression.CodeSchema.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.GraphModel">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.GraphModel.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
@@ -167,11 +167,10 @@ let asyncBody () =
     }
     |> Async.RunSynchronously
 
-/// Two levels on purpose. The debugger reconstructs a logical async stack by walking continuations,
-/// so the inner body is reached from the outer one through `let!` - a continuation it can follow and
-/// the pipeline can draw as an indirect link. The last hop out, `GetResult`, is a blocking wait
-/// rather than an await: whoever is parked on it is on another thread, and no continuation leads
-/// back there.
+/// Two levels, and a stop in each. The inner body runs on a thread-pool thread; the outer one is
+/// resumed after `let!` by the inner task completing, so its frame is a continuation too. The last
+/// hop out, `GetResult`, is a blocking wait rather than an await: whoever is parked on it is on
+/// another thread, and no continuation leads back there - `taskBody` itself is never on the stack.
 let taskBody () =
     let inner () =
         task {
@@ -182,7 +181,7 @@ let taskBody () =
     let outer =
         task {
             let! value = inner ()
-            return value
+            return value + sink "task continuation"
         }
 
     outer.GetAwaiter().GetResult()
@@ -233,6 +232,9 @@ let delegateCall () =
 type Publisher() =
     let fired = Event<int>()
 
+    /// An event is never a frame a debugger stops in. F# reads `p.Fired` by building an `IEvent`
+    /// over `add_Fired`/`remove_Fired` rather than by calling the getter, C# subscribes through the
+    /// same accessors, and those hold no user code. What reaches the stack is the handler.
     [<CLIEvent>]
     member _.Fired = fired.Publish
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+/// Every call shape a debugger stack can take in F#, in one compiled file. The tests run a scenario,
+/// take the frame names the runtime reports for it, and put those through the frame parser and the
+/// call stack resolver - so the corpus is observed rather than written by hand.
+///
+/// Nothing here is `private`: a private binding never reaches the assembly signature the resolver
+/// reads, and every frame in this file is meant to resolve.
+module FSharp.Editor.Tests.CodeMap.CallStackSample
+
+open System
+open System.Diagnostics
+open System.IO
+open System.Reflection
+open System.Threading.Tasks
+
+/// This file's own text, embedded beside the compiled copy, so a test can hand a workspace exactly
+/// the source the captured frames were compiled from.
+let sourceText () =
+    let assembly = Assembly.GetExecutingAssembly()
+
+    let name =
+        assembly.GetManifestResourceNames()
+        |> Array.find (fun name -> name.EndsWith("CallStackSample.fs", StringComparison.Ordinal))
+
+    use stream = assembly.GetManifestResourceStream name
+    use reader = new StreamReader(stream)
+    reader.ReadToEnd()
+
+/// This module's own compiled type. Everything the scenarios build - closures, state machines, the
+/// types declared below - is nested inside it, which is what tells its frames apart from the test
+/// runner's.
+[<Literal>]
+let private SampleType = "FSharp.Editor.Tests.CodeMap.CallStackSample"
+
+let mutable private lastFrames: struct (string * int) array = [||]
+
+/// The frames of the scenario that ran last, innermost first: the name the runtime reports and the
+/// line it sits on, which is what a debug engine hands the provider.
+let frames () = lastFrames
+
+/// Every scenario funnels here, so one call captures exactly the stack that scenario built. Frames
+/// from outside this file - the test runner, FSharp.Core's own plumbing - are dropped, leaving the
+/// shapes the provider has to resolve.
+let sink (scenario: string) =
+    lastFrames <-
+        StackTrace(true).GetFrames()
+        |> Array.choose (fun frame ->
+            match frame.GetMethod() with
+            | null -> None
+            | method ->
+                match method.DeclaringType with
+                | null -> None
+                | declaringType ->
+                    match declaringType.FullName with
+                    | null -> None
+                    | fullName when
+                        fullName = SampleType
+                        || fullName.StartsWith(SampleType + "+", StringComparison.Ordinal)
+                        ->
+                        Some(struct ($"{fullName}.{method.Name}", frame.GetFileLineNumber()))
+                    | _ -> None)
+
+    scenario.Length
+
+let moduleLevelThree (_a: int, _b: string) = sink "module functions"
+let moduleLevelTwo (a: int) (b: string) (_c: float) = moduleLevelThree (a, b)
+let moduleFunctions () = moduleLevelTwo 1 "x" 2.0
+
+let pipelineLambdas () =
+    [ 1 ]
+    |> List.map (fun x -> x + 1)
+    |> List.collect (fun x -> [ x ])
+    |> List.map (fun _x -> sink "pipeline lambdas")
+    |> List.sum
+
+let nestedClosures () =
+    let outer factor =
+        let middle scale =
+            let inner () = sink "nested closures"
+            inner () * scale
+
+        middle 2 * factor
+
+    outer 3
+
+let localFunctions (n: int) =
+    let helperTwo _k = sink "local functions"
+    let helperOne k = helperTwo (k + 1)
+    helperOne n
+
+let genericFunction<'T> (_value: 'T) = sink "generic function"
+
+let (>=>) a b =
+    sink "custom operator" |> ignore
+    a + b
+
+let customOperator () = 1 >=> 2
+
+[<CompiledName("RenamedInMetadata")>]
+let originalSourceName () = sink "CompiledName rename"
+
+let (|Even|Odd|) n =
+    sink "active pattern" |> ignore
+    if n % 2 = 0 then Even else Odd
+
+let activePattern () =
+    match 4 with
+    | Even -> 0
+    | Odd -> 1
+
+let (|Positive|_|) n =
+    sink "partial active pattern" |> ignore
+    if n > 0 then Some n else None
+
+let partialActivePattern () =
+    match 3 with
+    | Positive _ -> 0
+    | _ -> 1
+
+let rec countdown n =
+    if n <= 0 then sink "recursion" else countdown (n - 1)
+
+let recursion () = countdown 5
+
+let rec isEven n =
+    if n = 0 then sink "mutual recursion" else isOdd (n - 1)
+
+and isOdd n =
+    if n = 0 then sink "mutual recursion" else isEven (n - 1)
+
+let mutualRecursion () = isEven 4
+
+let applyTwice (f: int -> int) x = f (f x)
+
+let higherOrder () =
+    applyTwice (fun _x -> sink "higher order") 1
+
+let asyncBody () =
+    async {
+        do! Async.Sleep 1
+        return sink "async body"
+    }
+    |> Async.RunSynchronously
+
+let taskBody () =
+    let work =
+        task {
+            do! Task.Delay 1
+            return sink "task body"
+        }
+
+    work.GetAwaiter().GetResult()
+
+let seqBody () =
+    seq {
+        yield sink "seq body"
+        yield 0
+    }
+    |> Seq.head
+
+module Outer =
+    module Middle =
+        module Inner =
+            let deeplyNested () = sink "nested modules"
+
+let nestedModules () = Outer.Middle.Inner.deeplyNested ()
+
+type Worker(seed: int) =
+    let mutable state = seed
+
+    member this.Start() = this.CurriedStep 1 2
+    member _.CurriedStep (_a: int) (_b: int) = sink "class members"
+
+    member _.Computed =
+        state <- state + 1
+        sink "property getter"
+
+    member _.Tuned
+        with get () = state
+        and set value =
+            sink "property setter" |> ignore
+            state <- value
+
+    static member StaticEntry() = sink "static member"
+
+type IRunner =
+    abstract Run: string -> int
+
+type Runner() =
+    interface IRunner with
+        member _.Run _name = sink "interface implementation"
+
+type Box<'T>(_value: 'T) =
+    member _.Unwrap() = sink "generic type member"
+
+type Initialized(seed: int) =
+    /// Private, and so absent from the assembly signature: a frame landing on this line can only be
+    /// named after the type whose static constructor runs it.
+    static let staticState = 7
+
+    let state = sink "constructor" + seed
+    member _.State = state + staticState
+
+/// A module and a type of the same name, which is what makes the compiler add the `Module` suffix
+/// the resolver has to undo.
+type Collision = { Value: int }
+
+module Collision =
+    let helper () = sink "module and type collision"
+
+module Startup =
+    let initialized = 3
+
+type Shape =
+    | Circle of radius: float
+    | Rect of width: float * height: float
+
+    member this.Area() =
+        sink "union member" |> ignore
+
+        match this with
+        | Circle r -> Math.PI * r * r
+        | Rect(w, h) -> w * h
+
+type Point =
+    {
+        X: float
+        Y: float
+    }
+
+    member this.Norm() =
+        sink "record member" |> ignore
+        sqrt (this.X * this.X + this.Y * this.Y)
+
+/// The zero-argument entry points the tests call, so a scenario is one function to invoke.
+let worker = Worker 10
+
+let instanceMember () = worker.Start()
+let propertyGetter () = worker.Computed
+
+let propertySetter () =
+    worker.Tuned <- 5
+    worker.Tuned
+
+let staticMember () = Worker.StaticEntry()
+let interfaceImplementation () = (Runner() :> IRunner).Run "x"
+let genericTypeMember () = Box<string>("s").Unwrap()
+let constructors () = Initialized(1).State
+let unionMember () = int ((Shape.Circle 1.0).Area())
+let recordMember () = int ({ X = 3.0; Y = 4.0 }.Norm())
+let genericFunctionScenario () = genericFunction 42

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
@@ -143,14 +143,25 @@ let asyncBody () =
     }
     |> Async.RunSynchronously
 
+/// Two levels on purpose. The debugger reconstructs a logical async stack by walking continuations,
+/// so the inner body is reached from the outer one through `let!` - a continuation it can follow and
+/// the pipeline can draw as an indirect link. The last hop out, `GetResult`, is a blocking wait
+/// rather than an await: whoever is parked on it is on another thread, and no continuation leads
+/// back there.
 let taskBody () =
-    let work =
+    let inner () =
         task {
             do! Task.Delay 1
             return sink "task body"
         }
 
-    work.GetAwaiter().GetResult()
+    let outer =
+        task {
+            let! value = inner ()
+            return value
+        }
+
+    outer.GetAwaiter().GetResult()
 
 let seqBody () =
     seq {

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
@@ -184,6 +184,32 @@ type Worker(seed: int) =
 
     static member StaticEntry() = sink "static member"
 
+/// A delegate call reaches the lambda through `Invoke` on a generated type, so the frame the
+/// debugger reports for the body is a closure rather than anything the user named.
+type Callback = delegate of int -> int
+
+let throughDelegate (callback: Callback) = callback.Invoke 1
+
+let delegateCall () =
+    throughDelegate (Callback(fun _ -> sink "delegate call"))
+
+/// An event adds a second indirection: the handler runs through `MulticastDelegate.Invoke`, and the
+/// accessors the compiler writes for `[<CLIEvent>]` are the only `add_`/`remove_` frames F# produces.
+type Publisher() =
+    let fired = Event<int>()
+
+    [<CLIEvent>]
+    member _.Fired = fired.Publish
+
+    member _.Fire() = fired.Trigger 1
+
+let eventHandler () =
+    let publisher = Publisher()
+    let mutable result = 0
+    publisher.Fired.Add(fun _ -> result <- sink "event handler")
+    publisher.Fire()
+    result
+
 type IRunner =
     abstract Run: string -> int
 
@@ -191,8 +217,13 @@ type Runner() =
     interface IRunner with
         member _.Run _name = sink "interface implementation"
 
+/// Declared immediately before `Initialized` on purpose: a frame in one of these two types must be
+/// answered with the type it is actually in. Reading a stale line once answered a frame in
+/// `Initialized` with `Box`, because `Box` is the nearest declaration above the wrong line.
 type Box<'T>(_value: 'T) =
-    member _.Unwrap() = sink "generic type member"
+    member _.Unwrap() =
+        // Nothing is declared on the line below, so a frame there can only be placed by its type.
+        sink "generic type member"
 
 type Initialized(seed: int) =
     /// Private, and so absent from the assembly signature: a frame landing on this line can only be

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/CallStackSample.fs
@@ -33,33 +33,57 @@ let sourceText () =
 [<Literal>]
 let private SampleType = "FSharp.Editor.Tests.CodeMap.CallStackSample"
 
+[<Literal>]
+let private FSharpCore = "FSharp.Core"
+
 let mutable private lastFrames: struct (string * int) array = [||]
+let mutable private lastPlumbingFrames: string array = [||]
 
 /// The frames of the scenario that ran last, innermost first: the name the runtime reports and the
 /// line it sits on, which is what a debug engine hands the provider.
 let frames () = lastFrames
 
-/// Every scenario funnels here, so one call captures exactly the stack that scenario built. Frames
-/// from outside this file - the test runner, FSharp.Core's own plumbing - are dropped, leaving the
-/// shapes the provider has to resolve.
+/// The frames of that same stack that belong to FSharp.Core: the plumbing a pipeline, a computation
+/// expression or an event runs through. Every one of them has to be folded off the map rather than
+/// resolved, and there are more of them than the names suggest - `List.map` alone contributes two.
+let plumbingFrames () = lastPlumbingFrames
+
+/// Every scenario funnels here, so one call captures exactly the stack that scenario built: the
+/// shapes the provider has to resolve, and beside them the FSharp.Core plumbing it has to fold away.
 let sink (scenario: string) =
+    let declarationOf (frame: StackFrame) =
+        match frame.GetMethod() with
+        | null -> ValueNone
+        | method ->
+            match method.DeclaringType with
+            | null -> ValueNone
+            | declaringType ->
+                match declaringType.FullName with
+                | null -> ValueNone
+                | fullName -> ValueSome(struct (declaringType, $"{fullName}.{method.Name}"))
+
+    let stack = StackTrace(true).GetFrames()
+
     lastFrames <-
-        StackTrace(true).GetFrames()
+        stack
         |> Array.choose (fun frame ->
-            match frame.GetMethod() with
-            | null -> None
-            | method ->
-                match method.DeclaringType with
-                | null -> None
-                | declaringType ->
-                    match declaringType.FullName with
-                    | null -> None
-                    | fullName when
-                        fullName = SampleType
-                        || fullName.StartsWith(SampleType + "+", StringComparison.Ordinal)
-                        ->
-                        Some(struct ($"{fullName}.{method.Name}", frame.GetFileLineNumber()))
-                    | _ -> None)
+            match declarationOf frame with
+            | ValueSome(struct (declaringType, name)) when
+                declaringType.FullName = SampleType
+                || declaringType.FullName.StartsWith(SampleType + "+", StringComparison.Ordinal)
+                ->
+                Some(struct (name, frame.GetFileLineNumber()))
+            | _ -> None)
+
+    lastPlumbingFrames <-
+        stack
+        |> Array.choose (fun frame ->
+            match declarationOf frame with
+            | ValueSome(struct (declaringType, name)) when
+                String.Equals(declaringType.Assembly.GetName().Name, FSharpCore, StringComparison.Ordinal)
+                ->
+                Some name
+            | _ -> None)
 
     scenario.Length
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackPlanTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackPlanTests.fs
@@ -4,6 +4,7 @@
 /// of the frame alone, and the workspace reaches it only as "which assembly owns this file".
 module FSharp.Editor.Tests.CodeMap.FSharpCallStackPlanTests
 
+open System
 open Xunit
 open Microsoft.VisualStudio.FSharp.Editor
 
@@ -121,3 +122,83 @@ let ``Frames disagreeing about the line yield no position`` () =
 [<Fact>]
 let ``A frame nothing claims yields no position`` () =
     Assert.True (FSharpCallStackPlan.positionOf []).IsNone
+
+/// The FSharp.Core frames a scenario actually put on the stack, taken from the runtime rather than
+/// written down here: what the plumbing of a pipeline or a computation expression is made of is
+/// FSharp.Core's business and changes with it.
+let private plumbingOf (scenario: unit -> int) =
+    scenario () |> ignore
+    CallStackSample.plumbingFrames ()
+
+/// A frame the parser rejects is a frame the provider never builds facts for, so nothing folds it
+/// and it stands on the map as a bare `Map`, `Invoke` or `MoveNext`. Both halves are asserted: the
+/// name reads, and the decision is to fold.
+let private assertEveryFrameFolds (frames: string array) =
+    Assert.NotEmpty frames
+
+    for name in frames do
+        match FSharpStackFrameNameParser.parse name with
+        | ValueNone -> failwith $"the parser rejects this FSharp.Core frame, so nothing folds it: %s{name}"
+        | ValueSome frame ->
+            {
+                Frame = frame
+                ModuleAssembly = ValueSome "FSharp.Core"
+            }
+            |> decide
+            |> fun action -> Assert.Equal(FoldAsExternalCode, action)
+
+/// One `List.map` is two frames - `ListModule.Map` and the `Primitives.Basics.List.map` it calls -
+/// and both reached the map as their own nodes, `Map` above `map`. How many of them survive depends
+/// on how FSharp.Core was optimized, so both are named here rather than counted; the debugger spells
+/// them with the type arguments it resolved, the runtime without.
+[<Theory>]
+[<InlineData("Microsoft.FSharp.Collections.ListModule.Map")>]
+[<InlineData("Microsoft.FSharp.Collections.ListModule.Map<int, int>")>]
+[<InlineData("Microsoft.FSharp.Primitives.Basics.List.map")>]
+[<InlineData("Microsoft.FSharp.Primitives.Basics.List.map<int, int>")>]
+let ``Both halves of a List.map fold into External Code`` (name: string) =
+    facts name (ValueSome "FSharp.Core") ValueNone
+    |> decide
+    |> fun action -> Assert.Equal(FoldAsExternalCode, action)
+
+[<Fact>]
+let ``Every FSharp.Core frame of a pipeline folds into External Code`` () =
+    assertEveryFrameFolds (plumbingOf CallStackSample.pipelineLambdas)
+
+/// The other shapes FSharp.Core reaches a stack in: a trampolined continuation and a closure the
+/// compiler numbered from inside `<StartupCode$FSharp-Core>`; a generated state machine reached
+/// through an explicitly implemented `IEnumerator.MoveNext`; a subscription reached through an
+/// explicitly implemented `IObserver.OnNext`.
+[<Fact>]
+let ``Every FSharp.Core frame of an async body folds into External Code`` () =
+    assertEveryFrameFolds (plumbingOf CallStackSample.asyncBody)
+
+[<Fact>]
+let ``Every FSharp.Core frame of a task body folds into External Code`` () =
+    assertEveryFrameFolds (plumbingOf CallStackSample.taskBody)
+
+[<Fact>]
+let ``Every FSharp.Core frame of a seq body folds into External Code`` () =
+    assertEveryFrameFolds (plumbingOf CallStackSample.seqBody)
+
+[<Fact>]
+let ``Every FSharp.Core frame of an event handler folds into External Code`` () =
+    assertEveryFrameFolds (plumbingOf CallStackSample.eventHandler)
+
+/// The module settles it on its own, so a name too mangled to read is still folded rather than left
+/// standing. This is what the provider falls back to when the parser returns nothing.
+[<Theory>]
+[<InlineData("FSharp.Core")>]
+[<InlineData("fsharp.core")>]
+let ``An FSharp.Core module folds whatever its frame name`` (assembly: string) =
+    Assert.True(FSharpCallStackPlan.isFSharpCoreModule (ValueSome assembly))
+
+[<Theory>]
+[<InlineData("ClassLibrary")>]
+[<InlineData("FSharp.Core.Extra")>]
+let ``Another module does not fold`` (assembly: string) =
+    Assert.False(FSharpCallStackPlan.isFSharpCoreModule (ValueSome assembly))
+
+[<Fact>]
+let ``No module does not fold on its own`` () =
+    Assert.False(FSharpCallStackPlan.isFSharpCoreModule ValueNone)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackPlanTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackPlanTests.fs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+/// What the provider decides to do with a frame, tested without a graph: the decision is a function
+/// of the frame alone, and the workspace reaches it only as "which assembly owns this file".
+module FSharp.Editor.Tests.CodeMap.FSharpCallStackPlanTests
+
+open Xunit
+open Microsoft.VisualStudio.FSharp.Editor
+
+[<Literal>]
+let private ProjectFile = @"C:\Demo\ClassLibrary\Demo.fs"
+
+/// The one thing the decision asks of the workspace.
+let private assemblyForFile file =
+    if file = ProjectFile then
+        ValueSome "ClassLibrary"
+    else
+        ValueNone
+
+let private frameNamed name =
+    match FSharpStackFrameNameParser.parse name with
+    | ValueNone -> failwith $"frame name did not parse: %s{name}"
+    | ValueSome frame -> frame
+
+let private facts name moduleAssembly position =
+    {
+        Frame =
+            { frameNamed name with
+                SourcePosition = position
+            }
+        ModuleAssembly = moduleAssembly
+    }
+
+let private decide facts =
+    FSharpCallStackPlan.decide assemblyForFile facts
+
+[<Fact>]
+let ``A frame naming its module resolves in that assembly`` () =
+    facts "ClassLibrary.Demo.sink" (ValueSome "ClassLibrary") ValueNone
+    |> decide
+    |> fun action -> Assert.Equal(ResolveIn "ClassLibrary", action)
+
+/// The debugger leaves the module empty on accessors and on module initialization, which is what
+/// once kept them off the map entirely.
+[<Fact>]
+let ``A frame without a module is addressed by the file it runs in`` () =
+    facts "ClassLibrary.Worker.Computed.get" ValueNone (ValueSome { File = ProjectFile; Line = 144 })
+    |> decide
+    |> fun action -> Assert.Equal(ResolveIn "ClassLibrary", action)
+
+[<Fact>]
+let ``A frame with neither a module nor a known file is left alone`` () =
+    facts
+        "Some.Other.Thing"
+        ValueNone
+        (ValueSome
+            {
+                File = @"C:\Elsewhere\Other.fs"
+                Line = 1
+            })
+    |> decide
+    |> fun action -> Assert.Equal(LeaveUnresolved, action)
+
+[<Fact>]
+let ``A frame with no position and no module is left alone`` () =
+    facts "Some.Other.Thing" ValueNone ValueNone
+    |> decide
+    |> fun action -> Assert.Equal(LeaveUnresolved, action)
+
+/// FSharp.Core's plumbing is folded into External Code rather than resolved - the assembly is no
+/// project of the workspace, and a node of its own would be a bare `MoveNext` or `Invoke`.
+[<Theory>]
+[<InlineData("<StartupCode$FSharp-Core>.$Async.Sleep@1814-3.Invoke")>]
+[<InlineData("<StartupCode$FSharp-Core>.$Tasks.resumptionInfo@159<int>.MoveNext")>]
+[<InlineData("Microsoft.FSharp.Collections.ListModule.Map<int, int>")>]
+let ``FSharp.Core frames fold into External Code`` (name: string) =
+    facts name (ValueSome "FSharp.Core") ValueNone
+    |> decide
+    |> fun action -> Assert.Equal(FoldAsExternalCode, action)
+
+/// SourceLink puts FSharp.Core's own source path on frames the debugger reports without a module.
+[<Fact>]
+let ``An FSharp.Core frame is recognised by its source path when it names no module`` () =
+    let position =
+        ValueSome
+            {
+                File = "/_/src/FSharp.Core/async.fs"
+                Line = 1818
+            }
+
+    facts "Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke" ValueNone position
+    |> decide
+    |> fun action -> Assert.Equal(FoldAsExternalCode, action)
+
+/// Case matters nowhere in an assembly name.
+[<Fact>]
+let ``FSharp.Core is recognised whatever its casing`` () =
+    facts "Whatever.Thing" (ValueSome "fsharp.core") ValueNone
+    |> decide
+    |> fun action -> Assert.Equal(FoldAsExternalCode, action)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackPlanTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackPlanTests.fs
@@ -98,3 +98,26 @@ let ``FSharp.Core is recognised whatever its casing`` () =
     facts "Whatever.Thing" (ValueSome "fsharp.core") ValueNone
     |> decide
     |> fun action -> Assert.Equal(FoldAsExternalCode, action)
+
+/// The pipeline removes neither nodes nor links, so a map accumulates them and one method node ends
+/// up claimed by frames from several runs. Guessing between them once gave a static initializer the
+/// name of whichever type sat above a stale line.
+[<Fact>]
+let ``A position claimed by one frame is used`` () =
+    let position = { File = ProjectFile; Line = 168 }
+    Assert.Equal(ValueSome position, FSharpCallStackPlan.positionOf [ position ])
+
+[<Fact>]
+let ``Frames agreeing on a position are used`` () =
+    let position = { File = ProjectFile; Line = 168 }
+
+    Assert.Equal(ValueSome position, FSharpCallStackPlan.positionOf [ position; position ])
+
+[<Fact>]
+let ``Frames disagreeing about the line yield no position`` () =
+    FSharpCallStackPlan.positionOf [ { File = ProjectFile; Line = 168 }; { File = ProjectFile; Line = 164 } ]
+    |> fun position -> Assert.True position.IsNone
+
+[<Fact>]
+let ``A frame nothing claims yields no position`` () =
+    Assert.True (FSharpCallStackPlan.positionOf []).IsNone

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -55,7 +55,12 @@ let private resolveStartupAt (snippet: string) =
     | ValueSome frame ->
         resolveParsed
             { frame with
-                SourcePosition = ValueSome(struct (document.FilePath, lineOf snippet))
+                SourcePosition =
+                    ValueSome
+                        {
+                            File = document.FilePath
+                            Line = lineOf snippet
+                        }
             }
 
 /// Frame names whose path the resolver has to take apart, rather than constructs a scenario would
@@ -151,7 +156,7 @@ let ``Module initialization resolves to the binding on the line`` () =
     match resolveStartupAt "let initialized" with
     | ValueNone -> failwith "expected the module initializer to resolve"
     | ValueSome resolved ->
-        Assert.Equal(ValueSome "initialized", resolved.DisplayName)
+        Assert.Equal("initialized", resolved.DisplayName)
         Assert.Equal(lineOf "let initialized", resolved.DeclarationRange.StartLine)
 
 /// A private `static let` runs in its type's static constructor and never reaches the assembly
@@ -161,7 +166,7 @@ let ``A private static let resolves to its type's static constructor`` () =
     match resolveStartupAt "static let staticState" with
     | ValueNone -> failwith "expected the static initializer to resolve"
     | ValueSome resolved ->
-        Assert.Equal(ValueSome "Initialized", resolved.DisplayName)
+        Assert.Equal("Initialized", resolved.DisplayName)
         Assert.Equal(ValueSome ".cctor", resolved.MemberName)
         Assert.True resolved.Modifiers.IsStatic
         Assert.True resolved.Modifiers.IsConstructor

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
+/// The frames a running scenario cannot produce, resolved against the same source `CallStackSample`
+/// is compiled from: the spellings only a debug engine uses, the ones that need a source position
+/// rather than a name, and the identity a resolved frame has to carry.
+///
+/// Everything a scenario *can* produce is covered end to end by `FSharpCallStackSampleTests`.
 module FSharp.Editor.Tests.CodeMap.FSharpCallStackResolverTests
 
 open System
@@ -8,33 +13,10 @@ open Microsoft.VisualStudio.FSharp.Editor
 open Microsoft.VisualStudio.FSharp.Editor.CancellableTasks
 open FSharp.Editor.Tests.Helpers
 
-let private source =
-    """
-module Sample.Library
+[<Literal>]
+let private Sample = "FSharp.Editor.Tests.CodeMap.CallStackSample"
 
-type Collision = { Value: int }
-
-module Collision =
-    let helper () = ()
-
-type SampleClass(seed: int) =
-    member _.InstanceMethod(x: int) = ()
-    member _.Property with get () = seed
-
-let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
-
-let moduleFunction (a: int) (b: string) = ()
-
-let pipelineLambda (xs: int list) =
-    xs |> List.map (fun x -> x * 2)
-
-type Box<'T>(value: 'T) =
-    member _.Unwrap() = value
-
-module Outer =
-    module Inner =
-        let deepest () = 3
-"""
+let private source = CallStackSample.sourceText ()
 
 /// The resolver reports declaration ranges, so expectations are pinned to the source line a
 /// construct is written on rather than to a hard-coded number.
@@ -46,32 +28,43 @@ let private lineOf (snippet: string) =
         |> Array.tryFindIndexV (fun line -> line.IndexOf(snippet, StringComparison.Ordinal) >= 0)
     with
     | ValueSome i -> i + 1
-    | ValueNone -> failwith $"snippet not found in test source: %s{snippet}"
+    | ValueNone -> failwith $"snippet not found in the sample: %s{snippet}"
 
-let private resolve (frameName: string) =
-    let solution = RoslynTestHelpers.CreateSolution source
+let private solution = lazy RoslynTestHelpers.CreateSolution source
+
+let private resolveParsed (frame: ParsedFrame) =
+    let solution = solution.Value
     let project = solution.Projects |> Seq.exactlyOne
 
+    FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
+    |> CancellableTask.runSynchronouslyWithoutCancellation
+
+let private resolve (frameName: string) =
     match FSharpStackFrameNameParser.parse frameName with
     | ValueNone -> failwith $"frame name did not parse: %s{frameName}"
-    | ValueSome frame ->
-        FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
-        |> CancellableTask.runSynchronouslyWithoutCancellation
+    | ValueSome frame -> resolveParsed frame
 
+/// A `<StartupCode$…>` frame names the file rather than the construct, so the line the debugger
+/// reports is the only anchor. The provider reads it off the frame node and fills it in here.
+let private resolveStartupAt (snippet: string) =
+    let solution = solution.Value
+    let document = solution.Projects |> Seq.exactlyOne |> _.Documents |> Seq.exactlyOne
+
+    match FSharpStackFrameNameParser.parse $"<StartupCode$Sample>.$%s{Sample}" with
+    | ValueNone -> failwith "the startup frame did not parse"
+    | ValueSome frame ->
+        resolveParsed
+            { frame with
+                SourcePosition = ValueSome(struct (document.FilePath, lineOf snippet))
+            }
+
+/// Frame names whose path the resolver has to take apart, rather than constructs a scenario would
+/// exercise anyway: a module renamed by a collision, modules nested three deep, a generic type.
 let frames: obj[] list =
     [
-        [| "Sample.Library.moduleFunction"; "let moduleFunction" |]
-        [| "Sample.Library.SampleClass.InstanceMethod"; "member _.InstanceMethod" |]
-        [| "Sample.Library.SampleClass..ctor"; "type SampleClass" |]
-        [| "Sample.Library.SampleClass.get_Property"; "member _.Property" |]
-        [| "Sample.Library.|Even|Odd|"; "let (|Even|Odd|)" |]
-        // the `Module` suffix the compiler adds when a module collides with a type must be undone
-        [| "Sample.Library.CollisionModule.helper"; "let helper" |]
-        // a lambda has no signature entity of its own, so it reports the binding containing it
-        [| "Sample.Library.pipelineLambda@18.Invoke"; "let pipelineLambda" |]
-        // the entity index stores mangled names, so the generic arity must survive the lookup
-        [| "Sample.Library.Box`1.Unwrap"; "member _.Unwrap" |]
-        [| "Sample.Library.Outer.Inner.deepest"; "let deepest" |]
+        [| $"%s{Sample}.CollisionModule.helper"; "let helper ()" |]
+        [| $"%s{Sample}.Outer.Middle.Inner.deeplyNested"; "let deeplyNested" |]
+        [| $"%s{Sample}.Box`1.Unwrap"; "member _.Unwrap" |]
     ]
 
 [<Theory>]
@@ -82,32 +75,93 @@ let ``Frame resolves to the declaring source line`` (frameName: string) (snippet
     | ValueSome resolved -> Assert.Equal(lineOf snippet, resolved.DeclarationRange.StartLine)
 
 [<Theory>]
-[<InlineData("Sample.Library.noSuchFunction")>]
-[<InlineData("Some.Other.Assembly.thing")>]
-let ``Unknown frames stay unresolved`` (frameName: string) = Assert.True((resolve frameName).IsNone)
-
-[<Fact>]
-let ``Resolved identity separates namespace from the type chain`` () =
-    match resolve "Sample.Library.Outer.Inner.deepest" with
-    | ValueNone -> failwith "expected the nested-module frame to resolve"
-    | ValueSome resolved ->
-        Assert.Equal(ValueSome "Sample", resolved.Namespace)
-        Assert.Equal<struct (string * int)>([| struct ("Library", 0); struct ("Outer", 0); struct ("Inner", 0) |], resolved.TypeChain)
-
-[<Fact>]
-let ``Generic type carries its arity in the type chain`` () =
-    match resolve "Sample.Library.Box`1.Unwrap" with
-    | ValueNone -> failwith "expected the generic-type frame to resolve"
-    | ValueSome resolved -> Assert.Equal<struct (string * int)>([| struct ("Library", 0); struct ("Box", 1) |], resolved.TypeChain)
+[<InlineData("noSuchFunction")>]
+[<InlineData("Worker.NoSuchMember")>]
+let ``Unknown frames stay unresolved`` (member': string) =
+    Assert.True((resolve $"%s{Sample}.%s{member'}").IsNone)
 
 [<Fact>]
 let ``Frames from another assembly are not resolved`` () =
-    let solution = RoslynTestHelpers.CreateSolution source
-
-    let frame = (FSharpStackFrameNameParser.parse "Sample.Library.moduleFunction").Value
+    let frame = (FSharpStackFrameNameParser.parse $"%s{Sample}.moduleFunctions").Value
 
     let resolved =
-        FSharpCallStackResolver.tryResolve solution.Workspace "SomeOtherAssembly" frame
+        FSharpCallStackResolver.tryResolve solution.Value.Workspace "SomeOtherAssembly" frame
         |> CancellableTask.runSynchronouslyWithoutCancellation
 
     Assert.True resolved.IsNone
+
+/// A debug engine spells an accessor with a trailing segment, where metadata - and so the frame a
+/// running scenario produces - spells it `get_Computed`.
+[<Fact>]
+let ``The debug engine's spelling of a getter resolves as a property`` () =
+    match resolve $"%s{Sample}.Worker.Computed.get" with
+    | ValueNone -> failwith "expected the getter to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ResolvedProperty, resolved.Kind)
+        Assert.Equal(lineOf "member _.Computed", resolved.DeclarationRange.StartLine)
+
+[<Fact>]
+let ``The debug engine's spelling of a setter resolves as a property`` () =
+    match resolve $"%s{Sample}.Worker.Tuned.set" with
+    | ValueNone -> failwith "expected the setter to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ResolvedProperty, resolved.Kind)
+        Assert.Equal(lineOf "member _.Tuned", resolved.DeclarationRange.StartLine)
+
+[<Fact>]
+let ``Sibling closures stay distinct nodes`` () =
+    let line = lineOf "let inner () = sink"
+
+    let identityOf frameName =
+        match resolve frameName with
+        | ValueNone -> failwith $"expected %s{frameName} to resolve"
+        | ValueSome resolved -> resolved.MemberName
+
+    let first = identityOf $"%s{Sample}.inner@%d{line}.Invoke"
+    let second = identityOf $"%s{Sample}.inner@%d{line}-1.Invoke"
+
+    Assert.NotEqual(first, second)
+    Assert.Equal(ValueSome $"inner@%d{line}", first)
+
+[<Fact>]
+let ``Resolved identity separates namespace from the type chain`` () =
+    match resolve $"%s{Sample}.Outer.Middle.Inner.deeplyNested" with
+    | ValueNone -> failwith "expected the nested-module frame to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ValueSome "FSharp.Editor.Tests.CodeMap", resolved.Namespace)
+
+        Assert.Equal<struct (string * int)>(
+            [|
+                struct ("CallStackSample", 0)
+                struct ("Outer", 0)
+                struct ("Middle", 0)
+                struct ("Inner", 0)
+            |],
+            resolved.TypeChain
+        )
+
+[<Fact>]
+let ``Generic type carries its arity in the type chain`` () =
+    match resolve $"%s{Sample}.Box`1.Unwrap" with
+    | ValueNone -> failwith "expected the generic-type frame to resolve"
+    | ValueSome resolved -> Assert.Equal<struct (string * int)>([| struct ("CallStackSample", 0); struct ("Box", 1) |], resolved.TypeChain)
+
+[<Fact>]
+let ``Module initialization resolves to the binding on the line`` () =
+    match resolveStartupAt "let initialized" with
+    | ValueNone -> failwith "expected the module initializer to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ValueSome "initialized", resolved.DisplayName)
+        Assert.Equal(lineOf "let initialized", resolved.DeclarationRange.StartLine)
+
+/// A private `static let` runs in its type's static constructor and never reaches the assembly
+/// signature, so the enclosing type is the closest name the signature can offer.
+[<Fact>]
+let ``A private static let resolves to its type's static constructor`` () =
+    match resolveStartupAt "static let staticState" with
+    | ValueNone -> failwith "expected the static initializer to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ValueSome "Initialized", resolved.DisplayName)
+        Assert.Equal(ValueSome ".cctor", resolved.MemberName)
+        Assert.True resolved.Modifiers.IsStatic
+        Assert.True resolved.Modifiers.IsConstructor

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -312,3 +312,35 @@ let ``A method that raises an event stays a method`` () =
         Assert.Equal(ResolvedMethod, resolved.Kind)
         Assert.DoesNotContain(PropertyGet, resolved.Traits)
         Assert.DoesNotContain(PropertySet, resolved.Traits)
+
+/// A file's module-level bindings and the `static let` of a type declared in it all run in the one
+/// `<StartupCode$…>.$File.$File()` method the compiler writes per file. The debugger reports the same
+/// frame name for every one of them, so the line is the only thing that tells them apart - and two
+/// different lines must not resolve to the same identity.
+[<Fact>]
+let ``Two initializers in one startup method resolve to different identities`` () =
+    let identityOf snippet =
+        match resolveStartupAt snippet with
+        | ValueNone -> failwith $"expected the line of %s{snippet} to resolve"
+        | ValueSome resolved -> resolved
+
+    let moduleInitializer = identityOf "let initialized"
+    let staticInitializer = identityOf "static let staticState"
+
+    Assert.True(
+        moduleInitializer.DisplayName <> staticInitializer.DisplayName,
+        $"both initializers were named %s{moduleInitializer.DisplayName}"
+    )
+
+    Assert.True(
+        moduleInitializer.MemberName <> staticInitializer.MemberName,
+        $"both initializers claim the member %A{moduleInitializer.MemberName}"
+    )
+
+    Assert.True(
+        moduleInitializer.TypeChain <> staticInitializer.TypeChain,
+        $"both initializers claim the type chain %A{moduleInitializer.TypeChain}"
+    )
+
+    Assert.DoesNotContain(Constructor, moduleInitializer.Traits)
+    Assert.Contains(Constructor, staticInitializer.Traits)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Editor.Tests.CodeMap
+module FSharp.Editor.Tests.CodeMap.FSharpCallStackResolverTests
 
 open System
 open Xunit
@@ -8,10 +8,8 @@ open Microsoft.VisualStudio.FSharp.Editor
 open Microsoft.VisualStudio.FSharp.Editor.CancellableTasks
 open FSharp.Editor.Tests.Helpers
 
-module FSharpCallStackResolverTests =
-
-    let private source =
-        """
+let private source =
+    """
 module Sample.Library
 
 type Collision = { Value: int }
@@ -31,58 +29,61 @@ let pipelineLambda (xs: int list) =
     xs |> List.map (fun x -> x * 2)
 """
 
-    /// The resolver reports declaration ranges, so expectations are pinned to the source line a
-    /// construct is written on rather than to a hard-coded number.
-    let private lineOf (snippet: string) =
-        let lines = source.Replace("\r\n", "\n").Split('\n')
+/// The resolver reports declaration ranges, so expectations are pinned to the source line a
+/// construct is written on rather than to a hard-coded number.
+let private lineOf (snippet: string) =
+    let lines = source.Replace("\r\n", "\n").Split('\n')
 
-        match lines |> Array.tryFindIndex (fun line -> line.IndexOf(snippet, StringComparison.Ordinal) >= 0) with
-        | Some i -> i + 1
-        | None -> failwith $"snippet not found in test source: %s{snippet}"
+    match
+        lines
+        |> Array.tryFindIndexV (fun line -> line.IndexOf(snippet, StringComparison.Ordinal) >= 0)
+    with
+    | ValueSome i -> i + 1
+    | ValueNone -> failwith $"snippet not found in test source: %s{snippet}"
 
-    let private resolve (frameName: string) =
-        let solution = RoslynTestHelpers.CreateSolution source
-        let project = solution.Projects |> Seq.exactlyOne
+let private resolve (frameName: string) =
+    let solution = RoslynTestHelpers.CreateSolution source
+    let project = solution.Projects |> Seq.exactlyOne
 
-        match FSharpStackFrameNameParser.parse frameName with
-        | ValueNone -> failwith $"frame name did not parse: %s{frameName}"
-        | ValueSome frame ->
-            FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
-            |> CancellableTask.runSynchronouslyWithoutCancellation
+    match FSharpStackFrameNameParser.parse frameName with
+    | ValueNone -> failwith $"frame name did not parse: %s{frameName}"
+    | ValueSome frame ->
+        FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
+        |> CancellableTask.runSynchronouslyWithoutCancellation
 
-    let frames: obj[] list =
-        [
-            [| "Sample.Library.moduleFunction"; "let moduleFunction" |]
-            [| "Sample.Library.SampleClass.InstanceMethod"; "member _.InstanceMethod" |]
-            [| "Sample.Library.SampleClass..ctor"; "type SampleClass" |]
-            [| "Sample.Library.SampleClass.get_Property"; "member _.Property" |]
-            [| "Sample.Library.|Even|Odd|"; "let (|Even|Odd|)" |]
-            // the `Module` suffix the compiler adds when a module collides with a type must be undone
-            [| "Sample.Library.CollisionModule.helper"; "let helper" |]
-            // a lambda has no signature entity of its own, so it reports the binding containing it
-            [| "Sample.Library.pipelineLambda@18.Invoke"; "let pipelineLambda" |]
-        ]
+let frames: obj[] list =
+    [
+        [| "Sample.Library.moduleFunction"; "let moduleFunction" |]
+        [| "Sample.Library.SampleClass.InstanceMethod"; "member _.InstanceMethod" |]
+        [| "Sample.Library.SampleClass..ctor"; "type SampleClass" |]
+        [| "Sample.Library.SampleClass.get_Property"; "member _.Property" |]
+        [| "Sample.Library.|Even|Odd|"; "let (|Even|Odd|)" |]
+        // the `Module` suffix the compiler adds when a module collides with a type must be undone
+        [| "Sample.Library.CollisionModule.helper"; "let helper" |]
+        // a lambda has no signature entity of its own, so it reports the binding containing it
+        [| "Sample.Library.pipelineLambda@18.Invoke"; "let pipelineLambda" |]
+    ]
 
-    [<Theory>]
-    [<MemberData(nameof frames)>]
-    let ``Frame resolves to the declaring source line`` (frameName: string) (snippet: string) =
-        match resolve frameName with
-        | ValueNone -> failwith $"expected %s{frameName} to resolve"
-        | ValueSome resolved -> Assert.Equal(lineOf snippet, resolved.DeclarationRange.StartLine)
+[<Theory>]
+[<MemberData(nameof frames)>]
+let ``Frame resolves to the declaring source line`` (frameName: string) (snippet: string) =
+    match resolve frameName with
+    | ValueNone -> failwith $"expected %s{frameName} to resolve"
+    | ValueSome resolved -> Assert.Equal(lineOf snippet, resolved.DeclarationRange.StartLine)
 
-    [<Theory>]
-    [<InlineData("Sample.Library.noSuchFunction")>]
-    [<InlineData("Some.Other.Assembly.thing")>]
-    let ``Unknown frames stay unresolved`` (frameName: string) = Assert.True((resolve frameName).IsNone)
+[<Theory>]
+[<InlineData("Sample.Library.noSuchFunction")>]
+[<InlineData("Some.Other.Assembly.thing")>]
+let ``Unknown frames stay unresolved`` (frameName: string) = Assert.True((resolve frameName).IsNone)
 
-    [<Fact>]
-    let ``Frames from another assembly are not resolved`` () =
-        let solution = RoslynTestHelpers.CreateSolution source
+[<Fact>]
+let ``Frames from another assembly are not resolved`` () =
+    let solution = RoslynTestHelpers.CreateSolution source
 
-        let frame = (FSharpStackFrameNameParser.parse "Sample.Library.moduleFunction").Value
+    let frame = (FSharpStackFrameNameParser.parse "Sample.Library.moduleFunction").Value
 
-        let resolved =
-            FSharpCallStackResolver.tryResolve solution.Workspace "SomeOtherAssembly" frame
-            |> CancellableTask.runSynchronouslyWithoutCancellation
+    let resolved =
+        FSharpCallStackResolver.tryResolve solution.Workspace "SomeOtherAssembly" frame
+        |> CancellableTask.runSynchronouslyWithoutCancellation
 
-        Assert.True resolved.IsNone
+    Assert.True resolved.IsNone

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -27,6 +27,13 @@ let moduleFunction (a: int) (b: string) = ()
 
 let pipelineLambda (xs: int list) =
     xs |> List.map (fun x -> x * 2)
+
+type Box<'T>(value: 'T) =
+    member _.Unwrap() = value
+
+module Outer =
+    module Inner =
+        let deepest () = 3
 """
 
 /// The resolver reports declaration ranges, so expectations are pinned to the source line a
@@ -62,6 +69,9 @@ let frames: obj[] list =
         [| "Sample.Library.CollisionModule.helper"; "let helper" |]
         // a lambda has no signature entity of its own, so it reports the binding containing it
         [| "Sample.Library.pipelineLambda@18.Invoke"; "let pipelineLambda" |]
+        // the entity index stores mangled names, so the generic arity must survive the lookup
+        [| "Sample.Library.Box`1.Unwrap"; "member _.Unwrap" |]
+        [| "Sample.Library.Outer.Inner.deepest"; "let deepest" |]
     ]
 
 [<Theory>]
@@ -75,6 +85,20 @@ let ``Frame resolves to the declaring source line`` (frameName: string) (snippet
 [<InlineData("Sample.Library.noSuchFunction")>]
 [<InlineData("Some.Other.Assembly.thing")>]
 let ``Unknown frames stay unresolved`` (frameName: string) = Assert.True((resolve frameName).IsNone)
+
+[<Fact>]
+let ``Resolved identity separates namespace from the type chain`` () =
+    match resolve "Sample.Library.Outer.Inner.deepest" with
+    | ValueNone -> failwith "expected the nested-module frame to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ValueSome "Sample", resolved.Namespace)
+        Assert.Equal<struct (string * int)>([| struct ("Library", 0); struct ("Outer", 0); struct ("Inner", 0) |], resolved.TypeChain)
+
+[<Fact>]
+let ``Generic type carries its arity in the type chain`` () =
+    match resolve "Sample.Library.Box`1.Unwrap" with
+    | ValueNone -> failwith "expected the generic-type frame to resolve"
+    | ValueSome resolved -> Assert.Equal<struct (string * int)>([| struct ("Library", 0); struct ("Box", 1) |], resolved.TypeChain)
 
 [<Fact>]
 let ``Frames from another assembly are not resolved`` () =

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -168,5 +168,5 @@ let ``A private static let resolves to its type's static constructor`` () =
     | ValueSome resolved ->
         Assert.Equal("Initialized", resolved.DisplayName)
         Assert.Equal(ValueSome ".cctor", resolved.MemberName)
-        Assert.True resolved.Modifiers.IsStatic
-        Assert.True resolved.Modifiers.IsConstructor
+        Assert.Contains(Static, resolved.Traits)
+        Assert.Contains(Constructor, resolved.Traits)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -344,3 +344,17 @@ let ``Two initializers in one startup method resolve to different identities`` (
 
     Assert.DoesNotContain(Constructor, moduleInitializer.Traits)
     Assert.Contains(Constructor, staticInitializer.Traits)
+
+/// `Fired` is the event, `Fire` beside it the method that raises it. The compiler exposes an
+/// `[<CLIEvent>]` through a getter as well as through `add_`/`remove_`, so the member found by name
+/// carries both `IsProperty` and `IsEvent` - and whichever of the two is answered, it is an event.
+[<Theory>]
+[<InlineData("Fired")>]
+[<InlineData("get_Fired")>]
+[<InlineData("Fired.get")>]
+let ``The event itself resolves as an event`` (member': string) =
+    match resolve $"%s{Sample}.Publisher.%s{member'}" with
+    | ValueNone -> failwith $"expected %s{member'} to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ResolvedEvent, resolved.Kind)
+        Assert.Equal(lineOf "member _.Fired", resolved.DeclarationRange.StartLine)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -301,3 +301,14 @@ let ``A member's own line is answered with the member`` (snippet: string) (expec
     match resolveStartupIn TypesSeparatedByTrivia snippet with
     | ValueNone -> failwith $"expected the line of %s{snippet} to resolve"
     | ValueSome resolved -> Assert.Equal(expected, resolved.DisplayName)
+
+/// `Fire` raises an event; it is not one, and it is not a property either. Only the `add_`/`remove_`
+/// accessors beside it are events, and a stack that goes through both must tell them apart.
+[<Fact>]
+let ``A method that raises an event stays a method`` () =
+    match resolve $"%s{Sample}.Publisher.Fire" with
+    | ValueNone -> failwith "expected Fire to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ResolvedMethod, resolved.Kind)
+        Assert.DoesNotContain(PropertyGet, resolved.Traits)
+        Assert.DoesNotContain(PropertySet, resolved.Traits)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -46,22 +46,24 @@ let private resolve (frameName: string) =
 
 /// A `<StartupCode$…>` frame names the file rather than the construct, so the line the debugger
 /// reports is the only anchor. The provider reads it off the frame node and fills it in here.
-let private resolveStartupAt (snippet: string) =
-    let solution = solution.Value
-    let document = solution.Projects |> Seq.exactlyOne |> _.Documents |> Seq.exactlyOne
-
+let private startupFrame () =
     match FSharpStackFrameNameParser.parse $"<StartupCode$Sample>.$%s{Sample}" with
     | ValueNone -> failwith "the startup frame did not parse"
-    | ValueSome frame ->
-        resolveParsed
-            { frame with
-                SourcePosition =
-                    ValueSome
-                        {
-                            File = document.FilePath
-                            Line = lineOf snippet
-                        }
-            }
+    | ValueSome frame -> frame
+
+let private resolveStartupAt (snippet: string) =
+    let document =
+        solution.Value.Projects |> Seq.exactlyOne |> _.Documents |> Seq.exactlyOne
+
+    resolveParsed
+        { startupFrame () with
+            SourcePosition =
+                ValueSome
+                    {
+                        File = document.FilePath
+                        Line = lineOf snippet
+                    }
+        }
 
 /// Frame names whose path the resolver has to take apart, rather than constructs a scenario would
 /// exercise anyway: a module renamed by a collision, modules nested three deep, a generic type.
@@ -112,6 +114,19 @@ let ``The debug engine's spelling of a setter resolves as a property`` () =
     | ValueSome resolved ->
         Assert.Equal(ResolvedProperty, resolved.Kind)
         Assert.Equal(lineOf "member _.Tuned", resolved.DeclarationRange.StartLine)
+
+/// The accessors the compiler writes for `[<CLIEvent>]` are the only `add_`/`remove_` frames F#
+/// produces, and no scenario can stop inside one - they contain no user code. They are what makes a
+/// node an event rather than a method.
+[<Theory>]
+[<InlineData("add_Fired")>]
+[<InlineData("remove_Fired")>]
+let ``An event accessor resolves as an event`` (accessor: string) =
+    match resolve $"%s{Sample}.Publisher.%s{accessor}" with
+    | ValueNone -> failwith $"expected %s{accessor} to resolve"
+    | ValueSome resolved ->
+        Assert.Equal(ResolvedEvent, resolved.Kind)
+        Assert.Equal(lineOf "member _.Fired", resolved.DeclarationRange.StartLine)
 
 [<Fact>]
 let ``Sibling closures stay distinct nodes`` () =
@@ -170,3 +185,23 @@ let ``A private static let resolves to its type's static constructor`` () =
         Assert.Equal(ValueSome ".cctor", resolved.MemberName)
         Assert.Contains(Static, resolved.Traits)
         Assert.Contains(Constructor, resolved.Traits)
+
+/// `Box` is declared immediately before `Initialized`, so "the nearest declaration above the line"
+/// is only the right answer while the line itself is right. A line read off a frame belonging to a
+/// different run put a frame from `Initialized` several lines higher, and the nearest declaration
+/// above *there* is `Box` - which is how a static initializer came to be labelled `Box` on a map.
+/// Both sides of that boundary are pinned here.
+[<Theory>]
+[<InlineData("sink \"generic type member\"", "Box")>]
+[<InlineData("static let staticState", "Initialized")>]
+let ``A line is answered with the type it is in, not the one before it`` (snippet: string) (expected: string) =
+    match resolveStartupAt snippet with
+    | ValueNone -> failwith $"expected the line of %s{snippet} to resolve"
+    | ValueSome resolved -> Assert.Equal(expected, resolved.DisplayName)
+
+/// Module initialization is named after its file rather than after any construct, so a frame with
+/// no line has nothing to resolve to. That is what frames disagreeing now leaves behind, and a grey
+/// node is the honest answer where guessing produced `Box`.
+[<Fact>]
+let ``A startup frame with no position stays unresolved`` () =
+    Assert.True (resolveParsed (startupFrame ())).IsNone

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Editor.Tests.CodeMap
+
+open System
+open Xunit
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.CancellableTasks
+open FSharp.Editor.Tests.Helpers
+
+module FSharpCallStackResolverTests =
+
+    let private source =
+        """
+module Sample.Library
+
+type Collision = { Value: int }
+
+module Collision =
+    let helper () = ()
+
+type SampleClass(seed: int) =
+    member _.InstanceMethod(x: int) = ()
+    member _.Property with get () = seed
+
+let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
+
+let moduleFunction (a: int) (b: string) = ()
+
+let pipelineLambda (xs: int list) =
+    xs |> List.map (fun x -> x * 2)
+"""
+
+    /// The resolver reports declaration ranges, so expectations are pinned to the source line a
+    /// construct is written on rather than to a hard-coded number.
+    let private lineOf (snippet: string) =
+        let lines = source.Replace("\r\n", "\n").Split('\n')
+
+        match lines |> Array.tryFindIndex (fun line -> line.IndexOf(snippet, StringComparison.Ordinal) >= 0) with
+        | Some i -> i + 1
+        | None -> failwith $"snippet not found in test source: %s{snippet}"
+
+    let private resolve (frameName: string) =
+        let solution = RoslynTestHelpers.CreateSolution source
+        let project = solution.Projects |> Seq.exactlyOne
+
+        match FSharpStackFrameNameParser.parse frameName with
+        | ValueNone -> failwith $"frame name did not parse: %s{frameName}"
+        | ValueSome frame ->
+            FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
+            |> CancellableTask.runSynchronouslyWithoutCancellation
+
+    let frames: obj[] list =
+        [
+            [| "Sample.Library.moduleFunction"; "let moduleFunction" |]
+            [| "Sample.Library.SampleClass.InstanceMethod"; "member _.InstanceMethod" |]
+            [| "Sample.Library.SampleClass..ctor"; "type SampleClass" |]
+            [| "Sample.Library.SampleClass.get_Property"; "member _.Property" |]
+            [| "Sample.Library.|Even|Odd|"; "let (|Even|Odd|)" |]
+            // the `Module` suffix the compiler adds when a module collides with a type must be undone
+            [| "Sample.Library.CollisionModule.helper"; "let helper" |]
+            // a lambda has no signature entity of its own, so it reports the binding containing it
+            [| "Sample.Library.pipelineLambda@18.Invoke"; "let pipelineLambda" |]
+        ]
+
+    [<Theory>]
+    [<MemberData(nameof frames)>]
+    let ``Frame resolves to the declaring source line`` (frameName: string) (snippet: string) =
+        match resolve frameName with
+        | ValueNone -> failwith $"expected %s{frameName} to resolve"
+        | ValueSome resolved -> Assert.Equal(lineOf snippet, resolved.DeclarationRange.StartLine)
+
+    [<Theory>]
+    [<InlineData("Sample.Library.noSuchFunction")>]
+    [<InlineData("Some.Other.Assembly.thing")>]
+    let ``Unknown frames stay unresolved`` (frameName: string) = Assert.True((resolve frameName).IsNone)
+
+    [<Fact>]
+    let ``Frames from another assembly are not resolved`` () =
+        let solution = RoslynTestHelpers.CreateSolution source
+
+        let frame = (FSharpStackFrameNameParser.parse "Sample.Library.moduleFunction").Value
+
+        let resolved =
+            FSharpCallStackResolver.tryResolve solution.Workspace "SomeOtherAssembly" frame
+            |> CancellableTask.runSynchronouslyWithoutCancellation
+
+        Assert.True resolved.IsNone

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackResolverTests.fs
@@ -20,8 +20,8 @@ let private source = CallStackSample.sourceText ()
 
 /// The resolver reports declaration ranges, so expectations are pinned to the source line a
 /// construct is written on rather than to a hard-coded number.
-let private lineOf (snippet: string) =
-    let lines = source.Replace("\r\n", "\n").Split('\n')
+let private lineIn (text: string) (snippet: string) =
+    let lines = text.Replace("\r\n", "\n").Split('\n')
 
     match
         lines
@@ -29,6 +29,8 @@ let private lineOf (snippet: string) =
     with
     | ValueSome i -> i + 1
     | ValueNone -> failwith $"snippet not found in the sample: %s{snippet}"
+
+let private lineOf = lineIn source
 
 let private solution = lazy RoslynTestHelpers.CreateSolution source
 
@@ -205,3 +207,97 @@ let ``A line is answered with the type it is in, not the one before it`` (snippe
 [<Fact>]
 let ``A startup frame with no position stays unresolved`` () =
     Assert.True (resolveParsed (startupFrame ())).IsNone
+
+/// A generic type, then the blank line, doc comment and attribute belonging to the type after it.
+/// Those lines are inside no entity: FCS reports an entity's own line and its members' lines, and
+/// nothing claims the trivia between two declarations.
+[<Literal>]
+let private TypesSeparatedByTrivia =
+    """
+namespace Shipped
+
+open System
+
+module Helpers =
+    let sink (scenario: string) = scenario.Length
+
+type Box<'T>(value: 'T) =
+    member _.Unwrap() = Helpers.sink "generic type member"
+
+/// Doc comment belonging to Initialized.
+[<Sealed>]
+type Initialized(seed: int) =
+    static let staticState = Helpers.sink "static constructor"
+    let state = Helpers.sink "constructor" + seed
+
+    member _.State = state
+    static member StaticState = staticState
+"""
+
+let private resolveStartupIn (text: string) (snippet: string) =
+    let solution = RoslynTestHelpers.CreateSolution text
+    let project = solution.Projects |> Seq.exactlyOne
+    let document = project.Documents |> Seq.exactlyOne
+
+    let frame =
+        { startupFrame () with
+            SourcePosition =
+                ValueSome
+                    {
+                        File = document.FilePath
+                        Line = lineIn text snippet
+                    }
+        }
+
+    FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
+    |> CancellableTask.runSynchronouslyWithoutCancellation
+
+/// The demo's static initializer reached the map labelled `Box` - the generic type declared above
+/// `Initialized`, which has no static constructor at all. Every line from the one after `Box`'s last
+/// member down to `Initialized`'s own is a line the answer must not be `Box` on.
+[<Theory>]
+[<InlineData("/// Doc comment belonging to Initialized.", "Initialized")>]
+[<InlineData("[<Sealed>]", "Initialized")>]
+[<InlineData("static let staticState", "Initialized")>]
+[<InlineData("let state = Helpers.sink \"constructor\"", "Initialized")>]
+let ``Trivia between two types is answered with the type below it`` (snippet: string) (expected: string) =
+    match resolveStartupIn TypesSeparatedByTrivia snippet with
+    | ValueNone -> failwith $"expected the line of %s{snippet} to resolve"
+    | ValueSome resolved -> Assert.Equal(expected, resolved.DisplayName)
+
+/// The blank line between `Box`'s last member and `Initialized`'s doc comment, addressed by number
+/// because it holds nothing to search for.
+[<Fact>]
+let ``The blank line between two types is answered with the type below it`` () =
+    let blank = lineIn TypesSeparatedByTrivia "member _.Unwrap" + 1
+
+    let solution = RoslynTestHelpers.CreateSolution TypesSeparatedByTrivia
+    let project = solution.Projects |> Seq.exactlyOne
+    let document = project.Documents |> Seq.exactlyOne
+
+    let frame =
+        { startupFrame () with
+            SourcePosition =
+                ValueSome
+                    {
+                        File = document.FilePath
+                        Line = blank
+                    }
+        }
+
+    match
+        FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName frame
+        |> CancellableTask.runSynchronouslyWithoutCancellation
+    with
+    | ValueNone -> failwith "expected the blank line to resolve"
+    | ValueSome resolved -> Assert.Equal("Initialized", resolved.DisplayName)
+
+/// A line that is a member's own is answered with that member, not with the type around it.
+[<Theory>]
+[<InlineData("member _.Unwrap", "Unwrap")>]
+[<InlineData("type Initialized", "``.ctor``")>]
+[<InlineData("static member StaticState", "StaticState")>]
+let ``A member's own line is answered with the member`` (snippet: string) (expected: string) =
+    match resolveStartupIn TypesSeparatedByTrivia snippet with
+    | ValueNone -> failwith $"expected the line of %s{snippet} to resolve"
+    | ValueSome resolved -> Assert.Equal(expected, resolved.DisplayName)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
@@ -214,3 +214,11 @@ let ``A pipeline stage is labelled by the function it runs in`` () =
     CallStackSample.pipelineLambdas () |> ignore
 
     Assert.StartsWith("pipelineLambdas@", labelOf "Pipe #1 stage")
+
+[<Fact>]
+let ``A delegate call resolves`` () =
+    assertScenarioResolves CallStackSample.delegateCall
+
+[<Fact>]
+let ``An event handler resolves`` () =
+    assertScenarioResolves CallStackSample.eventHandler

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
@@ -29,7 +29,11 @@ let private resolveFrame (struct (frameName: string, line: int)) =
             { frame with
                 SourcePosition =
                     if line > 0 then
-                        ValueSome(struct (document.FilePath, line))
+                        ValueSome
+                            {
+                                File = document.FilePath
+                                Line = line
+                            }
                     else
                         ValueNone
             }
@@ -164,7 +168,7 @@ let ``A property getter resolves as a property`` () =
             | _, ValueSome resolved when resolved.Kind = ResolvedProperty -> Some resolved
             | _ -> None)
 
-    Assert.Equal(ValueSome "Computed", accessor.DisplayName)
+    Assert.Equal("Computed", accessor.DisplayName)
 
 [<Fact>]
 let ``A property setter resolves as a property`` () =
@@ -177,7 +181,7 @@ let ``A property setter resolves as a property`` () =
             | _, ValueSome resolved when resolved.Kind = ResolvedProperty -> Some resolved
             | _ -> None)
 
-    Assert.Equal(ValueSome "Tuned", accessor.DisplayName)
+    Assert.Equal("Tuned", accessor.DisplayName)
 
 /// The label a closure node carries. A named binding reads well on its own; a computation-expression
 /// body or a pipeline stage is named by a phrase the compiler invented, so it takes the enclosing
@@ -197,20 +201,16 @@ let private labelOf (contains: string) =
 [<Fact>]
 let ``A closure lifted from a named binding is labelled with that name`` () =
     CallStackSample.nestedClosures () |> ignore
-    Assert.Equal(ValueSome "inner", labelOf "inner@")
+    Assert.Equal("inner", labelOf "inner@")
 
 [<Fact>]
 let ``An async body is labelled by the function that opened it`` () =
     CallStackSample.asyncBody () |> ignore
 
-    match labelOf "Pipe #1 input at line" with
-    | ValueNone -> failwith "the async body resolved without a label"
-    | ValueSome label -> Assert.StartsWith("asyncBody@", label)
+    Assert.StartsWith("asyncBody@", labelOf "Pipe #1 input at line")
 
 [<Fact>]
 let ``A pipeline stage is labelled by the function it runs in`` () =
     CallStackSample.pipelineLambdas () |> ignore
 
-    match labelOf "Pipe #1 stage" with
-    | ValueNone -> failwith "the pipeline stage resolved without a label"
-    | ValueSome label -> Assert.StartsWith("pipelineLambdas@", label)
+    Assert.StartsWith("pipelineLambdas@", labelOf "Pipe #1 stage")

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
@@ -222,3 +222,26 @@ let ``A delegate call resolves`` () =
 [<Fact>]
 let ``An event handler resolves`` () =
     assertScenarioResolves CallStackSample.eventHandler
+
+/// An event is never on a stack: F# reads `p.Fired` by building an `IEvent` over the `add_`/`remove_`
+/// accessors rather than by calling the getter, and those hold no user code. The handler is what
+/// the scenario puts on the stack, and it is the only frame there from this file.
+[<Fact>]
+let ``An event handler is the only frame of its scenario`` () =
+    CallStackSample.eventHandler () |> ignore
+
+    let own =
+        CallStackSample.frames ()
+        |> Array.map (fun (struct (frameName, _)) -> frameName)
+        |> Array.filter (fun name -> name.Contains "Publisher" || name.Contains "eventHandler")
+
+    Assert.All(own, fun name -> Assert.DoesNotContain("Fired", name))
+    Assert.Contains(own, fun name -> name.Contains "eventHandler@")
+
+/// The outer task is resumed after `let!` by the inner one completing, so its body is on the stack
+/// as a continuation of its own - the only way a task shows on the map beyond its innermost body,
+/// since the function that built it is parked on another thread.
+[<Fact>]
+let ``A task continuation is labelled by the binding it was written in`` () =
+    CallStackSample.taskBody () |> ignore
+    Assert.Equal("outer", labelOf "outer@")

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpCallStackSampleTests.fs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+/// Runs each scenario in `CallStackSample`, takes the frame names the runtime reports for it, and puts
+/// them through the frame parser and the call stack resolver. The corpus is therefore whatever the
+/// compiler actually mangled the sample into - a naming change surfaces here rather than on a map.
+module FSharp.Editor.Tests.CodeMap.FSharpCallStackSampleTests
+
+open System
+open Xunit
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.CancellableTasks
+open FSharp.Editor.Tests.Helpers
+
+let private solution =
+    lazy RoslynTestHelpers.CreateSolution(CallStackSample.sourceText ())
+
+/// Resolves one captured frame the way the provider does: the parsed name, plus the source position
+/// the debugger would have supplied - which is the only anchor for a `task` body's closure, named
+/// after line 1 rather than the line it was written on.
+let private resolveFrame (struct (frameName: string, line: int)) =
+    let solution = solution.Value
+    let project = solution.Projects |> Seq.exactlyOne
+    let document = project.Documents |> Seq.exactlyOne
+
+    match FSharpStackFrameNameParser.parse frameName with
+    | ValueNone -> failwith $"frame name did not parse: %s{frameName}"
+    | ValueSome frame ->
+        let positioned =
+            { frame with
+                SourcePosition =
+                    if line > 0 then
+                        ValueSome(struct (document.FilePath, line))
+                    else
+                        ValueNone
+            }
+
+        positioned,
+        (FSharpCallStackResolver.tryResolve solution.Workspace project.AssemblyName positioned
+         |> CancellableTask.runSynchronouslyWithoutCancellation)
+
+/// A scenario's whole stack has to come back resolved. Module initialization is the one frame that
+/// cannot: its name points at the file rather than a construct, so it needs the source position the
+/// debugger supplies, which `FSharpCallStackResolverTests` covers directly.
+let private assertScenarioResolves (scenario: unit -> int) =
+    scenario () |> ignore
+
+    let frames = CallStackSample.frames ()
+    Assert.NotEmpty frames
+
+    let unresolved =
+        frames
+        |> Array.choose (fun captured ->
+            let struct (frameName, line) = captured
+
+            match resolveFrame captured with
+            | { Member = FrameStartupCode }, _ -> None
+            | _, ValueNone -> Some $"{frameName} (line {line})"
+            | _, ValueSome _ -> None)
+
+    if not (Array.isEmpty unresolved) then
+        failwith $"""frames left unresolved:{Environment.NewLine}%s{String.Join(Environment.NewLine, unresolved)}"""
+
+[<Fact>]
+let ``Module functions resolve`` () =
+    assertScenarioResolves CallStackSample.moduleFunctions
+
+[<Fact>]
+let ``Pipeline lambdas resolve`` () =
+    assertScenarioResolves CallStackSample.pipelineLambdas
+
+[<Fact>]
+let ``Nested closures resolve`` () =
+    assertScenarioResolves CallStackSample.nestedClosures
+
+[<Fact>]
+let ``Local functions resolve`` () =
+    assertScenarioResolves (fun () -> CallStackSample.localFunctions 1)
+
+[<Fact>]
+let ``A generic function resolves`` () =
+    assertScenarioResolves CallStackSample.genericFunctionScenario
+
+[<Fact>]
+let ``A custom operator resolves`` () =
+    assertScenarioResolves CallStackSample.customOperator
+
+[<Fact>]
+let ``A CompiledName rename resolves`` () =
+    assertScenarioResolves CallStackSample.originalSourceName
+
+[<Fact>]
+let ``An active pattern resolves`` () =
+    assertScenarioResolves CallStackSample.activePattern
+
+[<Fact>]
+let ``A partial active pattern resolves`` () =
+    assertScenarioResolves CallStackSample.partialActivePattern
+
+[<Fact>]
+let ``Recursion resolves`` () =
+    assertScenarioResolves CallStackSample.recursion
+
+[<Fact>]
+let ``Mutual recursion resolves`` () =
+    assertScenarioResolves CallStackSample.mutualRecursion
+
+[<Fact>]
+let ``A higher order function resolves`` () =
+    assertScenarioResolves CallStackSample.higherOrder
+
+[<Fact>]
+let ``An async body resolves`` () =
+    assertScenarioResolves CallStackSample.asyncBody
+
+[<Fact>]
+let ``A task body resolves`` () =
+    assertScenarioResolves CallStackSample.taskBody
+
+[<Fact>]
+let ``A seq body resolves`` () =
+    assertScenarioResolves CallStackSample.seqBody
+
+[<Fact>]
+let ``Nested modules resolve`` () =
+    assertScenarioResolves CallStackSample.nestedModules
+
+[<Fact>]
+let ``Class members resolve`` () =
+    assertScenarioResolves CallStackSample.instanceMember
+
+[<Fact>]
+let ``A static member resolves`` () =
+    assertScenarioResolves CallStackSample.staticMember
+
+[<Fact>]
+let ``An interface implementation resolves`` () =
+    assertScenarioResolves CallStackSample.interfaceImplementation
+
+[<Fact>]
+let ``A generic type member resolves`` () =
+    assertScenarioResolves CallStackSample.genericTypeMember
+
+[<Fact>]
+let ``A constructor resolves`` () =
+    assertScenarioResolves CallStackSample.constructors
+
+[<Fact>]
+let ``A union member resolves`` () =
+    assertScenarioResolves CallStackSample.unionMember
+
+[<Fact>]
+let ``A record member resolves`` () =
+    assertScenarioResolves CallStackSample.recordMember
+
+/// The accessors are the pair that reached the map as bare `get` and `set` nodes.
+[<Fact>]
+let ``A property getter resolves as a property`` () =
+    assertScenarioResolves CallStackSample.propertyGetter
+
+    let accessor =
+        CallStackSample.frames ()
+        |> Array.pick (fun captured ->
+            match resolveFrame captured with
+            | _, ValueSome resolved when resolved.Kind = ResolvedProperty -> Some resolved
+            | _ -> None)
+
+    Assert.Equal(ValueSome "Computed", accessor.DisplayName)
+
+[<Fact>]
+let ``A property setter resolves as a property`` () =
+    assertScenarioResolves CallStackSample.propertySetter
+
+    let accessor =
+        CallStackSample.frames ()
+        |> Array.pick (fun captured ->
+            match resolveFrame captured with
+            | _, ValueSome resolved when resolved.Kind = ResolvedProperty -> Some resolved
+            | _ -> None)
+
+    Assert.Equal(ValueSome "Tuned", accessor.DisplayName)
+
+/// The label a closure node carries. A named binding reads well on its own; a computation-expression
+/// body or a pipeline stage is named by a phrase the compiler invented, so it takes the enclosing
+/// declaration's name and the line - the `async` block's own function is not on the stack at all.
+let private labelOf (contains: string) =
+    CallStackSample.frames ()
+    |> Array.pick (fun captured ->
+        let struct (frameName, _) = captured
+
+        if frameName.Contains contains then
+            match resolveFrame captured with
+            | _, ValueSome resolved -> Some resolved.DisplayName
+            | _, ValueNone -> None
+        else
+            None)
+
+[<Fact>]
+let ``A closure lifted from a named binding is labelled with that name`` () =
+    CallStackSample.nestedClosures () |> ignore
+    Assert.Equal(ValueSome "inner", labelOf "inner@")
+
+[<Fact>]
+let ``An async body is labelled by the function that opened it`` () =
+    CallStackSample.asyncBody () |> ignore
+
+    match labelOf "Pipe #1 input at line" with
+    | ValueNone -> failwith "the async body resolved without a label"
+    | ValueSome label -> Assert.StartsWith("asyncBody@", label)
+
+[<Fact>]
+let ``A pipeline stage is labelled by the function it runs in`` () =
+    CallStackSample.pipelineLambdas () |> ignore
+
+    match labelOf "Pipe #1 stage" with
+    | ValueNone -> failwith "the pipeline stage resolved without a label"
+    | ValueSome label -> Assert.StartsWith("pipelineLambdas@", label)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpStackFrameNameParserTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpStackFrameNameParserTests.fs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Editor.Tests.CodeMap
+
+open System
+open Xunit
+open Microsoft.VisualStudio.FSharp.Editor
+
+/// The frame names below were captured from managed stack traces of a sample exercising every
+/// construct the F# compiler mangles differently, so they are the shapes a debug engine reports.
+module FSharpStackFrameNameParserTests =
+
+    let private renderMember frameMember =
+        match frameMember with
+        | FrameMethod name -> $"method %s{name}"
+        | FrameConstructor -> "ctor"
+        | FrameStaticConstructor -> "cctor"
+        | FramePropertyGetter name -> $"get %s{name}"
+        | FramePropertySetter name -> $"set %s{name}"
+        | FrameActivePattern cases -> $"""activepattern %s{String.Join("|", cases)}"""
+        | FrameClosureBody origin ->
+            let ordinal =
+                match origin.Ordinal with
+                | ValueSome n -> $"-%d{n}"
+                | ValueNone -> ""
+
+            $"closure %s{origin.EnclosingName}@%d{origin.Line}%s{ordinal}"
+        | FrameStartupCode -> "startupcode"
+
+    let private render (frame: ParsedFrame) =
+        let path =
+            frame.Path
+            |> List.map (fun segment ->
+                if segment.GenericArity = 0 then
+                    segment.Name
+                else
+                    $"%s{segment.Name}`%d{segment.GenericArity}")
+            |> String.concat "."
+
+        let arity =
+            if frame.MethodGenericArity = 0 then
+                ""
+            else
+                $" <%d{frame.MethodGenericArity}>"
+
+        $"%s{path} :: %s{renderMember frame.Member}%s{arity}"
+
+    let frames: obj[] list =
+        [
+            // module-level functions: curried and tupled arguments are both flattened by the compiler
+            [|
+                "GateCSample.Library.tupledFunction"
+                "GateCSample.Library :: method tupledFunction"
+            |]
+            [|
+                "GateCSample.Library.curriedFunction"
+                "GateCSample.Library :: method curriedFunction"
+            |]
+            [|
+                "GateCSample.Library.recursiveFunction"
+                "GateCSample.Library :: method recursiveFunction"
+            |]
+            [| "GateCSample.Program.main"; "GateCSample.Program :: method main" |]
+
+            // generic methods carry their arguments in brackets
+            [|
+                "GateCSample.Library.genericFunction[T]"
+                "GateCSample.Library :: method genericFunction <1>"
+            |]
+            [|
+                "GateCSample.Library.inlineFunction[a]"
+                "GateCSample.Library :: method inlineFunction <1>"
+            |]
+            [|
+                "GateCSample.Library.SampleClass.GenericMember[T]"
+                "GateCSample.Library.SampleClass :: method GenericMember <1>"
+            |]
+
+            // generic types carry arity on the type segment
+            [|
+                "GateCSample.Library.GenericClass`1.Get"
+                "GateCSample.Library.GenericClass`1 :: method Get"
+            |]
+
+            // operators and [<CompiledName>] reach metadata renamed
+            [|
+                "GateCSample.Library.op_PlusBangPlus"
+                "GateCSample.Library :: method op_PlusBangPlus"
+            |]
+            [|
+                "GateCSample.Library.RenamedInMetadata"
+                "GateCSample.Library :: method RenamedInMetadata"
+            |]
+
+            // active patterns keep their pipes in metadata
+            [|
+                "GateCSample.Library.|Even|Odd|"
+                "GateCSample.Library :: activepattern Even|Odd"
+            |]
+            [|
+                "GateCSample.Library.|Positive|_|"
+                "GateCSample.Library :: activepattern Positive|_"
+            |]
+
+            // closures, lambdas, local functions and computation-expression bodies all lift to `name@line`
+            [|
+                "GateCSample.Library.pipelineLambda@42.Invoke"
+                "GateCSample.Library :: closure pipelineLambda@42"
+            |]
+            [|
+                "GateCSample.Library.inner@48.Invoke"
+                "GateCSample.Library :: closure inner@48"
+            |]
+            [|
+                "GateCSample.Library.outer@47-1.Invoke"
+                "GateCSample.Library :: closure outer@47-1"
+            |]
+            [|
+                "GateCSample.Library.localHelper@55.Invoke"
+                "GateCSample.Library :: closure localHelper@55"
+            |]
+            [|
+                "GateCSample.Library.asyncFunction@61-1.Invoke"
+                "GateCSample.Library :: closure asyncFunction@61-1"
+            |]
+            [|
+                "GateCSample.Library.taskFunction@67-3.Invoke"
+                "GateCSample.Library :: closure taskFunction@67-3"
+            |]
+            [|
+                "GateCSample.Library.taskFunction@1-2.Invoke"
+                "GateCSample.Library :: closure taskFunction@1-2"
+            |]
+            [|
+                "GateCSample.Library.seqFunction@72.GenerateNext"
+                "GateCSample.Library :: closure seqFunction@72"
+            |]
+
+            // `@` without a line number is not a closure - the compiler also uses it for debug proxies
+            [|
+                "GateCSample.Library.Shape.Circle@DebugTypeProxy.Item"
+                "GateCSample.Library.Shape.Circle@DebugTypeProxy :: method Item"
+            |]
+
+            // constructors
+            [|
+                "GateCSample.Library.SampleClass..ctor"
+                "GateCSample.Library.SampleClass :: ctor"
+            |]
+            [|
+                "GateCSample.Library.SampleClass..cctor"
+                "GateCSample.Library.SampleClass :: cctor"
+            |]
+
+            // properties
+            [|
+                "GateCSample.Library.SampleClass.get_Property"
+                "GateCSample.Library.SampleClass :: get Property"
+            |]
+            [|
+                "GateCSample.Library.SampleClass.set_Property"
+                "GateCSample.Library.SampleClass :: set Property"
+            |]
+
+            // members on classes, unions and records
+            [|
+                "GateCSample.Library.SampleClass.InstanceMethod"
+                "GateCSample.Library.SampleClass :: method InstanceMethod"
+            |]
+            [|
+                "GateCSample.Library.SampleClass.StaticMethod"
+                "GateCSample.Library.SampleClass :: method StaticMethod"
+            |]
+            [|
+                "GateCSample.Library.Shape.Area"
+                "GateCSample.Library.Shape :: method Area"
+            |]
+            [|
+                "GateCSample.Library.Point.Norm"
+                "GateCSample.Library.Point :: method Norm"
+            |]
+
+            // an explicit interface implementation embeds the whole interface name in the method name
+            [|
+                "GateCSample.Library.Greeter.GateCSample.Library.IGreeter.Greet"
+                "GateCSample.Library.Greeter.GateCSample.Library.IGreeter :: method Greet"
+            |]
+
+            // nested modules, and the `Module` suffix added when a module collides with a type
+            [|
+                "GateCSample.Library.Nested.nestedFunction"
+                "GateCSample.Library.Nested :: method nestedFunction"
+            |]
+            [|
+                "GateCSample.Library.Nested.Deeper.deeperFunction"
+                "GateCSample.Library.Nested.Deeper :: method deeperFunction"
+            |]
+            [|
+                "GateCSample.Library.CollisionModule.helper"
+                "GateCSample.Library.CollisionModule :: method helper"
+            |]
+
+            // module-level initialization
+            [|
+                "<StartupCode$GateCSample>.$GateCSample.Library.main@"
+                "GateCSample.Library :: startupcode"
+            |]
+
+            // nested types may be reported with the metadata separator instead of a dot
+            [|
+                "GateCSample.Library+SampleClass.InstanceMethod"
+                "GateCSample.Library.SampleClass :: method InstanceMethod"
+            |]
+
+            // a parameter list is decoration, not identity
+            [|
+                "GateCSample.Library.tupledFunction(Int32 a, String b)"
+                "GateCSample.Library :: method tupledFunction"
+            |]
+            [|
+                "GateCSample.Library.SampleClass..ctor(Int32 seed)"
+                "GateCSample.Library.SampleClass :: ctor"
+            |]
+        ]
+
+    [<Theory>]
+    [<MemberData(nameof frames)>]
+    let ``Frame name is parsed into path and member`` (frameName: string) (expected: string) =
+        match FSharpStackFrameNameParser.parse frameName with
+        | ValueNone -> failwith $"expected %s{frameName} to parse"
+        | ValueSome frame -> Assert.Equal(expected, render frame)
+
+    [<Theory>]
+    [<InlineData("")>]
+    [<InlineData("   ")>]
+    [<InlineData(null)>]
+    let ``Blank frame names do not parse`` (frameName: string) =
+        Assert.True((FSharpStackFrameNameParser.parse frameName).IsNone)

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpStackFrameNameParserTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpStackFrameNameParserTests.fs
@@ -165,6 +165,26 @@ let frames: obj[] list =
             "GateCSample.Library.outer@10 :: closure inner@20"
         |]
 
+        // the debug engine formats differently from metadata: instantiations in angle brackets,
+        // a constructor as `Type.Type`, an accessor as a trailing `.get`/`.set` segment, and a
+        // trailing `T` on generic closure classes
+        [|
+            "ClassLibrary.Demo.genericFunction<int>"
+            "ClassLibrary.Demo :: method genericFunction <1>"
+        |]
+        [|
+            "ClassLibrary.Box<System.String>.Unwrap"
+            "ClassLibrary.Box`1 :: method Unwrap"
+        |]
+        [| "ClassLibrary.Initialized.Initialized"; "ClassLibrary.Initialized :: ctor" |]
+        [| "ClassLibrary.Worker.Computed.get"; "ClassLibrary.Worker :: get Computed" |]
+        [| "ClassLibrary.Worker.Tuned.set"; "ClassLibrary.Worker :: set Tuned" |]
+        [|
+            "ClassLibrary.Demo.helperTwo@42T<int>.Invoke"
+            "ClassLibrary.Demo :: closure helperTwo@42"
+        |]
+        [| "M.f@10T.Invoke"; "M :: closure f@10" |]
+
         // constructors
         [|
             "GateCSample.Library.SampleClass..ctor"
@@ -243,6 +263,48 @@ let frames: obj[] list =
         [|
             "GateCSample.Library.SampleClass..ctor(Int32 seed)"
             "GateCSample.Library.SampleClass :: ctor"
+        |]
+
+        // Captured verbatim from a Code Map's DGML - these are the frames the debug engine really
+        // produced for the demo, and each one is a shape that once reached the map unresolved.
+        [| "<StartupCode$ClassLibrary>.$Demo.$Demo"; "Demo.Demo :: startupcode" |]
+        [|
+            "ClassLibrary.Demo.work@107-3.Invoke"
+            "ClassLibrary.Demo :: closure work@107-3"
+        |]
+
+        // a computation-expression body or pipeline stage is named by a phrase, spaces and all
+        [|
+            "ClassLibrary.Demo.Pipe #1 input at line 97@99-1.Invoke"
+            "ClassLibrary.Demo :: closure Pipe #1 input at line 97@99-1"
+        |]
+        [|
+            "ClassLibrary.Demo.Pipe #1 stage #3 at line 26@26.Invoke"
+            "ClassLibrary.Demo :: closure Pipe #1 stage #3 at line 26@26"
+        |]
+
+        // FSharp.Core's async/task/seq plumbing. Nothing resolves these - they are marked external so
+        // the map folds them away - but they must still parse, because a frame that does not parse is
+        // never seen by the provider and so reaches the map as a bare `Invoke` or `MoveNext`.
+        [|
+            "<StartupCode$FSharp-Core>.$Async.Sleep@1814-3.Invoke"
+            "Async.Sleep@1814-3.Invoke :: startupcode"
+        |]
+        [|
+            "<StartupCode$FSharp-Core>.$Tasks.resumptionInfo@159<int>.MoveNext"
+            "Tasks.resumptionInfo@159`1.MoveNext :: startupcode"
+        |]
+        [|
+            "Microsoft.FSharp.Core.CompilerServices.ResumableStateMachine<Microsoft.FSharp.Control.TaskStateMachineData<int>>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext"
+            "Microsoft.FSharp.Core.CompilerServices.ResumableStateMachine`1.System.Runtime.CompilerServices.IAsyncStateMachine :: method MoveNext"
+        |]
+        [|
+            "Microsoft.FSharp.Collections.ListModule.Map<int, int>"
+            "Microsoft.FSharp.Collections.ListModule :: method Map <2>"
+        |]
+        [|
+            "Microsoft.FSharp.Primitives.Basics.List.map<int, int>"
+            "Microsoft.FSharp.Primitives.Basics.List :: method map <2>"
         |]
     ]
 

--- a/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpStackFrameNameParserTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/CodeMap/FSharpStackFrameNameParserTests.fs
@@ -1,238 +1,261 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
 
-namespace FSharp.Editor.Tests.CodeMap
+/// The frame names below were captured from managed stack traces of a sample exercising every
+/// construct the F# compiler mangles differently, so they are the shapes a debug engine reports.
+module FSharp.Editor.Tests.CodeMap.FSharpStackFrameNameParserTests
 
 open System
 open Xunit
 open Microsoft.VisualStudio.FSharp.Editor
 
-/// The frame names below were captured from managed stack traces of a sample exercising every
-/// construct the F# compiler mangles differently, so they are the shapes a debug engine reports.
-module FSharpStackFrameNameParserTests =
+let private renderMember frameMember =
+    match frameMember with
+    | FrameMethod name -> $"method %s{name}"
+    | FrameConstructor -> "ctor"
+    | FrameStaticConstructor -> "cctor"
+    | FramePropertyGetter name -> $"get %s{name}"
+    | FramePropertySetter name -> $"set %s{name}"
+    | FrameActivePattern cases -> $"""activepattern %s{String.Join("|", cases)}"""
+    | FrameClosureBody origin ->
+        let ordinal =
+            match origin.Ordinal with
+            | ValueSome n -> $"-%d{n}"
+            | ValueNone -> ""
 
-    let private renderMember frameMember =
-        match frameMember with
-        | FrameMethod name -> $"method %s{name}"
-        | FrameConstructor -> "ctor"
-        | FrameStaticConstructor -> "cctor"
-        | FramePropertyGetter name -> $"get %s{name}"
-        | FramePropertySetter name -> $"set %s{name}"
-        | FrameActivePattern cases -> $"""activepattern %s{String.Join("|", cases)}"""
-        | FrameClosureBody origin ->
-            let ordinal =
-                match origin.Ordinal with
-                | ValueSome n -> $"-%d{n}"
-                | ValueNone -> ""
+        $"closure %s{origin.EnclosingName}@%d{origin.Line}%s{ordinal}"
+    | FrameStartupCode -> "startupcode"
 
-            $"closure %s{origin.EnclosingName}@%d{origin.Line}%s{ordinal}"
-        | FrameStartupCode -> "startupcode"
-
-    let private render (frame: ParsedFrame) =
-        let path =
-            frame.Path
-            |> List.map (fun segment ->
-                if segment.GenericArity = 0 then
-                    segment.Name
-                else
-                    $"%s{segment.Name}`%d{segment.GenericArity}")
-            |> String.concat "."
-
-        let arity =
-            if frame.MethodGenericArity = 0 then
-                ""
+let private render (frame: ParsedFrame) =
+    let path =
+        frame.Path
+        |> Seq.map (fun segment ->
+            if segment.GenericArity = 0 then
+                segment.Name
             else
-                $" <%d{frame.MethodGenericArity}>"
+                $"%s{segment.Name}`%d{segment.GenericArity}")
+        |> String.concat "."
 
-        $"%s{path} :: %s{renderMember frame.Member}%s{arity}"
+    let arity =
+        if frame.MethodGenericArity = 0 then
+            ""
+        else
+            $" <%d{frame.MethodGenericArity}>"
 
-    let frames: obj[] list =
-        [
-            // module-level functions: curried and tupled arguments are both flattened by the compiler
-            [|
-                "GateCSample.Library.tupledFunction"
-                "GateCSample.Library :: method tupledFunction"
-            |]
-            [|
-                "GateCSample.Library.curriedFunction"
-                "GateCSample.Library :: method curriedFunction"
-            |]
-            [|
-                "GateCSample.Library.recursiveFunction"
-                "GateCSample.Library :: method recursiveFunction"
-            |]
-            [| "GateCSample.Program.main"; "GateCSample.Program :: method main" |]
+    $"%s{path} :: %s{renderMember frame.Member}%s{arity}"
 
-            // generic methods carry their arguments in brackets
-            [|
-                "GateCSample.Library.genericFunction[T]"
-                "GateCSample.Library :: method genericFunction <1>"
-            |]
-            [|
-                "GateCSample.Library.inlineFunction[a]"
-                "GateCSample.Library :: method inlineFunction <1>"
-            |]
-            [|
-                "GateCSample.Library.SampleClass.GenericMember[T]"
-                "GateCSample.Library.SampleClass :: method GenericMember <1>"
-            |]
+let frames: obj[] list =
+    [
+        // module-level functions: curried and tupled arguments are both flattened by the compiler
+        [|
+            "GateCSample.Library.tupledFunction"
+            "GateCSample.Library :: method tupledFunction"
+        |]
+        [|
+            "GateCSample.Library.curriedFunction"
+            "GateCSample.Library :: method curriedFunction"
+        |]
+        [|
+            "GateCSample.Library.recursiveFunction"
+            "GateCSample.Library :: method recursiveFunction"
+        |]
+        [| "GateCSample.Program.main"; "GateCSample.Program :: method main" |]
 
-            // generic types carry arity on the type segment
-            [|
-                "GateCSample.Library.GenericClass`1.Get"
-                "GateCSample.Library.GenericClass`1 :: method Get"
-            |]
+        // generic methods carry their arguments in brackets
+        [|
+            "GateCSample.Library.genericFunction[T]"
+            "GateCSample.Library :: method genericFunction <1>"
+        |]
+        [|
+            "GateCSample.Library.inlineFunction[a]"
+            "GateCSample.Library :: method inlineFunction <1>"
+        |]
+        [|
+            "GateCSample.Library.SampleClass.GenericMember[T]"
+            "GateCSample.Library.SampleClass :: method GenericMember <1>"
+        |]
 
-            // operators and [<CompiledName>] reach metadata renamed
-            [|
-                "GateCSample.Library.op_PlusBangPlus"
-                "GateCSample.Library :: method op_PlusBangPlus"
-            |]
-            [|
-                "GateCSample.Library.RenamedInMetadata"
-                "GateCSample.Library :: method RenamedInMetadata"
-            |]
+        // generic types carry arity on the type segment
+        [|
+            "GateCSample.Library.GenericClass`1.Get"
+            "GateCSample.Library.GenericClass`1 :: method Get"
+        |]
 
-            // active patterns keep their pipes in metadata
-            [|
-                "GateCSample.Library.|Even|Odd|"
-                "GateCSample.Library :: activepattern Even|Odd"
-            |]
-            [|
-                "GateCSample.Library.|Positive|_|"
-                "GateCSample.Library :: activepattern Positive|_"
-            |]
+        // operators and [<CompiledName>] reach metadata renamed
+        [|
+            "GateCSample.Library.op_PlusBangPlus"
+            "GateCSample.Library :: method op_PlusBangPlus"
+        |]
+        [|
+            "GateCSample.Library.RenamedInMetadata"
+            "GateCSample.Library :: method RenamedInMetadata"
+        |]
 
-            // closures, lambdas, local functions and computation-expression bodies all lift to `name@line`
-            [|
-                "GateCSample.Library.pipelineLambda@42.Invoke"
-                "GateCSample.Library :: closure pipelineLambda@42"
-            |]
-            [|
-                "GateCSample.Library.inner@48.Invoke"
-                "GateCSample.Library :: closure inner@48"
-            |]
-            [|
-                "GateCSample.Library.outer@47-1.Invoke"
-                "GateCSample.Library :: closure outer@47-1"
-            |]
-            [|
-                "GateCSample.Library.localHelper@55.Invoke"
-                "GateCSample.Library :: closure localHelper@55"
-            |]
-            [|
-                "GateCSample.Library.asyncFunction@61-1.Invoke"
-                "GateCSample.Library :: closure asyncFunction@61-1"
-            |]
-            [|
-                "GateCSample.Library.taskFunction@67-3.Invoke"
-                "GateCSample.Library :: closure taskFunction@67-3"
-            |]
-            [|
-                "GateCSample.Library.taskFunction@1-2.Invoke"
-                "GateCSample.Library :: closure taskFunction@1-2"
-            |]
-            [|
-                "GateCSample.Library.seqFunction@72.GenerateNext"
-                "GateCSample.Library :: closure seqFunction@72"
-            |]
+        // active patterns keep their pipes in metadata
+        [|
+            "GateCSample.Library.|Even|Odd|"
+            "GateCSample.Library :: activepattern Even|Odd"
+        |]
+        [|
+            "GateCSample.Library.|Positive|_|"
+            "GateCSample.Library :: activepattern Positive|_"
+        |]
 
-            // `@` without a line number is not a closure - the compiler also uses it for debug proxies
-            [|
-                "GateCSample.Library.Shape.Circle@DebugTypeProxy.Item"
-                "GateCSample.Library.Shape.Circle@DebugTypeProxy :: method Item"
-            |]
+        // closures, lambdas, local functions and computation-expression bodies all lift to `name@line`
+        [|
+            "GateCSample.Library.pipelineLambda@42.Invoke"
+            "GateCSample.Library :: closure pipelineLambda@42"
+        |]
+        [|
+            "GateCSample.Library.inner@48.Invoke"
+            "GateCSample.Library :: closure inner@48"
+        |]
+        [|
+            "GateCSample.Library.outer@47-1.Invoke"
+            "GateCSample.Library :: closure outer@47-1"
+        |]
+        [|
+            "GateCSample.Library.localHelper@55.Invoke"
+            "GateCSample.Library :: closure localHelper@55"
+        |]
+        [|
+            "GateCSample.Library.asyncFunction@61-1.Invoke"
+            "GateCSample.Library :: closure asyncFunction@61-1"
+        |]
+        [|
+            "GateCSample.Library.taskFunction@67-3.Invoke"
+            "GateCSample.Library :: closure taskFunction@67-3"
+        |]
+        [|
+            "GateCSample.Library.taskFunction@1-2.Invoke"
+            "GateCSample.Library :: closure taskFunction@1-2"
+        |]
+        [|
+            "GateCSample.Library.seqFunction@72.GenerateNext"
+            "GateCSample.Library :: closure seqFunction@72"
+        |]
 
-            // constructors
-            [|
-                "GateCSample.Library.SampleClass..ctor"
-                "GateCSample.Library.SampleClass :: ctor"
-            |]
-            [|
-                "GateCSample.Library.SampleClass..cctor"
-                "GateCSample.Library.SampleClass :: cctor"
-            |]
+        // `@` without a line number is not a closure - the compiler also uses it for debug proxies
+        [|
+            "GateCSample.Library.Shape.Circle@DebugTypeProxy.Item"
+            "GateCSample.Library.Shape.Circle@DebugTypeProxy :: method Item"
+        |]
 
-            // properties
-            [|
-                "GateCSample.Library.SampleClass.get_Property"
-                "GateCSample.Library.SampleClass :: get Property"
-            |]
-            [|
-                "GateCSample.Library.SampleClass.set_Property"
-                "GateCSample.Library.SampleClass :: set Property"
-            |]
+        // malformed `@` suffixes must not be mistaken for closures
+        [|
+            "GateCSample.Library.trailingAt@"
+            "GateCSample.Library :: method trailingAt@"
+        |]
+        [|
+            "GateCSample.Library.trailingDash@12-"
+            "GateCSample.Library :: method trailingDash@12-"
+        |]
+        [|
+            "GateCSample.Library.notDigits@1a2"
+            "GateCSample.Library :: method notDigits@1a2"
+        |]
+        [|
+            "GateCSample.Library.twoDashes@12-3-4"
+            "GateCSample.Library :: method twoDashes@12-3-4"
+        |]
+        [| "GateCSample.Library.@12"; "GateCSample.Library :: method @12" |]
 
-            // members on classes, unions and records
-            [|
-                "GateCSample.Library.SampleClass.InstanceMethod"
-                "GateCSample.Library.SampleClass :: method InstanceMethod"
-            |]
-            [|
-                "GateCSample.Library.SampleClass.StaticMethod"
-                "GateCSample.Library.SampleClass :: method StaticMethod"
-            |]
-            [|
-                "GateCSample.Library.Shape.Area"
-                "GateCSample.Library.Shape :: method Area"
-            |]
-            [|
-                "GateCSample.Library.Point.Norm"
-                "GateCSample.Library.Point :: method Norm"
-            |]
+        // the last `@` wins, so a closure lifted out of an already-mangled name still parses
+        [|
+            "GateCSample.Library.outer@10.inner@20.Invoke"
+            "GateCSample.Library.outer@10 :: closure inner@20"
+        |]
 
-            // an explicit interface implementation embeds the whole interface name in the method name
-            [|
-                "GateCSample.Library.Greeter.GateCSample.Library.IGreeter.Greet"
-                "GateCSample.Library.Greeter.GateCSample.Library.IGreeter :: method Greet"
-            |]
+        // constructors
+        [|
+            "GateCSample.Library.SampleClass..ctor"
+            "GateCSample.Library.SampleClass :: ctor"
+        |]
+        [|
+            "GateCSample.Library.SampleClass..cctor"
+            "GateCSample.Library.SampleClass :: cctor"
+        |]
 
-            // nested modules, and the `Module` suffix added when a module collides with a type
-            [|
-                "GateCSample.Library.Nested.nestedFunction"
-                "GateCSample.Library.Nested :: method nestedFunction"
-            |]
-            [|
-                "GateCSample.Library.Nested.Deeper.deeperFunction"
-                "GateCSample.Library.Nested.Deeper :: method deeperFunction"
-            |]
-            [|
-                "GateCSample.Library.CollisionModule.helper"
-                "GateCSample.Library.CollisionModule :: method helper"
-            |]
+        // properties
+        [|
+            "GateCSample.Library.SampleClass.get_Property"
+            "GateCSample.Library.SampleClass :: get Property"
+        |]
+        [|
+            "GateCSample.Library.SampleClass.set_Property"
+            "GateCSample.Library.SampleClass :: set Property"
+        |]
 
-            // module-level initialization
-            [|
-                "<StartupCode$GateCSample>.$GateCSample.Library.main@"
-                "GateCSample.Library :: startupcode"
-            |]
+        // members on classes, unions and records
+        [|
+            "GateCSample.Library.SampleClass.InstanceMethod"
+            "GateCSample.Library.SampleClass :: method InstanceMethod"
+        |]
+        [|
+            "GateCSample.Library.SampleClass.StaticMethod"
+            "GateCSample.Library.SampleClass :: method StaticMethod"
+        |]
+        [|
+            "GateCSample.Library.Shape.Area"
+            "GateCSample.Library.Shape :: method Area"
+        |]
+        [|
+            "GateCSample.Library.Point.Norm"
+            "GateCSample.Library.Point :: method Norm"
+        |]
 
-            // nested types may be reported with the metadata separator instead of a dot
-            [|
-                "GateCSample.Library+SampleClass.InstanceMethod"
-                "GateCSample.Library.SampleClass :: method InstanceMethod"
-            |]
+        // an explicit interface implementation embeds the whole interface name in the method name
+        [|
+            "GateCSample.Library.Greeter.GateCSample.Library.IGreeter.Greet"
+            "GateCSample.Library.Greeter.GateCSample.Library.IGreeter :: method Greet"
+        |]
 
-            // a parameter list is decoration, not identity
-            [|
-                "GateCSample.Library.tupledFunction(Int32 a, String b)"
-                "GateCSample.Library :: method tupledFunction"
-            |]
-            [|
-                "GateCSample.Library.SampleClass..ctor(Int32 seed)"
-                "GateCSample.Library.SampleClass :: ctor"
-            |]
-        ]
+        // nested modules, and the `Module` suffix added when a module collides with a type
+        [|
+            "GateCSample.Library.Nested.nestedFunction"
+            "GateCSample.Library.Nested :: method nestedFunction"
+        |]
+        [|
+            "GateCSample.Library.Nested.Deeper.deeperFunction"
+            "GateCSample.Library.Nested.Deeper :: method deeperFunction"
+        |]
+        [|
+            "GateCSample.Library.CollisionModule.helper"
+            "GateCSample.Library.CollisionModule :: method helper"
+        |]
 
-    [<Theory>]
-    [<MemberData(nameof frames)>]
-    let ``Frame name is parsed into path and member`` (frameName: string) (expected: string) =
-        match FSharpStackFrameNameParser.parse frameName with
-        | ValueNone -> failwith $"expected %s{frameName} to parse"
-        | ValueSome frame -> Assert.Equal(expected, render frame)
+        // module-level initialization
+        [|
+            "<StartupCode$GateCSample>.$GateCSample.Library.main@"
+            "GateCSample.Library :: startupcode"
+        |]
 
-    [<Theory>]
-    [<InlineData("")>]
-    [<InlineData("   ")>]
-    [<InlineData(null)>]
-    let ``Blank frame names do not parse`` (frameName: string) =
-        Assert.True((FSharpStackFrameNameParser.parse frameName).IsNone)
+        // nested types may be reported with the metadata separator instead of a dot
+        [|
+            "GateCSample.Library+SampleClass.InstanceMethod"
+            "GateCSample.Library.SampleClass :: method InstanceMethod"
+        |]
+
+        // a parameter list is decoration, not identity
+        [|
+            "GateCSample.Library.tupledFunction(Int32 a, String b)"
+            "GateCSample.Library :: method tupledFunction"
+        |]
+        [|
+            "GateCSample.Library.SampleClass..ctor(Int32 seed)"
+            "GateCSample.Library.SampleClass :: ctor"
+        |]
+    ]
+
+[<Theory>]
+[<MemberData(nameof frames)>]
+let ``Frame name is parsed into path and member`` (frameName: string) (expected: string) =
+    match FSharpStackFrameNameParser.parse frameName with
+    | ValueNone -> failwith $"expected %s{frameName} to parse"
+    | ValueSome frame -> Assert.Equal(expected, render frame)
+
+[<Theory>]
+[<InlineData("")>]
+[<InlineData("   ")>]
+[<InlineData(null)>]
+let ``Blank frame names do not parse`` (frameName: string) =
+    Assert.True((FSharpStackFrameNameParser.parse frameName).IsNone)

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -32,8 +32,13 @@
     <Compile Include="QuickInfoTests.fs" />
     <Compile Include="TaskListServiceTests.fs" />
     <Compile Include="NavigateToSearchServiceTests.fs" />
+    <Compile Include="CodeMap\CallStackSample.fs" />
+    <!-- Compiled so the tests can run its scenarios, embedded so they can hand the very same text to
+         the workspace the resolver reads. -->
+    <EmbeddedResource Include="CodeMap\CallStackSample.fs" />
     <Compile Include="CodeMap\FSharpStackFrameNameParserTests.fs" />
     <Compile Include="CodeMap\FSharpCallStackResolverTests.fs" />
+    <Compile Include="CodeMap\FSharpCallStackSampleTests.fs" />
     <Compile Include="CodeFixes\CodeFixTestFramework.fs" />
     <Compile Include="CodeFixes\AddInstanceMemberParameterTests.fs" />
     <Compile Include="CodeFixes\ConvertToAnonymousRecordTests.fs" />

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -37,6 +37,7 @@
          the workspace the resolver reads. -->
     <EmbeddedResource Include="CodeMap\CallStackSample.fs" />
     <Compile Include="CodeMap\FSharpStackFrameNameParserTests.fs" />
+    <Compile Include="CodeMap\FSharpCallStackPlanTests.fs" />
     <Compile Include="CodeMap\FSharpCallStackResolverTests.fs" />
     <Compile Include="CodeMap\FSharpCallStackSampleTests.fs" />
     <Compile Include="CodeFixes\CodeFixTestFramework.fs" />

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -32,6 +32,8 @@
     <Compile Include="QuickInfoTests.fs" />
     <Compile Include="TaskListServiceTests.fs" />
     <Compile Include="NavigateToSearchServiceTests.fs" />
+    <Compile Include="CodeMap\FSharpStackFrameNameParserTests.fs" />
+    <Compile Include="CodeMap\FSharpCallStackResolverTests.fs" />
     <Compile Include="CodeFixes\CodeFixTestFramework.fs" />
     <Compile Include="CodeFixes\AddInstanceMemberParameterTests.fs" />
     <Compile Include="CodeFixes\ConvertToAnonymousRecordTests.fs" />


### PR DESCRIPTION
Addresses the debugging half of #11787: F# support for **Debug ▸ Show Call Stack on Code Map**.

VS Progression dispatches `Actions.ResolveCallStack` to language providers, and none is registered for F#, so every F# frame reaches the map as a grey unresolved node carrying a mangled name and no source location, while the C# and VB frames on the same stack resolve around it. This adds that provider: a frame name is taken apart, mapped back to its declaration through the Roslyn workspace and FCS, and given the node identity Roslyn itself builds, so a resolved frame fuses with the node the metadata provider creates for the same method instead of sitting beside it as a duplicate.

`Microsoft.VisualStudio.Progression.Interfaces` has no NuGet package in any version — Roslyn consumed it from an internal DevDiv feed and removed its Progression code in June 2025 — so the provider references the assemblies installed with Visual Studio and is compiled only where they are present. Everything carrying language knowledge builds everywhere. **Whether CI produces a VSIX with the provider in it depends on the build machines having the Architecture Tools component installed, and I would like guidance on that.** The alternatives are checked-in reference assemblies or a reflection bridge, both avoidable if the package can be published.

Not for merge as-is: the first three commits are agent-instruction files that belong in their own PR. Say the word and I will split them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
