### PR TITLE
Build F# projects with the .NET SDK compiler by default in Visual Studio

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -2,6 +2,7 @@
 
 * Code-fixes for FS3888 (compiler-semantic attribute on the `.fs` but not the `.fsi`): copy the attribute into the `.fsi`, or remove it from the `.fs`. ([Issue #19560](https://github.com/dotnet/fsharp/issues/19560), [PR #19880](https://github.com/dotnet/fsharp/pull/19880))
 * Expand `<inheritdoc/>` in IDE tooltips, completion, and signature help, inheriting XML documentation from base classes, interfaces, overridden members, and constructors. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19188](https://github.com/dotnet/fsharp/pull/19188))
+* Added a **Tools > Options > F# Tools > Compiler** option, **"Use the .NET SDK F# compiler for builds"**, on by default. Visual Studio now builds F# projects with the F# compiler from the installed .NET SDK (matching `dotnet build`); turn the option off to build with the .NET Framework compiler bundled with Visual Studio. Command-line builds are unaffected. ([Issue #20484](https://github.com/dotnet/fsharp/issues/20484))
 
 ### Fixed
 

--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -2,7 +2,7 @@
 
 * Code-fixes for FS3888 (compiler-semantic attribute on the `.fs` but not the `.fsi`): copy the attribute into the `.fsi`, or remove it from the `.fs`. ([Issue #19560](https://github.com/dotnet/fsharp/issues/19560), [PR #19880](https://github.com/dotnet/fsharp/pull/19880))
 * Expand `<inheritdoc/>` in IDE tooltips, completion, and signature help, inheriting XML documentation from base classes, interfaces, overridden members, and constructors. ([Issue #19175](https://github.com/dotnet/fsharp/issues/19175), [PR #19188](https://github.com/dotnet/fsharp/pull/19188))
-* Added a **Tools > Options > F# Tools > Compiler** option, **"Use the .NET SDK F# compiler for builds"**, on by default. Visual Studio now builds F# projects with the F# compiler from the installed .NET SDK (matching `dotnet build`); turn the option off to build with the .NET Framework compiler bundled with Visual Studio. Command-line builds are unaffected. ([Issue #20484](https://github.com/dotnet/fsharp/issues/20484))
+* Added a **Tools > Options > F# Tools > Compiler** option, **"Use the .NET SDK F# compiler for builds"**, on by default. Visual Studio uses the .NET SDK F# compiler when the project supplies SDK paths, matching `dotnet build`. Otherwise, it uses the bundled .NET Framework compiler. Turn the option off to use the bundled compiler for all projects. Command-line builds are unaffected. ([Issue #20484](https://github.com/dotnet/fsharp/issues/20484), [PR #20485](https://github.com/dotnet/fsharp/pull/20485))
 
 ### Fixed
 

--- a/src/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Targets
@@ -54,7 +54,11 @@ this file.
       Project file properties that control compiler selection:
       ========================================================
       Suggest that the compiler used be the desktop framework version.  On computers without Visual Studio these properties is ignored.
-      <FSharpPreferNetFrameworkTools>  boolean: true or false === default value true
+      <FSharpPreferNetFrameworkTools>  boolean: true or false === default value false (use the .NET SDK F# compiler)
+      When unset, Visual Studio builds default to the .NET SDK compiler; the .NET Framework compiler is used
+      only if this property is set to true in the project, or if the Tools > Options > F# Tools > Compiler
+      option "Use the .NET SDK F# compiler for builds" is turned off (HKCU\Software\Microsoft\VisualStudio\FSharp,
+      DWORD UseNetSdkCompiler = 0). Command-line (dotnet build) builds are unaffected.
 
       Suggest that the compiler used be the 64 Bit compiler.  On computers without Visual Studio this property is ignored.
       <FSharpPreferAnyCpuTools>      boolean: true or false === default value true
@@ -66,8 +70,10 @@ this file.
       On Windows Arm64 default to Arm64 build, otherwise default to AnyCpu.
     -->
 
-    <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true'">
-        <FSharpPreferNetFrameworkTools Condition="'$(FSharpPreferNetFrameworkTools)' == ''">true</FSharpPreferNetFrameworkTools>
+    <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true' and '$(FSharpPreferNetFrameworkTools)' == ''">
+        <_FSharpUseNetSdkCompilerVsOption>$([MSBuild]::GetRegistryValueFromView('HKEY_CURRENT_USER\Software\Microsoft\VisualStudio\FSharp', 'UseNetSdkCompiler', null, RegistryView.Default))</_FSharpUseNetSdkCompilerVsOption>
+        <FSharpPreferNetFrameworkTools Condition="'$(_FSharpUseNetSdkCompilerVsOption)' == '0'">true</FSharpPreferNetFrameworkTools>
+        <FSharpPreferNetFrameworkTools Condition="'$(FSharpPreferNetFrameworkTools)' == ''">false</FSharpPreferNetFrameworkTools>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true' and '$(FSharpPreferNetFrameworkTools)' == 'true'">

--- a/src/FSharp.Build/Microsoft.FSharp.Targets
+++ b/src/FSharp.Build/Microsoft.FSharp.Targets
@@ -54,11 +54,13 @@ this file.
       Project file properties that control compiler selection:
       ========================================================
       Suggest that the compiler used be the desktop framework version.  On computers without Visual Studio these properties is ignored.
-      <FSharpPreferNetFrameworkTools>  boolean: true or false === default value false (use the .NET SDK F# compiler)
-      When unset, Visual Studio builds default to the .NET SDK compiler; the .NET Framework compiler is used
-      only if this property is set to true in the project, or if the Tools > Options > F# Tools > Compiler
-      option "Use the .NET SDK F# compiler for builds" is turned off (HKCU\Software\Microsoft\VisualStudio\FSharp,
-      DWORD UseNetSdkCompiler = 0). Command-line (dotnet build) builds are unaffected.
+      <FSharpPreferNetFrameworkTools>  boolean: true or false === default value false when SDK paths are available
+      When unset, Visual Studio builds use the .NET SDK compiler if NetCoreRoot and NETCoreSdkVersion are available.
+      Otherwise, they use the bundled .NET Framework compiler.
+      Set this property to true to use the .NET Framework compiler, or turn off
+      Tools > Options > F# Tools > Compiler > "Use the .NET SDK F# compiler for builds"
+      (HKCU\Software\Microsoft\VisualStudio\FSharp, DWORD UseNetSdkCompiler = 0).
+      Command-line (dotnet build) builds are unaffected.
 
       Suggest that the compiler used be the 64 Bit compiler.  On computers without Visual Studio this property is ignored.
       <FSharpPreferAnyCpuTools>      boolean: true or false === default value true
@@ -72,7 +74,7 @@ this file.
 
     <PropertyGroup Condition="'$(FSharp_Shim_Present)' == 'true' and '$(FSharpPreferNetFrameworkTools)' == ''">
         <_FSharpUseNetSdkCompilerVsOption>$([MSBuild]::GetRegistryValueFromView('HKEY_CURRENT_USER\Software\Microsoft\VisualStudio\FSharp', 'UseNetSdkCompiler', null, RegistryView.Default))</_FSharpUseNetSdkCompilerVsOption>
-        <FSharpPreferNetFrameworkTools Condition="'$(_FSharpUseNetSdkCompilerVsOption)' == '0'">true</FSharpPreferNetFrameworkTools>
+        <FSharpPreferNetFrameworkTools Condition="'$(_FSharpUseNetSdkCompilerVsOption)' == '0' or '$(NetCoreRoot)' == '' or '$(NETCoreSdkVersion)' == ''">true</FSharpPreferNetFrameworkTools>
         <FSharpPreferNetFrameworkTools Condition="'$(FSharpPreferNetFrameworkTools)' == ''">false</FSharpPreferNetFrameworkTools>
     </PropertyGroup>
 

--- a/tests/fsharp/SDKTests/AllSdkTargetsTests.proj
+++ b/tests/fsharp/SDKTests/AllSdkTargetsTests.proj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
     <TestsToRun Include="tests\*.proj" />
+    <TestsToRun Include="tests\WhichFSharpCompiler - Missing SDK Paths.proj" AdditionalProperties="MissingSdkPath=Root" />
+    <TestsToRun Include="tests\WhichFSharpCompiler - Missing SDK Paths.proj" AdditionalProperties="MissingSdkPath=Version" />
   </ItemGroup>
 
   <Target Name="Build">

--- a/tests/fsharp/SDKTests/RegistryCompilerSelection.Tests.ps1
+++ b/tests/fsharp/SDKTests/RegistryCompilerSelection.Tests.ps1
@@ -47,11 +47,14 @@ function Get-Props([string[]]$extra) {
     Push-Location $work
     try {
         $args = @("msbuild", "probe.proj",
+                  "-getProperty:MSBuildToolsPath",
                   "-getProperty:FSharp_Shim_Present",
                   "-getProperty:FSharpPreferNetFrameworkTools",
+                  "-getProperty:FscToolPath",
                   "-getProperty:FscToolExe",
                   "-getProperty:DotnetFscCompilerPath") + $extra
         $json = & $DotNet @args 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) { throw "MSBuild probe failed: $json" }
         return ($json | ConvertFrom-Json).Properties
     } finally { Pop-Location }
 }
@@ -63,37 +66,44 @@ function Check($name, $cond, $detail) {
 }
 
 try {
-    # Case 1: no registry value -> SDK selected (default flipped)
-    Clear-Reg
-    $p = Get-Props @()
-    Check "Case1 no-registry -> SDK" `
-        ($p.FSharpPreferNetFrameworkTools -eq 'false' -and $p.FscToolExe -eq 'dotnet.exe' -and $p.DotnetFscCompilerPath -match 'fsc\.dll') `
-        ("got: $($p | ConvertTo-Json -Compress)")
-
-    # Case 2: registry 0 -> .NET Framework selected
-    Set-Reg 0
-    $p = Get-Props @()
-    Check "Case2 registry=0 -> .NET Framework" `
-        ($p.FSharpPreferNetFrameworkTools -eq 'true' -and $p.FscToolExe -match '^fsc.*\.exe$' -and $p.DotnetFscCompilerPath -eq '') `
-        ("got: $($p | ConvertTo-Json -Compress)")
-
-    # Case 3: registry 1 -> SDK selected
-    Set-Reg 1
-    $p = Get-Props @()
-    Check "Case3 registry=1 -> SDK" `
-        ($p.FSharpPreferNetFrameworkTools -eq 'false' -and $p.FscToolExe -eq 'dotnet.exe' -and $p.DotnetFscCompilerPath -match 'fsc\.dll') `
-        ("got: $($p | ConvertTo-Json -Compress)")
-
-    # Case 4: explicit project value wins over registry 1
-    Set-Reg 1
-    $p = Get-Props @("-p:FSharpPreferNetFrameworkTools=true")
-    Check "Case4 explicit=true beats registry=1 -> .NET Framework" `
-        ($p.FSharpPreferNetFrameworkTools -eq 'true' -and $p.FscToolExe -match '^fsc.*\.exe$' -and $p.DotnetFscCompilerPath -eq '') `
-        ("got: $($p | ConvertTo-Json -Compress)")
+    $sdk = Get-Props @()
+    $sdkRoot = (Split-Path (Split-Path $sdk.MSBuildToolsPath -Parent) -Parent) + '\'
+    $sdkVersion = Split-Path $sdk.MSBuildToolsPath -Leaf
+    $sdkCases = @(
+        @{ Name = 'resolved SDK'; Root = $sdkRoot; Version = $sdkVersion },
+        @{ Name = 'missing root'; Root = ''; Version = $sdkVersion },
+        @{ Name = 'missing version'; Root = $sdkRoot; Version = '' },
+        @{ Name = 'non-SDK project'; Root = ''; Version = '' }
+    )
+    foreach ($registry in @($null, 0, 1)) {
+        if ($null -eq $registry) { Clear-Reg } else { Set-Reg $registry }
+        foreach ($sdkCase in $sdkCases) {
+            foreach ($explicit in @('', 'true', 'false')) {
+                $properties = @("-p:NetCoreRoot=$($sdkCase.Root)", "-p:NETCoreSdkVersion=$($sdkCase.Version)")
+                if ($explicit -ne '') { $properties += "-p:FSharpPreferNetFrameworkTools=$explicit" }
+                $p = Get-Props $properties
+                $desktop = $explicit -eq 'true' -or
+                    ($explicit -eq '' -and ($registry -eq 0 -or $sdkCase.Root -eq '' -or $sdkCase.Version -eq ''))
+                if ($desktop) {
+                    $correct = $p.FSharpPreferNetFrameworkTools -eq 'true' -and
+                        $p.FscToolExe -match '^fsc.*\.exe$' -and
+                        $p.FscToolPath -like '*/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/' -and
+                        $p.DotnetFscCompilerPath -eq ''
+                } else {
+                    $correct = $p.FSharpPreferNetFrameworkTools -eq 'false' -and
+                        $p.FscToolExe -eq 'dotnet.exe' -and $p.FscToolPath -eq $sdkCase.Root -and
+                        $p.DotnetFscCompilerPath -eq "`"$($sdkCase.Root)sdk/$($sdkCase.Version)/FSharp/fsc.dll`""
+                }
+                Check "$($sdkCase.Name), registry='$registry', explicit='$explicit'" `
+                    ($p.FSharp_Shim_Present -eq 'true' -and $correct) `
+                    ("got: $($p | ConvertTo-Json -Compress)")
+            }
+        }
+    }
 
     # Case 5 (NEGATIVE): CLI build (shim absent) -> selection blocks skipped, unaffected
     Set-Reg 0
-    $p = Get-Props @("-p:FSharpCompilerPath=/Explicit/")
+    $p = Get-Props @("-p:FSharpCompilerPath=C:\Explicit\")
     Check "Case5 CLI (shim absent) -> unaffected (no fsc selection)" `
         ($p.FSharp_Shim_Present -eq '' -and $p.FscToolExe -eq '' -and $p.DotnetFscCompilerPath -eq '') `
         ("got: $($p | ConvertTo-Json -Compress)")

--- a/tests/fsharp/SDKTests/RegistryCompilerSelection.Tests.ps1
+++ b/tests/fsharp/SDKTests/RegistryCompilerSelection.Tests.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 5
+<#
+  Verifies src/FSharp.Build/Microsoft.FSharp.Targets selects the F# compiler correctly based on the
+  HKCU\Software\Microsoft\VisualStudio\FSharp\UseNetSdkCompiler value and the FSharp_Shim_Present gate.
+  Windows-only (registry + VS shim). Evaluates the SOURCE targets via `dotnet msbuild -getProperty`
+  from a temp directory OUTSIDE the repo so the repo's global.json (which pins an SDK that may not be
+  installed) does not apply.
+#>
+[CmdletBinding()]
+param(
+    [string] $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path,
+    [string] $DotNet = "dotnet"
+)
+
+$ErrorActionPreference = "Stop"
+
+$shim    = Join-Path $RepoRoot "vsintegration\shims\Microsoft.FSharp.ShimHelpers.props"
+$targets = Join-Path $RepoRoot "src\FSharp.Build\Microsoft.FSharp.Targets"
+if (-not (Test-Path $shim))    { throw "Shim not found: $shim" }
+if (-not (Test-Path $targets)) { throw "Targets not found: $targets" }
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("fsc_regsel_" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $work | Out-Null
+$probe = Join-Path $work "probe.proj"
+@"
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Language>F#</Language>
+    <Configuration>Debug</Configuration>
+    <FSharpCompilerPath></FSharpCompilerPath>
+  </PropertyGroup>
+  <Import Project="$shim" />
+  <Import Project="$targets" />
+</Project>
+"@ | Set-Content -Path $probe -Encoding UTF8
+
+$regKey = "HKCU\Software\Microsoft\VisualStudio\FSharp"
+$regVal = "UseNetSdkCompiler"
+
+# Save & later restore any pre-existing value so we never corrupt a developer's setting.
+$saved = (reg query $regKey /v $regVal 2>$null | Select-String $regVal)
+
+function Clear-Reg { reg delete $regKey /v $regVal /f 2>$null | Out-Null }
+function Set-Reg([int]$v) { reg add $regKey /v $regVal /t REG_DWORD /d $v /f | Out-Null }
+
+function Get-Props([string[]]$extra) {
+    Push-Location $work
+    try {
+        $args = @("msbuild", "probe.proj",
+                  "-getProperty:FSharp_Shim_Present",
+                  "-getProperty:FSharpPreferNetFrameworkTools",
+                  "-getProperty:FscToolExe",
+                  "-getProperty:DotnetFscCompilerPath") + $extra
+        $json = & $DotNet @args 2>&1 | Out-String
+        return ($json | ConvertFrom-Json).Properties
+    } finally { Pop-Location }
+}
+
+$failures = New-Object System.Collections.Generic.List[string]
+function Check($name, $cond, $detail) {
+    if ($cond) { Write-Host "PASS: $name" -ForegroundColor Green }
+    else { Write-Host "FAIL: $name -- $detail" -ForegroundColor Red; $failures.Add($name) }
+}
+
+try {
+    # Case 1: no registry value -> SDK selected (default flipped)
+    Clear-Reg
+    $p = Get-Props @()
+    Check "Case1 no-registry -> SDK" `
+        ($p.FSharpPreferNetFrameworkTools -eq 'false' -and $p.FscToolExe -eq 'dotnet.exe' -and $p.DotnetFscCompilerPath -match 'fsc\.dll') `
+        ("got: $($p | ConvertTo-Json -Compress)")
+
+    # Case 2: registry 0 -> .NET Framework selected
+    Set-Reg 0
+    $p = Get-Props @()
+    Check "Case2 registry=0 -> .NET Framework" `
+        ($p.FSharpPreferNetFrameworkTools -eq 'true' -and $p.FscToolExe -match '^fsc.*\.exe$' -and $p.DotnetFscCompilerPath -eq '') `
+        ("got: $($p | ConvertTo-Json -Compress)")
+
+    # Case 3: registry 1 -> SDK selected
+    Set-Reg 1
+    $p = Get-Props @()
+    Check "Case3 registry=1 -> SDK" `
+        ($p.FSharpPreferNetFrameworkTools -eq 'false' -and $p.FscToolExe -eq 'dotnet.exe' -and $p.DotnetFscCompilerPath -match 'fsc\.dll') `
+        ("got: $($p | ConvertTo-Json -Compress)")
+
+    # Case 4: explicit project value wins over registry 1
+    Set-Reg 1
+    $p = Get-Props @("-p:FSharpPreferNetFrameworkTools=true")
+    Check "Case4 explicit=true beats registry=1 -> .NET Framework" `
+        ($p.FSharpPreferNetFrameworkTools -eq 'true' -and $p.FscToolExe -match '^fsc.*\.exe$' -and $p.DotnetFscCompilerPath -eq '') `
+        ("got: $($p | ConvertTo-Json -Compress)")
+
+    # Case 5 (NEGATIVE): CLI build (shim absent) -> selection blocks skipped, unaffected
+    Set-Reg 0
+    $p = Get-Props @("-p:FSharpCompilerPath=/Explicit/")
+    Check "Case5 CLI (shim absent) -> unaffected (no fsc selection)" `
+        ($p.FSharp_Shim_Present -eq '' -and $p.FscToolExe -eq '' -and $p.DotnetFscCompilerPath -eq '') `
+        ("got: $($p | ConvertTo-Json -Compress)")
+}
+finally {
+    # restore registry
+    if ($saved) {
+        $v = ($saved -split '\s+')[-1]
+        if ($v -match '^0x') { $v = [Convert]::ToInt32($v,16) }
+        Set-Reg ([int]$v)
+    } else { Clear-Reg }
+    Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) { Write-Error "Registry compiler-selection matrix FAILED: $($failures -join ', ')"; exit 1 }
+Write-Host "All registry compiler-selection cases passed." -ForegroundColor Green

--- a/tests/fsharp/SDKTests/tests/CompileOrder - BeforeAndAfter.proj
+++ b/tests/fsharp/SDKTests/tests/CompileOrder - BeforeAndAfter.proj
@@ -9,9 +9,9 @@
   <PropertyGroup>
     <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
     <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
-    <ExpectedFscToolExe>fscAnyCpu.exe</ExpectedFscToolExe>
-    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
-    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
+    <ExpectedFscToolExe>dotnet.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>/_NetCoreRoot_/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath>/FSharp/fsc.dll</ExpectedDotnetFscCompilerPath>
     <ExpectedCompile>One;Two;Three;Four;Five;Six;Seven;Eight;Nine;Ten;Eleven;Twelve;Thirteen;Fourteen</ExpectedCompile>
   </PropertyGroup>
 

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Default Settings.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Default Settings.proj
@@ -9,9 +9,9 @@
   <PropertyGroup>
     <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
     <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
-    <ExpectedFscToolExe>fscAnyCpu.exe</ExpectedFscToolExe>
-    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
-    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
+    <ExpectedFscToolExe>dotnet.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>/_NetCoreRoot_/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath>/FSharp/fsc.dll</ExpectedDotnetFscCompilerPath>
   </PropertyGroup>
 
   <Import Project="ToolsTest.props" />

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Missing SDK Paths.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Missing SDK Paths.proj
@@ -12,8 +12,8 @@
   <Import Project="ToolsTest.props" />
 
   <PropertyGroup>
-    <NetCoreRoot></NetCoreRoot>
-    <NETCoreSdkVersion></NETCoreSdkVersion>
+    <NetCoreRoot Condition="'$(MissingSdkPath)' != 'Version'"></NetCoreRoot>
+    <NETCoreSdkVersion Condition="'$(MissingSdkPath)' != 'Root'"></NETCoreSdkVersion>
     <FSharpPreferAnyCpuTools>true</FSharpPreferAnyCpuTools>
   </PropertyGroup>
 

--- a/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Missing SDK Paths.proj
+++ b/tests/fsharp/SDKTests/tests/WhichFSharpCompiler - Missing SDK Paths.proj
@@ -1,0 +1,22 @@
+<Project ToolsVersion="4.0" DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <FSharpCompilerPath></FSharpCompilerPath>
+    <ExpectedFSharpShimPresent>true</ExpectedFSharpShimPresent>
+    <ExpectedFSharpCompilerPath>/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFSharpCompilerPath>
+    <ExpectedFscToolExe>fscAnyCpu.exe</ExpectedFscToolExe>
+    <ExpectedFscToolPath>_VsInstallRoot_/Common7/IDE/CommonExtensions/Microsoft/FSharp/Tools/</ExpectedFscToolPath>
+    <ExpectedDotnetFscCompilerPath></ExpectedDotnetFscCompilerPath>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.props" />
+
+  <PropertyGroup>
+    <NetCoreRoot></NetCoreRoot>
+    <NETCoreSdkVersion></NETCoreSdkVersion>
+    <FSharpPreferAnyCpuTools>true</FSharpPreferAnyCpuTools>
+  </PropertyGroup>
+
+  <Import Project="ToolsTest.targets" />
+
+</Project>

--- a/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/LanguageService.fs
@@ -249,6 +249,7 @@ type internal FSharpSettingsFactory [<Composition.ImportingConstructor>] (settin
 
 [<Guid(FSharpConstants.packageGuidString)>]
 [<ProvideOptionPage(typeof<FSharp.Interactive.FsiPropertyPage>, "F# Tools", "F# Interactive", 6000s, 6001s, true)>] // true = supports automation
+[<ProvideOptionPage(typeof<FSharp.Interactive.FSharpCompilerPropertyPage>, "F# Tools", "Compiler", 6000s, 6015s, true)>]
 
 [<ProvideKeyBindingTable("{dee22b65-9761-4a26-8fb2-759b971d6dfc}", 6001s)>] // <-- resource ID for localised name
 

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/VSPackage.resx
@@ -457,6 +457,9 @@
   <data name="6003" xml:space="preserve">
     <value>Visual F# Files (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</value>
   </data>
+  <data name="6015" xml:space="preserve">
+    <value>Compiler</value>
+  </data>
   <data name="7000" xml:space="preserve">
     <value>Visual F#</value>
   </data>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.cs.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Soubory Visual F# (*.fs, *.fsi, *.fsx, *.fsscript); *.fs, *.fsi, *.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.de.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Visual F#-Dateien (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.es.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Archivos de Visual F# (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.fr.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Fichiers Visual F# (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.it.xlf
@@ -422,6 +422,11 @@
         <target state="translated">File Visual F# (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ja.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Visual F# ファイル (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ko.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Visual F# 파일 (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pl.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Pliki języka Visual F# (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.pt-BR.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Arquivos Visual F# (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.ru.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Файлы Visual F# (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.tr.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Visual F# Dosyaları (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hans.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Visual F# 文件(*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.ProjectSystem.FSharp/xlf/VSPackage.zh-Hant.xlf
@@ -422,6 +422,11 @@
         <target state="translated">Visual F# 檔案 (*.fs,*.fsi,*.fsx,*.fsscript);*.fs,*.fsi,*.fsx,*.fsscript</target>
         <note />
       </trans-unit>
+      <trans-unit id="6015">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
       <trans-unit id="7000">
         <source>Visual F#</source>
         <target state="translated">Visual F#</target>

--- a/vsintegration/src/FSharp.VS.FSI/Properties.resx
+++ b/vsintegration/src/FSharp.VS.FSI/Properties.resx
@@ -162,4 +162,13 @@
   <data name="FSharpInteractiveUseNetCoreDescr" xml:space="preserve">
     <value>Enable .NET Core script editing and execution for all F# scripts and the F# Interactive window</value>
   </data>
+  <data name="FSharpCompilerMisc" xml:space="preserve">
+    <value>Compiler</value>
+  </data>
+  <data name="FSharpCompilerUseNetSdk" xml:space="preserve">
+    <value>Use the .NET SDK F# compiler for builds</value>
+  </data>
+  <data name="FSharpCompilerUseNetSdkDescr" xml:space="preserve">
+    <value>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.VS.FSI/VSPackage.resx
+++ b/vsintegration/src/FSharp.VS.FSI/VSPackage.resx
@@ -122,4 +122,7 @@
   <data name="101" xml:space="preserve">
     <value>J1H0RTAZRQRKDEJ2I3A2PCIAPQQRQIDZI3CTKAIAQPJIE3EPHAMRRKAJCHI1PJM2CPDIRZKMMJHKPHJ9E1HDZHZDC1DEHHR0QIARA8RKA3PICCHAA3QKA1QMJZMKKZKZ</value>
   </data>
+  <data name="6015" xml:space="preserve">
+    <value>Compiler</value>
+  </data>
 </root>

--- a/vsintegration/src/FSharp.VS.FSI/VSPackage.resx
+++ b/vsintegration/src/FSharp.VS.FSI/VSPackage.resx
@@ -122,7 +122,4 @@
   <data name="101" xml:space="preserve">
     <value>J1H0RTAZRQRKDEJ2I3A2PCIAPQQRQIDZI3CTKAIAQPJIE3EPHAMRRKAJCHI1PJM2CPDIRZKMMJHKPHJ9E1HDZHZDC1DEHHR0QIARA8RKA3PICCHAA3QKA1QMJZMKKZKZ</value>
   </data>
-  <data name="6015" xml:space="preserve">
-    <value>Compiler</value>
-  </data>
 </root>

--- a/vsintegration/src/FSharp.VS.FSI/fsiBasis.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiBasis.fs
@@ -99,8 +99,11 @@ module internal Util =
 
         /// write value to HKCU subkey, uses default .NET/registry type conversions
         let writeHKCU subkey valueName value =
-            use key = Registry.CurrentUser.OpenSubKey(subkey, true)
+            use key = Registry.CurrentUser.CreateSubKey(subkey)
             key.SetValue(valueName, value)
+
+    let fsharpCompilerRegSubKey = @"Software\Microsoft\VisualStudio\FSharp"
+    let useNetSdkCompilerRegValue = "UseNetSdkCompiler" // DWORD; absent/1 = SDK (ON), 0 = .NET Framework
 
     module ArgParsing =
         let private lastIndexOfPattern s patt =

--- a/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
+++ b/vsintegration/src/FSharp.VS.FSI/fsiLanguageService.fs
@@ -61,6 +61,28 @@ type FsiPropertyPage() =
     [<ResourceDescription(SRProperties.FSharpInteractivePreviewModeDescr)>]
     member this.FsiPreview with get() = SessionsProperties.fsiPreview and set (x:bool) = SessionsProperties.fsiPreview <- x
 
+// FSharpCompilerPropertyPage - Tools > Options > F# Tools > Compiler
+[<ComVisible(true)>]
+[<CLSCompliant(false)>]
+[<ClassInterface(ClassInterfaceType.AutoDual)>]
+[<Guid("e63ff489-9d7c-45be-95a0-2ce82de93aad")>]
+type FSharpCompilerPropertyPage() =
+    inherit DialogPage()
+
+    // Registry (HKCU) is the single source of truth shared with the MSBuild build process,
+    // so disable the base DialogPage storage to avoid spurious writes on VS start.
+    override _.LoadSettingsFromStorage() = ()
+    override _.SaveSettingsToStorage() = ()
+
+    [<ResourceCategory(SRProperties.FSharpCompilerMisc)>]
+    [<ResourceDisplayName(SRProperties.FSharpCompilerUseNetSdk)>]
+    [<ResourceDescription(SRProperties.FSharpCompilerUseNetSdkDescr)>]
+    member _.UseNetSdkCompiler
+        with get () =
+            RegistryHelpers.tryReadHKCU<int> fsharpCompilerRegSubKey useNetSdkCompilerRegValue <> Some 0
+        and set v =
+            RegistryHelpers.writeHKCU fsharpCompilerRegSubKey useNetSdkCompilerRegValue (if v then 1 else 0)
+
 // CompletionSet
 type internal FsiCompletionSet(imageList,source:Source) =
     inherit CompletionSet(imageList, source)

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Použít fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">„fsiAnyCpu.exe“ verwenden</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Use fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Use fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Usare fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">fsiAnyCpu.exe を使用する</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">fsiAnyCpu.exe 사용</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Użyj fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Usar fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Использовать fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">fsiAnyCpu.exe dosyasını kullanın</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">Use fsiAnyCpu.exe</target>

--- a/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
+++ b/vsintegration/src/FSharp.VS.FSI/xlf/Properties.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Properties.resx">
     <body>
+      <trans-unit id="FSharpCompilerMisc">
+        <source>Compiler</source>
+        <target state="new">Compiler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdk">
+        <source>Use the .NET SDK F# compiler for builds</source>
+        <target state="new">Use the .NET SDK F# compiler for builds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FSharpCompilerUseNetSdkDescr">
+        <source>When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</source>
+        <target state="new">When enabled (the default), Visual Studio builds F# projects with the compiler from the installed .NET SDK, matching command-line 'dotnet build'. Turn it off to build with the .NET Framework F# compiler bundled with Visual Studio - for example when a project uses a type provider that ships only a .NET Framework build. Command-line builds are unaffected. Changing this takes effect on the next (re)build.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FSharpInteractiveAnyCpu">
         <source>Use fsiAnyCpu.exe</source>
         <target state="translated">使用 fsiAnyCpu.exe</target>

--- a/vsintegration/tests/UnitTests/Tests.FSharpCompilerOptionPage.fs
+++ b/vsintegration/tests/UnitTests/Tests.FSharpCompilerOptionPage.fs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information.
+
+namespace Tests
+
+open System
+open System.Runtime.Serialization
+open Xunit
+open Microsoft.Win32
+open Microsoft.VisualStudio.FSharp.Interactive
+
+module FSharpCompilerOptionPageTests =
+
+    let private subKey = @"Software\Microsoft\VisualStudio\FSharp"
+    let private valueName = "UseNetSdkCompiler"
+
+    // The base DialogPage constructor needs live VS services (JoinableTaskContext), which are
+    // unavailable in a headless unit-test host. The UseNetSdkCompiler get/set only touch HKCU and
+    // never read base/DialogPage state, so bypass the constructor to exercise the real property.
+    let private newPage () =
+        FormatterServices.GetUninitializedObject(typeof<FSharpCompilerPropertyPage>) :?> FSharpCompilerPropertyPage
+
+    // Save/restore the real HKCU value so the test never corrupts a developer's setting.
+    let private withCleanRegistry (body: unit -> unit) =
+        let original =
+            use k = Registry.CurrentUser.OpenSubKey(subKey)
+            if isNull k then None else Option.ofObj (k.GetValue(valueName))
+        // start from "absent"
+        (use k = Registry.CurrentUser.OpenSubKey(subKey, true)
+         if not (isNull k) then k.DeleteValue(valueName, false))
+        try
+            body ()
+        finally
+            use k = Registry.CurrentUser.CreateSubKey(subKey)
+            match original with
+            | Some v -> k.SetValue(valueName, v)
+            | None -> k.DeleteValue(valueName, false)
+
+    let private readRaw () =
+        use k = Registry.CurrentUser.OpenSubKey(subKey)
+        if isNull k then None else Option.ofObj (k.GetValue(valueName))
+
+    [<Fact>]
+    let ``Default is ON when no registry value is present`` () =
+        withCleanRegistry (fun () ->
+            let page = newPage ()
+            Assert.True(page.UseNetSdkCompiler)
+            // merely constructing + getting must not write anything
+            Assert.Equal<int option>(None, readRaw () |> Option.map (fun o -> unbox<int> o)))
+
+    [<Fact>]
+    let ``Setting false writes DWORD 0 and get returns false`` () =
+        withCleanRegistry (fun () ->
+            let page = newPage ()
+            page.UseNetSdkCompiler <- false
+            Assert.Equal<int option>(Some 0, readRaw () |> Option.map (fun o -> unbox<int> o))
+            Assert.False(page.UseNetSdkCompiler))
+
+    [<Fact>]
+    let ``Setting true writes DWORD 1 and get returns true`` () =
+        withCleanRegistry (fun () ->
+            let page = newPage ()
+            page.UseNetSdkCompiler <- true
+            Assert.Equal<int option>(Some 1, readRaw () |> Option.map (fun o -> unbox<int> o))
+            Assert.True(page.UseNetSdkCompiler))
+
+    [<Fact>]
+    let ``A get-only cycle does not write to the registry`` () =
+        withCleanRegistry (fun () ->
+            let page = newPage ()
+            page.UseNetSdkCompiler |> ignore
+            page.UseNetSdkCompiler |> ignore
+            Assert.True(readRaw () |> Option.isNone))

--- a/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
+++ b/vsintegration/tests/UnitTests/VisualFSharp.UnitTests.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="TestLib.ProjectSystem.fs" />
     <Compile Include="Tests.InternalCollections.fs" />
     <Compile Include="Tests.Build.fs" />
+    <Compile Include="Tests.FSharpCompilerOptionPage.fs" />
     <Compile Include="Tests.TaskReporter.fs" />
     <Compile Include="Tests.Watson.fs" />
     <Compile Include="Tests.XmlDocComments.fs" />


### PR DESCRIPTION
Fixes #20484

Visual Studio now builds F# projects with the F# compiler from the installed .NET SDK by default, matching `dotnet build`. A new **Tools > Options > F# Tools > Compiler** option, **"Use the .NET SDK F# compiler for builds"**, turns this off to fall back to the .NET Framework compiler bundled with Visual Studio. The default is registry-driven (`HKCU\...\FSharp\UseNetSdkCompiler`); explicit project values still win, and command-line builds are unaffected.
