### PR TITLE
Say why CommitDelayedDiagnostics copies the collection

### DIFF
--- a/src/Compiler/Facilities/DiagnosticsLogger.fs
+++ b/src/Compiler/Facilities/DiagnosticsLogger.fs
@@ -409,9 +409,9 @@ type CapturingDiagnosticsLogger(nm, ?eagerFormat) =
     member _.Diagnostics = diagnostics |> Seq.toList
 
     member _.CommitDelayedDiagnostics(diagnosticsLogger: DiagnosticsLogger) =
-        // Eagerly grab all the errors and warnings from the mutable collection
-        let errors = diagnostics.ToArray()
-        errors |> Array.iter diagnosticsLogger.DiagnosticSink
+        // A sink can report back into this logger while replaying, so iterate a snapshot.
+        let snapshot = diagnostics.ToArray()
+        snapshot |> Array.iter diagnosticsLogger.DiagnosticSink
 
 let buildPhase = AsyncLocal<BuildPhase voption>()
 let diagnosticsLogger = AsyncLocal<DiagnosticsLogger voption>()


### PR DESCRIPTION
## Description

Comment and local-name only change in `CapturingDiagnosticsLogger.CommitDelayedDiagnostics`. No behaviour change.

```fsharp
member _.CommitDelayedDiagnostics(diagnosticsLogger: DiagnosticsLogger) =
    // A sink can report back into this logger while replaying, so iterate a snapshot.
    let snapshot = diagnostics.ToArray()
    snapshot |> Array.iter diagnosticsLogger.DiagnosticSink
```

The old comment ("Eagerly grab all the errors and warnings from the mutable collection") said *that* the copy is eager but not *what it protects against*, and `errors` named a collection that also holds warnings. Together they read like a gratuitous copy of a `ResizeArray` that is consumed in full, immediately, by the very next line — an inviting target for "just iterate it lazily".

It is not gratuitous. A sink can report a diagnostic back into the logger being replayed, and a lazy traversal would then die with `Collection was modified; enumeration operation may not execute`:

* `fsc.fs` installs `delayForFlagsLogger` as the thread's logger ([`fsc.fs#L498`](https://github.com/dotnet/fsharp/blob/main/src/Compiler/Driver/fsc.fs#L498)) and never unwinds it across the commits that follow. Each of those builds a console logger whose `DiagnosticSink` calls `TcConfig.Create(tcConfigB, validate = false)` ([`fsc.fs#L78`](https://github.com/dotnet/fsharp/blob/main/src/Compiler/Driver/fsc.fs#L78)), which reports through the ambient logger — still the `CapturingDiagnosticsLogger` mid-replay.
* `RunWithBufferedReporting` commits from its exception path while `use _restoreLogger = UseDiagnosticsLogger capturingLogger` is still in scope ([`NameResolution.fs#L2594`](https://github.com/dotnet/fsharp/blob/main/src/Compiler/Checking/NameResolution.fs#L2594)).

With the snapshot, a diagnostic reported during a replay simply stays in the collection for the next commit. Without it, the failure is an `InvalidOperationException` far from its cause and only on the re-entrant paths.

Fixes # (issue, if applicable) — none.

## Checklist

- [ ] Test cases added — not applicable; nothing observable changed. `FSharp.Compiler.Service.Tests.BuildGraphTests` (15 tests, the existing coverage for `CommitDelayedDiagnostics` via `MultipleDiagnosticsLoggers.Parallel`/`Sequential`, including diagnostic ordering) passes.
- [ ] Performance benchmarks added in case of performance changes — not applicable.
- [ ] Release notes entry updated — not applicable, no user-visible change. Please apply `NO_RELEASE_NOTES`; I cannot set labels on this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
