### PR TITLE
Build a project's TcGlobals with its own path map when the framework imports are cached

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -148,6 +148,7 @@
 * Import: Don't walk non-F# assemblies when labelling trait constraint sources (PR [#20090](https://github.com/dotnet/fsharp/pull/20090))
 * Avoid per-instance lock object in InterruptibleLazy and DelayInitArrayMap (PR [#20088](https://github.com/dotnet/fsharp/pull/20088))
 * IL: fix leaking binary view ([PR #20250](https://github.com/dotnet/fsharp/pull/20250))
+* A project reusing cached framework imports is checked with its own `--pathmap` instead of the map of the project that filled the cache, so the ranges of its in-memory reference data name its real files. ([Issue #20474](https://github.com/dotnet/fsharp/issues/20474), [PR #20476](https://github.com/dotnet/fsharp/pull/20476))
 
 ### Added
 

--- a/src/Compiler/Service/IncrementalBuild.fs
+++ b/src/Compiler/Service/IncrementalBuild.fs
@@ -557,12 +557,13 @@ type FrameworkImportsCache(size) =
         let node = this.GetNode(tcConfig, frameworkDLLs, nonFrameworkResolutions)
         let! tcGlobals, frameworkTcImports = node.GetOrComputeValue()
 
-        // If the tcGlobals was loaded from a different project, langVersion and realsig may be different
-        // for each cached project.  So here we create a new tcGlobals, with the existing framework values
-        // and updated realsig and langversion
+        // If the tcGlobals was loaded from a different project, langVersion, realsig and pathMap may be
+        // different for each cached project.  So here we create a new tcGlobals, with the existing framework
+        // values and the updated realsig, langversion and pathMap
         let tcGlobals =
             if tcGlobals.langVersion <> tcConfig.langVersion
-                || tcGlobals.realsig <> tcConfig.realsig then
+                || tcGlobals.realsig <> tcConfig.realsig
+                || tcGlobals.pathMap <> tcConfig.pathMap then
                     TcGlobals(
                         tcGlobals.compilingFSharpCore,
                         tcGlobals.ilg,
@@ -574,7 +575,7 @@ type FrameworkImportsCache(size) =
                         tcGlobals.tryFindSysTypeCcuHelper,
                         tcGlobals.emitDebugInfoInQuotations,
                         tcGlobals.noDebugAttributes,
-                        tcGlobals.pathMap,
+                        tcConfig.pathMap,
                         tcConfig.langVersion,
                         tcConfig.realsig,
                         tcConfig.compilationMode

--- a/src/Compiler/Service/TransparentCompiler.fs
+++ b/src/Compiler/Service/TransparentCompiler.fs
@@ -964,13 +964,14 @@ type internal TransparentCompiler
                 // Prepare the frameworkTcImportsCache
                 let! tcGlobals, frameworkTcImports = ComputeFrameworkImports tcConfig frameworkDLLs nonFrameworkResolutions
 
-                // If the tcGlobals was loaded from a different project, langVersion and realsig may be different
-                // for each cached project.  So here we create a new tcGlobals, with the existing framework values
-                // and updated realsig and langversion
+                // If the tcGlobals was loaded from a different project, langVersion, realsig and pathMap may be
+                // different for each cached project.  So here we create a new tcGlobals, with the existing
+                // framework values and the updated realsig, langversion and pathMap
                 let tcGlobals =
                     if
                         tcGlobals.langVersion <> tcConfig.langVersion
                         || tcGlobals.realsig <> tcConfig.realsig
+                        || tcGlobals.pathMap <> tcConfig.pathMap
                     then
                         TcGlobals(
                             tcGlobals.compilingFSharpCore,
@@ -983,7 +984,7 @@ type internal TransparentCompiler
                             tcGlobals.tryFindSysTypeCcuHelper,
                             tcGlobals.emitDebugInfoInQuotations,
                             tcGlobals.noDebugAttributes,
-                            tcGlobals.pathMap,
+                            tcConfig.pathMap,
                             tcConfig.langVersion,
                             tcConfig.realsig,
                             tcConfig.compilationMode

--- a/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
+++ b/tests/FSharp.Compiler.ComponentTests/FSharp.Compiler.ComponentTests.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
@@ -540,6 +540,7 @@
     <Compile Include="Signatures\MemberTests.fs" />
     <Compile Include="StaticLinking\StaticLinking.fs" />
     <Compile Include="FSharpChecker\CommonWorkflows.fs" />
+    <Compile Include="FSharpChecker\PathMap.fs" />
     <Compile Include="FSharpChecker\ProjectSnapshot.fs" />
     <Compile Include="FSharpChecker\TransparentCompiler.fs" />
     <Compile Include="FSharpChecker\SymbolUse.fs" />

--- a/tests/FSharp.Compiler.ComponentTests/FSharpChecker/PathMap.fs
+++ b/tests/FSharp.Compiler.ComponentTests/FSharpChecker/PathMap.fs
@@ -1,0 +1,57 @@
+module FSharpChecker.PathMap
+
+open System.IO
+open System.Threading.Tasks
+open Xunit
+open FSharp.Test.ProjectGeneration
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Text
+
+let private checkWith (checker: FSharpChecker) (project: SyntheticProject) =
+    ProjectWorkflowBuilder(project, checker = checker).Yield() |> Async.Ignore
+
+/// The framework imports, and the TcGlobals with them, are cached per framework set; the path map of
+/// the project that filled the cache must not reach the ranges a sibling exposes to its consumers.
+[<Theory>]
+[<InlineData(false)>]
+[<InlineData(true)>]
+let ``a sibling's path map does not reach the ranges of a project without one`` (useTransparentCompiler: bool) : Task =
+    task {
+        let checker = FSharpChecker.Create(useTransparentCompiler = useTransparentCompiler)
+        let library = SyntheticProject.Create("Library", sourceFile "Library" [])
+
+        let mapped =
+            { SyntheticProject.Create("Mapped", sourceFile "Mapped" []) with
+                OtherOptions = [ $"--pathmap:{Path.GetDirectoryName library.ProjectDir}=.\\" ] }
+
+        let app =
+            { SyntheticProject.Create("App", sourceFile "App" [ "Library" ]) with
+                DependsOn = [ library ] }
+
+        do! checkWith checker mapped
+        do! checkWith checker app
+
+        let appFile = app.GetFilePath "App"
+
+        let! _, answer =
+            checker.ParseAndCheckFileInProject(
+                appFile,
+                0,
+                SourceText.ofString (File.ReadAllText appFile),
+                app.GetProjectOptions checker
+            )
+
+        let checkResults =
+            match answer with
+            | FSharpCheckFileAnswer.Succeeded checkResults -> checkResults
+            | FSharpCheckFileAnswer.Aborted -> failwith "the check was aborted"
+
+        let libraryFunction =
+            checkResults.GetAllUsesOfAllSymbolsInFile()
+            |> Seq.tryFind (fun symbolUse -> symbolUse.Symbol.FullName = $"{library.Name}.ModuleLibrary.f")
+            |> Option.defaultWith (fun () ->
+                failwith
+                    $"""ModuleLibrary.f not used; symbols: %A{checkResults.GetAllUsesOfAllSymbolsInFile() |> Seq.map _.Symbol.FullName |> Seq.distinct |> List.ofSeq}""")
+
+        Assert.Equal(library.GetFilePath "Library", libraryFunction.Symbol.DeclarationLocation.Value.FileName)
+    }


### PR DESCRIPTION
Fixes #20474

`FrameworkImportsCache` caches the framework `TcImports` together with the `TcGlobals` built for the first project of a framework set, and its key does not include the path map. A project reusing the entry got a new `TcGlobals` only when `langVersion` or `realsig` differed, and copied `pathMap` from the cached instance even then. `TypedTreePickle.p_range` applies that map to every range it writes and `EncodeSignatureData` to `compileTimeWorkingDir`, so the in-memory reference data a project exposes to its consumers was mapped with the `--pathmap` of whichever project filled the cache first: a project without a map lent mapped, relative file names to its consumers, and a project with a map lost it when a sibling came first.

Seen in Visual Studio on a solution with `<PathMap>` in `Directory.Build.props`: symbols imported from a sibling project carried a doubled, relative file name and Go To Definition opened the generated signature.

`pathMap` now takes part in the decision to rebuild `TcGlobals`, like `langVersion` and `realsig`, and the new instance takes it from the project's own `TcConfig`. The cached framework imports do not depend on the map, so the key is unchanged.

#20470 keeps the IDE from passing `--pathmap` at all; this makes the cache correct for any host that checks mapped and unmapped projects with one `FSharpChecker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
