### PR TITLE
Keep single-file project options in a named record

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -22,3 +22,4 @@
 * Unused analyzers: disable in VS when file has errors ([PR #19892](https://github.com/dotnet/fsharp/pull/19892))
 * Move to Roslyn's unified ExternalAccess library ([PR #20099](https://github.com/dotnet/fsharp/pull/20099))
 * Remove trailing whitespace from source files. No functional change: whitespace inside string literals and inactive `#if` regions is preserved. ([PR #20355](https://github.com/dotnet/fsharp/pull/20355))
+* The VS project options reactor keeps single-file and script project options in a named record instead of a five-place tuple, and its text-view subscription plumbing uses `voption` instead of `option`. ([PR #20455](https://github.com/dotnet/fsharp/pull/20455))

--- a/vsintegration/src/FSharp.Editor/Common/Extensions.fs
+++ b/vsintegration/src/FSharp.Editor/Common/Extensions.fs
@@ -71,14 +71,14 @@ type Project with
 
 type TextViewEventsHandler
     (
-        onChangeCaretHandler: (IVsTextView * int * int -> unit) option,
-        onKillFocus: (IVsTextView -> unit) option,
-        onSetFocus: (IVsTextView -> unit) option
+        onChangeCaretHandler: (IVsTextView * int * int -> unit) voption,
+        onKillFocus: (IVsTextView -> unit) voption,
+        onSetFocus: (IVsTextView -> unit) voption
     ) =
     interface IVsTextViewEvents with
         member this.OnChangeCaretLine(view: IVsTextView, newline: int, oldline: int) =
             onChangeCaretHandler
-            |> Option.iter (fun handler -> handler (view, newline, oldline))
+            |> ValueOption.iter (fun handler -> handler (view, newline, oldline))
 
         member this.OnChangeScrollInfo
             (_view: IVsTextView, _iBar: int, _iMinUnit: int, _iMaxUnits: int, _iVisibleUnits: int, _iFirstVisibleUnit: int)
@@ -86,17 +86,17 @@ type TextViewEventsHandler
             ()
 
         member this.OnKillFocus(view: IVsTextView) =
-            onKillFocus |> Option.iter (fun handler -> handler (view))
+            onKillFocus |> ValueOption.iter (fun handler -> handler (view))
 
         member this.OnSetBuffer(_view: IVsTextView, _buffer: IVsTextLines) = ()
 
         member this.OnSetFocus(view: IVsTextView) =
-            onSetFocus |> Option.iter (fun handler -> handler (view))
+            onSetFocus |> ValueOption.iter (fun handler -> handler (view))
 
-type ConnectionPointSubscription = System.IDisposable option
+type ConnectionPointSubscription = System.IDisposable voption
 
 // Usage example:
-//  If a handler is None, to not handle that event
+//  If a handler is ValueNone, to not handle that event
 //  let subscription = subscribeToTextViewEvents (textView, onChangeCaretHandler, onKillFocus, onSetFocus)
 //  Unsubscribe using subscription.Dispose()
 let subscribeToTextViewEvents (textView: IVsTextView, onChangeCaretHandler, onKillFocus, onSetFocus) : ConnectionPointSubscription =
@@ -108,16 +108,16 @@ let subscribeToTextViewEvents (textView: IVsTextView, onChangeCaretHandler, onKi
         let mutable cookie = 0u
 
         match cpContainer.FindConnectionPoint(ref riid) with
-        | null -> None
+        | null -> ValueNone
         | cp ->
-            Some(
+            ValueSome(
                 cp.Advise(handler, &cookie)
 
                 { new IDisposable with
                     member _.Dispose() = cp.Unadvise(cookie)
                 }
             )
-    | _ -> None
+    | _ -> ValueNone
 
 type Document with
 
@@ -129,7 +129,7 @@ type Document with
             | null -> None
             | languageServices -> languageServices.GetService<'T>() |> Some
 
-    member this.TryGetIVsTextView() : IVsTextView option =
+    member this.TryGetIVsTextView() : IVsTextView voption =
         match ServiceProvider.GlobalProvider.GetService(typeof<SVsTextManager>) with
         | :? IVsTextManager as textManager ->
             // Grab IVsRunningDocumentTable
@@ -140,20 +140,20 @@ type Document with
                     match Marshal.GetObjectForIUnknown docData with
                     | :? IVsTextBuffer as ivsTextBuffer ->
                         match textManager.GetActiveView(0, ivsTextBuffer) with
-                        | hr, vsTextView when ErrorHandler.Succeeded(hr) -> Some vsTextView
-                        | _ -> None
-                    | _ -> None
-                | _ -> None
-            | _ -> None
-        | _ -> None
+                        | hr, vsTextView when ErrorHandler.Succeeded(hr) -> ValueSome vsTextView
+                        | _ -> ValueNone
+                    | _ -> ValueNone
+                | _ -> ValueNone
+            | _ -> ValueNone
+        | _ -> ValueNone
 
-    member this.TryGetTextViewAndCaretPos() : (IVsTextView * Position) option =
+    member this.TryGetTextViewAndCaretPos() : (IVsTextView * Position) voption =
         match this.TryGetIVsTextView() with
-        | Some textView ->
+        | ValueSome textView ->
             match textView.GetCaretPos() with
-            | hr, line, column when ErrorHandler.Succeeded(hr) -> Some(textView, Position.fromZ line column)
-            | _ -> None
-        | None -> None
+            | hr, line, column when ErrorHandler.Succeeded(hr) -> ValueSome(textView, Position.fromZ line column)
+            | _ -> ValueNone
+        | ValueNone -> ValueNone
 
     member this.IsFSharpScript = isScriptFile this.FilePath
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -101,6 +101,15 @@ module private FSharpProjectOptionsHelpers =
         else
             hasProjectVersionChanged
 
+type private SingleFileCacheEntry =
+    {
+        Project: Project
+        FileStamp: VersionStamp
+        ParsingOptions: FSharpParsingOptions
+        ProjectOptions: FSharpProjectOptions
+        Subscription: ConnectionPointSubscription
+    }
+
 [<RequireQualifiedAccess>]
 type private FSharpProjectOptionsMessage =
     | TryGetOptionsByDocument of
@@ -128,8 +137,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
     let cache =
         ConcurrentDictionary<ProjectId, struct (Project * FSharpParsingOptions * FSharpProjectOptions)>()
 
-    let singleFileCache =
-        ConcurrentDictionary<DocumentId, Project * VersionStamp * FSharpParsingOptions * FSharpProjectOptions * ConnectionPointSubscription>()
+    let singleFileCache = ConcurrentDictionary<DocumentId, SingleFileCacheEntry>()
 
     // This is used to not constantly emit the same compilation.
     let weakPEReferences = ConditionalWeakTable<Compilation, FSharpReferencedProject>()
@@ -283,31 +291,43 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                 let onKillFocus (_) = updateProjectOptions ()
                 let onSetFocus (_) = updateProjectOptions ()
 
-                let addToCacheAndSubscribe value =
-                    match value with
-                    | projectId, fileStamp, parsingOptions, projectOptions, _ ->
-                        let subscription =
-                            match textViewAndCaret () with
-                            | Some(textView, _) ->
-                                subscribeToTextViewEvents (textView, (Some onChangeCaretHandler), (Some onKillFocus), (Some onSetFocus))
-                            | None -> None
+                let addToCacheAndSubscribe (entry: SingleFileCacheEntry) =
+                    let subscription =
+                        match textViewAndCaret () with
+                        | Some(textView, _) ->
+                            subscribeToTextViewEvents (textView, (Some onChangeCaretHandler), (Some onKillFocus), (Some onSetFocus))
+                        | None -> None
 
-                        (projectId, fileStamp, parsingOptions, projectOptions, subscription)
+                    { entry with
+                        Subscription = subscription
+                    }
 
                 singleFileCache.AddOrUpdate(
                     document.Id, // The key to the cache
                     (fun _ value -> addToCacheAndSubscribe value), // Function to add the cached value if the key does not exist
                     (fun _ _ value -> value), // Function to update the value if the key exists
-                    (document.Project, fileStamp, parsingOptions, projectOptions, None) // The value to add or update
+                    {
+                        Project = document.Project
+                        FileStamp = fileStamp
+                        ParsingOptions = parsingOptions
+                        ProjectOptions = projectOptions
+                        Subscription = None
+                    } // The value to add or update
                 )
                 |> ignore
 
                 return ValueSome struct (parsingOptions, projectOptions)
 
-            | true, (oldProject, oldFileStamp, parsingOptions, projectOptions, _) ->
+            | true,
+              {
+                  Project = oldProject
+                  FileStamp = oldFileStamp
+                  ParsingOptions = parsingOptions
+                  ProjectOptions = projectOptions
+              } ->
                 if fileStamp <> oldFileStamp || isProjectInvalidated document.Project oldProject ct then
                     match singleFileCache.TryRemove(document.Id) with
-                    | true, (_, _, _, _, Some subscription) -> subscription.Dispose()
+                    | true, { Subscription = Some subscription } -> subscription.Dispose()
                     | _ -> ()
 
                     return! tryComputeOptionsBySingleScriptOrFile document userOpName
@@ -520,7 +540,11 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                     legacyProjectSites.TryRemove(projectId) |> ignore
                 | FSharpProjectOptionsMessage.ClearSingleFileOptionsCache(documentId) ->
                     match singleFileCache.TryRemove(documentId) with
-                    | true, (_, _, _, projectOptions, subscription) ->
+                    | true,
+                      {
+                          ProjectOptions = projectOptions
+                          Subscription = subscription
+                      } ->
                         lastSuccessfulCompilations.TryRemove(documentId.ProjectId) |> ignore
                         checker.ClearCache([ projectOptions ])
                         subscription |> Option.iter (fun handler -> handler.Dispose())

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -212,7 +212,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
         cancellableTask {
             let! ct = CancellableTask.getCancellationToken ()
             let! fileStamp = document.GetTextVersionAsync(ct)
-            let textViewAndCaret () : (IVsTextView * Position) option = document.TryGetTextViewAndCaretPos()
+            let textViewAndCaret () : (IVsTextView * Position) voption = document.TryGetTextViewAndCaretPos()
 
             match singleFileCache.TryGetValue(document.Id) with
             | false, _ ->
@@ -222,7 +222,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                     let caret = textViewAndCaret ()
 
                     match caret with
-                    | None ->
+                    | ValueNone ->
                         checker.GetProjectOptionsFromScript(
                             document.FilePath,
                             sourceText.ToFSharpSourceText(),
@@ -231,7 +231,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                             userOpName = userOpName
                         )
 
-                    | Some(_, caret) ->
+                    | ValueSome(_, caret) ->
                         checker.GetProjectOptionsFromScript(
                             document.FilePath,
                             sourceText.ToFSharpSourceText(),
@@ -294,9 +294,14 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                 let addToCacheAndSubscribe (entry: SingleFileCacheEntry) =
                     let subscription =
                         match textViewAndCaret () with
-                        | Some(textView, _) ->
-                            subscribeToTextViewEvents (textView, (Some onChangeCaretHandler), (Some onKillFocus), (Some onSetFocus))
-                        | None -> None
+                        | ValueSome(textView, _) ->
+                            subscribeToTextViewEvents (
+                                textView,
+                                (ValueSome onChangeCaretHandler),
+                                (ValueSome onKillFocus),
+                                (ValueSome onSetFocus)
+                            )
+                        | ValueNone -> ValueNone
 
                     { entry with
                         Subscription = subscription
@@ -311,7 +316,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                         FileStamp = fileStamp
                         ParsingOptions = parsingOptions
                         ProjectOptions = projectOptions
-                        Subscription = None
+                        Subscription = ValueNone
                     } // The value to add or update
                 )
                 |> ignore
@@ -327,7 +332,10 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
               } ->
                 if fileStamp <> oldFileStamp || isProjectInvalidated document.Project oldProject ct then
                     match singleFileCache.TryRemove(document.Id) with
-                    | true, { Subscription = Some subscription } -> subscription.Dispose()
+                    | true,
+                      {
+                          Subscription = ValueSome subscription
+                      } -> subscription.Dispose()
                     | _ -> ()
 
                     return! tryComputeOptionsBySingleScriptOrFile document userOpName
@@ -547,7 +555,7 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                       } ->
                         lastSuccessfulCompilations.TryRemove(documentId.ProjectId) |> ignore
                         checker.ClearCache([ projectOptions ])
-                        subscription |> Option.iter (fun handler -> handler.Dispose())
+                        subscription |> ValueOption.iter (fun handler -> handler.Dispose())
                     | _ -> ()
         }
 


### PR DESCRIPTION
`FSharpProjectOptionsReactor`'s cache of script / single-file project options stored each entry as a 5-tuple destructured positionally at every consumer; it is a record with named fields now. A second commit moves `ConnectionPointSubscription` and the text-view lookups around it from `option` to `voption` — none of those values leave the editor's VS-interop layer. No behaviour change.

A reference record and not a struct: `FSharp.Editor` targets `net472`, where a multi-field struct entry is copied out of the `ConcurrentDictionary` on every hit and forces a new node on update, while the reference record matches the tuple it replaces in time and allocations on both runtimes. Numbers in [a comment below](https://github.com/dotnet/fsharp/pull/20455#issuecomment-5696275398).

Follows the [discussion on #20274](https://github.com/dotnet/fsharp/pull/20274#discussion_r3941379823), where a struct value for this dictionary was proposed and deferred to its own PR. That PR's diff already touches the same `Subscription` match arms as part of a broader `option`→`voption` sweep, so whichever of the two merges first, the other needs a real rebase on these lines.
