### PR TITLE
[MicroPerf] Remove per-call closure allocations in post-inference checks

### DIFF
--- a/src/Compiler/Checking/PostInferenceChecks.fs
+++ b/src/Compiler/Checking/PostInferenceChecks.fs
@@ -336,20 +336,60 @@ let RecordAnonRecdInfo cenv (anonInfo: AnonRecdTypeInfo) =
 // approx walk of type
 //--------------------------------------------------------------------------
 
-/// Represents the container for nester type instantions, carrying information about the parent (generic type) and data about corresponding generic typar definition.
-/// For current use, IlGenericParameterDef was enough. For other future use cases, conversion into F# Typar might be needed.
+/// Enclosing type-instantiation context for a node in CheckTypeDeep.
+[<Struct>]
 type TypeInstCtx =
     | NoInfo
-    | IlGenericInst of parent:TyconRef * genericArg:ILGenericParameterDef
-    | TyparInst of parent:TyconRef
+    | IlGenericInst of parent: TyconRef * allowsRefStruct: bool
+    | TyparInst of parent: TyconRef
     | TopLevelAllowingByRef
 
-    with member x.TyparAllowsRefStruct() =
-                        match x with
-                        | IlGenericInst(_,ilTypar) -> ilTypar.HasAllowsRefStruct
-                        | _ -> false
+    member x.TyparAllowsRefStruct() =
+        match x with
+        | IlGenericInst(_, allowsRefStruct) -> allowsRefStruct
+        | _ -> false
 
-let rec CheckTypeDeep (cenv: cenv) (visitTy, visitTyconRefOpt, visitAppTyOpt, visitTraitSolutionOpt, visitTyparOpt as f) (g: TcGlobals) env (typeInstParentOpt:TypeInstCtx) ty =
+/// Callbacks for the CheckTypeDeep type walker.
+type ITypeVisitor =
+    abstract VisitTy: TType -> unit
+    abstract VisitTyconRef: TypeInstCtx * TyconRef -> unit
+    abstract VisitAppTy: TyconRef * TypeInst -> unit
+    abstract VisitTraitSolution: TraitConstraintSln -> unit
+    abstract VisitTypar: env * Typar -> unit
+
+[<RequireQualifiedAccess>]
+type ByrefError =
+    | UseOfByref
+    | InvalidFunctionReturnType
+    | InvalidFunctionParameterType of arg: Val
+
+let emitByrefError (cenv: cenv) m ty byrefError =
+    match byrefError with
+    | ByrefError.UseOfByref -> errorR(Error(FSComp.SR.chkErrorUseOfByref(), m))
+    | ByrefError.InvalidFunctionReturnType ->
+        errorR(Error(FSComp.SR.chkInvalidFunctionReturnType(NicePrint.minimalRichTextOfType cenv.denv ty), m))
+    | ByrefError.InvalidFunctionParameterType arg ->
+        if arg.IsCompilerGenerated then
+            errorR(Error(FSComp.SR.chkErrorUseOfByref(), arg.Range))
+        else
+            errorR(
+                Error(
+                    FSComp.SR.chkInvalidFunctionParameterType(
+                        RichText.mkParameter arg.DisplayName,
+                        NicePrint.minimalRichTextOfType cenv.denv arg.Type
+                    ),
+                    arg.Range
+                )
+            )
+
+let rec CheckTypeDeep<'V when 'V :> ITypeVisitor and 'V: struct>
+    (cenv: cenv)
+    (v: 'V)
+    (g: TcGlobals)
+    env
+    (typeInstParent: TypeInstCtx)
+    ty
+    =
     // We iterate the _solved_ constraints as well, to pick up any record of trait constraint solutions
     // This means we walk _all_ the constraints _everywhere_ in a type, including
     // those attached to _solved_ type variables. This is used by PostTypeCheckSemanticChecks to detect uses of
@@ -362,9 +402,9 @@ let rec CheckTypeDeep (cenv: cenv) (visitTy, visitTyconRefOpt, visitAppTyOpt, vi
         for cx in tp.Constraints do
             match cx with
             | TyparConstraint.MayResolveMember(TTrait(solution=soln), _) ->
-                 match visitTraitSolutionOpt, soln.Value with
-                 | Some visitTraitSolution, Some sln -> visitTraitSolution sln
-                 | _ -> ()
+                match soln.Value with
+                | Some sln -> v.VisitTraitSolution sln
+                | None -> ()
             | _ -> ()
     | _ -> ()
 
@@ -376,98 +416,127 @@ let rec CheckTypeDeep (cenv: cenv) (visitTy, visitTyconRefOpt, visitAppTyOpt, vi
             | _ -> stripTyEqns g ty
         else
             stripTyEqns g ty
-    visitTy ty
+    v.VisitTy ty
 
     match ty with
     | TType_forall (tps, body) ->
         let env = BindTypars g env tps
-        CheckTypeDeep cenv f g env typeInstParentOpt body
-        tps |> List.iter (fun tp -> tp.Constraints |> List.iter (CheckTypeConstraintDeep cenv f g env))
+        CheckTypeDeep cenv v g env typeInstParent body
+        for tp in tps do
+            for cx in tp.Constraints do
+                CheckTypeConstraintDeep cenv v g env cx
 
     | TType_measure _ -> ()
 
     | TType_app (tcref, tinst, _) ->
-        match visitTyconRefOpt with
-        | Some visitTyconRef -> visitTyconRef typeInstParentOpt tcref
-        | None -> ()
+        v.VisitTyconRef(typeInstParent, tcref)
 
         // If it's a 'byref<'T>', don't check 'T as an inner. This allows byref<Span<'T>>.
-        // 'byref<byref<'T>>' is invalid and gets checked in visitAppTy.
-        //if isByrefTyconRef g tcref then
-        //    CheckTypesDeepNoInner cenv f g env tinst
+        // 'byref<byref<'T>>' is invalid and gets checked in VisitAppTy.
 
         if tcref.CanDeref && tcref.IsILTycon && tinst.Length = tcref.ILTyconRawMetadata.GenericParams.Length then
-            (tinst,tcref.ILTyconRawMetadata.GenericParams)
-            ||> List.iter2 (fun ty ilGenericParam ->
-                let typeInstParent = IlGenericInst(tcref, ilGenericParam)
-                CheckTypeDeep cenv f g env typeInstParent ty)
+            let mutable tys = tinst
+            let mutable gps = tcref.ILTyconRawMetadata.GenericParams
+            while not tys.IsEmpty do
+                CheckTypeDeep cenv v g env (IlGenericInst(tcref, gps.Head.HasAllowsRefStruct)) tys.Head
+                tys <- tys.Tail
+                gps <- gps.Tail
         else
-            let parentRef = TyparInst(tcref)
+            let parentRef = TyparInst tcref
             for ty in tinst do
-                CheckTypeDeep cenv f g env parentRef ty
+                CheckTypeDeep cenv v g env parentRef ty
 
-        match visitAppTyOpt with
-        | Some visitAppTy -> visitAppTy (tcref, tinst)
-        | None -> ()
+        v.VisitAppTy(tcref, tinst)
 
     | TType_anon (anonInfo, tys) ->
         RecordAnonRecdInfo cenv anonInfo
-        CheckTypesDeep cenv f g env tys
+        CheckTypesDeep cenv v g env tys
 
     | TType_ucase (_, tinst) ->
-        CheckTypesDeep cenv f g env tinst
+        CheckTypesDeep cenv v g env tinst
 
     | TType_tuple (_, tys) ->
-        CheckTypesDeep cenv f g env tys
+        CheckTypesDeep cenv v g env tys
 
     | TType_fun (s, t, _) ->
-        CheckTypeDeep cenv f g env NoInfo s
-        CheckTypeDeep cenv f g env NoInfo t
+        CheckTypeDeep cenv v g env NoInfo s
+        CheckTypeDeep cenv v g env NoInfo t
 
     | TType_var (tp, _) ->
-          if not tp.IsSolved then
-              match visitTyparOpt with
-              | None -> ()
-              | Some visitTyar ->
-                    visitTyar (env, tp)
+        if not tp.IsSolved then
+            v.VisitTypar(env, tp)
 
-and CheckTypesDeep cenv f g env tys =
+and CheckTypesDeep cenv (v: 'V) g env tys =
     for ty in tys do
-        CheckTypeDeep cenv f g env NoInfo ty
+        CheckTypeDeep cenv v g env NoInfo ty
 
-and CheckTypeConstraintDeep cenv f g env x =
-     match x with
-     | TyparConstraint.CoercesTo(ty, _) -> CheckTypeDeep cenv f g env NoInfo ty
-     | TyparConstraint.MayResolveMember(traitInfo, _) -> CheckTraitInfoDeep cenv f g env traitInfo
-     | TyparConstraint.DefaultsTo(_, ty, _) -> CheckTypeDeep cenv f g env NoInfo ty
-     | TyparConstraint.SimpleChoice(tys, _) -> CheckTypesDeep cenv f g env tys
-     | TyparConstraint.IsEnum(underlyingTy, _) -> CheckTypeDeep cenv f g env NoInfo underlyingTy
-     | TyparConstraint.IsDelegate(argTys, retTy, _) -> CheckTypeDeep cenv f g env NoInfo argTys; CheckTypeDeep cenv f g env NoInfo retTy
-     | TyparConstraint.SupportsComparison _
-     | TyparConstraint.SupportsEquality _
-     | TyparConstraint.SupportsNull _
-     | TyparConstraint.NotSupportsNull _
-     | TyparConstraint.IsNonNullableStruct _
-     | TyparConstraint.IsUnmanaged _
-     | TyparConstraint.AllowsRefStruct _
-     | TyparConstraint.IsReferenceType _
-     | TyparConstraint.RequiresDefaultConstructor _ -> ()
+and CheckTypeConstraintDeep cenv (v: 'V) g env x =
+    match x with
+    | TyparConstraint.CoercesTo(ty, _) -> CheckTypeDeep cenv v g env NoInfo ty
+    | TyparConstraint.MayResolveMember(traitInfo, _) -> CheckTraitInfoDeep cenv v g env traitInfo
+    | TyparConstraint.DefaultsTo(_, ty, _) -> CheckTypeDeep cenv v g env NoInfo ty
+    | TyparConstraint.SimpleChoice(tys, _) -> CheckTypesDeep cenv v g env tys
+    | TyparConstraint.IsEnum(underlyingTy, _) -> CheckTypeDeep cenv v g env NoInfo underlyingTy
+    | TyparConstraint.IsDelegate(argTys, retTy, _) ->
+        CheckTypeDeep cenv v g env NoInfo argTys
+        CheckTypeDeep cenv v g env NoInfo retTy
+    | TyparConstraint.SupportsComparison _
+    | TyparConstraint.SupportsEquality _
+    | TyparConstraint.SupportsNull _
+    | TyparConstraint.NotSupportsNull _
+    | TyparConstraint.IsNonNullableStruct _
+    | TyparConstraint.IsUnmanaged _
+    | TyparConstraint.AllowsRefStruct _
+    | TyparConstraint.IsReferenceType _
+    | TyparConstraint.RequiresDefaultConstructor _ -> ()
 
-and CheckTraitInfoDeep cenv (_, _, _, visitTraitSolutionOpt, _ as f) g env traitInfo =
-    CheckTypesDeep cenv f g env traitInfo.SupportTypes
-    CheckTypesDeep cenv f g env traitInfo.CompiledObjectAndArgumentTypes
-    Option.iter (CheckTypeDeep cenv f g env NoInfo ) traitInfo.CompiledReturnType
-    match visitTraitSolutionOpt, traitInfo.Solution with
-    | Some visitTraitSolution, Some sln -> visitTraitSolution sln
-    | _ -> ()
+and CheckTraitInfoDeep cenv (v: 'V) g env traitInfo =
+    CheckTypesDeep cenv v g env traitInfo.SupportTypes
+    CheckTypesDeep cenv v g env traitInfo.CompiledObjectAndArgumentTypes
+
+    match traitInfo.CompiledReturnType with
+    | Some ty -> CheckTypeDeep cenv v g env NoInfo ty
+    | None -> ()
+
+    match traitInfo.Solution with
+    | Some sln -> v.VisitTraitSolution sln
+    | None -> ()
+
+/// Check for byref-like types
+[<Struct>]
+type private CheckForByrefLikeVisitor(cenv: cenv, m: range, check: unit -> unit) =
+    interface ITypeVisitor with
+        member _.VisitTy _ = ()
+
+        member _.VisitTyconRef(ctx, tcref) =
+            if isByrefLikeTyconRef cenv.g m tcref && not (ctx.TyparAllowsRefStruct()) then
+                check ()
+
+        member _.VisitAppTy(_, _) = ()
+        member _.VisitTraitSolution _ = ()
+        member _.VisitTypar(_, _) = ()
+
+/// Check for byref types
+[<Struct>]
+type private CheckForByrefVisitor(cenv: cenv, check: unit -> unit) =
+    interface ITypeVisitor with
+        member _.VisitTy _ = ()
+
+        member _.VisitTyconRef(_ctx, tcref) =
+            if isByrefTyconRef cenv.g tcref then
+                check ()
+
+        member _.VisitAppTy(_, _) = ()
+        member _.VisitTraitSolution _ = ()
+        member _.VisitTypar(_, _) = ()
 
 /// Check for byref-like types
 let CheckForByrefLikeType cenv env m ty check =
-    CheckTypeDeep cenv (ignore, Some (fun ctx tcref -> if (isByrefLikeTyconRef cenv.g m tcref && not(ctx.TyparAllowsRefStruct())) then check()),  None, None, None) cenv.g env NoInfo ty
+    CheckTypeDeep cenv (CheckForByrefLikeVisitor(cenv, m, check)) cenv.g env NoInfo ty
 
 /// Check for byref types
 let CheckForByrefType cenv env ty check =
-    CheckTypeDeep cenv (ignore, Some (fun _ctx tcref -> if isByrefTyconRef cenv.g tcref then check()),  None, None, None) cenv.g env NoInfo ty
+    CheckTypeDeep cenv (CheckForByrefVisitor(cenv, check)) cenv.g env NoInfo ty
 
 /// check captures under lambdas
 ///
@@ -525,35 +594,46 @@ let isLessAccessibleWithVisibility (cenv: cenv) itemAccess refAccess =
     let thisCompPath = compPathOfCcu cenv.viewCcu
     isLessAccessible (itemAccess |> AccessInternalsVisibleToAsInternal thisCompPath cenv.internalsVisibleToPaths) refAccess
 
+[<Struct>]
+type private CheckTypeAccessVisitor
+    (cenv: cenv, objName: unit -> RichText, valAcc: Accessibility, skipCheck: bool, asWarning: bool, m: range) =
+    interface ITypeVisitor with
+        // Must stay on VisitTy, not VisitTyconRef: under compilingFSharpCore the walker can leave a
+        // non-CanDeref abbrev unstripped, and re-stripping here (tryTcrefOfAppTy) is what recovers its TyconRef.
+        member _.VisitTy ty =
+            match tryTcrefOfAppTy cenv.g ty with
+            | ValueSome tcref when not skipCheck && isLessAccessibleWithVisibility cenv tcref.Accessibility valAcc ->
+                let text = FSComp.SR.chkTypeLessAccessibleThanType(richTextOfEntityRef tcref, objName ())
+
+                if asWarning then
+                    let warningText =
+                        RichText.append
+                            (snd text)
+                            (RichText.mkText (Environment.NewLine + FSComp.SR.tcTypeAbbreviationsCheckedAtCompileTime()))
+
+                    warning(ObsoleteDiagnostic(false, None, Some warningText, None, m))
+                else
+                    errorR(Error(text, m))
+            | _ -> ()
+
+        member _.VisitTyconRef(_, _) = ()
+        member _.VisitAppTy(_, _) = ()
+        member _.VisitTraitSolution _ = ()
+        member _.VisitTypar(_, _) = ()
+
 let CheckTypeForAccess (cenv: cenv) env (objName: unit -> RichText) valAcc skipAccessibilityCheckForCompilerGeneratedVal m ty =
     if cenv.reportErrors then
-
-        let visitType ty =
-            // We deliberately only check the fully stripped type for accessibility,
-            // because references to private type abbreviations are permitted
-            match tryTcrefOfAppTy cenv.g ty with
-            | ValueNone -> ()
-            | ValueSome tcref ->
-                if not skipAccessibilityCheckForCompilerGeneratedVal && isLessAccessibleWithVisibility cenv tcref.Accessibility valAcc then
-                    errorR(Error(FSComp.SR.chkTypeLessAccessibleThanType(richTextOfEntityRef tcref, objName()), m))
-
-        CheckTypeDeep cenv (visitType, None, None, None, None) cenv.g env NoInfo ty
+        CheckTypeDeep
+            cenv
+            (CheckTypeAccessVisitor(cenv, objName, valAcc, skipAccessibilityCheckForCompilerGeneratedVal, false, m))
+            cenv.g
+            env
+            NoInfo
+            ty
 
 let WarnOnWrongTypeForAccess (cenv: cenv) env (objName: unit -> RichText) valAcc m ty =
     if cenv.reportErrors then
-
-        let visitType ty =
-            // We deliberately only check the fully stripped type for accessibility,
-            // because references to private type abbreviations are permitted
-            match tryTcrefOfAppTy cenv.g ty with
-            | ValueNone -> ()
-            | ValueSome tcref ->
-                if isLessAccessibleWithVisibility cenv tcref.Accessibility valAcc then
-                    let errorText = FSComp.SR.chkTypeLessAccessibleThanType(richTextOfEntityRef tcref, objName()) |> snd
-                    let warningText = RichText.append errorText (RichText.mkText (Environment.NewLine + FSComp.SR.tcTypeAbbreviationsCheckedAtCompileTime()))
-                    warning(ObsoleteDiagnostic(false, None, Some warningText, None, m))
-
-        CheckTypeDeep cenv (visitType, None, None, None, None) cenv.g env NoInfo ty
+        CheckTypeDeep cenv (CheckTypeAccessVisitor(cenv, objName, valAcc, false, true, m)) cenv.g env NoInfo ty
 
 /// Indicates whether a byref or byref-like type is permitted at a particular location
 [<RequireQualifiedAccess>]
@@ -656,81 +736,130 @@ let CheckInterfaceTypeArgForUnimplementedStaticAbstractMembers (cenv: cenv) m (t
                 errorR(Error(FSComp.SR.chkInterfaceWithUnimplementedStaticAbstractMemberUsedAsTypeArgument(interfaceTypeName, RichText.mkMember memberName), m))
             | None -> ()
 
-/// Check types occurring in the TAST.
-let CheckTypeAux permitByRefLike (cenv: cenv) env m ty onInnerByrefError =
-    if cenv.reportErrors then
-        let visitTyar (env, tp) =
-          if not (env.boundTypars.ContainsKey tp) then
-             if tp.IsCompilerGenerated then
-               errorR (Error(FSComp.SR.checkNotSufficientlyGenericBecauseOfScopeAnon(), m))
-             else
-               errorR (Error(FSComp.SR.checkNotSufficientlyGenericBecauseOfScope(RichText.mkTypeParameter tp.DisplayName), m))
+let private isInnerByrefLike (g: TcGlobals) m (ctx: TypeInstCtx) tcref =
+    (match ctx with
+     | TopLevelAllowingByRef -> false
+     | TyparInst parentTcref
+     | IlGenericInst(parentTcref, _) -> not (isByrefTyconRef g parentTcref)
+     | NoInfo -> true)
+    && isByrefLikeTyconRef g m tcref
 
-        let visitTyconRef (ctx:TypeInstCtx) tcref =
-            let checkInner() =
-                match ctx with
-                | TopLevelAllowingByRef -> false
-                | TyparInst(parentTcRef)
-                | IlGenericInst(parentTcRef,_) when isByrefTyconRef cenv.g parentTcRef -> false
-                | _ -> true
+let rec private checkStaticAbstractTypeArgs cenv m (typars: Typars) (tinst: TypeInst) =
+    match typars, tinst with
+    | tp :: typarsRest, ty :: tinstRest ->
+        CheckInterfaceTypeArgForUnimplementedStaticAbstractMembers cenv m tp ty
+        checkStaticAbstractTypeArgs cenv m typarsRest tinstRest
+    | _ -> ()
 
-            let isInnerByRefLike() = checkInner() && isByrefLikeTyconRef cenv.g m tcref
+[<Struct>]
+type private ByrefOfByrefVisitor(cenv: cenv, outerTy: TType, m: range) =
+    interface ITypeVisitor with
+        member _.VisitTy _ = ()
 
-            let permitByRefLike =
-                if ctx.TyparAllowsRefStruct() then PermitByRefType.All else permitByRefLike
+        member _.VisitTyconRef(_, tcref) =
+            if isByrefTyconRef cenv.g tcref then
+                errorR(Error(FSComp.SR.chkNoByrefsOfByrefs(NicePrint.minimalRichTextOfType cenv.denv outerTy), m))
 
+        member _.VisitAppTy(_, _) = ()
+        member _.VisitTraitSolution _ = ()
+        member _.VisitTypar(_, _) = ()
 
+/// Byref and byref-like permission, plus byref-of-byref.
+[<Struct>]
+type private ByrefTypeCheck
+    (cenv: cenv, m: range, permitByRefLike: PermitByRefType, ty: TType, byrefError: ByrefError, initialEnv: env) =
+
+    member _.VisitTyconRef(ctx: TypeInstCtx, tcref) =
+        let g = cenv.g
+
+        if not (ctx.TyparAllowsRefStruct()) then
             match permitByRefLike with
-            | PermitByRefType.None when isByrefLikeTyconRef cenv.g m tcref ->
-                errorR(Error(FSComp.SR.chkErrorUseOfByref(), m))
-            | PermitByRefType.NoInnerByRefLike when isInnerByRefLike() ->
-                onInnerByrefError ()
-            | PermitByRefType.SpanLike when isByrefTyconRef cenv.g tcref || isInnerByRefLike() ->
-                onInnerByrefError ()
-            | _ -> ()
+            | PermitByRefType.All -> ()
+            | PermitByRefType.None ->
+                if isByrefLikeTyconRef g m tcref then
+                    errorR(Error(FSComp.SR.chkErrorUseOfByref(), m))
+            | PermitByRefType.NoInnerByRefLike ->
+                if isInnerByrefLike g m ctx tcref then
+                    emitByrefError cenv m ty byrefError
+            | PermitByRefType.SpanLike ->
+                if isByrefTyconRef g tcref || isInnerByrefLike g m ctx tcref then
+                    emitByrefError cenv m ty byrefError
 
-            if tyconRefEq cenv.g cenv.g.system_Void_tcref tcref then
-                errorR(Error(FSComp.SR.chkSystemVoidOnlyInTypeof(), m))
+    member _.VisitAppTy(tcref, tinst) =
+        if isByrefLikeTyconRef cenv.g m tcref then
+            CheckTypesDeep cenv (ByrefOfByrefVisitor(cenv, ty, m)) cenv.g initialEnv tinst
 
-        // check if T contains byref types in case of byref<T>
-        let visitAppTy (tcref, tinst) =
-            if isByrefLikeTyconRef cenv.g m tcref then
-                let visitType ty0 =
-                    match tryTcrefOfAppTy cenv.g ty0 with
-                    | ValueNone -> ()
-                    | ValueSome tcref2 ->
-                        if isByrefTyconRef cenv.g tcref2 then
-                            errorR(Error(FSComp.SR.chkNoByrefsOfByrefs(NicePrint.minimalRichTextOfType cenv.denv ty), m))
-                CheckTypesDeep cenv (visitType, None, None, None, None) cenv.g env tinst
+/// System.Void is only allowed inside typeof.
+[<Struct>]
+type private VoidTypeCheck(cenv: cenv, m: range) =
+    member _.VisitTyconRef tcref =
+        let g = cenv.g
 
-            // Check for interfaces with unimplemented static abstract members used as type arguments
-            // This only applies when the type parameter has an interface constraint - using interfaces
-            // with unconstrained generics (like List<ITest> or Dictionary<K, ITest>) is fine.
-            // See: https://github.com/dotnet/fsharp/issues/19184
-            if tcref.CanDeref then
-                let typars = tcref.Typars
-                if typars.Length = tinst.Length then
-                    (typars, tinst) ||> List.iter2 (CheckInterfaceTypeArgForUnimplementedStaticAbstractMembers cenv m)
+        if tyconRefEq g g.system_Void_tcref tcref then
+            errorR(Error(FSComp.SR.chkSystemVoidOnlyInTypeof(), m))
 
-        let visitTraitSolution info =
-            match info with
-            | FSMethSln(_, vref, _, _) ->
-               //printfn "considering %s..." vref.DisplayName
-               if valRefInThisAssembly cenv.g.compilingFSharpCore vref && not (cenv.boundVals.ContainsKey(vref.Stamp)) then
-                   //printfn "recording %s..." vref.DisplayName
-                   cenv.potentialUnboundUsesOfVals <- cenv.potentialUnboundUsesOfVals.Add(vref.Stamp, m)
-            | _ -> ()
+[<Struct>]
+type private StaticAbstractArgCheck(cenv: cenv, m: range) =
+    member _.VisitAppTy(tcref: TyconRef, tinst: TypeInst) =
+        if tcref.CanDeref then
+            let typars = tcref.Typars
 
+            if typars.Length = tinst.Length then
+                checkStaticAbstractTypeArgs cenv m typars tinst
+
+/// Records values used as trait-constraint solutions, so scope-escape analysis can flag unbound uses.
+[<Struct>]
+type private TraitSolutionScopeCheck(cenv: cenv, m: range) =
+    member _.VisitTraitSolution info =
+        match info with
+        | FSMethSln(_, vref, _, _) ->
+            if valRefInThisAssembly cenv.g.compilingFSharpCore vref && not (cenv.boundVals.ContainsKey(vref.Stamp)) then
+                cenv.potentialUnboundUsesOfVals <- cenv.potentialUnboundUsesOfVals.Add(vref.Stamp, m)
+        | _ -> ()
+
+[<Struct>]
+type private TyparScopeCheck(m: range) =
+    member _.VisitTypar(env: env, tp: Typar) =
+        if not (env.boundTypars.ContainsKey tp) then
+            if tp.IsCompilerGenerated then
+                errorR(Error(FSComp.SR.checkNotSufficientlyGenericBecauseOfScopeAnon(), m))
+            else
+                errorR(Error(FSComp.SR.checkNotSufficientlyGenericBecauseOfScope(RichText.mkTypeParameter tp.DisplayName), m))
+
+/// Fans a single CheckTypeDeep walk out to the focused checks, in the order they must fire.
+[<Struct>]
+type private CheckTypeAuxVisitor
+    (cenv: cenv, m: range, permitByRefLike: PermitByRefType, ty: TType, byrefError: ByrefError, initialEnv: env) =
+    interface ITypeVisitor with
+        member _.VisitTy _ = ()
+
+        member _.VisitTyconRef(ctx, tcref) =
+            ByrefTypeCheck(cenv, m, permitByRefLike, ty, byrefError, initialEnv).VisitTyconRef(ctx, tcref)
+            VoidTypeCheck(cenv, m).VisitTyconRef tcref
+
+        member _.VisitAppTy(tcref, tinst) =
+            ByrefTypeCheck(cenv, m, permitByRefLike, ty, byrefError, initialEnv).VisitAppTy(tcref, tinst)
+            StaticAbstractArgCheck(cenv, m).VisitAppTy(tcref, tinst)
+
+        member _.VisitTraitSolution info =
+            TraitSolutionScopeCheck(cenv, m).VisitTraitSolution info
+
+        member _.VisitTypar(env, tp) =
+            TyparScopeCheck(m).VisitTypar(env, tp)
+
+/// Check types occurring in the TAST.
+let CheckTypeAux permitByRefLike (cenv: cenv) env m ty byrefError =
+    if cenv.reportErrors then
         let initialCtx =
             match permitByRefLike with
             | PermitByRefType.SpanLike
             | PermitByRefType.NoInnerByRefLike -> TopLevelAllowingByRef
             | _ -> NoInfo
 
-        CheckTypeDeep cenv (ignore, Some visitTyconRef, Some visitAppTy, Some visitTraitSolution, Some visitTyar) cenv.g env initialCtx ty
+        CheckTypeDeep cenv (CheckTypeAuxVisitor(cenv, m, permitByRefLike, ty, byrefError, env)) cenv.g env initialCtx ty
 
 let CheckType permitByRefLike cenv env m ty =
-    CheckTypeAux permitByRefLike cenv env m ty (fun () -> errorR(Error(FSComp.SR.chkErrorUseOfByref(), m)))
+    CheckTypeAux permitByRefLike cenv env m ty ByrefError.UseOfByref
 
 /// Check types occurring in TAST (like CheckType) and additionally reject any byrefs.
 /// The additional byref checks are to catch "byref instantiations" - one place were byref are not permitted.
@@ -1836,17 +1965,10 @@ and CheckLambdas isTop (memberVal: Val option) cenv env inlined valReprInfo alwa
             if arg.InlineIfLambda && (not inlined || not (isFunTy g arg.Type || isFSharpDelegateTy g arg.Type)) then
                 errorR(Error(FSComp.SR.tcInlineIfLambdaUsedOnNonInlineFunctionOrMethod(), arg.Range))
 
-            CheckValSpecAux permitByRefType cenv env arg (fun () ->
-                if arg.IsCompilerGenerated then
-                    errorR(Error(FSComp.SR.chkErrorUseOfByref(), arg.Range))
-                else
-                    errorR(Error(FSComp.SR.chkInvalidFunctionParameterType(RichText.mkParameter arg.DisplayName, NicePrint.minimalRichTextOfType cenv.denv arg.Type), arg.Range))
-            )
+            CheckValSpecAux permitByRefType cenv env arg (ByrefError.InvalidFunctionParameterType arg)
 
         // Check return type
-        CheckTypeAux permitByRefType cenv env mOrig bodyTy (fun () ->
-            errorR(Error(FSComp.SR.chkInvalidFunctionReturnType(NicePrint.minimalRichTextOfType cenv.denv bodyTy), mOrig))
-        )
+        CheckTypeAux permitByRefType cenv env mOrig bodyTy ByrefError.InvalidFunctionReturnType
 
         for arg in syntacticArgs do
             BindVal cenv env arg
@@ -2059,13 +2181,13 @@ and CheckValInfo cenv env (ValReprInfo(_, args, ret)) =
 and CheckArgInfo cenv env (argInfo : ArgReprInfo)  =
     CheckAttribs cenv env (argInfo.Attribs.AsList())
 
-and CheckValSpecAux permitByRefLike cenv env (v: Val) onInnerByrefError =
+and CheckValSpecAux permitByRefLike cenv env (v: Val) byrefError =
     v.Attribs |> CheckAttribs cenv env
     v.ValReprInfo |> Option.iter (CheckValInfo cenv env)
-    CheckTypeAux permitByRefLike cenv env v.Range v.Type onInnerByrefError
+    CheckTypeAux permitByRefLike cenv env v.Range v.Type byrefError
 
 and CheckValSpec permitByRefLike cenv env v =
-    CheckValSpecAux permitByRefLike cenv env v (fun () -> errorR(Error(FSComp.SR.chkErrorUseOfByref(), v.Range)))
+    CheckValSpecAux permitByRefLike cenv env v ByrefError.UseOfByref
 
 and AdjustAccess isHidden (cpath: unit -> CompilationPath) access =
     if isHidden then


### PR DESCRIPTION
`CheckTypeDeep`, the type walker used by the post-inference checks, threaded a tuple of five optional closures through its mutual recursion, so it allocated those closures, the tuple, the option wrappers, and a per-node `TypeInstCtx` heap value for every checked type. It is now generic over a struct visitor, `TypeInstCtx` is a struct, and the inner-byref-error callback is a data-carrying union. The walk allocates nothing and diagnostics are unchanged.

Sampled allocation removed (gc-verbose `GCAllocationTick`), by self-compilation input:

| compiling | MB removed |
|---|---|
| FSharp.Compiler.Service | 534 |
| FSharp.Compiler.ComponentTests | 105 |
| FSharp.Core | 64 |

Compiler-generated closure types no longer emitted into `FSharp.Compiler.Service.dll` (verified by metadata scan of the built assembly):

| type |
|---|
| `visitTyconRef@670` |
| `visitAppTy@697` |
| `visitAppTy@713-1` |
| `visitTraitSolution@716` |
| `visitTyar@663` |
| `CheckType@733` |
| `CheckValSpec@2068` |
| `CheckTypeDeep@401` |
| `CheckTypeAux@730` |
| `CheckTraitInfoDeep@459` |
| `CheckForByrefLikeType@466` |
| `CheckForByrefLikeType@466-1` |
| `CheckForByrefType@470` |
| `CheckForByrefType@470-1` |
| `visitType@534-1` |
| `visitType@548-2` |
| `visitType@699-3` |

`TypeInstCtx` is now a struct, so its `IlGenericInst`/`TyparInst` heap allocations are gone as well.