### PR TITLE
[MicroPerf] Drop the per-call closure in generic type-argument codegen

### DIFF
--- a/src/Compiler/CodeGen/IlxGen.fs
+++ b/src/Compiler/CodeGen/IlxGen.fs
@@ -639,7 +639,8 @@ let rec GenTypeArgAux cenv m tyenv tyarg =
     GenTypeAux cenv m tyenv VoidNotOK PtrTypesNotOK tyarg
 
 and GenTypeArgsAux cenv m tyenv tyargs =
-    List.map (GenTypeArgAux cenv m tyenv) (DropErasedTyargs tyargs)
+    DropErasedTyargs tyargs
+    |> ListInline.map (fun tyarg -> GenTypeArgAux cenv m tyenv tyarg)
 
 and GenTyAppAux cenv m tyenv repr tinst =
     match repr with


### PR DESCRIPTION
`GenTypeArgsAux` fed the partial application `GenTypeArgAux cenv m tyenv` to `List.map`, so every IL generic type-instantiation heap-allocated the mapping closure (`ilTypeInst@655`, 21.9 MB sampled) on one of the hottest codegen paths. `ListInline.map` folds the mapping in, so nothing is allocated per instantiation.

| closure | mechanism | before (MB) | after |
|---|---|--:|---|
| `ilTypeInst@655` | `ListInline.map` in `GenTypeArgsAux` | 21.9 | gone |
