### PR TITLE
Keep collapsed regions while a project has no options

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -16,6 +16,7 @@
 * Fix `NotSupportedException` in the memory-mapped-file optimization when copying `ReadOnlyMemory` into `MemoryMappedFileViewStream`. ([Issue #20263](https://github.com/dotnet/fsharp/issues/20263))
 * Reduce allocations in the VS project options reactor: the command-line options and project options caches and the mailbox reply payloads now hold struct tuples, and `IProjectSite.CompilationBinOutputPath` returns `string voption` picked with a new `Array.tryPickV`. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
 * Fix semantic colours of open documents disappearing: their classification was stored in the unopened-documents cache and only covered the requested span, so scrolling re-ran the checker or got nothing back, and a check that could not complete answered with no classifications, which clears the colours already shown. ([Issue #20445](https://github.com/dotnet/fsharp/issues/20445), [PR #20450](https://github.com/dotnet/fsharp/pull/20450))
+* Keep the collapsed regions of a file while its project is loading or reloading: outlining now parses with the quick parsing options instead of answering with no regions, which expanded everything the user had folded. ([PR #20451](https://github.com/dotnet/fsharp/pull/20451))
 
 ### Changed
 

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -15,6 +15,7 @@
 * Fix doubled F# diagnostics in tooltips. ([Issue #16360](https://github.com/dotnet/fsharp/issues/16360))
 * Fix `NotSupportedException` in the memory-mapped-file optimization when copying `ReadOnlyMemory` into `MemoryMappedFileViewStream`. ([Issue #20263](https://github.com/dotnet/fsharp/issues/20263))
 * Reduce allocations in the VS project options reactor: the command-line options and project options caches and the mailbox reply payloads now hold struct tuples, and `IProjectSite.CompilationBinOutputPath` returns `string voption` picked with a new `Array.tryPickV`. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
+* Fix semantic colours of open documents disappearing: their classification was stored in the unopened-documents cache and only covered the requested span, so scrolling re-ran the checker or got nothing back, and a check that could not complete answered with no classifications, which clears the colours already shown. ([Issue #20445](https://github.com/dotnet/fsharp/issues/20445), [PR #20450](https://github.com/dotnet/fsharp/pull/20450))
 
 ### Changed
 

--- a/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
+++ b/vsintegration/src/FSharp.Editor/Classification/ClassificationService.fs
@@ -8,6 +8,7 @@ open System.Collections.Generic
 open System.Collections.Immutable
 open System.Threading
 open System.Runtime.Caching
+open System.Runtime.CompilerServices
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Classification
@@ -29,6 +30,12 @@ open Microsoft.VisualStudio.FSharp.Editor.Telemetry
 
 type SemanticClassificationData = SemanticClassificationView
 type SemanticClassificationLookup = IReadOnlyDictionary<int, ResizeArray<SemanticClassificationItem>>
+
+type internal LastGoodSemanticClassification =
+    {
+        Text: SourceText
+        Lookup: SemanticClassificationLookup
+    }
 
 [<Export(typeof<IFSharpClassificationService>)>]
 type internal FSharpClassificationService [<ImportingConstructor>] () =
@@ -149,6 +156,41 @@ type internal FSharpClassificationService [<ImportingConstructor>] () =
     static let openedDocumentsSemanticClassificationCache =
         new DocumentCache<SemanticClassificationLookup>("fsharp-opened-documents-semantic-classification-cache", 2.)
 
+    // Roslyn replaces a span's semantic tags with whatever this service returns, so answering "nothing"
+    // while the checker is unavailable (project loading or reloading, a superseded check) strips the
+    // colours the user already sees. Keep the last whole-file lookup per document, outliving the
+    // version-keyed cache above, and re-emit it for those requests.
+    static let lastGoodSemanticClassification =
+        ConditionalWeakTable<DocumentId, LastGoodSemanticClassification>()
+
+    static let rememberLastGood (documentId: DocumentId) (text: SourceText) (lookup: SemanticClassificationLookup) =
+        let lastGood = { Text = text; Lookup = lookup }
+        // net472 has no ConditionalWeakTable.AddOrUpdate.
+        lock lastGoodSemanticClassification (fun () ->
+            lastGoodSemanticClassification.Remove documentId |> ignore
+            lastGoodSemanticClassification.Add(documentId, lastGood))
+
+    // Only for the text it was computed from: the lookup names positions, so against edited text it
+    // would colour the wrong characters.
+    static let addLastGood (documentId: DocumentId) (sourceText: SourceText) (targetSpan: TextSpan) (result: List<ClassifiedSpan>) =
+        match lastGoodSemanticClassification.TryGetValue documentId with
+        | true, lastGood when lastGood.Text.ContentEquals sourceText ->
+            addSemanticClassificationByLookup sourceText targetSpan lastGood.Lookup result
+        | _ -> ()
+
+    static let addLastGoodForCurrentText (document: Document) (targetSpan: TextSpan) (result: List<ClassifiedSpan>) =
+        match document.TryGetText() with
+        | true, sourceText -> addLastGood document.Id sourceText targetSpan result
+        | _ -> ()
+
+    // Which of the two caches a document lands in is not observable from its classifications - a miss
+    // only costs a recheck - so tests reach the caches directly to tell the branches apart.
+    static member internal OpenedDocumentsSemanticClassificationCache =
+        openedDocumentsSemanticClassificationCache
+
+    static member internal UnopenedDocumentsSemanticClassificationCache =
+        unopenedDocumentsSemanticClassificationCache
+
     interface IFSharpClassificationService with
         // Do not perform classification if we don't have project options (#defines matter)
         member _.AddLexicalClassifications(_: SourceText, _: TextSpan, _: List<ClassifiedSpan>, _: CancellationToken) = ()
@@ -252,11 +294,12 @@ type internal FSharpClassificationService [<ImportingConstructor>] () =
                             use _eventDuration =
                                 TelemetryReporter.ReportSingleEventWithDuration(TelemetryEvents.AddSemanticClassifications, eventProps)
 
-                            let! classificationData = document.GetFSharpSemanticClassificationAsync(nameof (FSharpClassificationService))
-
-                            let classificationDataLookup = toSemanticClassificationLookup classificationData
-                            do! unopenedDocumentsSemanticClassificationCache.SetAsync(document, classificationDataLookup)
-                            addSemanticClassificationByLookup sourceText textSpan classificationDataLookup result
+                            match! document.TryGetFSharpSemanticClassificationAsync(nameof (FSharpClassificationService)) with
+                            | ValueNone -> ()
+                            | ValueSome classificationData ->
+                                let classificationDataLookup = toSemanticClassificationLookup classificationData
+                                do! unopenedDocumentsSemanticClassificationCache.SetAsync(document, classificationDataLookup)
+                                addSemanticClassificationByLookup sourceText textSpan classificationDataLookup result
                     else
 
                         match! openedDocumentsSemanticClassificationCache.TryGetValueAsync document with
@@ -288,21 +331,28 @@ type internal FSharpClassificationService [<ImportingConstructor>] () =
                             use _eventDuration =
                                 TelemetryReporter.ReportSingleEventWithDuration(TelemetryEvents.AddSemanticClassifications, eventProps)
 
-                            let! _, checkResults = document.GetFSharpParseAndCheckResultsAsync(nameof (IFSharpClassificationService))
+                            match! document.TryGetFSharpParseAndCheckResultsAsync(nameof (IFSharpClassificationService)) with
+                            | ValueNone -> addLastGood document.Id sourceText textSpan result
+                            | ValueSome(struct (_, checkResults)) ->
+                                // The cache is keyed by text version only, so it has to hold the whole file:
+                                // the next request at this version is usually for a different span.
+                                let classificationData =
+                                    checkResults.GetSemanticClassification(None, RelatedSymbolUseKind.All)
 
-                            let targetRange =
-                                RoslynHelpers.TextSpanToFSharpRange(document.FilePath, textSpan, sourceText)
-
-                            let classificationData =
-                                checkResults.GetSemanticClassification(Some targetRange, RelatedSymbolUseKind.All)
-
-                            if classificationData.Length > 0 then
-                                let classificationDataLookup = itemToSemanticClassificationLookup classificationData
-                                do! unopenedDocumentsSemanticClassificationCache.SetAsync(document, classificationDataLookup)
-
-                                addSemanticClassification sourceText textSpan classificationData result
+                                // Every checked file resolves at least its enclosing module, so nothing here means
+                                // the classification itself failed (SemanticClassification.fs recovers with an empty
+                                // array). Caching that would pin the version to no colours.
+                                if classificationData.Length = 0 then
+                                    addLastGood document.Id sourceText textSpan result
+                                else
+                                    let classificationDataLookup = itemToSemanticClassificationLookup classificationData
+                                    do! openedDocumentsSemanticClassificationCache.SetAsync(document, classificationDataLookup)
+                                    rememberLastGood document.Id sourceText classificationDataLookup
+                                    addSemanticClassificationByLookup sourceText textSpan classificationDataLookup result
                 }
-                |> CancellableTask.ifCanceledReturn ()
+                // A cancellation that is not Roslyn's own (a superseded or aborted check surfaces as one)
+                // must not turn into an empty answer, which Roslyn would paint as "no colours".
+                |> CancellableTask.ifCanceledThen (fun () -> addLastGoodForCurrentText document textSpan result)
                 |> CancellableTask.startAsTask cancellationToken
 
         // Do not perform classification if we don't have project options (#defines matter)

--- a/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
@@ -1160,6 +1160,17 @@ module CancellableTasks =
                     return value
             }
 
+        /// If this CancellableTask gets canceled for another reason than the token being canceled, run the fallback instead.
+        let inline ifCanceledThen ([<InlineIfLambda>] fallback: unit -> unit) (ctask: CancellableTask<unit>) =
+            cancellableTask {
+                let! ct = getCancellationToken ()
+
+                try
+                    return! ctask
+                with :? OperationCanceledException when ct.IsCancellationRequested = false ->
+                    return fallback ()
+            }
+
     /// <exclude />
     [<AutoOpen>]
     module MergeSourcesExtensions =

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -631,7 +631,9 @@ type internal FSharpProjectOptionsManager(checker: FSharpChecker, workspace: Wor
         match reactor.TryGetCachedOptionsByProjectId(documentId.ProjectId) with
         | Some(_, parsingOptions, _) -> parsingOptions
         | _ ->
+            // ParseFile takes the last entry of SourceFiles as the last compiland; with none it throws.
             { FSharpParsingOptions.Default with
+                SourceFiles = [| path |]
                 IsInteractive = CompilerEnvironment.IsScriptFile path
             }
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -619,16 +619,25 @@ type Document with
         match this.GetFsharpParsingOptions() with
         | defines, _ -> defines
 
+    /// Parses the given F# document; ValueNone while its project has no compilation options.
+    member this.TryGetFSharpParseResultsAsync(userOpName) : CancellableTask<FSharpParseFileResults voption> =
+        cancellableTask {
+            match! this.TryGetFSharpCompilationOptionsAsync(userOpName) with
+            | ValueNone -> return ValueNone
+            | ValueSome options ->
+                let! parseResults =
+                    if this.Project.UseTransparentCompiler then
+                        options.Checker.ParseDocumentUsingTransparentCompiler(this, options.ProjectOptions, userOpName)
+                    else
+                        options.Checker.ParseDocument(this, options.ParsingOptions, userOpName)
+
+                return ValueSome parseResults
+        }
+
     /// Parses the given F# document.
     member this.GetFSharpParseResultsAsync(userOpName) =
-        cancellableTask {
-            let! checker, _, parsingOptions, options = this.GetFSharpCompilationOptionsAsync(userOpName)
-
-            if this.Project.UseTransparentCompiler then
-                return! checker.ParseDocumentUsingTransparentCompiler(this, options, userOpName)
-            else
-                return! checker.ParseDocument(this, parsingOptions, userOpName)
-        }
+        this.TryGetFSharpParseResultsAsync(userOpName)
+        |> CancellableTask.map (orRaise "FSharp project options not found.")
 
     /// Parses and checks the given F# document; ValueNone while its project has no compilation options
     /// or the check was aborted.

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -24,14 +24,22 @@ open System.Text.Json.Nodes
 
 #nowarn "57" // Experimental stuff
 
+/// Everything the checker needs for one Roslyn project, resolved once and cached per project.
+type internal FSharpCompilationOptions =
+    {
+        Checker: FSharpChecker
+        OptionsManager: FSharpProjectOptionsManager
+        ParsingOptions: FSharpParsingOptions
+        ProjectOptions: FSharpProjectOptions
+    }
+
 [<RequireQualifiedAccess>]
 module internal ProjectCache =
 
     /// This is a cache to maintain FSharpParsingOptions and FSharpProjectOptions per Roslyn Project.
     /// The Roslyn Project is held weakly meaning when it is cleaned up by the GC, the FSharParsingOptions and FSharpProjectOptions will be cleaned up by the GC.
     /// At some point, this will be the main caching mechanism for FCS projects instead of FCS itself.
-    let Projects =
-        ConditionalWeakTable<Project, FSharpChecker * FSharpProjectOptionsManager * FSharpParsingOptions * FSharpProjectOptions>()
+    let Projects = ConditionalWeakTable<Project, FSharpCompilationOptions>()
 
 module internal SolutionConfigCache =
 
@@ -170,12 +178,12 @@ module private CheckerExtensions =
 
     let exist xs = xs |> Seq.isEmpty |> not
 
-    let getFSharpOptionsForProject (this: Project) =
+    let tryGetFSharpOptionsForProject (this: Project) : CancellableTask<FSharpCompilationOptions voption> =
         if not this.IsFSharp then
-            raise (OperationCanceledException("Project is not a FSharp project."))
+            CancellableTask.singleton ValueNone
         else
             match ProjectCache.Projects.TryGetValue(this) with
-            | true, result -> CancellableTask.singleton result
+            | true, result -> CancellableTask.singleton (ValueSome result)
             | _ ->
                 cancellableTask {
 
@@ -185,13 +193,31 @@ module private CheckerExtensions =
                     let projectOptionsManager = service.FSharpProjectOptionsManager
 
                     match! projectOptionsManager.TryGetOptionsByProject(this, ct) with
-                    | ValueNone -> return raise (OperationCanceledException("FSharp project options not found."))
+                    | ValueNone -> return ValueNone
                     | ValueSome(parsingOptions, projectOptions) ->
                         let result =
-                            (service.Checker, projectOptionsManager, parsingOptions, projectOptions)
+                            {
+                                Checker = service.Checker
+                                OptionsManager = projectOptionsManager
+                                ParsingOptions = parsingOptions
+                                ProjectOptions = projectOptions
+                            }
 
-                        return ProjectCache.Projects.GetValue(this, ConditionalWeakTable<_, _>.CreateValueCallback(fun _ -> result))
+                        return
+                            ValueSome(ProjectCache.Projects.GetValue(this, ConditionalWeakTable<_, _>.CreateValueCallback(fun _ -> result)))
                 }
+
+    // The raising members predate the `Try` ones; they keep their tuple shape until every caller has
+    // moved over, so a missing result stays an OperationCanceledException with the same message there.
+    let getFSharpOptionsForProject (this: Project) =
+        if not this.IsFSharp then
+            raise (OperationCanceledException("Project is not a FSharp project."))
+        else
+            cancellableTask {
+                match! tryGetFSharpOptionsForProject this with
+                | ValueSome options -> return options.Checker, options.OptionsManager, options.ParsingOptions, options.ProjectOptions
+                | ValueNone -> return raise (OperationCanceledException("FSharp project options not found."))
+            }
 
     let documentToSnapshot (document: Document) =
         cancellableTask {
@@ -512,13 +538,14 @@ module private CheckerExtensions =
 
 type Document with
 
-    /// Get the FSharpParsingOptions and FSharpProjectOptions from the F# project that is associated with the given F# document.
-    member this.GetFSharpCompilationOptionsAsync(userOpName) =
+    /// Get the compilation options of the F# project that is associated with the given F# document,
+    /// or ValueNone while the project has none yet (still loading, reloading, a miscellaneous file).
+    member this.TryGetFSharpCompilationOptionsAsync(userOpName) : CancellableTask<FSharpCompilationOptions voption> =
         if not this.Project.IsFSharp then
-            raise (OperationCanceledException("Document is not a FSharp document."))
+            CancellableTask.singleton ValueNone
         else
             match ProjectCache.Projects.TryGetValue(this.Project) with
-            | true, result -> CancellableTask.singleton result
+            | true, result -> CancellableTask.singleton (ValueSome result)
             | _ ->
                 cancellableTask {
                     let service = this.Project.Solution.GetFSharpWorkspaceService()
@@ -526,13 +553,35 @@ type Document with
                     let! ct = CancellableTask.getCancellationToken ()
 
                     match! projectOptionsManager.TryGetOptionsForDocumentOrProject(this, ct, userOpName) with
-                    | ValueNone -> return raise (OperationCanceledException("FSharp project options not found."))
+                    | ValueNone -> return ValueNone
                     | ValueSome(parsingOptions, projectOptions) ->
                         let result =
-                            (service.Checker, projectOptionsManager, parsingOptions, projectOptions)
+                            {
+                                Checker = service.Checker
+                                OptionsManager = projectOptionsManager
+                                ParsingOptions = parsingOptions
+                                ProjectOptions = projectOptions
+                            }
 
-                        return ProjectCache.Projects.GetValue(this.Project, ConditionalWeakTable<_, _>.CreateValueCallback(fun _ -> result))
+                        return
+                            ValueSome(
+                                ProjectCache.Projects.GetValue(
+                                    this.Project,
+                                    ConditionalWeakTable<_, _>.CreateValueCallback(fun _ -> result)
+                                )
+                            )
                 }
+
+    /// Get the FSharpParsingOptions and FSharpProjectOptions from the F# project that is associated with the given F# document.
+    member this.GetFSharpCompilationOptionsAsync(userOpName) =
+        if not this.Project.IsFSharp then
+            raise (OperationCanceledException("Document is not a FSharp document."))
+        else
+            cancellableTask {
+                match! this.TryGetFSharpCompilationOptionsAsync(userOpName) with
+                | ValueSome options -> return options.Checker, options.OptionsManager, options.ParsingOptions, options.ProjectOptions
+                | ValueNone -> return raise (OperationCanceledException("FSharp project options not found."))
+            }
 
     /// Get the compilation defines and language version from F# project that is associated with the given F# document.
     member this.GetFsharpParsingOptionsAsync(userOpName) =
@@ -581,33 +630,55 @@ type Document with
                 return! checker.ParseDocument(this, parsingOptions, userOpName)
         }
 
+    /// Parses and checks the given F# document; ValueNone while its project has no compilation options
+    /// or the check was aborted.
+    member this.TryGetFSharpParseAndCheckResultsAsync
+        (userOpName)
+        : CancellableTask<struct (FSharpParseFileResults * FSharpCheckFileResults) voption> =
+        cancellableTask {
+            match! this.TryGetFSharpCompilationOptionsAsync(userOpName) with
+            | ValueNone -> return ValueNone
+            | ValueSome options ->
+                match! options.Checker.ParseAndCheckDocument(this, options.ProjectOptions, userOpName, allowStaleResults = false) with
+                | Some(parseResults, checkResults) -> return ValueSome(struct (parseResults, checkResults))
+                | None -> return ValueNone
+        }
+
     /// Parses and checks the given F# document.
     member this.GetFSharpParseAndCheckResultsAsync(userOpName) =
         cancellableTask {
-            let! checker, _, _, projectOptions = this.GetFSharpCompilationOptionsAsync(userOpName)
+            match! this.TryGetFSharpParseAndCheckResultsAsync(userOpName) with
+            | ValueSome(struct (parseResults, checkResults)) -> return parseResults, checkResults
+            | ValueNone -> return raise (OperationCanceledException("Unable to get FSharp parse and check results."))
+        }
 
-            match! checker.ParseAndCheckDocument(this, projectOptions, userOpName, allowStaleResults = false) with
-            | Some results -> return results
-            | _ -> return raise (OperationCanceledException("Unable to get FSharp parse and check results."))
+    /// Get the semantic classifications of the given F# document; ValueNone while its project has no
+    /// compilation options or the background check produced none.
+    member this.TryGetFSharpSemanticClassificationAsync
+        (userOpName)
+        : CancellableTask<FSharp.Compiler.EditorServices.SemanticClassificationView voption> =
+        cancellableTask {
+            match! this.TryGetFSharpCompilationOptionsAsync(userOpName) with
+            | ValueNone -> return ValueNone
+            | ValueSome options ->
+                let! result =
+                    if this.Project.UseTransparentCompiler then
+                        async {
+                            let! projectSnapshot = getProjectSnapshotForDocument (this, options.ProjectOptions)
+                            return! options.Checker.GetBackgroundSemanticClassificationForFile(this.FilePath, projectSnapshot)
+                        }
+                    else
+                        options.Checker.GetBackgroundSemanticClassificationForFile(this.FilePath, options.ProjectOptions)
+
+                return ValueOption.ofOption result
         }
 
     /// Get the semantic classifications of the given F# document.
     member this.GetFSharpSemanticClassificationAsync(userOpName) =
         cancellableTask {
-            let! checker, _, _, projectOptions = this.GetFSharpCompilationOptionsAsync(userOpName)
-
-            let! result =
-                if this.Project.UseTransparentCompiler then
-                    async {
-                        let! projectSnapshot = getProjectSnapshotForDocument (this, projectOptions)
-                        return! checker.GetBackgroundSemanticClassificationForFile(this.FilePath, projectSnapshot)
-                    }
-                else
-                    checker.GetBackgroundSemanticClassificationForFile(this.FilePath, projectOptions)
-
-            return
-                result
-                |> Option.defaultWith (fun _ -> raise (OperationCanceledException("Unable to get FSharp semantic classification.")))
+            match! this.TryGetFSharpSemanticClassificationAsync(userOpName) with
+            | ValueSome classification -> return classification
+            | ValueNone -> return raise (OperationCanceledException("Unable to get FSharp semantic classification."))
         }
 
     /// Find F# references in the given F# document.

--- a/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/WorkspaceExtensions.fs
@@ -536,6 +536,9 @@ module private CheckerExtensions =
                         checker.ParseAndCheckDocumentWithPossibleStaleResults(document, options, allowStaleResults, userOpName = userOpName)
             }
 
+let private orRaise message =
+    ValueOption.defaultWith (fun () -> raise (OperationCanceledException(message: string)))
+
 type Document with
 
     /// Get the compilation options of the F# project that is associated with the given F# document,

--- a/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
+++ b/vsintegration/src/FSharp.Editor/Structure/BlockStructureService.fs
@@ -156,8 +156,6 @@ open CancellableTasks
 [<Export(typeof<IFSharpBlockStructureService>)>]
 type internal FSharpBlockStructureService [<ImportingConstructor>] () =
 
-    let emptyValue = FSharpBlockStructure ImmutableArray.empty
-
     interface IFSharpBlockStructureService with
 
         member _.GetBlockStructureAsync(document, cancellationToken) : Task<FSharpBlockStructure> =
@@ -166,12 +164,33 @@ type internal FSharpBlockStructureService [<ImportingConstructor>] () =
 
                 let! sourceText = document.GetTextAsync(cancellationToken)
 
-                let! parseResults = document.GetFSharpParseResultsAsync(nameof (FSharpBlockStructureService))
+                let! parseResults =
+                    cancellableTask {
+                        // A cancellation of its own making - the checker relabels the internal ones with
+                        // the caller's token - is no more an answer here than missing options are.
+                        let! parseResults =
+                            document.TryGetFSharpParseResultsAsync(nameof (FSharpBlockStructureService))
+                            |> CancellableTask.ifCanceledReturn ValueNone
+
+                        match parseResults with
+                        | ValueSome parseResults -> return parseResults
+                        | ValueNone ->
+                            // Outlining only needs a parse; while the project has no options (loading or
+                            // reloading) parse with the quick ones rather than collapse every region.
+                            return!
+                                document
+                                    .GetFSharpChecker()
+                                    .ParseFile(
+                                        document.FilePath,
+                                        sourceText.ToFSharpSourceText(),
+                                        document.GetFSharpQuickParsingOptions(),
+                                        userOpName = nameof (FSharpBlockStructureService)
+                                    )
+                    }
 
                 return
                     createBlockSpans document.Project.IsFSharpBlockStructureEnabled sourceText parseResults.ParseTree
                     |> Seq.toImmutableArray
                     |> FSharpBlockStructure
             }
-            |> CancellableTask.ifCanceledReturn emptyValue
             |> CancellableTask.start cancellationToken

--- a/vsintegration/tests/FSharp.Editor.Tests/BlockStructureServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/BlockStructureServiceTests.fs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace FSharp.Editor.Tests
+
+open System.Threading
+open Xunit
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Structure
+open Microsoft.VisualStudio.FSharp.Editor
+open FSharp.Editor.Tests.Helpers
+
+type BlockStructureServiceTests() =
+
+    let getBlockStructure (document: Document) =
+        (FSharpBlockStructureService() :> IFSharpBlockStructureService)
+            .GetBlockStructureAsync(document, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult()
+
+    // Outlining needs only a parse, so a project without options yet (Visual Studio still loading it)
+    // must not answer with no regions and collapse everything the user had folded.
+    [<Fact>]
+    member _.``Block structure falls back to quick parsing options when project options are unavailable``() =
+        let projectId = ProjectId.CreateNewId()
+
+        let documentInfo =
+            RoslynTestHelpers.CreateDocumentInfo projectId "test.fs" "module M\n\nlet f x =\n    let y = x + 1\n    y * 2\n"
+
+        let projectInfo =
+            RoslynTestHelpers.CreateProjectInfo projectId "test.fsproj" [ documentInfo ]
+
+        let solution = RoslynTestHelpers.CreateSolution [ projectInfo ]
+        let document = RoslynTestHelpers.GetSingleDocument solution
+
+        let structure = getBlockStructure document
+
+        Assert.NotEmpty structure.Spans

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="EditorFormattingServiceTests.fs" />
     <Compile Include="RoslynSourceTextTests.fs" />
     <Compile Include="SemanticClassificationServiceTests.fs" />
+    <Compile Include="BlockStructureServiceTests.fs" />
     <Compile Include="SyntacticColorizationServiceTests.fs" />
     <Compile Include="DocumentHighlightsServiceTests.fs" />
   </ItemGroup>

--- a/vsintegration/tests/FSharp.Editor.Tests/SemanticClassificationServiceTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/SemanticClassificationServiceTests.fs
@@ -2,12 +2,16 @@
 
 namespace FSharp.Editor.Tests
 
+open System
+open System.Threading
 open Xunit
+open Microsoft.CodeAnalysis
 open Microsoft.VisualStudio.FSharp.Editor
 open FSharp.Compiler.EditorServices
 open FSharp.Compiler.Text
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.Classification
+open Microsoft.CodeAnalysis.ExternalAccess.FSharp.Classification
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Editor.Tests.Helpers
 open FSharp.Test
@@ -30,6 +34,53 @@ type SemanticClassificationServiceTests() =
         |> Async.RunSynchronously
         |> Option.toList
         |> List.collect Array.toList
+
+    let openDocument (source: string) =
+        let solution = RoslynTestHelpers.CreateSolution source
+        let workspace = solution.Workspace
+        let documentId = (RoslynTestHelpers.GetSingleDocument solution).Id
+        workspace.OpenDocument documentId
+        let document = workspace.CurrentSolution.GetDocument documentId
+        Assert.True(workspace.IsDocumentOpen documentId, "The document under test has to be open.")
+        document
+
+    let sourceTextOf (document: Document) =
+        document.GetTextAsync(CancellationToken.None).GetAwaiter().GetResult()
+
+    let classifyWith (ct: CancellationToken) (document: Document) (span: TextSpan) =
+        let result = ResizeArray<ClassifiedSpan>()
+
+        (FSharpClassificationService() :> IFSharpClassificationService)
+            .AddSemanticClassificationsAsync(document, span, result, ct)
+            .GetAwaiter()
+            .GetResult()
+
+        List.ofSeq result
+
+    let classify document span =
+        classifyWith CancellationToken.None document span
+
+    let isCached (cache: DocumentCache<SemanticClassificationLookup>) (document: Document) =
+        (cache.TryGetValueAsync document CancellationToken.None).GetAwaiter().GetResult().IsSome
+
+    let lineSpan (text: SourceText) firstLine lastLine =
+        TextSpan.FromBounds(text.Lines[firstLine].Start, text.Lines[lastLine].End)
+
+    let clearProjectOptions (document: Document) =
+        document.Project.Solution.Workspace.Services.GetService<IFSharpWorkspaceService>().FSharpProjectOptionsManager.ClearAllCaches()
+
+    // A project whose options were never supplied, i.e. one Visual Studio is still loading.
+    let openDocumentWithoutProjectOptions (source: string) =
+        let projectId = ProjectId.CreateNewId()
+        let documentInfo = RoslynTestHelpers.CreateDocumentInfo projectId "test.fs" source
+
+        let projectInfo =
+            RoslynTestHelpers.CreateProjectInfo projectId "test.fsproj" [ documentInfo ]
+
+        let solution = RoslynTestHelpers.CreateSolution [ projectInfo ]
+        let documentId = (RoslynTestHelpers.GetSingleDocument solution).Id
+        solution.Workspace.OpenDocument documentId
+        solution.Workspace.CurrentSolution.GetDocument documentId
 
     let verifyClassificationAtEndOfMarker (fileContents: string, marker: string, classificationType: string) =
         let text = SourceText.From(fileContents)
@@ -416,3 +467,115 @@ let result2 = s.(*2*)IsHyperbolicCaseWithLongName
                 && Range.rangeContainsPos item.Range longCasePos)
 
         Assert.True(longCaseUnionItems.Length > 0, "Expected a UnionCase classification covering 'IsHyperbolicCaseWithLongName'")
+
+    // Which cache a document lands in is invisible in its classifications - a miss only costs a
+    // recheck - so these reach the caches directly. Splitting one cache in two (#15954) left the
+    // open-document branch reading the opened cache and writing the unopened one, so the opened
+    // cache was never populated and every request for an open file re-ran the checker.
+    [<Fact>]
+    member _.``Semantic classification of an open document is cached for opened documents``() =
+        let document = openDocument "let x = 1"
+        let text = sourceTextOf document
+
+        Assert.NotEmpty(classify document (TextSpan(0, text.Length)))
+
+        Assert.True(
+            isCached FSharpClassificationService.OpenedDocumentsSemanticClassificationCache document,
+            "Classifying an open document must populate the opened-documents cache."
+        )
+
+        Assert.False(
+            isCached FSharpClassificationService.UnopenedDocumentsSemanticClassificationCache document,
+            "An open document must not be cached as an unopened one."
+        )
+
+    // The cache is keyed by text version only, so what it holds has to cover the whole file:
+    // Roslyn asks for the visible span, then for other spans of the same version as the user scrolls.
+    [<Fact>]
+    member _.``Semantic classification computed for one span of an open document serves another span at the same version``() =
+        let source =
+            [
+                "type R = { Doop: int }"
+                "let r = { Doop = 12 }"
+                ""
+                "let mutable first = 12"
+                "let g () = first"
+            ]
+            |> String.concat "\n"
+
+        let document = openDocument source
+        let text = sourceTextOf document
+        let spanA = lineSpan text 0 1
+        let spanB = lineSpan text 3 4
+        Assert.False(spanA.IntersectsWith spanB)
+
+        let first = classify document spanA
+        Assert.NotEmpty first
+
+        let second = classify document spanB
+        Assert.NotEmpty second
+        Assert.All(second, fun span -> Assert.True(spanB.Contains span.TextSpan))
+
+        // A freshly opened copy has a new DocumentId and therefore cold caches: a direct computation for B.
+        Assert.Equal<ClassifiedSpan list>(classify (openDocument source) spanB, second)
+        Assert.Equal<ClassifiedSpan list>(first, classify document spanA)
+
+    // Roslyn replaces a span's tags with whatever comes back, so "no result" must re-emit the last
+    // good one rather than strip the colours the user already sees.
+    [<Fact>]
+    member _.``Semantic classification serves the last good lookup when project options become unavailable``() =
+        let source = "let x = 1\nlet y = 2"
+        let document = openDocument source
+        let text = sourceTextOf document
+        Assert.NotEmpty(classify document (TextSpan(0, text.Length)))
+
+        clearProjectOptions document
+        // A new text version misses the versioned cache; the text itself is unchanged, so the last
+        // good lookup still describes it.
+        let reopened = document.WithText(SourceText.From source)
+        let reopenedText = sourceTextOf reopened
+
+        Assert.NotEmpty(classify reopened (TextSpan(0, reopenedText.Length)))
+
+        Assert.False(
+            isCached FSharpClassificationService.OpenedDocumentsSemanticClassificationCache reopened,
+            "A miss must not be cached as a result."
+        )
+
+    // The lookup names positions in the text it was computed from, so against edited text it would
+    // colour the wrong characters.
+    [<Fact>]
+    member _.``Semantic classification does not serve the last good lookup for edited text``() =
+        let document = openDocument "let x = 1\nlet y = 2"
+        let text = sourceTextOf document
+        Assert.NotEmpty(classify document (TextSpan(0, text.Length)))
+
+        clearProjectOptions document
+        let edited = document.WithText(SourceText.From "// a comment\nlet x = 1\nlet y = 2")
+        let editedText = sourceTextOf edited
+
+        Assert.Empty(classify edited (TextSpan(0, editedText.Length)))
+
+    [<Fact>]
+    member _.``Semantic classification without project options and without an earlier result returns nothing and caches nothing``() =
+        let document = openDocumentWithoutProjectOptions "let x = 1"
+        let text = sourceTextOf document
+
+        Assert.Empty(classify document (TextSpan(0, text.Length)))
+        Assert.False(isCached FSharpClassificationService.OpenedDocumentsSemanticClassificationCache document)
+        Assert.False(isCached FSharpClassificationService.UnopenedDocumentsSemanticClassificationCache document)
+
+    // Roslyn keeps the previous tags only for a cancellation carrying its own token; nothing may catch it.
+    [<Fact>]
+    member _.``Semantic classification propagates cancellation as a canceled task``() =
+        let document = openDocument "let x = 1"
+        let text = sourceTextOf document
+
+        let task =
+            (FSharpClassificationService() :> IFSharpClassificationService)
+                .AddSemanticClassificationsAsync(document, TextSpan(0, text.Length), ResizeArray(), CancellationToken(true))
+
+        Assert.ThrowsAny<OperationCanceledException>(fun () -> task.GetAwaiter().GetResult())
+        |> ignore
+
+        Assert.True task.IsCanceled


### PR DESCRIPTION
## Description

Outlining needs a parse and nothing else, but `FSharpBlockStructureService` asked for the parse of a fully configured project and answered with no regions whenever that was unavailable — while a project loads or reloads, and for any cancellation the checker relabels with the caller's token. Roslyn takes "no regions" literally and expands every region the user had folded.

It now parses with the quick parsing options in that case, the same ones syntactic classification and brace matching already use, so the folds survive a project reload. Those options carried no source files, which made `ParseFile` throw looking for the last compiland, so they now carry the file being parsed.

Depends on #20450 — it is the head of this branch and supplies `Document.TryGetFSharpParseResultsAsync`. Only the last commit, "Outline with the quick parsing options when a project has none", belongs to this pull request; please review it after #20450 merges.

## Checklist

- [x] Test cases added
- [ ] Performance benchmarks added in case of performance changes
- [x] Release notes entry updated
