### PR TITLE
Avoid the intermediate array allocation in project `OtherOptions`

### DIFF
--- a/docs/release-notes/.VisualStudio/18.vNext.md
+++ b/docs/release-notes/.VisualStudio/18.vNext.md
@@ -15,6 +15,7 @@
 * Fix doubled F# diagnostics in tooltips. ([Issue #16360](https://github.com/dotnet/fsharp/issues/16360))
 * Fix `NotSupportedException` in the memory-mapped-file optimization when copying `ReadOnlyMemory` into `MemoryMappedFileViewStream`. ([Issue #20263](https://github.com/dotnet/fsharp/issues/20263))
 * Reduce allocations in the VS project options reactor: the command-line options and project options caches and the mailbox reply payloads now hold struct tuples, and `IProjectSite.CompilationBinOutputPath` returns `string voption` picked with a new `Array.tryPickV`. ([PR #20413](https://github.com/dotnet/fsharp/pull/20413))
+* Build a single-file project's `OtherOptions` reference flags with one array comprehension instead of two `Array.ofSeq` calls and an `Array.append`. ([PR #20499](https://github.com/dotnet/fsharp/pull/20499))
 
 ### Changed
 

--- a/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
+++ b/vsintegration/src/FSharp.Editor/LanguageService/FSharpProjectOptionsManager.fs
@@ -238,14 +238,12 @@ type private FSharpProjectOptionsReactor(checker: FSharpChecker) =
 
                 let otherOptions =
                     if project.IsFSharpMetadata then
-                        project.ProjectReferences
-                        |> Seq.map (fun x -> "-r:" + project.Solution.GetProject(x.ProjectId).OutputFilePath)
-                        |> Array.ofSeq
-                        |> Array.append (
-                            project.MetadataReferences.OfType<PortableExecutableReference>()
-                            |> Seq.map (fun x -> "-r:" + x.FilePath)
-                            |> Array.ofSeq
-                        )
+                        [|
+                            for x in project.MetadataReferences.OfType<PortableExecutableReference>() do
+                                yield "-r:" + x.FilePath
+                            for x in project.ProjectReferences do
+                                yield "-r:" + project.Solution.GetProject(x.ProjectId).OutputFilePath
+                        |]
                     else
                         [||]
 


### PR DESCRIPTION
## Description

Split out of #20274 at [T-Gro's request](https://github.com/dotnet/fsharp/pull/20274#discussion_r3965895113) — the original rewrite there also silently reversed the `-r:` flag order, which this version does not.

`FSharpProjectOptionsReactor.tryComputeOptionsBySingleScriptOrFile` built the `OtherOptions` array for an F#-metadata project as:

```fsharp
project.ProjectReferences
|> Seq.map (fun x -> "-r:" + project.Solution.GetProject(x.ProjectId).OutputFilePath)
|> Array.ofSeq
|> Array.append (
    project.MetadataReferences.OfType<PortableExecutableReference>()
    |> Seq.map (fun x -> "-r:" + x.FilePath)
    |> Array.ofSeq
)
```

Two arrays are allocated (`Array.ofSeq` twice) and a third for the concatenation (`Array.append`). Replaced with a single array comprehension that yields both reference kinds directly, preserving the original element order (metadata references, then project references) so no consumer-visible behavior changes.

This runs once per non-open-document, non-script F# file whose project is compiled from a project-system snapshot, so the allocation count scales with reference count × such computations.

## Checklist

- [ ] Test cases added — mechanical allocation-only refactor, no behavior change to cover.
- [x] Performance benchmarks added in case of performance changes — not applicable; this is a straightforward allocation-count reduction (3 arrays → 1), not a hot-path change requiring a BDN benchmark.
- [x] Release notes entry updated: `docs/release-notes/.VisualStudio/18.vNext.md` (added in a follow-up commit once this PR's number was known).

🤖 Generated with [Claude Code](https://claude.com/claude-code)