### PR TITLE
Improve FCS docs

### DIFF
--- a/.github/skills/postmortem/SKILL.md
+++ b/.github/skills/postmortem/SKILL.md
@@ -32,6 +32,17 @@ Before writing a single line, answer these questions:
 
 Write the file in `docs/postmortems/` with a descriptive filename (e.g., `regression-fs0229-bstream-misalignment.md`).
 
+Start the file with fsdocs front matter so the page lands under "Postmortems" in the navigation of the published docs at https://fsharp.github.io/fsharp-compiler-docs/. Without it, the page ends up in an unnamed group. Keep `title` short (it is the navigation entry; the `# Regression: ...` heading below stays descriptive), and pick the next free `index` after the existing postmortems:
+
+```yaml
+---
+title: FS0229 B-stream misalignment
+category: Postmortems
+categoryindex: 550
+index: 600
+---
+```
+
 Use this outline:
 
 ### Summary
@@ -72,4 +83,4 @@ What has been or should be added to prevent recurrence: tests, agentic instructi
 
 3. **Do not create instructions without path scoping.** A postmortem lesson that applies "everywhere" is too vague to be actionable. If you can't name the files where the lesson matters, the postmortem may not meet the threshold for this skill.
 
-4. **Update `docs/postmortems/README.md`** if it maintains an index.
+4. **Update `docs/postmortems/README.md`**, which maintains an index. Links there must be relative to the file or absolute GitHub URLs; paths that climb out of `docs/` (such as `../../.github/`) do not resolve on the published site.

--- a/docs/fcs/editor.fsx
+++ b/docs/fcs/editor.fsx
@@ -215,9 +215,7 @@ let methods =
 
 // Print concatenated parameter lists
 for mi in methods.Methods do
-    [ for p in mi.Parameters do
-          for tt in p.Display do
-              yield tt.Text ]
+    [ for p in mi.Parameters -> p.Display.Text ]
     |> String.concat ", "
     |> printfn "%s(%s)" methods.MethodName
 (**

--- a/docs/fcs/tokenizer.fsx
+++ b/docs/fcs/tokenizer.fsx
@@ -30,13 +30,13 @@ To use the tokenizer, reference `FSharp.Compiler.Service.dll` and open the
 #r "FSharp.Compiler.Service.dll"
 open FSharp.Compiler.Tokenization
 (**
-Now you can create an instance of `FSharpSourceTokenizer`. The class takes two 
-arguments - the first is the list of defined symbols and the second is the
-file name of the source code. The defined symbols are required because the
-tokenizer handles `#if` directives. The file name is required only to specify
-locations of the source code (and it does not have to exist):
+Now you can create an instance of `FSharpSourceTokenizer`. The class takes three
+arguments - the first is the list of defined symbols, the second is the
+file name of the source code and the third is the language version. The defined symbols
+are required because the tokenizer handles `#if` directives. The file name is required only
+to specify locations of the source code (and it does not have to exist):
 *)
-let sourceTok = FSharpSourceTokenizer([], Some "C:\\test.fsx", Some "PREVIEW", None)
+let sourceTok = FSharpSourceTokenizer([], Some "C:\\test.fsx", Some "PREVIEW")
 (**
 Using the `sourceTok` object, we can now (repeatedly) tokenize lines of 
 F# source code.

--- a/docs/fcs/typedtree.fsx
+++ b/docs/fcs/typedtree.fsx
@@ -48,7 +48,7 @@ One difference is that we set keepAssemblyContents to true.
 // Create an interactive checker instance 
 let checker = FSharpChecker.Create(keepAssemblyContents=true)
 
-let parseAndCheckSingleFile (input) = 
+let parseAndCheckSingleFile (input: string) = 
     let file = Path.ChangeExtension(System.IO.Path.GetTempFileName(), "fsx")  
     File.WriteAllText(file, input)
     // Get context representing a stand-alone (script) file

--- a/docs/fcs/untypedtree-apis.fsx
+++ b/docs/fcs/untypedtree-apis.fsx
@@ -363,8 +363,8 @@ let outermostNestedModule = // Some ["N"].
     (posInsideOfInnermostNestedModule, mkTree nestedModules)
     ||> ParsedInput.tryPick (fun _path node ->
         match node with
-        | SyntaxNode.SynModule(SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = longId))) ->
-            Some [for ident in longId -> ident.idText]
+        | SyntaxNode.SynModule(SynModuleDecl.NestedModule(moduleInfo = moduleInfo)) ->
+            Some [for ident in moduleInfo.LongIdent -> ident.idText]
         | _ -> None)
 
 (**
@@ -378,8 +378,8 @@ let innermostNestedModule = // Some ["P"].
     (posInsideOfInnermostNestedModule, mkTree nestedModules)
     ||> ParsedInput.tryPickLast (fun _path node ->
         match node with
-        | SyntaxNode.SynModule(SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = longId))) ->
-            Some [for ident in longId -> ident.idText]
+        | SyntaxNode.SynModule(SynModuleDecl.NestedModule(moduleInfo = moduleInfo)) ->
+            Some [for ident in moduleInfo.LongIdent -> ident.idText]
         | _ -> None)
 
 (**
@@ -391,8 +391,8 @@ let nextToInnermostNestedModule = // Some ["O"].
     ||> ParsedInput.tryPickLast (fun path node ->
         match node, path with
         | SyntaxNode.SynModule(SynModuleDecl.NestedModule _),
-          SyntaxNode.SynModule(SynModuleDecl.NestedModule(moduleInfo = SynComponentInfo(longId = longId))) :: _ ->
-            Some [for ident in longId -> ident.idText]
+          SyntaxNode.SynModule(SynModuleDecl.NestedModule(moduleInfo = moduleInfo)) :: _ ->
+            Some [for ident in moduleInfo.LongIdent -> ident.idText]
         | _ -> None)
 
 (**

--- a/docs/fcs/untypedtree.fsx
+++ b/docs/fcs/untypedtree.fsx
@@ -141,7 +141,7 @@ let rec visitExpression e =
       visitExpression trueBranch
       falseBranchOpt |> Option.iter visitExpression 
 
-  | SynExpr.LetOrUse(_, _, bindings, body, _, _) ->
+  | SynExpr.LetOrUse { Bindings = bindings; Body = body } ->
       // Visit bindings (there may be multiple 
       // for 'let .. = .. and .. = .. in ...'
       printfn "LetOrUse with the following bindings:"
@@ -172,7 +172,7 @@ functions):
 let visitDeclarations decls = 
   for declaration in decls do
     match declaration with
-    | SynModuleDecl.Let(isRec, bindings, range) ->
+    | SynModuleDecl.Let(bindings = bindings) ->
         // Let binding as a declaration is similar to let binding
         // as an expression (in visitExpression), but has no body
         for binding in bindings do

--- a/docs/labelops.md
+++ b/docs/labelops.md
@@ -1,3 +1,9 @@
+---
+title: LabelOps
+category: Compiler Internals
+categoryindex: 200
+index: 960
+---
 # LabelOps
 
 Opt-in, label-gated agentic workflows that keep open PRs healthy. Add a label to a PR → the agent checks it every 3 hours.

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -1,3 +1,9 @@
+---
+title: F# LSP
+category: Language Service Internals
+categoryindex: 300
+index: 500
+---
 # F# LSP
 
 F# LSP support design proposal. To be expanded as we learn more / settle on things.

--- a/docs/optimizations-equality.md
+++ b/docs/optimizations-equality.md
@@ -1,3 +1,9 @@
+---
+title: Equality optimizations
+category: Compiler Internals
+categoryindex: 200
+index: 450
+---
 # Compiling Equality
 
 This spec covers how equality is compiled and executed by the F# compiler and library, based mainly on the types involved in the equality operation after all inlining, type specialization and other optimizations have been applied.

--- a/docs/perf-discussions-archive.md
+++ b/docs/perf-discussions-archive.md
@@ -1,3 +1,9 @@
+---
+title: Perf discussions archive
+category: Compiler Internals
+categoryindex: 200
+index: 970
+---
 This is just a typed version of [these notes](https://github.com/dotnet/fsharp/issues/16498), generated during perf discussions on summer of 2023. Can be used as a reference point.
 
 ---

--- a/docs/postmortems/README.md
+++ b/docs/postmortems/README.md
@@ -1,8 +1,14 @@
+---
+title: Overview
+category: Postmortems
+categoryindex: 550
+index: 100
+---
 # Postmortems
 
 Detailed write-ups of bugs that were hard to diagnose, had non-obvious root causes, or taught us something worth preserving. Each document captures the symptoms, root cause, fix, and timeline so that future contributors can recognize similar patterns early.
 
-These are referenced from [agentic instructions](../../.github/instructions/) and serve as deeper reading — the instructions tell you *what* to do, the postmortems explain *why* the rules exist.
+These are referenced from [agentic instructions](https://github.com/dotnet/fsharp/tree/main/.github/instructions) and serve as deeper reading — the instructions tell you *what* to do, the postmortems explain *why* the rules exist.
 
 ## Index
 

--- a/docs/postmortems/regression-fs0229-bstream-misalignment.md
+++ b/docs/postmortems/regression-fs0229-bstream-misalignment.md
@@ -1,3 +1,9 @@
+---
+title: FS0229 B-stream misalignment
+category: Postmortems
+categoryindex: 550
+index: 200
+---
 # Regression: FS0229 B-Stream Misalignment in TypedTreePickle
 
 ## Summary

--- a/docs/postmortems/regression-legacy-inline-metadata-dynamic-invocation.md
+++ b/docs/postmortems/regression-legacy-inline-metadata-dynamic-invocation.md
@@ -1,3 +1,9 @@
+---
+title: Legacy inline metadata dynamic invocation
+category: Postmortems
+categoryindex: 550
+index: 300
+---
 # Regression: Legacy inline metadata decoded as non-inline, breaking cross-assembly SRTP
 
 ## Summary

--- a/docs/postmortems/regression-parse-tree-fidelity-return-attributes.md
+++ b/docs/postmortems/regression-parse-tree-fidelity-return-attributes.md
@@ -1,3 +1,9 @@
+---
+title: Parse tree fidelity of return attributes
+category: Postmortems
+categoryindex: 550
+index: 500
+---
 # Regression: `[<return: X>]` Attributes Disappeared From the Untyped Syntax Tree
 
 ## Summary

--- a/docs/postmortems/regression-sourcebuild-cpm-runtime-version-floor.md
+++ b/docs/postmortems/regression-sourcebuild-cpm-runtime-version-floor.md
@@ -1,3 +1,9 @@
+---
+title: Source-build CPM runtime version floor
+category: Postmortems
+categoryindex: 550
+index: 400
+---
 # Regression: renamed CPM runtime-package pins broke VMR source-build
 
 ## Summary

--- a/docs/reflectionfree-printing.md
+++ b/docs/reflectionfree-printing.md
@@ -1,3 +1,9 @@
+---
+title: Reflection-free printing
+category: FSharp.Core
+categoryindex: 500
+index: 200
+---
 # Simple vs Reflection-based DU and Record printing
 
 This document describes two modes for printing Discriminated Unions (DUs) and Records in F#: a **simple** reflection-free mode that delegates to a `string`-like operator for printing field values, and a `sprintf` mode (`sprintf "%A"`), which uses **reflection** to create output looking like F# code. In this document, the terms *simple* and *reflection* are used to distinguish the two modes.

--- a/docs/regression-testing-pipeline.md
+++ b/docs/regression-testing-pipeline.md
@@ -1,3 +1,9 @@
+---
+title: Regression testing pipeline
+category: Compiler Internals
+categoryindex: 200
+index: 950
+---
 # F# Compiler Regression Testing
 
 This document describes the F# compiler regression testing functionality implemented as a reusable Azure DevOps template in `eng/templates/regression-test-jobs.yml` and integrated into the main PR pipeline (`azure-pipelines-PR.yml`).

--- a/docs/release-notes/.aux/Common.fsx
+++ b/docs/release-notes/.aux/Common.fsx
@@ -1,11 +1,15 @@
 ﻿#i "nuget: https://api.nuget.org/v3/index.json"
-#r "nuget: Markdig, 0.33.0"
-#r "nuget: FsHttp, 12.1.0"
+#r "nuget: Markdig, 1.3.2"
+#r "nuget: FsHttp, 15.0.3"
 
 open System.IO
 open System.Xml.Linq
 open System.Text.RegularExpressions
+open Markdig
 open FsHttp
+
+// FsHttp logs every request to the console in FSI, which is noise in the docs build.
+Fsi.disableDebugLogs ()
 
 let versionProps = Path.Combine(__SOURCE_DIRECTORY__, "../../../eng/Versions.props")
 let versionPropsDoc = XDocument.Load(versionProps)
@@ -19,18 +23,130 @@ let getAvailableNuGetVersions (packageName: string) : Set<string> =
     |> Response.deserializeJson<{| versions: string array |}>
     |> fun json -> Set.ofArray json.versions
 
-/// Try and find the publish date on NuGet
-let tryGetReleaseDate (packageName: string) (version: string) : string option =
-    let packageName = packageName.ToLowerInvariant()
+/// How a version of a package stands on NuGet
+type NuGetRelease =
+    /// The package version does not exist on NuGet
+    | Unreleased
+    /// The package version exists but the owner unlisted it. NuGet reports 1900-01-01 as its
+    /// publish date, so the date is meaningless.
+    | Unlisted
+    /// Published on the given date (yyyy-MM-dd)
+    | Published of date: string
 
-    http { GET $"https://api.nuget.org/v3/registration5-gz-semver2/%s{packageName}/%s{version}.json" }
-    |> Request.send
-    |> Response.deserializeJson<{| published: string |}>
-    |> fun json ->
-        if System.String.IsNullOrWhiteSpace json.published then
-            None
-        else
-            Some(json.published.Split('T').[0])
+/// Find out whether a version of a package is published on NuGet, and when
+let getRelease (packageName: string) (availableVersions: Set<string>) (version: string) : NuGetRelease =
+    if not (availableVersions.Contains version) then
+        Unreleased
+    else
+        let packageName = packageName.ToLowerInvariant()
+
+        http { GET $"https://api.nuget.org/v3/registration5-gz-semver2/%s{packageName}/%s{version}.json" }
+        |> Request.send
+        |> Response.deserializeJson<{| published: string; listed: bool |}>
+        |> fun json ->
+            if not json.listed then Unlisted
+            elif System.String.IsNullOrWhiteSpace json.published then Unreleased
+            else Published(json.published.Split('T').[0])
+
+/// The heading for a version: the version and its release date or status
+let releaseTitle (version: string) (release: NuGetRelease) : string =
+    match release with
+    | Unreleased -> $"%s{version} - Not on NuGet"
+    | Unlisted -> $"%s{version} - Unlisted on NuGet"
+    | Published date -> $"%s{version} - %s{date}"
+
+/// A badge linking to the package version on NuGet
+let nugetBadgeLink (packageName: string) (version: string) : string =
+    $"<a href=\"https://www.nuget.org/packages/%s{packageName}/%s{version}\" target=\"_blank\"><img alt=\"Nuget\" src=\"https://img.shields.io/badge/NuGet-%s{version}-blue\"></a>"
+
+/// A badge linking to the package version on NuGet, for versions that exist there
+let nugetBadge (packageName: string) (version: string) (release: NuGetRelease) : string =
+    match release with
+    | Unreleased -> System.String.Empty
+    | Unlisted
+    | Published _ -> nugetBadgeLink packageName version
+
+/// The F# version a package was built from, as FSMajor.FSMinor.FSBuild in eng/Versions.props of
+/// the source commit that the nuspec on NuGet records. Packages are built from dotnet/fsharp or,
+/// since .NET 10, from the dotnet/dotnet VMR where the repo lives under src/fsharp.
+let tryGetSourceFSharpVersion (packageName: string) (version: string) : Async<string option> =
+    async {
+        try
+            let packageName = packageName.ToLowerInvariant()
+
+            let! nuspec =
+                http { GET $"https://api.nuget.org/v3-flatcontainer/%s{packageName}/%s{version}/%s{packageName}.nuspec" }
+                |> Request.sendAsync
+
+            let nuspec = nuspec |> Response.toText
+            let repository = Regex.Match(nuspec, "<repository [^>]*url=\"([^\"]+)\"[^>]*commit=\"([0-9a-f]+)\"")
+
+            if not repository.Success then
+                eprintfn "%s %s: no source repository in nuspec" packageName version
+                return None
+            else
+                let url = repository.Groups.[1].Value.TrimEnd('/')
+                let commit = repository.Groups.[2].Value
+
+                let versionsProps =
+                    if url.EndsWith "dotnet/dotnet" then
+                        $"https://raw.githubusercontent.com/dotnet/dotnet/%s{commit}/src/fsharp/eng/Versions.props"
+                    else
+                        $"https://raw.githubusercontent.com/dotnet/fsharp/%s{commit}/eng/Versions.props"
+
+                let! props = http { GET versionsProps } |> Request.sendAsync
+                let doc = XDocument.Parse(props |> Response.toText)
+                // The first element wins: FSMinorVersion is redefined further down for FSharp.Core only.
+                let value name = (doc.Descendants(XName.Get name) |> Seq.head).Value
+                let major = value "FSMajorVersion"
+                let minor = value "FSMinorVersion"
+                let build = value "FSBuildVersion"
+                return Some $"%s{major}.%s{minor}.%s{build}"
+        with ex ->
+            eprintfn "%s %s: could not determine the source F# version: %s" packageName version ex.Message
+            return None
+    }
+
+/// The release notes file an F# version belongs to: the highest notes version at or below it in
+/// the same hundreds band. So with files 9.0.200 and 9.0.202, F# 9.0.201 belongs to 9.0.200 and
+/// F# 9.0.203 to 9.0.202, while 9.0.303 belongs to 9.0.300.
+let releaseNotesVersionOf (notesVersions: string seq) (fsharpVersion: string) : string option =
+    let version = System.Version.Parse fsharpVersion
+
+    notesVersions
+    |> Seq.map System.Version.Parse
+    |> Seq.filter (fun notes ->
+        notes.Major = version.Major
+        && notes.Minor = version.Minor
+        && notes.Build / 100 = version.Build / 100
+        && notes <= version)
+    |> Seq.sortDescending
+    |> Seq.tryHead
+    |> Option.map string
+
+/// Groups package versions on NuGet by the release notes file they belong to, looking up the
+/// F# version each package was built from. Versions within a group are sorted ascending.
+let getPackagesByReleaseNotes
+    (packageName: string)
+    (notesVersions: string seq)
+    (versions: string seq)
+    : Map<string, string list> =
+    let numericPrefix (version: string) =
+        System.Version.Parse(version.Split('-').[0])
+
+    versions
+    |> Seq.map (fun version ->
+        async {
+            let! fsharpVersion = tryGetSourceFSharpVersion packageName version
+            return fsharpVersion |> Option.bind (releaseNotesVersionOf notesVersions) |> Option.map (fun notes -> notes, version)
+        })
+    |> fun lookups -> Async.Parallel(lookups, maxDegreeOfParallelism = 8)
+    |> Async.RunSynchronously
+    |> Seq.choose id
+    |> Seq.groupBy fst
+    |> Seq.map (fun (notes, packages) ->
+        notes, packages |> Seq.map snd |> Seq.sortBy numericPrefix |> List.ofSeq)
+    |> Map.ofSeq
 
 /// In order for the heading to appear in the page content menu in fsdocs,
 /// they need to follow a specific HTML structure.
@@ -42,9 +158,95 @@ let transformH3 (version: string) (input: string) : string =
 
     Regex.Replace(input, pattern, replacement)
 
-/// Process all MarkDown files from the given release folder
+/// Orders release note file names newest first. Version numbers compare numerically, so that
+/// 10.0.100 comes before 9.0.300. Names that are not a version, such as "preview" or "18.vNext",
+/// are the upcoming release and go on top.
+let compareVersionsDescending (a: string) (b: string) : int =
+    let tryParse (name: string) =
+        match System.Version.TryParse name with
+        | true, version -> Some version
+        | _ -> None
+
+    match tryParse a, tryParse b with
+    | Some a, Some b -> compare b a
+    | Some _, None -> 1
+    | None, Some _ -> -1
+    | None, None -> compare b a
+
+/// The F# version main is at, and the FCS version that goes with it
+let upcomingFSharpVersion, upcomingFcsVersion =
+    let value name = (versionPropsDoc.Descendants(XName.Get name) |> Seq.head).Value
+    let build = value "FSBuildVersion"
+    System.Version.Parse $"""{value "FSMajorVersion"}.{value "FSMinorVersion"}.{build}""",
+    System.Version.Parse $"""{value "FCSMajorVersion"}.{value "FCSMinorVersion"}.{build}"""
+
+/// Renders the release notes of a package: one section per notes file in `path`, ordered by
+/// package version, newest first. Which package versions belong to a notes file is looked up
+/// from the source commit of each package on NuGet, from `minPackageVersion` on.
+///
+/// Notes without a package are either the upcoming release, placed at the top as `upcomingVersion`,
+/// or an old servicing version that never shipped, placed where `packageVersionOfNotes` puts it.
+let renderPackageReleaseNotes
+    (packageName: string)
+    (path: string)
+    (minPackageVersion: System.Version)
+    (packageVersionOfNotes: System.Version -> System.Version)
+    (upcomingVersion: System.Version)
+    : string =
+    let numericPrefix (version: string) =
+        System.Version.Parse(version.Split('-').[0])
+
+    let availableVersions = getAvailableNuGetVersions packageName
+
+    let notesVersions =
+        Directory.EnumerateFiles(path, "*.md") |> Seq.map Path.GetFileNameWithoutExtension |> List.ofSeq
+
+    let packagesByReleaseNotes =
+        availableVersions
+        |> Seq.filter (fun version -> numericPrefix version >= minPackageVersion)
+        |> getPackagesByReleaseNotes packageName notesVersions
+
+    notesVersions
+    |> List.map (fun notesVersion ->
+        let file = Path.Combine(path, notesVersion + ".md")
+        let packages = packagesByReleaseNotes.TryFind notesVersion |> Option.defaultValue []
+        let stable = packages |> List.filter (fun version -> not (version.Contains '-'))
+
+        // The heading is the first package that shipped for these notes; later ones are servicing
+        // rebuilds and get a badge each. Without a stable package, show the latest prerelease.
+        let version, title, badges =
+            match stable, List.rev packages with
+            | first :: _, _ ->
+                let release = getRelease packageName availableVersions first
+                let badges = stable |> List.map (nugetBadgeLink packageName)
+                first, releaseTitle first release, String.concat " " badges
+            | [], latestPrerelease :: _ ->
+                latestPrerelease, $"%s{latestPrerelease} - Prerelease", nugetBadgeLink packageName latestPrerelease
+            | [], [] -> notesVersion, $"F# %s{notesVersion} - Not on NuGet", System.String.Empty
+
+        let sortKey =
+            match packages with
+            | _ :: _ -> numericPrefix version
+            | [] ->
+                let notes = System.Version.Parse notesVersion
+
+                if notes >= upcomingFSharpVersion then
+                    upcomingVersion
+                else
+                    packageVersionOfNotes notes
+
+        let content = File.ReadAllText file |> Markdown.ToHtml |> transformH3 version
+
+        sortKey,
+        $"""<h2><a name="%s{version}" class="anchor" href="#%s{version}">%s{title}</a></h2>%s{badges}%s{content}""")
+    |> List.sortByDescending fst
+    |> List.map snd
+    |> String.concat "\n"
+
+/// Process all MarkDown files from the given release folder, newest version first
 let processFolder (path: string) (processFile: string -> string) : string =
     Directory.EnumerateFiles(path, "*.md")
-    |> Seq.sortByDescending Path.GetFileNameWithoutExtension
+    |> Seq.sortWith (fun a b ->
+        compareVersionsDescending (Path.GetFileNameWithoutExtension a) (Path.GetFileNameWithoutExtension b))
     |> Seq.map processFile
     |> String.concat "\n"

--- a/docs/release-notes/FSharp.Compiler.Service.fsx
+++ b/docs/release-notes/FSharp.Compiler.Service.fsx
@@ -11,37 +11,20 @@ title: FSharp.Compiler.Service
 #load "./.aux/Common.fsx"
 
 open System.IO
-open System.Xml.XPath
+open System.Xml.Linq
 open Markdig
 open Common
 
 let path = Path.Combine(__SOURCE_DIRECTORY__, ".FSharp.Compiler.Service")
-let fcsMajorVersion = versionPropsDoc.XPathSelectElement("//FCSMajorVersion").Value
-let nugetPackage = "FSharp.Compiler.Service"
-let availableNuGetVersions = getAvailableNuGetVersions nugetPackage
 
-processFolder path (fun file ->
-    let versionInFileName = Path.GetFileNameWithoutExtension(file)
-    // Example: 8.0.200
-    let versionParts = versionInFileName.Split '.'
-
-    let version = $"%s{fcsMajorVersion}.%s{versionParts.[0]}.%s{versionParts.[2]}"
-    // TODO: Can we determine if the current version is in code freeze based on the Version.props info?
-    let title =
-        if not (availableNuGetVersions.Contains version) then
-            $"%s{version} - Unreleased"
-        else
-            match tryGetReleaseDate nugetPackage version with
-            | None -> $"%s{version} - Unreleased"
-            | Some d -> $"%s{version} - %s{d}"
-
-    let nugetBadge =
-        if not (availableNuGetVersions.Contains version) then
-            System.String.Empty
-        else
-            $"<a href=\"https://www.nuget.org/packages/%s{nugetPackage}/%s{version}\" target=\"_blank\"><img alt=\"Nuget\" src=\"https://img.shields.io/badge/NuGet-%s{version}-blue\"></a>"
-
-    let content = File.ReadAllText file |> Markdown.ToHtml |> transformH3 version
-
-    $"""<h2><a name="%s{version}" class="anchor" href="#%s{version}">%s{title}</a></h2>%s{nugetBadge}%s{content}""")
+// The FCS package version cannot be derived from the release notes file name: its minor number
+// is bumped independently of the F# version (43.12.100 is F# 11.0.100, 43.12.204 is F# 10.0.204).
+// The lookup by source commit handles that; the F# major is only used to place notes that never
+// shipped. Packages before 43.8 predate the release notes folder.
+renderPackageReleaseNotes
+    "FSharp.Compiler.Service"
+    path
+    (System.Version(43, 8, 0))
+    (fun notes -> System.Version(43, notes.Major, notes.Build))
+    upcomingFcsVersion
 (*** include-it-raw ***)

--- a/docs/release-notes/FSharp.Core.fsx
+++ b/docs/release-notes/FSharp.Core.fsx
@@ -15,28 +15,9 @@ open Markdig
 open Common
 
 let path = Path.Combine(__SOURCE_DIRECTORY__, ".FSharp.Core")
-let nugetPackage = "FSharp.Core"
-let availableNuGetVersions = getAvailableNuGetVersions nugetPackage
 
-processFolder path (fun file ->
-    let version = Path.GetFileNameWithoutExtension(file)
-
-    // TODO: Can we determine if the current version is in code freeze based on the Version.props info?
-    let title =
-        if not (availableNuGetVersions.Contains version) then
-            $"%s{version} - Unreleased"
-        else
-            match tryGetReleaseDate nugetPackage version with
-            | None -> $"%s{version} - Unreleased"
-            | Some d -> $"%s{version} - %s{d}"
-
-    let nugetBadge =
-        if not (availableNuGetVersions.Contains version) then
-            System.String.Empty
-        else
-            $"<a href=\"https://www.nuget.org/packages/%s{nugetPackage}/%s{version}\" target=\"_blank\"><img alt=\"Nuget\" src=\"https://img.shields.io/badge/NuGet-%s{version}-blue\"></a>"
-
-    let content = File.ReadAllText file |> Markdown.ToHtml |> transformH3 version
-
-    $"""<h2><a name="%s{version}" class="anchor" href="#%s{version}">%s{title}</a></h2>%s{nugetBadge}%s{content}""")
+// FSharp.Core mostly follows the F# version, but not always: the F# 10 packages shipped as 10.1.x
+// to signal breaking changes, while the notes file stays 10.0.x. The lookup by source commit
+// handles that. Packages before 8.0 predate the release notes folder.
+renderPackageReleaseNotes "FSharp.Core" path (System.Version(8, 0, 0)) id upcomingFSharpVersion
 (*** include-it-raw ***)

--- a/docs/release-notes/Language.fsx
+++ b/docs/release-notes/Language.fsx
@@ -16,24 +16,9 @@ open Common
 
 let path = Path.Combine(__SOURCE_DIRECTORY__, ".Language")
 
-Directory.EnumerateFiles(path, "*.md")
-|> Seq.sortWith (fun a b ->
-    let a = Path.GetFileNameWithoutExtension a
-    let b = Path.GetFileNameWithoutExtension b
-
-    match a, b with
-    | "preview", "preview" -> 0
-    | "preview", _ -> -1
-    | _, "preview" -> 1
-    | _, _ -> 
-        match System.Decimal.TryParse(b), System.Decimal.TryParse(b) with
-        | (true, a) , ( true, b) -> compare (int b) (int a)
-        | _ -> failwithf "Cannot compare %s with %s" b a
-    )
-|> Seq.map (fun file ->
+processFolder path (fun file ->
     let version = Path.GetFileNameWithoutExtension(file)
     let version = if version = "preview" then "Preview" else version
     let content = File.ReadAllText file |> Markdown.ToHtml |> transformH3 version
     $"""<h2><a name="%s{version}" class="anchor" href="#%s{version}">%s{version}</a></h2>%s{content}""")
-|> String.concat "\n"
 (*** include-it-raw ***)

--- a/docs/release-notes/PENDING_BREAKING_CHANGES.md
+++ b/docs/release-notes/PENDING_BREAKING_CHANGES.md
@@ -1,3 +1,9 @@
+---
+title: Pending breaking changes
+category: Release Notes
+categoryindex: 600
+index: 5
+---
 # Breaking Changes in Query Expression Fixes
 
 ## AnonymousObject Structural Equality 🔴

--- a/docs/running-documentation-locally.md
+++ b/docs/running-documentation-locally.md
@@ -11,36 +11,48 @@ You can follow this guide to see the results of your document changes rendered i
 
 ## Setup
 
-`fsharp/fsharp-compiler-docs` will clone the `dotnet/fsharp` repository first to generate the documentation.  
-You can however, easily run the documentation locally and modify the `docs` from `dotnet/fsharp`.
+`fsharp/fsharp-compiler-docs` is driven by a [Fun.Build](https://github.com/slaveOftime/Fun.Build) script, `build.fsx`.
+By default it clones `dotnet/fsharp` into a git-ignored `fsharp` folder, builds `FSharp.Compiler.Service` and
+generates the site from that clone. To work on the `docs` of your own `dotnet/fsharp` checkout instead, point the
+`FSHARP_REPO` environment variable at it: the clone is skipped and your checkout is built and read in place.
 
-* Clone `fsharp/fsharp-compiler-docs` at the same level as your local `dotnet/fsharp` repository:
+* Clone `fsharp/fsharp-compiler-docs`:
 
 
     git clone https://github.com/fsharp/fsharp-compiler-docs.git
+    cd fsharp-compiler-docs
 
 
-* Restore the `FSharp.Compiler.Service` project in `fsharp-compiler-docs`:
+* Run the `Build` pipeline once. It builds `FSharp.Compiler.Service.slnx` with the SDK your checkout pins (using
+  the `eng/common/dotnet.sh` bootstrap, so that SDK does not need to be on your `PATH`), restores the `fsdocs` tool
+  and generates the site into `output/`:
 
 
-    cd fsharp-compiler-docs/FSharp.Compiler.Service
-    dotnet restore
+    FSHARP_REPO=/path/to/your/fsharp dotnet fsi build.fsx
 
 
-* Restore the local tools in `fsharp-compiler-docs`:
+* Then serve the docs with live reload:
 
 
-    cd ..
-    dotnet tool restore
+    FSHARP_REPO=/path/to/your/fsharp dotnet fsi build.fsx -- -p Watch
 
 
-* Run the documentation tool using your `dotnet/fsharp` fork as input.
+Anything after the pipeline name is passed on to `fsdocs watch`, for example `-- -p Watch --nolaunch --port 8080`.
+The `Watch` pipeline does not rebuild `FSharp.Compiler.Service`. Rerun `Build` after changing signature files or
+XML documentation in `src/Compiler`.
 
+## How watch works
 
-    dotnet fsdocs watch --eval --sourcefolder ../fsharp/ --input ../fsharp/docs/
+`fsdocs watch` is a lazy development server: a page is built the first time it is requested and cached until a
+file that influences it changes. Diagnostics, including which `FSharp.Compiler.Service.dll` is being documented,
+are at `/.fsdocs/doctor` on the served site.
 
+A page is rebuilt when the content of its own `.md` or `.fsx` file changes. Files a script pulls in through
+`#load`, and files it reads while evaluating, are not tracked
+([FSharp.Formatting#1309](https://github.com/fsprojects/FSharp.Formatting/issues/1309)). This affects the release
+notes pages in `docs/release-notes`, which are composed from the MarkDown files in the hidden subfolders through
+`.aux/Common.fsx`: editing those does not regenerate the served page. Make any edit to the `.fsx` of the page
+(touching the file is not enough, the content has to change), or restart the watch.
 
-## Release notes caveat
-
-The release notes pages from `docs/release-notes` are composed from the MarkDown files in subfolders.  
-Changing any of these files, won't regenerate the served webpage. Only the changes to the `.fsx` will trigger the tool. This is a known limitation.
+Restart the watch as well after changing the package versions referenced from `.aux/Common.fsx`. The running F#
+Interactive session keeps the assemblies it already loaded.

--- a/docs/srtp-guide.md
+++ b/docs/srtp-guide.md
@@ -1,4 +1,8 @@
 ---
+title: SRTP guide (draft)
+category: Compiler Internals
+categoryindex: 200
+index: 980
 status: draft
 target: Microsoft Learn (F# language guide)
 notes: >


### PR DESCRIPTION
Hello @T-Gro, sorry for ignoring the PR template. I'm gonna yap a bit.
This is PR purely about the docs over at  https://fsharp.github.io/fsharp-compiler-docs/

So, earlier today I fixed the GitHub Action that automatically publishes these (see https://github.com/fsharp/fsharp-compiler-docs/pull/1018)

And I noticed a few small things I wanted to fix in this PR:

- Some fsx scripts were broken due to API changes.
- The release notes pages did not quite show the NuGet packages linked to the notes. I improved that and did some tweaks to the ordering so latest stuff is shown first:

<img width="911" height="432" alt="image" src="https://github.com/user-attachments/assets/3114fb34-c194-4a61-b6a1-49c7355af791" />

<img width="596" height="359" alt="image" src="https://github.com/user-attachments/assets/e9b8a72b-fe58-4029-af30-edecb0a510dd" />

And some newer pages like the postmortems and LSP did not have frontmatter and did not end up in their own section. I changed that (and updated the skill as well)

<img width="278" height="325" alt="image" src="https://github.com/user-attachments/assets/1af55af2-58c9-4a74-9c31-d7139ef6128e" />

<img width="277" height="285" alt="image" src="https://github.com/user-attachments/assets/4f1b261b-0c55-4c94-8af7-aec5beddc276" />

I also bumped the fsdocs-tool to 23.alpha.1, I'm not sure if you need anything on MS side to allow that tool version to be used. But really, it is worth it:

<img width="523" height="488" alt="image" src="https://github.com/user-attachments/assets/3edddf99-0af1-4029-8858-3b0a0afeed60" />

In `docs/release-notes/.aux/Common.fsx` I also bumped some NuGet package versions. Not sure if that part matters much for this repo.

I hope this works for you.