### PR TITLE
Publish NavigableContainer's cases

### DIFF
--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -180,6 +180,7 @@
 * IL: hold custom attributes in fields rather than a union case ([PR #20287](https://github.com/dotnet/fsharp/pull/20287))
 * IL: reuse the cached ILTypeRef in ILTypeInfo.FromType ([PR #20255](https://github.com/dotnet/fsharp/pull/20255))
 * Name resolution: group C#-style extension members per `open` and extended type ([PR #20298](https://github.com/dotnet/fsharp/pull/20298))
+* `NavigableContainer` publishes its `File` and `Container` cases, so a consumer of `NavigateTo.GetNavigableItems` can take a container apart and rebuild one — needed to cache navigable items outside the process that produced them. `Container` now carries a `[<Struct>]` record, `NavigableContainerInfo`, in place of its three-element tuple: the fields gain names at no cost, since a struct record is laid out inside the case exactly as the tuple was.
 
 ### Improved
 

--- a/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
+++ b/docs/release-notes/.FSharp.Compiler.Service/11.0.100.md
@@ -180,7 +180,7 @@
 * IL: hold custom attributes in fields rather than a union case ([PR #20287](https://github.com/dotnet/fsharp/pull/20287))
 * IL: reuse the cached ILTypeRef in ILTypeInfo.FromType ([PR #20255](https://github.com/dotnet/fsharp/pull/20255))
 * Name resolution: group C#-style extension members per `open` and extended type ([PR #20298](https://github.com/dotnet/fsharp/pull/20298))
-* `NavigableContainer` publishes its `File` and `Container` cases, so a consumer of `NavigateTo.GetNavigableItems` can take a container apart and rebuild one — needed to cache navigable items outside the process that produced them. `Container` now carries a `[<Struct>]` record, `NavigableContainerInfo`, in place of its three-element tuple: the fields gain names at no cost, since a struct record is laid out inside the case exactly as the tuple was.
+* `NavigableContainer` publishes its `File` and `Container` cases, so a consumer of `NavigateTo.GetNavigableItems` can take a container apart and rebuild one — needed to cache navigable items outside the process that produced them. `Container` now carries a `[<Struct>]` record, `NavigableContainerInfo`, in place of its three-element tuple: the fields gain names at no cost, since a struct record is laid out inside the case exactly as the tuple was. ([PR #20529](https://github.com/dotnet/fsharp/pull/20529))
 
 ### Improved
 

--- a/src/Compiler/Service/ServiceNavigation.fs
+++ b/src/Compiler/Service/ServiceNavigation.fs
@@ -731,28 +731,36 @@ type NavigableContainerType =
     | Type
     | Exception
 
-type NavigableContainer =
+[<Struct>]
+type NavigableContainerInfo =
+    {
+        ContainerType: NavigableContainerType
+        NameParts: string list
+        Parent: NavigableContainer
+    }
+
+and NavigableContainer =
     | File of fileName: string
-    | Container of containerType: NavigableContainerType * nameParts: string list * parent: NavigableContainer
+    | Container of info: NavigableContainerInfo
 
     member x.FullName =
         let rec loop acc =
             function
             | File _ -> acc
-            | Container(_, nameParts, parent) -> loop (nameParts @ acc) parent
+            | Container info -> loop (info.NameParts @ acc) info.Parent
 
         loop [] x |> textOfPath
 
     member x.Type =
         match x with
         | File _ -> NavigableContainerType.File
-        | Container(t, _, _) -> t
+        | Container info -> info.ContainerType
 
     member x.Name =
         match x with
         | File name -> name
-        | Container(nameParts = []) -> ""
-        | Container(nameParts = ns) -> ns |> List.last
+        | Container { NameParts = [] } -> ""
+        | Container { NameParts = ns } -> ns |> List.last
 
 type NavigableItem =
     {
@@ -813,13 +821,24 @@ module NavigateTo =
         let addExceptionRepr exnRepr isSig container =
             let (SynExceptionDefnRepr(_, SynUnionCase(ident = SynIdent(id, _)), _, _, _, _)) = exnRepr
             addIdent NavigableItemKind.Exception id isSig container
-            NavigableContainer.Container(NavigableContainerType.Exception, [ id.idText ], container)
+
+            NavigableContainer.Container
+                {
+                    ContainerType = NavigableContainerType.Exception
+                    NameParts = [ id.idText ]
+                    Parent = container
+                }
 
         let addComponentInfo containerType kind (info: SynComponentInfo) isSig container =
             let lid = info.LongIdent
             addLongIdent kind lid isSig container
 
-            NavigableContainer.Container(containerType, pathOfLid lid, container)
+            NavigableContainer.Container
+                {
+                    ContainerType = containerType
+                    NameParts = pathOfLid lid
+                    Parent = container
+                }
 
         let addValSig kind synValSig isSig container =
             let (SynValSig(ident = SynIdent(id, _))) = synValSig
@@ -897,7 +916,14 @@ module NavigateTo =
                     NavigableContainerType.Namespace
 
             for decl in decls do
-                walkSynModuleSigDecl decl (NavigableContainer.Container(ctype, pathOfLid lid, container))
+                walkSynModuleSigDecl
+                    decl
+                    (NavigableContainer.Container
+                        {
+                            ContainerType = ctype
+                            NameParts = pathOfLid lid
+                            Parent = container
+                        })
 
         and walkSynModuleSigDecl (decl: SynModuleSigDecl) container =
             match decl with
@@ -956,7 +982,14 @@ module NavigateTo =
                     NavigableContainerType.Namespace
 
             for decl in decls do
-                walkSynModuleDecl decl (NavigableContainer.Container(ctype, pathOfLid lid, container))
+                walkSynModuleDecl
+                    decl
+                    (NavigableContainer.Container
+                        {
+                            ContainerType = ctype
+                            NameParts = pathOfLid lid
+                            Parent = container
+                        })
 
         and walkSynModuleDecl (decl: SynModuleDecl) container =
             match decl with

--- a/src/Compiler/Service/ServiceNavigation.fsi
+++ b/src/Compiler/Service/ServiceNavigation.fsi
@@ -99,8 +99,24 @@ type NavigableContainerType =
     | Type
     | Exception
 
-[<Sealed>]
-type NavigableContainer =
+/// What a container declared inside a file is, and what encloses it.
+[<Struct>]
+type NavigableContainerInfo =
+    {
+        /// The kind of container.
+        ContainerType: NavigableContainerType
+
+        /// The name of the container, one element per dotted part.
+        NameParts: string list
+
+        /// The container this one is declared in, ending at the file.
+        Parent: NavigableContainer
+    }
+
+and NavigableContainer =
+    | File of fileName: string
+    | Container of info: NavigableContainerInfo
+
     /// The kind of container.
     member Type: NavigableContainerType
 

--- a/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
+++ b/tests/FSharp.Compiler.Service.Tests/FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl
@@ -3877,9 +3877,25 @@ FSharp.Compiler.EditorServices.ModuleKind: Int32 GetHashCode()
 FSharp.Compiler.EditorServices.ModuleKind: Int32 GetHashCode(System.Collections.IEqualityComparer)
 FSharp.Compiler.EditorServices.ModuleKind: System.String ToString()
 FSharp.Compiler.EditorServices.ModuleKind: Void .ctor(Boolean, Boolean)
+FSharp.Compiler.EditorServices.NavigableContainer+Container: FSharp.Compiler.EditorServices.NavigableContainerInfo get_info()
+FSharp.Compiler.EditorServices.NavigableContainer+Container: FSharp.Compiler.EditorServices.NavigableContainerInfo info
+FSharp.Compiler.EditorServices.NavigableContainer+File: System.String fileName
+FSharp.Compiler.EditorServices.NavigableContainer+File: System.String get_fileName()
+FSharp.Compiler.EditorServices.NavigableContainer+Tags: Int32 Container
+FSharp.Compiler.EditorServices.NavigableContainer+Tags: Int32 File
 FSharp.Compiler.EditorServices.NavigableContainer: Boolean Equals(FSharp.Compiler.EditorServices.NavigableContainer)
+FSharp.Compiler.EditorServices.NavigableContainer: Boolean Equals(FSharp.Compiler.EditorServices.NavigableContainer, System.Collections.IEqualityComparer)
 FSharp.Compiler.EditorServices.NavigableContainer: Boolean Equals(System.Object)
 FSharp.Compiler.EditorServices.NavigableContainer: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.EditorServices.NavigableContainer: Boolean IsContainer
+FSharp.Compiler.EditorServices.NavigableContainer: Boolean IsFile
+FSharp.Compiler.EditorServices.NavigableContainer: Boolean get_IsContainer()
+FSharp.Compiler.EditorServices.NavigableContainer: Boolean get_IsFile()
+FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainer NewContainer(FSharp.Compiler.EditorServices.NavigableContainerInfo)
+FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainer NewFile(System.String)
+FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainer+Container
+FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainer+File
+FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainer+Tags
 FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainerType Type
 FSharp.Compiler.EditorServices.NavigableContainer: FSharp.Compiler.EditorServices.NavigableContainerType get_Type()
 FSharp.Compiler.EditorServices.NavigableContainer: Int32 CompareTo(FSharp.Compiler.EditorServices.NavigableContainer)
@@ -3887,11 +3903,30 @@ FSharp.Compiler.EditorServices.NavigableContainer: Int32 CompareTo(System.Object
 FSharp.Compiler.EditorServices.NavigableContainer: Int32 CompareTo(System.Object, System.Collections.IComparer)
 FSharp.Compiler.EditorServices.NavigableContainer: Int32 GetHashCode()
 FSharp.Compiler.EditorServices.NavigableContainer: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.EditorServices.NavigableContainer: Int32 Tag
+FSharp.Compiler.EditorServices.NavigableContainer: Int32 get_Tag()
 FSharp.Compiler.EditorServices.NavigableContainer: System.String FullName
 FSharp.Compiler.EditorServices.NavigableContainer: System.String Name
 FSharp.Compiler.EditorServices.NavigableContainer: System.String ToString()
 FSharp.Compiler.EditorServices.NavigableContainer: System.String get_FullName()
 FSharp.Compiler.EditorServices.NavigableContainer: System.String get_Name()
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Boolean Equals(FSharp.Compiler.EditorServices.NavigableContainerInfo)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Boolean Equals(FSharp.Compiler.EditorServices.NavigableContainerInfo, System.Collections.IEqualityComparer)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Boolean Equals(System.Object)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Boolean Equals(System.Object, System.Collections.IEqualityComparer)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: FSharp.Compiler.EditorServices.NavigableContainer Parent
+FSharp.Compiler.EditorServices.NavigableContainerInfo: FSharp.Compiler.EditorServices.NavigableContainer get_Parent()
+FSharp.Compiler.EditorServices.NavigableContainerInfo: FSharp.Compiler.EditorServices.NavigableContainerType ContainerType
+FSharp.Compiler.EditorServices.NavigableContainerInfo: FSharp.Compiler.EditorServices.NavigableContainerType get_ContainerType()
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Int32 CompareTo(FSharp.Compiler.EditorServices.NavigableContainerInfo)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Int32 CompareTo(System.Object)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Int32 CompareTo(System.Object, System.Collections.IComparer)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Int32 GetHashCode()
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Int32 GetHashCode(System.Collections.IEqualityComparer)
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Microsoft.FSharp.Collections.FSharpList`1[System.String] NameParts
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Microsoft.FSharp.Collections.FSharpList`1[System.String] get_NameParts()
+FSharp.Compiler.EditorServices.NavigableContainerInfo: System.String ToString()
+FSharp.Compiler.EditorServices.NavigableContainerInfo: Void .ctor(FSharp.Compiler.EditorServices.NavigableContainerType, Microsoft.FSharp.Collections.FSharpList`1[System.String], FSharp.Compiler.EditorServices.NavigableContainer)
 FSharp.Compiler.EditorServices.NavigableContainerType+Tags: Int32 Exception
 FSharp.Compiler.EditorServices.NavigableContainerType+Tags: Int32 File
 FSharp.Compiler.EditorServices.NavigableContainerType+Tags: Int32 Module


### PR DESCRIPTION
`NavigateTo.GetNavigableItems` returns items a consumer can read but not rebuild: the signature seals
`NavigableContainer` and hides its `File` and `Container` cases. That is enough to display a result, and not
enough to carry one out of the process that produced it. Visual Studio's Navigate To is to keep each file's
navigable items on disk between sessions, as Roslyn keeps its syntax index, and reading them back means
constructing containers.

### The change

- `NavigableContainer` publishes `File of fileName: string` and `Container of info: NavigableContainerInfo`. Its
  members `Type`, `FullName` and `Name` are unchanged.
- `Container` carried a three-element tuple, `containerType * nameParts * parent`. Published as it was, the tuple
  would be fixed into the API, so it becomes a record with named fields first:
  `NavigableContainerInfo { ContainerType; NameParts; Parent }`.
- The record is a `[<Struct>]`. A struct record lies inside the case exactly as the tuple's fields did — one
  allocation per container — where a reference record adds an object per container and an indirection on every
  access. Building a file and three nested containers a million times (x64, .NET 11, `fsi --optimize+`):

  | `Container` payload | bytes per chain |
  |---|---|
  | tuple (before) | 144 |
  | `[<Struct>]` record | 144 |
  | reference record | 216 |

  A struct union is not an option: `Parent` is recursive.

The change is additive: the surface-area baseline only gains lines. `NavigableContainer` keeps its structural
equality and comparison, which the struct record derives as well.

`SurfaceAreaTest` passes against the updated `FSharp.Compiler.Service.SurfaceArea.netstandard20.bsl`. The
consumer, a persistent cache for Navigate To in `FSharp.Editor`, is a separate PR that builds on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
