### PR TITLE
IL: intern the attributes and type references read from metadata

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -189,6 +189,7 @@
 * Direct delegate construction ([PR ##19993](https://github.com/dotnet/fsharp/pull/19993))
 * IL: add `ILPreNamespace`, make `ILPreTypeDef` creation lazy ([PR #20092](https://github.com/dotnet/fsharp/pull/20092))
 * IL: share ILCallingConv instances ([PR #20254](https://github.com/dotnet/fsharp/pull/20254))
+* IL: intern the attributes and type references read from metadata ([PR #20486](https://github.com/dotnet/fsharp/pull/20486))
 * IL: cache the ILTypeRef of a type def ([PR #20259](https://github.com/dotnet/fsharp/pull/20259))
 * IL: use empty tables for members when possible ([PR #20249](https://github.com/dotnet/fsharp/pull/20249))
 * Make Entity's adhoc members list lazy ([PR #20286](https://github.com/dotnet/fsharp/pull/20286/changes))

--- a/src/Compiler/AbstractIL/ilread.fs
+++ b/src/Compiler/AbstractIL/ilread.fs
@@ -15,6 +15,7 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.IO
 open System.Text
+open type System.Threading.Interlocked
 open Internal.Utilities.Collections
 open FSharp.Compiler.AbstractIL.Diagnostics
 open FSharp.Compiler.AbstractIL.IL
@@ -58,6 +59,58 @@ let stronglyHeldReaderCacheSize =
          | s -> int32 s)
     with _ ->
         stronglyHeldReaderCacheSizeDefault
+
+/// Readers are shared process-wide, and each reads the same values again. Bounded, because an entry
+/// outlives the reader that produced it: past the cap values simply stay unshared.
+[<Sealed>]
+type private InternTable<'T when 'T: not null and 'T: not struct and 'T: equality>(capacity: int, ?comparer: IEqualityComparer<'T>) =
+    let table =
+        ConcurrentDictionary<'T, 'T>(defaultArg comparer HashIdentity.Structural)
+
+    let mutable count = 0
+
+    member _.Intern(v: 'T) =
+        match table.TryGetValue v with
+        | true, existing -> existing
+        | _ when count >= capacity -> v
+        | _ ->
+            let interned = table.GetOrAdd(v, v)
+
+            if obj.ReferenceEquals(interned, v) then
+                Increment(&count) |> ignore
+
+            interned
+
+    member _.Clear() =
+        table.Clear()
+        Exchange(&count, 0) |> ignore
+
+/// Constructors are interned first, so comparing one by reference replaces walking its method ref,
+/// argument types and assembly ref on every attribute read.
+[<Sealed>]
+type private EncodedAttributeComparer() =
+    interface IEqualityComparer<ILAttribute> with
+        member _.Equals(x, y) =
+            match x, y with
+            | ILAttribute.Encoded(m1, d1, []), ILAttribute.Encoded(m2, d2, []) -> obj.ReferenceEquals(m1, m2) && d1 = d2
+            | _ -> x = y
+
+        member _.GetHashCode(x) =
+            match x with
+            | ILAttribute.Encoded(m, d, []) ->
+                let mutable h = LanguagePrimitives.PhysicalHash m
+
+                for i in 0 .. min d.Length 16 - 1 do
+                    h <- (h * 31) ^^^ int d[i]
+
+                (h * 31) ^^^ d.Length
+            | x -> hash x
+
+let private internedAttributes =
+    InternTable<ILAttribute>(8192, EncodedAttributeComparer())
+
+let private internedAttributeCtors = InternTable<ILMethodSpec>(2048)
+let private internedTypeRefs = InternTable<ILTypeRef>(8192)
 
 let singleOfBits (x: int32) =
     BitConverter.ToSingle(BitConverter.GetBytes x, 0)
@@ -1140,6 +1193,7 @@ type ILMetadataReader =
         seekReadMemberRefAsMethodData: MemberRefAsMspecIdx -> VarArgMethodData
         seekReadMemberRefAsFieldSpec: MemberRefAsFspecIdx -> ILFieldSpec
         seekReadCustomAttr: CustomAttrIdx -> ILAttribute
+        seekReadCustomAttrType: TaggedIndex<CustomAttributeTypeTag> -> ILMethodSpec
         seekReadTypeRef: int -> ILTypeRef
         seekReadTypeDefAsTypeRef: int -> ILTypeRef
         seekReadTypeRefAsType: TypeRefAsTypIdx -> ILType
@@ -2399,7 +2453,7 @@ and seekReadTypeRefUncached ctxtH idx =
     let scopeIdx, nameIdx, namespaceIdx = seekReadTypeRefRow ctxt mdv idx
     let scope, enc = seekReadTypeRefScope ctxt mdv scopeIdx
     let nm = readBlobHeapAsTypeName ctxt (nameIdx, namespaceIdx)
-    ILTypeRef.Create(scope = scope, enclosing = enc, name = nm)
+    internedTypeRefs.Intern(ILTypeRef.Create(scope = scope, enclosing = enc, name = nm))
 
 and seekReadTypeRefAsType (ctxt: ILMetadataReader) boxity ginst idx =
     ctxt.seekReadTypeRefAsType (TypeRefAsTypIdx(boxity, ginst, idx))
@@ -2463,19 +2517,26 @@ and seekReadMethodDefOrRefNoVarargs (ctxt: ILMetadataReader) numTypars x =
 
     MethodData(enclTy, cc, nm, argTys, retTy, methInst)
 
-and seekReadCustomAttrType (ctxt: ILMetadataReader) (TaggedIndex(tag, idx)) =
-    match tag with
-    | tag when tag = cat_MethodDef ->
-        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
-            seekReadMethodDefAsMethodData ctxt idx
+and seekReadCustomAttrType (ctxt: ILMetadataReader) idx = ctxt.seekReadCustomAttrType idx
 
-        mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
-    | tag when tag = cat_MemberRef ->
-        let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
-            seekReadMemberRefAsMethDataNoVarArgs ctxt 0 idx
+and seekReadCustomAttrTypeUncached ctxtH (TaggedIndex(tag, idx)) =
+    let (ctxt: ILMetadataReader) = getHole ctxtH
 
-        mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
-    | _ -> failwith "seekReadCustomAttrType ctxt"
+    let spec =
+        match tag with
+        | tag when tag = cat_MethodDef ->
+            let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
+                seekReadMethodDefAsMethodData ctxt idx
+
+            mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
+        | tag when tag = cat_MemberRef ->
+            let (MethodData(enclTy, cc, nm, argTys, retTy, methInst)) =
+                seekReadMemberRefAsMethDataNoVarArgs ctxt 0 idx
+
+            mkILMethSpecInTy (enclTy, cc, nm, argTys, retTy, methInst)
+        | _ -> failwith "seekReadCustomAttrTypeUncached"
+
+    internedAttributeCtors.Intern spec
 
 and seekReadImplAsScopeRef (ctxt: ILMetadataReader) mdv (TaggedIndex(tag, idx)) =
     if idx = 0 then
@@ -3345,7 +3406,7 @@ and seekReadCustomAttrUncached ctxtH (CustomAttrIdx(cat, idx, valIdx)) =
         | None -> Bytes.ofInt32Array [||]
 
     let elements = []
-    ILAttribute.Encoded(method, data, elements)
+    internedAttributes.Intern(ILAttribute.Encoded(method, data, elements))
 
 and securityDeclsReader ctxtH tag =
     mkILSecurityDeclsReader (fun idx ->
@@ -4495,6 +4556,9 @@ let openMetadataReader
     let cacheMemberRefAsMemberData =
         mkCacheGeneric reduceMemoryUsage inbase "MemberRefAsMemberData" (getNumRows TableNames.MemberRef / 20 + 1)
 
+    let cacheCustomAttrType =
+        mkCacheGeneric reduceMemoryUsage inbase "CustomAttrType" (getNumRows TableNames.CustomAttribute / 20 + 1)
+
     let cacheCustomAttr =
         mkCacheGeneric reduceMemoryUsage inbase "CustomAttr" (getNumRows TableNames.CustomAttribute / 50 + 1)
 
@@ -4588,6 +4652,7 @@ let openMetadataReader
             seekReadMemberRefAsMethodData = cacheMemberRefAsMemberData (seekReadMemberRefAsMethodDataUncached ctxtH)
             seekReadMemberRefAsFieldSpec = seekReadMemberRefAsFieldSpecUncached ctxtH
             seekReadCustomAttr = cacheCustomAttr (seekReadCustomAttrUncached ctxtH)
+            seekReadCustomAttrType = cacheCustomAttrType (seekReadCustomAttrTypeUncached ctxtH)
             seekReadTypeRef = cacheTypeRef (seekReadTypeRefUncached ctxtH)
             seekReadTypeDefAsTypeRef = cacheTypeDefAsTypeRef (seekReadTypeDefAsTypeRefUncached ctxtH)
             readBlobHeapAsPropertySig = cacheBlobHeapAsPropertySig (readBlobHeapAsPropertySigUncached ctxtH)
@@ -5099,6 +5164,9 @@ let OpenILModuleReaderFromStream fileName (peStream: Stream) options =
 let ClearAllILModuleReaderCache () =
     ilModuleReaderCache1.Clear(ILModuleReaderCache1LockToken())
     ilModuleReaderCache2.Clear()
+    internedAttributes.Clear()
+    internedAttributeCtors.Clear()
+    internedTypeRefs.Clear()
 
 let OpenILModuleReader fileName opts =
     // Pseudo-normalize the paths.


### PR DESCRIPTION
A metadata reader dedups a row within its own assembly, but the same value is read again in every
assembly that mentions it, and readers are shared process-wide. Reading the 489 references of a
ReSharper F# plugin project:

| read in `ilread` | values | distinct |
|---|--:|--:|
| `ILAttribute` (constructor + blob) | 22983 | **2896** |
| its constructor `ILMethodSpec` | 22983 | **338** |
| `ILTypeRef` (TypeRef table) | 9350 | **1186** |

Each occurrence rebuilt the chain behind one attribute: constructor, argument types, type reference,
scope reference, assembly reference, public key. Three capped tables in `ilread` now keep one instance
of each across readers.

- Cleared from `ClearAllILModuleReaderCache`, so `FSharpChecker.ClearCaches()` reaches them: an entry
  outlives the reader that produced it.
- Interning past the cap is skipped rather than evicting — an unshared value is correct, just larger.
- `Cache<_, _>` from illib does not fit: no `Clear`, and adding one means touching the eviction
  machinery shared with the type-subsumption and overload-resolution caches.
- Constructors are interned inside the cached `seekReadCustomAttrType`, not at the use site, so a
  constructor chain is hashed once per row per assembly instead of once per attribute; attributes then
  compare their constructor by reference. Without both, small projects paid ~4.5% of their check time.

## Retained memory

Whole solution checked and held at once, checker options as an editor passes them
(`keepAllBackgroundResolutions` and `keepAllBackgroundSymbolUses` off).

| solution | base MB | change MB | delta |
|---|--:|--:|--:|
| consoleapp | 29.17 | 27.96 | -1.21 (-4.1%) |
| oxpecker | 130.95 | 126.64 | -4.31 (-3.3%) |
| prime | 105.49 | 103.44 | -2.05 (-1.9%) |
| fstoolkit | 161.31 | 158.37 | -2.94 (-1.8%) |
| resharper | 385.08 | 378.40 | -6.68 (-1.7%) |
| icedtasks | 96.63 | 94.96 | -1.67 (-1.7%) |
| fantomas | 349.57 | 346.82 | -2.75 (-0.8%) |
| fcsrepo | 877.28 | 875.18 | -2.10 (-0.2%) |

The saving is a roughly fixed 1-7 MB per configuration rather than a share of the heap, so it reads
largest where the heap is smallest.
