### PR TITLE
Wait for Go To Definition through the threaded-wait dialog

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-* Go To Definition no longer blocks the UI thread with a bare `Task.Wait`: the synchronous `IFSharpGoToDefinitionService` call now waits through the cancellable threaded-wait dialog, and the editor's `TaskCompletionSource` bridges run their continuations on the thread pool instead of inline on whichever thread finished the check, so repeated F12 on a large solution no longer starves semantic classification and other main-thread work.
+* Go To Definition no longer blocks the UI thread with a bare `Task.Wait`: the synchronous `IFSharpGoToDefinitionService` call now waits through the cancellable threaded-wait dialog, and the editor's `TaskCompletionSource` bridges run their continuations on the thread pool instead of inline on whichever thread finished the check, so repeated F12 on a large solution no longer starves semantic classification and other main-thread work. ([PR #20482](https://github.com/dotnet/fsharp/pull/20482))
 * Improve Find All References performance by throttling parallel typechecks. ([PR #20128](https://github.com/dotnet/fsharp/pull/20128))
 * Fixed Rename incorrectly renaming `get` and `set` keywords for properties with explicit accessors. ([Issue #18270](https://github.com/dotnet/fsharp/issues/18270), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Fixed Find All References crash when F# project contains non-F# files like `.cshtml`. ([Issue #16394](https://github.com/dotnet/fsharp/issues/16394), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 
+* Go To Definition no longer blocks the UI thread with a bare `Task.Wait`: the synchronous `IFSharpGoToDefinitionService` call now waits through the cancellable threaded-wait dialog, and the editor's `TaskCompletionSource` bridges run their continuations on the thread pool instead of inline on whichever thread finished the check, so repeated F12 on a large solution no longer starves semantic classification and other main-thread work.
 * Improve Find All References performance by throttling parallel typechecks. ([PR #20128](https://github.com/dotnet/fsharp/pull/20128))
 * Fixed Rename incorrectly renaming `get` and `set` keywords for properties with explicit accessors. ([Issue #18270](https://github.com/dotnet/fsharp/issues/18270), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))
 * Fixed Find All References crash when F# project contains non-F# files like `.cshtml`. ([Issue #16394](https://github.com/dotnet/fsharp/issues/16394), [PR #19252](https://github.com/dotnet/fsharp/pull/19252))

--- a/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
+++ b/vsintegration/src/FSharp.Editor/Common/CancellableTasks.fs
@@ -777,7 +777,9 @@ module CancellableTasks =
                     }
 
             // try not to yield if on bg thread already
-            let tcs = new TaskCompletionSource<_>(TaskCreationOptions.None)
+            let tcs =
+                new TaskCompletionSource<_>(TaskCreationOptions.RunContinuationsAsynchronously)
+
             let barrier = VolatileBarrier()
 
             let reg =

--- a/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/RoslynHelpers.fs
@@ -135,7 +135,9 @@ module internal RoslynHelpers =
                     return! computation
                 }
 
-        let tcs = new TaskCompletionSource<_>(TaskCreationOptions.None)
+        let tcs =
+            new TaskCompletionSource<_>(TaskCreationOptions.RunContinuationsAsynchronously)
+
         let barrier = VolatileBarrier()
 
         let reg =

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -807,25 +807,24 @@ type internal FSharpNavigation(metadataAsSource: FSharpMetadataAsSourceService, 
             ThreadHelper.JoinableTaskFactory.Run(
                 SR.NavigatingTo(),
                 (fun _progress dialogCancellationToken ->
-                    task {
-                        use linked =
-                            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dialogCancellationToken)
+                    let linked =
+                        CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dialogCancellationToken)
 
-                        return!
-                            cancellableTask {
-                                match! gtd.FindDefinitionAsync(initialDoc, position) with
-                                | ValueSome(FSharpGoToDefinitionResult.NavigableItem(navItem), _) ->
-                                    gtd.NavigateToItem(navItem, linked.Token) |> ignore
-                                    navigated.Value <- true
-                                | ValueSome(FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), _) ->
-                                    gtd.NavigateToExternalDeclaration(targetSymbolUse, metadataReferences, linked.Token)
-                                    |> ignore
+                    cancellableTask {
+                        use _ = linked
 
-                                    navigated.Value <- true
-                                | _ -> ()
-                            }
-                            |> CancellableTask.start linked.Token
-                    }),
+                        match! gtd.FindDefinitionAsync(initialDoc, position) with
+                        | ValueSome(FSharpGoToDefinitionResult.NavigableItem(navItem), _) ->
+                            gtd.NavigateToItem(navItem, linked.Token) |> ignore
+                            navigated.Value <- true
+                        | ValueSome(FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), _) ->
+                            gtd.NavigateToExternalDeclaration(targetSymbolUse, metadataReferences, linked.Token)
+                            |> ignore
+
+                            navigated.Value <- true
+                        | _ -> ()
+                    }
+                    |> CancellableTask.start linked.Token),
                 TimeSpan.FromSeconds 1
             )
 

--- a/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
+++ b/vsintegration/src/FSharp.Editor/Navigation/GoToDefinition.fs
@@ -794,32 +794,45 @@ type internal FSharpNavigation(metadataAsSource: FSharpMetadataAsSourceService, 
         }
 
     member _.TryGoToDefinition(position, cancellationToken) =
-        // Once we migrate to Roslyn-exposed MAAS and sourcelink (https://github.com/dotnet/fsharp/issues/13951), this can be a "normal" task
-        // Wrap this in a try/with as if the user clicks "Cancel" on the thread dialog, we'll be cancelled.
-        // Task.Wait throws an exception if the task is cancelled, so be sure to catch it.
+        // Once we migrate to Roslyn-exposed MAAS and sourcelink (https://github.com/dotnet/fsharp/issues/13951), this can be a "normal" task.
+        // The IFSharpGoToDefinitionService contract is synchronous, so the main thread has to wait here: the threaded-wait dialog
+        // keeps it pumping and cancellable, where a bare Task.Wait froze it until the VS watchdog auto-cancelled.
         try
             use _ =
                 TelemetryReporter.ReportSingleEventWithDuration(TelemetryEvents.GoToDefinition, [||])
 
             let gtd = GoToDefinition(metadataAsSource)
-            let gtdTask = gtd.FindDefinitionAsync (initialDoc, position) cancellationToken
+            let navigated = ref false
 
-            gtdTask.Wait()
+            ThreadHelper.JoinableTaskFactory.Run(
+                SR.NavigatingTo(),
+                (fun _progress dialogCancellationToken ->
+                    task {
+                        use linked =
+                            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, dialogCancellationToken)
 
-            if gtdTask.Status = TaskStatus.RanToCompletion && gtdTask.Result.IsSome then
-                match gtdTask.Result with
-                | ValueSome(FSharpGoToDefinitionResult.NavigableItem(navItem), _) ->
-                    gtd.NavigateToItem(navItem, cancellationToken) |> ignore
-                    true
-                | ValueSome(FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), _) ->
-                    gtd.NavigateToExternalDeclaration(targetSymbolUse, metadataReferences, cancellationToken)
-                    |> ignore
+                        return!
+                            cancellableTask {
+                                match! gtd.FindDefinitionAsync(initialDoc, position) with
+                                | ValueSome(FSharpGoToDefinitionResult.NavigableItem(navItem), _) ->
+                                    gtd.NavigateToItem(navItem, linked.Token) |> ignore
+                                    navigated.Value <- true
+                                | ValueSome(FSharpGoToDefinitionResult.ExternalAssembly(targetSymbolUse, metadataReferences), _) ->
+                                    gtd.NavigateToExternalDeclaration(targetSymbolUse, metadataReferences, linked.Token)
+                                    |> ignore
 
-                    true
-                | _ -> false
-            else
-                false
-        with exc ->
+                                    navigated.Value <- true
+                                | _ -> ()
+                            }
+                            |> CancellableTask.start linked.Token
+                    }),
+                TimeSpan.FromSeconds 1
+            )
+
+            navigated.Value
+        with
+        | :? OperationCanceledException -> false
+        | exc ->
             TelemetryReporter.ReportFault(TelemetryEvents.GoToDefinition, FaultSeverity.General, exc)
             false
 


### PR DESCRIPTION
Repeated F12 on a large solution (89 projects) left files without semantic colours and Visual Studio showing "Please wait for an editor command to finish… Exceeded execution timeout, attempting to auto cancel". Classification was not failing — it was never reached.

`IFSharpGoToDefinitionService.TryGoToDefinition` is a synchronous contract Roslyn calls on the UI thread, and it waited for the checker with a bare `Task.Wait()`, which pumps nothing: the watchdog showed its dialog and auto-cancelled after two seconds while the check kept running, and every further F12 queued another waiter behind the same non-cancellable snapshot-version lazies. The dialog stealing focus then pushed the main thread into a focus-lost handler that blocked on the JTF context lock, so the taggers cancelled their work items and no colours arrived.

The wait now goes through the threaded-wait dialog, the way `NavigateTo` in the same file already does, so the main thread keeps pumping and the user gets a Cancel button; a user cancel returns `false` instead of reporting a telemetry fault. Separately, the two `TaskCompletionSource` bridges ran their continuations inline on whichever thread finished the F# async, landing the heavy post-check work of a navigation on the pool thread that completed the check; they complete asynchronously now.

No issue is filed for this; the diagnosis came from a live debugging session in the experimental instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
