### PR TITLE
Make OTel export opt-in via FSHARP_OTEL_EXPORT

### DIFF
--- a/vsintegration/Vsix/VisualFSharpFull/Properties/launchSettings.json
+++ b/vsintegration/Vsix/VisualFSharpFull/Properties/launchSettings.json
@@ -11,6 +11,21 @@
         "FSharp_Shim_Present": "true",
         "FSharpPreferAnyCpuTools": "true",
         "Fsc_NetFramework_ToolPath": "$(FSharpCompilerPathForDebuggingLocally)",
+        "Fsc_NetFramework_AnyCpu_ToolExe": "fscAnyCpu.exe",
+        "FSHARP_OTEL_EXPORT": "http://127.0.0.1:4317"
+      }
+    },
+    "No OTEL": {
+      "commandName": "Executable",
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
+      "environmentVariables": {
+        "FSharpCompilerPath": "$(FSharpCompilerPathForDebuggingLocally)",
+        "DisableAutoSetFscCompilerPath": "true",
+        "FSharpPreferNetFrameworkTools": "true",
+        "FSharp_Shim_Present": "true",
+        "FSharpPreferAnyCpuTools": "true",
+        "Fsc_NetFramework_ToolPath": "$(FSharpCompilerPathForDebuggingLocally)",
         "Fsc_NetFramework_AnyCpu_ToolExe": "fscAnyCpu.exe"
       }
     }

--- a/vsintegration/src/FSharp.Editor/Common/DebugHelpers.fs
+++ b/vsintegration/src/FSharp.Editor/Common/DebugHelpers.fs
@@ -136,10 +136,19 @@ module FSharpServiceTelemetry =
     open OpenTelemetry.Trace
     open OpenTelemetry.Metrics
 
-    let otelExport () =
-        // On Windows forwarding localhost to wsl2 docker container sometimes does not work. Use IP address instead.
-        let otlpEndpoint = Uri("http://127.0.0.1:4317")
+    // Nothing listening on the endpoint means an exporter retrying in the background and a 5s flush
+    // on shutdown, so exporting is opt-in: FSHARP_OTEL_EXPORT enables it and can carry the endpoint.
+    let private otelEndpoint =
+        match Environment.GetEnvironmentVariable "FSHARP_OTEL_EXPORT" with
+        | null
+        | "" -> ValueNone
+        | value ->
+            match Uri.TryCreate(value, UriKind.Absolute) with
+            | true, uri -> ValueSome uri
+            // On Windows forwarding localhost to wsl2 docker container sometimes does not work. Use IP address instead.
+            | _ -> ValueSome(Uri "http://127.0.0.1:4317")
 
+    let private startOtelExport (otlpEndpoint: Uri) =
         let meterProvider =
             // Configure OpenTelemetry metrics. Metrics can be viewed in Prometheus or other compatible tools.
             OpenTelemetry.Sdk
@@ -169,6 +178,11 @@ module FSharpServiceTelemetry =
             tracerProvider.ForceFlush(5000) |> ignore
             tracerProvider.Dispose()
             meterProvider.Dispose()
+
+    let otelExport () =
+        match otelEndpoint with
+        | ValueNone -> ignore
+        | ValueSome endpoint -> startOtelExport endpoint
 
     let listenToAll () = listen ""
 #endif


### PR DESCRIPTION
`otelExport()` unconditionally started exporting metrics and traces to `http://127.0.0.1:4317`. With nothing listening there — the normal case — that is a background exporter stuck retrying and a 5s flush on every shutdown, for every Debug VSIX session regardless of whether anyone is collecting the data.

Exporting now only starts when `FSHARP_OTEL_EXPORT` names a collector endpoint. The `VisualFSharpDebug` launch profile sets it so F5 behaves as before, and a new "No OTEL" profile omits it.

The code is under `#if DEBUG`, so this only affects Debug VSIX builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
