### PR TITLE
Ignore --pathmap in the IDE's F# project options

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -15,6 +15,7 @@
 * Fix doubled F# diagnostics in tooltips. ([Issue #16360](https://github.com/dotnet/fsharp/issues/16360))
 * Fix `NotSupportedException` in the memory-mapped-file optimization when copying `ReadOnlyMemory` into `MemoryMappedFileViewStream`. ([Issue #20263](https://github.com/dotnet/fsharp/issues/20263))
 * Reduce allocations in the VS project options reactor: the command-line options and project options caches and the mailbox reply payloads now hold struct tuples, and `IProjectSite.CompilationBinOutputPath` returns `string voption` picked with a new `Array.tryPickV`. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
+* Go To Definition into an F# project built with a path map (`DeterministicSourcePaths` or `PathMap`) opens its source instead of a generated signature: the IDE no longer applies `--pathmap` to the project options it checks with. ([PR #20470](https://github.com/dotnet/fsharp/pull/20470))
 
 ### Changed
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -366,8 +366,10 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
                             [|
                                 // Clear any references from CompilationOptions.
                                 // We get the references from Project.ProjectReferences/Project.MetadataReferences.
+                                // A path map belongs to the build output: applied here it rewrites the file name of
+                                // every range imported from a referenced project, and navigation finds no document.
                                 for x in projectSite.CompilationOptions do
-                                    if not (x.Contains("-r:")) then
+                                    if not (x.Contains("-r:") || x.StartsWith("--pathmap:", StringComparison.Ordinal)) then
                                         x
 
                                 for x in project.MetadataReferences.OfType<PortableExecutableReference>() do

--- a/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
+++ b/vsintegration/tests/FSharp.Editor.Tests/FSharp.Editor.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="CompletionProviderTests.fs" />
     <Compile Include="FindReferencesTests.fs" />
     <Compile Include="GoToDefinitionServiceTests.fs" />
+    <Compile Include="PathMapNavigationTests.fs" />
     <Compile Include="HelpContextServiceTests.fs" />
     <Compile Include="QuickInfoTests.fs" />
     <Compile Include="TaskListServiceTests.fs" />

--- a/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/Helpers/RoslynHelpers.fs
@@ -201,6 +201,14 @@ type TestHostServices() =
     override this.CreateWorkspaceServices(workspace) =
         new TestHostWorkspaceServices(this, workspace)
 
+/// One Roslyn project instance of a multi-targeted F# project: its extra defines and the
+/// synthetic files left out of it, as VS does per target framework.
+type TargetInstance =
+    {
+        Defines: string list
+        ExcludedFileIds: string list
+    }
+
 [<AbstractClass; Sealed>]
 type RoslynTestHelpers private () =
 
@@ -257,6 +265,33 @@ type RoslynTestHelpers private () =
             documents = documents,
             filePath = filePath
         )
+
+    static member private ProjectInfoFor
+        (id, name, filePath, outputFilePath, documents, projectReferences: ProjectReference list, metadataReferences: MetadataReference seq)
+        =
+        ProjectInfo.Create(
+            id,
+            VersionStamp.Create(DateTime.UtcNow),
+            name,
+            name,
+            LanguageNames.FSharp,
+            filePath = filePath,
+            outputFilePath = outputFilePath,
+            documents = documents,
+            projectReferences = projectReferences,
+            metadataReferences = metadataReferences
+        )
+
+    static member private MetadataReferencesOf(options: FSharpProjectOptions, excludedPaths: string seq) =
+        let excluded = HashSet(excludedPaths, StringComparer.OrdinalIgnoreCase)
+
+        options.OtherOptions
+        |> Seq.filter (fun x -> x.StartsWith("-r:", StringComparison.Ordinal))
+        |> Seq.map _.Substring(3)
+        |> Seq.filter (excluded.Contains >> not)
+        |> Seq.map MetadataReference.CreateFromFile
+        |> Seq.cast<MetadataReference>
+        |> Seq.toList
 
     static member SetProjectOptions projId (solution: Solution) (options: FSharpProjectOptions) =
         solution.Workspace.Services
@@ -331,18 +366,117 @@ type RoslynTestHelpers private () =
 
         let options = syntheticProject.GetProjectOptions checker
 
-        let metadataReferences =
-            options.OtherOptions
-            |> Seq.filter (fun x -> x.StartsWith("-r:"))
-            |> Seq.map (fun x -> x.Substring(3) |> MetadataReference.CreateFromFile :> MetadataReference)
-
-        let projInfo = projInfo.WithMetadataReferences metadataReferences
+        let projInfo =
+            projInfo.WithMetadataReferences(RoslynTestHelpers.MetadataReferencesOf(options, []))
 
         let solution = RoslynTestHelpers.CreateSolution [ projInfo ]
 
         options |> RoslynTestHelpers.SetProjectOptions projId solution
 
         solution, checker
+
+    /// One Roslyn project per synthetic project, wired with project references the way VS wires
+    /// project-to-project references, so the options manager builds in-memory F# references.
+    static member CreateMultiProjectSolution(syntheticProject: SyntheticProject) =
+        let checker = syntheticProject.SaveAndCheck()
+
+        let projects =
+            syntheticProject.GetAllProjects()
+            |> List.distinctBy _.Name
+            |> List.map (fun project -> project, ProjectId.CreateNewId())
+
+        let projectIds = dict [ for project, id in projects -> project.Name, id ]
+
+        let projectInfos =
+            [
+                for project, id in projects do
+                    let options = project.GetProjectOptions checker
+
+                    RoslynTestHelpers.ProjectInfoFor(
+                        id,
+                        project.Name,
+                        project.ProjectFileName,
+                        project.OutputFilename,
+                        [
+                            for path in project.SourceFilePaths -> RoslynTestHelpers.CreateDocumentInfo id path (File.ReadAllText path)
+                        ],
+                        [
+                            for dependency in project.DependsOn -> ProjectReference projectIds[dependency.Name]
+                        ],
+                        RoslynTestHelpers.MetadataReferencesOf(options, project.DependsOn |> List.map _.OutputFilename)
+                    )
+            ]
+
+        let solution = RoslynTestHelpers.CreateSolution projectInfos
+
+        for project, id in projects do
+            project.GetProjectOptions checker
+            |> RoslynTestHelpers.SetProjectOptions id solution
+
+        solution, checker
+
+    /// One Roslyn project per target instance, all sharing the .fsproj path and the document file
+    /// paths, like the per-target-framework projects VS creates for a multi-targeted project.
+    static member CreateMultiTargetSolution(syntheticProject: SyntheticProject, instances: TargetInstance list) =
+        assert (syntheticProject.DependsOn = [])
+
+        let checker = syntheticProject.SaveAndCheck()
+        let options = syntheticProject.GetProjectOptions checker
+        let metadataReferences = RoslynTestHelpers.MetadataReferencesOf(options, [])
+
+        let instances =
+            [
+                for instance in instances ->
+                    let excludedPaths =
+                        HashSet(
+                            [
+                                for fileId in instance.ExcludedFileIds do
+                                    syntheticProject.GetFilePath fileId
+
+                                    if (syntheticProject.Find fileId).HasSignatureFile then
+                                        syntheticProject.GetSignatureFilePath fileId
+                            ],
+                            StringComparer.OrdinalIgnoreCase
+                        )
+
+                    let sourceFiles =
+                        syntheticProject.SourceFilePaths |> List.filter (excludedPaths.Contains >> not)
+
+                    let id = ProjectId.CreateNewId()
+
+                    let projectInfo =
+                        RoslynTestHelpers.ProjectInfoFor(
+                            id,
+                            syntheticProject.Name,
+                            syntheticProject.ProjectFileName,
+                            syntheticProject.OutputFilename,
+                            [
+                                for path in sourceFiles -> RoslynTestHelpers.CreateDocumentInfo id path (File.ReadAllText path)
+                            ],
+                            [],
+                            metadataReferences
+                        )
+
+                    let instanceOptions =
+                        { options with
+                            SourceFiles = List.toArray sourceFiles
+                            OtherOptions =
+                                [|
+                                    yield! options.OtherOptions
+                                    for define in instance.Defines -> $"--define:{define}"
+                                |]
+                        }
+
+                    id, projectInfo, instanceOptions
+            ]
+
+        let solution =
+            RoslynTestHelpers.CreateSolution [ for _, projectInfo, _ in instances -> projectInfo ]
+
+        for id, _, instanceOptions in instances do
+            RoslynTestHelpers.SetProjectOptions id solution instanceOptions
+
+        solution, [ for id, _, _ in instances -> id ]
 
     static member GetFsDocument(code, ?customProjectOption: string, ?customEditorOptions) =
         let customProjectOptions =

--- a/vsintegration/tests/FSharp.Editor.Tests/PathMapNavigationTests.fs
+++ b/vsintegration/tests/FSharp.Editor.Tests/PathMapNavigationTests.fs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+/// A library whose build maps its source paths, as DeterministicSourcePaths does: the symbols another
+/// project imports from it must still name the files of the workspace.
+module FSharp.Editor.Tests.PathMapNavigationTests
+
+open System
+open System.IO
+open System.Threading
+open Xunit
+open Microsoft.VisualStudio.FSharp.Editor
+open Microsoft.VisualStudio.FSharp.Editor.CancellableTasks
+open FSharp.Editor.Tests.Helpers
+open FSharp.Test.ProjectGeneration
+
+/// As Directory.Build.props would set it: the same map on every project of the solution.
+let private pathMap (project: SyntheticProject) =
+    [ $"--pathmap:{Path.GetDirectoryName project.ProjectDir}=.\\" ]
+
+let private library =
+    let library = SyntheticProject.Create("Library", sourceFile "Library" [])
+
+    { library with
+        OtherOptions = pathMap library
+    }
+
+let private app =
+    let app = SyntheticProject.Create("App", sourceFile "App" [ "Library" ])
+
+    { app with
+        DependsOn = [ library ]
+        OtherOptions = pathMap app
+    }
+
+let private solution, _ = RoslynTestHelpers.CreateMultiProjectSolution app
+
+let private documentOf (project: SyntheticProject) fileId =
+    solution.GetDocumentIdsWithFilePath(project.GetFilePath fileId)
+    |> Seq.exactlyOne
+    |> solution.GetDocument
+
+[<Fact>]
+let ``the path map of a project is not applied in the IDE`` () =
+    let _, _, _, options =
+        (documentOf library "Library").GetFSharpCompilationOptionsAsync "test"
+        |> CancellableTask.runSynchronouslyWithoutCancellation
+
+    Assert.DoesNotContain(options.OtherOptions, fun option -> option.StartsWith("--pathmap:", StringComparison.Ordinal))
+
+[<Fact>]
+let ``goto definition into a project built with a path map reaches its source`` () =
+    let appDocument = documentOf app "App"
+    let text = appDocument.GetTextAsync(CancellationToken.None).Result.ToString()
+
+    let position =
+        text.IndexOf("ModuleLibrary.f", StringComparison.Ordinal)
+        + "ModuleLibrary.f".Length
+        - 1
+
+    let result =
+        GoToDefinition(FSharpMetadataAsSourceService()).FindDefinitionAtPosition(appDocument, position)
+        |> CancellableTask.runSynchronouslyWithoutCancellation
+
+    match result with
+    | ValueSome(FSharpGoToDefinitionResult.NavigableItem item, _) -> Assert.Equal(library.GetFilePath "Library", item.Document.FilePath)
+    | result -> failwith $"expected a navigable item, got %A{result}"


### PR DESCRIPTION
In a solution whose `Directory.Build.props` sets `<PathMap>$(MSBuildThisFileDirectory)=.\</PathMap>` or `DeterministicSourcePaths`, Go To Definition from an F# file into another F# project of the solution opens the generated signature instead of the source. The declaration comes back named `.\backend\Use cases\Circulars\GraphQL\.\backend\Use cases\Circulars\GraphQL\Types\Circular.fs`: the project system passes the build's `--pathmap:` into the IDE's compilation options, FCS applies it when it pickles the ranges of the in-memory referenced-assembly data, and the implicit include directory it is joined with is mapped too. No lookup by path can find such a file.

The map also leaks between projects. `TcGlobals` carries it, and FCS caches `TcGlobals` with the framework imports under a key that does not include it, so one project with a `--pathmap:` is enough to break navigation into any sibling of the same framework set, and a project with a map is checked without it when a sibling filled the cache first. #20476 fixes the cache; dropping the option in the IDE makes the cached map empty for all of them.

`FSharpProjectOptionsManager` now drops `--pathmap:` from the options it takes from the project site, next to the `-r:` options it already discards. The map only describes what the build should write into its output; nothing in the IDE needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
