### PR TITLE
[MicroPerf] Inline the remaining free-variable foldBacks

### DIFF
--- a/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fs
@@ -249,9 +249,9 @@ module internal FreeTypeVars =
         // Bound type vars form a recursively-referential set due to constraints, e.g. A: I<B>, B: I<A>
         // So collect up free vars in all constraints first, then bind all variables
         let acc =
-            List.foldBack (fun (tp: Typar) acc -> accFreeInTyparConstraints opts tp.Constraints acc) tps acc
+            ListInline.foldBack (fun (tp: Typar) acc -> accFreeInTyparConstraints opts tp.Constraints acc) tps acc
 
-        List.foldBack
+        ListInline.foldBack
             (fun tp acc ->
                 { acc with
                     FreeTypars = Zset.remove tp acc.FreeTypars
@@ -357,7 +357,7 @@ module internal FreeTypeVars =
         | TupInfo.Const _ -> acc
 
     and accFreeInMeasure opts unt acc =
-        List.foldBack (fun (tp, _) acc -> accFreeTyparRef opts tp acc) (ListMeasureVarOccsWithNonZeroExponents unt) acc
+        ListInline.foldBack (fun (tp, _) acc -> accFreeTyparRef opts tp acc) (ListMeasureVarOccsWithNonZeroExponents unt) acc
 
     and accFreeInTypes opts tys acc =
         match tys with
@@ -403,10 +403,10 @@ module internal FreeTypeVars =
     let rec boundTyparsLeftToRight g cxFlag thruFlag acc tps =
         // Bound type vars form a recursively-referential set due to constraints, e.g. A: I<B>, B: I<A>
         // So collect up free vars in all constraints first, then bind all variables
-        List.fold (fun acc (tp: Typar) -> accFreeInTyparConstraintsLeftToRight g cxFlag thruFlag acc tp.Constraints) tps acc
+        ListInline.fold (fun acc (tp: Typar) -> accFreeInTyparConstraintsLeftToRight g cxFlag thruFlag acc tp.Constraints) tps acc
 
     and accFreeInTyparConstraintsLeftToRight g cxFlag thruFlag acc cxs =
-        List.fold (accFreeInTyparConstraintLeftToRight g cxFlag thruFlag) acc cxs
+        ListInline.fold (fun acc cx -> accFreeInTyparConstraintLeftToRight g cxFlag thruFlag acc cx) acc cxs
 
     and accFreeInTyparConstraintLeftToRight g cxFlag thruFlag acc tpc =
         match tpc with
@@ -470,7 +470,7 @@ module internal FreeTypeVars =
 
         | TType_measure unt ->
             let mvars = ListMeasureVarOccsWithNonZeroExponents unt
-            List.foldBack (fun (tp, _) acc -> accFreeTyparRefLeftToRight g cxFlag thruFlag acc tp) mvars acc
+            ListInline.foldBack (fun (tp, _) acc -> accFreeTyparRefLeftToRight g cxFlag thruFlag acc tp) mvars acc
 
     and accFreeInTupInfoLeftToRight _g _cxFlag _thruFlag acc unt =
         match unt with

--- a/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.FreeVars.fs
@@ -260,7 +260,7 @@ module internal FreeTypeVars =
             acc
 
     and accFreeInTyparConstraints opts cxs acc =
-        List.foldBack (accFreeInTyparConstraint opts) cxs acc
+        ListInline.foldBack (accFreeInTyparConstraint opts) cxs acc
 
     and accFreeInTyparConstraint opts tpc acc =
         match tpc with
@@ -375,7 +375,7 @@ module internal FreeTypeVars =
         accFreeInTyparConstraints opts v emptyFreeTyvars
 
     let accFreeInTypars opts tps acc =
-        List.foldBack (accFreeTyparRef opts) tps acc
+        ListInline.foldBack (accFreeTyparRef opts) tps acc
 
     let rec addFreeInModuleTy (mtyp: ModuleOrNamespaceType) acc =
         QueueList.foldBack

--- a/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
+++ b/src/Compiler/TypedTree/TypedTreeOps.Remapping.fs
@@ -1064,13 +1064,13 @@ module internal ExprFreeVars =
         | _ -> fvs
 
     and accFreeInMethod opts (TObjExprMethod(slotsig, _attribs, tps, tmvs, e, _)) acc =
-        accFreeInSlotSig
-            opts
-            slotsig
-            (unionFreeVars (accFreeTyvars opts boundTypars tps (List.foldBack (boundLocalVals opts) tmvs (freeInExpr opts e))) acc)
+        let boundAcc =
+            ListInline.foldBack (fun v acc -> boundLocalVals opts v acc) tmvs (freeInExpr opts e)
+
+        accFreeInSlotSig opts slotsig (unionFreeVars (accFreeTyvars opts boundTypars tps boundAcc) acc)
 
     and accFreeInMethods opts methods acc =
-        List.foldBack (accFreeInMethod opts) methods acc
+        ListInline.foldBack (fun m acc -> accFreeInMethod opts m acc) methods acc
 
     and accFreeInInterfaceImpl opts (ty, overrides) acc =
         accFreeVarsInTy opts ty (accFreeInMethods opts overrides acc)
@@ -1127,7 +1127,10 @@ module internal ExprFreeVars =
         | Expr.LetRec(binds, bodyExpr, _, cache) ->
             unionFreeVars
                 (freeVarsCacheCompute opts cache (fun () ->
-                    List.foldBack (bindLhs opts) binds (List.foldBack (accBindRhs opts) binds (freeInExpr opts bodyExpr))))
+                    ListInline.foldBack
+                        (fun b acc -> bindLhs opts b acc)
+                        binds
+                        (ListInline.foldBack (fun b acc -> accBindRhs opts b acc) binds (freeInExpr opts bodyExpr))))
                 acc
 
         | Expr.Let _ -> failwith "unreachable - linear expr"
@@ -1144,7 +1147,10 @@ module internal ExprFreeVars =
                             (accFreeInExpr
                                 opts
                                 basecall
-                                (accFreeInMethods opts overrides (List.foldBack (accFreeInInterfaceImpl opts) iimpls emptyFreeVars))))
+                                (accFreeInMethods
+                                    opts
+                                    overrides
+                                    (ListInline.foldBack (fun i acc -> accFreeInInterfaceImpl opts i acc) iimpls emptyFreeVars))))
                 ))
                 acc
 
@@ -1282,7 +1288,7 @@ module internal ExprFreeVars =
 
     and accFreeInTarget opts (TTarget(vs, expr, flags)) acc =
         match flags with
-        | None -> List.foldBack (boundLocalVal opts) vs (accFreeInExpr opts expr acc)
+        | None -> ListInline.foldBack (fun v acc -> boundLocalVal opts v acc) vs (accFreeInExpr opts expr acc)
         | Some xs ->
             List.foldBack2
                 (fun v isStateVar acc -> if isStateVar then acc else boundLocalVal opts v acc)
@@ -1291,7 +1297,7 @@ module internal ExprFreeVars =
                 (accFreeInExpr opts expr acc)
 
     and accFreeInFlatExprs opts (exprs: Exprs) acc =
-        List.foldBack (accFreeInExpr opts) exprs acc
+        ListInline.foldBack (fun e acc -> accFreeInExpr opts e acc) exprs acc
 
     and accFreeInExprs opts (exprs: Exprs) acc =
         match exprs with

--- a/src/Compiler/Utilities/illib.fs
+++ b/src/Compiler/Utilities/illib.fs
@@ -466,6 +466,17 @@ module ListInline =
 
             state
 
+    /// List.fold, but inline so the folder is inlined (InlineIfLambda) rather than allocated as a closure.
+    let inline fold ([<InlineIfLambda>] folder: 'State -> 'T -> 'State) (state: 'State) (list: 'T list) =
+        let mutable state = state
+        let mutable rest = list
+
+        while not rest.IsEmpty do
+            state <- folder state rest.Head
+            rest <- rest.Tail
+
+        state
+
 module List =
 
     let sortWithOrder (c: IComparer<'T>) elements =

--- a/src/Compiler/Utilities/illib.fsi
+++ b/src/Compiler/Utilities/illib.fsi
@@ -159,6 +159,9 @@ module internal ListInline =
     /// List.foldBack, but inline so the folder is inlined (InlineIfLambda). Folds lengths up to 5 directly; longer lists use an array, staying stack-safe like List.foldBack.
     val inline foldBack: [<InlineIfLambda>] folder: ('T -> 'State -> 'State) -> list: 'T list -> state: 'State -> 'State
 
+    /// List.fold, but inline so the folder is inlined (InlineIfLambda) rather than allocated as a closure.
+    val inline fold: [<InlineIfLambda>] folder: ('State -> 'T -> 'State) -> state: 'State -> list: 'T list -> 'State
+
 module internal List =
 
     val sortWithOrder: c: IComparer<'T> -> elements: 'T list -> 'T list


### PR DESCRIPTION
Extends #20385: routes the remaining lambda / partial-application `List.foldBack`/`List.fold` sites in the free-variable walkers through the inline `ListInline.foldBack`/`ListInline.fold` twins, whose `InlineIfLambda` folder is inlined instead of allocated as a per-call closure. Fold order unchanged. Adds `ListInline.fold` next to the existing `ListInline.foldBack`.

Per-call closure classes in `FSharp.Compiler.Service.dll` (IL `TypeDefinition` enumeration): **22 → 6**. The 6 survivors are CPS continuations, an `Option.foldBack`, a `LetRec` cache thunk and a `List.foldBack2` lambda — none is a `List` fold this inlines.

Closure allocation removed, measured over a full **FSharp.Compiler.Service self-compile** (455 source files, GCAllocationTick sampling, 6 compiles; every class below reaches **0 samples** after, matching the IL count):

| eliminated closure class | MB / self-compile before | after |
|---|--:|--:|
| `accFreeInFlatExprs@` | 32.0 | 0 |
| `boundTypars@` | 17.6 | 0 |
| `accFreeInTarget@` | 14.6 | 0 |
| `accFreeInMethod@` | 0.1 | 0 |
| **total** | **~64 MB** | **0** |

`accFreeInMeasure@`, `boundTyparsLeftToRight@` and `accFreeInTyparConstraintsLeftToRight@` are eliminated too (part of the 22→6 IL count) but sit on the units-of-measure / signature-only left-to-right paths, which barely execute while compiling the compiler's own sources, so they don't register on this workload.
